### PR TITLE
[d3d11] add stub for ID3DUserDefinedAnnotation

### DIFF
--- a/src/d3d11/d3d11_context.cpp
+++ b/src/d3d11/d3d11_context.cpp
@@ -67,6 +67,7 @@ namespace dxvk {
     COM_QUERY_IFACE(riid, ppvObject, ID3D11DeviceContext);
     
     Logger::warn("D3D11DeviceContext::QueryInterface: Unknown interface query");
+    Logger::warn(str::format(riid));
     return E_NOINTERFACE;
   }
   

--- a/src/d3d11/d3d11_context.cpp
+++ b/src/d3d11/d3d11_context.cpp
@@ -66,6 +66,9 @@ namespace dxvk {
     COM_QUERY_IFACE(riid, ppvObject, ID3D11DeviceChild);
     COM_QUERY_IFACE(riid, ppvObject, ID3D11DeviceContext);
     
+    if (riid == __uuidof(ID3DUserDefinedAnnotation))
+      return E_NOINTERFACE;
+  
     Logger::warn("D3D11DeviceContext::QueryInterface: Unknown interface query");
     Logger::warn(str::format(riid));
     return E_NOINTERFACE;

--- a/src/d3d11/d3d11_device.cpp
+++ b/src/d3d11/d3d11_device.cpp
@@ -64,6 +64,9 @@ namespace dxvk {
     
     if (riid == __uuidof(IDXGIPresentDevicePrivate))
       return m_presentDevice->QueryInterface(riid, ppvObject);
+
+    if (riid == __uuidof(ID3D11Debug))
+      return E_NOINTERFACE;      
     
     Logger::warn("D3D11Device::QueryInterface: Unknown interface query");
     Logger::warn(str::format(riid));


### PR DESCRIPTION
This patch prevents insane amount of logs (about 80-100 MiB/min) from World of Tanks 1.0.