### PR TITLE
Improvements for log files

### DIFF
--- a/src/util/log/log.cpp
+++ b/src/util/log/log.cpp
@@ -2,7 +2,6 @@
 
 #include "../util_env.h"
 
-#include <ctime>
 #include <regex>
 
 namespace dxvk {
@@ -16,13 +15,6 @@ namespace dxvk {
       file += '/';
     std::regex ext(".exe$");
     file += std::regex_replace(env::getExeName(),ext,"") + "_";
-    if (!env::getEnvVar(L"DXVK_LOG_TIMESTAMP").empty()) {
-      std::time_t t = std::time(nullptr);
-      char mbstr[sizeof("2018-01-01_00.00.00")];
-      if (std::strftime(mbstr, sizeof(mbstr), "%Y-%m-%d_%H.%M.%S", std::localtime(&t))) {
-        file += std::string(mbstr) + "_";
-      }
-    }
     m_fileStream = std::ofstream(file + file_name);
   }
   

--- a/src/util/log/log.cpp
+++ b/src/util/log/log.cpp
@@ -2,11 +2,28 @@
 
 #include "../util_env.h"
 
+#include <ctime>
+
 namespace dxvk {
   
   Logger::Logger(const std::string& file_name)
-  : m_minLevel(getMinLogLevel()),
-    m_fileStream(file_name) { }
+  : m_minLevel(getMinLogLevel())
+  {
+    std::string path = env::getEnvVar(L"DXVK_LOG_PATH");
+    std::string file = path;
+    if (!file.empty() && *file.rbegin() != '/')
+      file += '/';
+    file += env::getExeName() + "_";
+    if (!env::getEnvVar(L"DXVK_LOG_TIMESTAMP").empty()) {
+      std::time_t t = std::time(nullptr);
+      char mbstr[sizeof("2018-01-01_00.00.00")];
+      if (std::strftime(mbstr, sizeof(mbstr), "%Y-%m-%d_%H.%M.%S", std::localtime(&t))) {
+        file += std::string(mbstr) + "_";
+      }
+    }
+      
+    m_fileStream = std::ofstream(file + file_name);
+  }
   
   
   Logger::~Logger() { }

--- a/src/util/log/log.cpp
+++ b/src/util/log/log.cpp
@@ -3,6 +3,7 @@
 #include "../util_env.h"
 
 #include <ctime>
+#include <regex>
 
 namespace dxvk {
   
@@ -13,7 +14,8 @@ namespace dxvk {
     std::string file = path;
     if (!file.empty() && *file.rbegin() != '/')
       file += '/';
-    file += env::getExeName() + "_";
+    std::regex ext(".exe$");
+    file += std::regex_replace(env::getExeName(),ext,"") + "_";
     if (!env::getEnvVar(L"DXVK_LOG_TIMESTAMP").empty()) {
       std::time_t t = std::time(nullptr);
       char mbstr[sizeof("2018-01-01_00.00.00")];
@@ -21,7 +23,6 @@ namespace dxvk {
         file += std::string(mbstr) + "_";
       }
     }
-      
     m_fileStream = std::ofstream(file + file_name);
   }
   

--- a/src/util/log/log.cpp
+++ b/src/util/log/log.cpp
@@ -15,7 +15,7 @@ namespace dxvk {
     if (!file.empty() && *file.rbegin() != '/')
       file += '/';
     std::string name = env::getExeName();
-    unsigned int extp = name.find_last_of('.');
+    auto extp = name.find_last_of('.');
     if (extp != std::string::npos && name.substr(extp +1) == "exe")
       name.erase(extp);
     file += name + "_";

--- a/src/util/log/log.cpp
+++ b/src/util/log/log.cpp
@@ -2,8 +2,6 @@
 
 #include "../util_env.h"
 
-#include <regex>
-
 namespace dxvk {
   
   Logger::Logger(const std::string& file_name)
@@ -13,8 +11,11 @@ namespace dxvk {
     std::string file = path;
     if (!file.empty() && *file.rbegin() != '/')
       file += '/';
-    std::regex ext(".exe$");
-    file += std::regex_replace(env::getExeName(),ext,"") + "_";
+    std::string name = env::getExeName();
+    unsigned int extp = name.find_last_of('.');
+    if (extp != std::string::npos && name.substr(extp +1) == "exe")
+      name.erase(extp);
+    file += name + "_";
     m_fileStream = std::ofstream(file + file_name);
   }
   

--- a/src/util/log/log.cpp
+++ b/src/util/log/log.cpp
@@ -7,6 +7,9 @@ namespace dxvk {
   Logger::Logger(const std::string& file_name)
   : m_minLevel(getMinLogLevel())
   {
+    if (m_minLevel == LogLevel::None)
+        return;
+    
     std::string path = env::getEnvVar(L"DXVK_LOG_PATH");
     std::string file = path;
     if (!file.empty() && *file.rbegin() != '/')
@@ -64,12 +67,13 @@ namespace dxvk {
   
   
   LogLevel Logger::getMinLogLevel() {
-    const std::array<std::pair<const char*, LogLevel>, 5> logLevels = {{
+    const std::array<std::pair<const char*, LogLevel>, 6> logLevels = {{
       { "trace", LogLevel::Trace },
       { "debug", LogLevel::Debug },
       { "info",  LogLevel::Info  },
       { "warn",  LogLevel::Warn  },
       { "error", LogLevel::Error },
+      { "none",  LogLevel::None  },
     }};
     
     const std::string logLevelStr = env::getEnvVar(L"DXVK_LOG_LEVEL");

--- a/src/util/log/log.h
+++ b/src/util/log/log.h
@@ -13,6 +13,7 @@ namespace dxvk {
     Info  = 2,
     Warn  = 3,
     Error = 4,
+    None  = 5,
   };
   
   /**


### PR DESCRIPTION
 - Added exec name to log files
 - Added DXVK_LOG_PATH environment variable to specify the log folder
 - Added DXVK_LOG_TIMESTAMP environment variable to add timestamps to file names

I'm not sure about DXVK_LOG_TIMESTAMP, the name may be misleading (timestamps are added to the file name, not to the log prints)