### PR TITLE
Throw error if requested layer is not installed

### DIFF
--- a/src/dxvk/dxvk_instance.cpp
+++ b/src/dxvk/dxvk_instance.cpp
@@ -79,7 +79,7 @@ namespace dxvk {
       if (layersAvailable.supports(l))
         layersEnabled.add(l);
       else
-        Logger::warn(str::format("Vulkan layer not installed, therefore not enabled: ", l));
+        throw DxvkError(str::format("Requested layer not installed: ", l));
     }
     
     return layersEnabled;

--- a/src/dxvk/dxvk_instance.cpp
+++ b/src/dxvk/dxvk_instance.cpp
@@ -78,6 +78,8 @@ namespace dxvk {
     for (auto l : layers) {
       if (layersAvailable.supports(l))
         layersEnabled.add(l);
+      else
+        Logger::warn(str::format("Vulkan layer not installed, therefore not enabled: ", l));
     }
     
     return layersEnabled;


### PR DESCRIPTION
This pull request will make missing layers crash the application (specifically, the standard validation layer).

Somebody might enable `DXVK_DEBUG_LAYERS`, and yet forget to install the validation layers. In that case, they would see no errors.