### PR TITLE
Add Custom PCI Vendor and Device ID Support

### DIFF
--- a/src/dxvk/dxvk_adapter.cpp
+++ b/src/dxvk/dxvk_adapter.cpp
@@ -32,6 +32,29 @@ namespace dxvk {
     VkPhysicalDeviceProperties properties;
     m_vki->vkGetPhysicalDeviceProperties(m_handle, &properties);
     
+    const std::string customVendorID = env::getEnvVar(L"DXVK_CUSTOM_VENDOR_ID");
+    const std::string customDeviceID = env::getEnvVar(L"DXVK_CUSTOM_DEVICE_ID");
+    
+    if (!customVendorID.empty()) {
+      Logger::info("Using Custom PCI Vendor ID " + customVendorID + " instead of " + std::to_string(properties.vendorID));
+      
+      uint32_t newID = 0;
+      
+      if (customVendorID == "AMD") newID    = DxvkGpuVendor::Amd;
+      if (customVendorID == "NVIDIA") newID = DxvkGpuVendor::Nvidia;
+      if (customVendorID == "INTEL") newID  = DxvkGpuVendor::Intel;
+      
+      if (newID == 0) newID = std::stoul(customVendorID, nullptr, 16);
+      
+      properties.vendorID = newID;
+    }
+    
+    if (!customDeviceID.empty()) {
+      Logger::info("Using Custom PCI Device ID " + customDeviceID + " instead of " + std::to_string(properties.deviceID));
+      
+      properties.deviceID = std::stoul(customDeviceID, nullptr, 16);  
+    }
+    
     if (DxvkGpuVendor(properties.vendorID) == DxvkGpuVendor::Nvidia) {
       properties.driverVersion = VK_MAKE_VERSION(
         VK_VERSION_MAJOR(properties.driverVersion),

--- a/src/dxvk/dxvk_adapter.cpp
+++ b/src/dxvk/dxvk_adapter.cpp
@@ -36,13 +36,13 @@ namespace dxvk {
     const std::string customDeviceID = env::getEnvVar(L"DXVK_CUSTOM_DEVICE_ID");
     
     if (!customVendorID.empty()) {
-      Logger::info("Using Custom PCI Vendor ID " + customVendorID + " instead of " + std::to_string(properties.vendorID));
+      Logger::info("Using Custom PCI Vendor ID " + customVendorID + " instead of " + str::format(std::hex, properties.vendorID));
       
       properties.vendorID = std::stoul(customVendorID, nullptr, 16);
     }
     
     if (!customDeviceID.empty()) {
-      Logger::info("Using Custom PCI Device ID " + customDeviceID + " instead of " + std::to_string(properties.deviceID));
+      Logger::info("Using Custom PCI Device ID " + customDeviceID + " instead of " + str::format(std::hex, properties.deviceID));
       
       properties.deviceID = std::stoul(customDeviceID, nullptr, 16);  
     }

--- a/src/dxvk/dxvk_adapter.cpp
+++ b/src/dxvk/dxvk_adapter.cpp
@@ -38,15 +38,7 @@ namespace dxvk {
     if (!customVendorID.empty()) {
       Logger::info("Using Custom PCI Vendor ID " + customVendorID + " instead of " + std::to_string(properties.vendorID));
       
-      uint32_t newID = 0;
-      
-      if (customVendorID == "AMD") newID    = DxvkGpuVendor::Amd;
-      if (customVendorID == "NVIDIA") newID = DxvkGpuVendor::Nvidia;
-      if (customVendorID == "INTEL") newID  = DxvkGpuVendor::Intel;
-      
-      if (newID == 0) newID = std::stoul(customVendorID, nullptr, 16);
-      
-      properties.vendorID = newID;
+      properties.vendorID = std::stoul(customVendorID, nullptr, 16);;
     }
     
     if (!customDeviceID.empty()) {

--- a/src/dxvk/dxvk_adapter.cpp
+++ b/src/dxvk/dxvk_adapter.cpp
@@ -38,7 +38,7 @@ namespace dxvk {
     if (!customVendorID.empty()) {
       Logger::info("Using Custom PCI Vendor ID " + customVendorID + " instead of " + std::to_string(properties.vendorID));
       
-      properties.vendorID = std::stoul(customVendorID, nullptr, 16);;
+      properties.vendorID = std::stoul(customVendorID, nullptr, 16);
     }
     
     if (!customDeviceID.empty()) {

--- a/src/dxvk/dxvk_adapter.h
+++ b/src/dxvk/dxvk_adapter.h
@@ -16,7 +16,7 @@ namespace dxvk {
    * \brief GPU vendors
    * Based on PCIe IDs.
    */
-  enum DxvkGpuVendor : uint16_t {
+  enum class DxvkGpuVendor : uint16_t {
     Amd    = 0x1002,
     Nvidia = 0x10de,
     Intel  = 0x8086,

--- a/src/dxvk/dxvk_adapter.h
+++ b/src/dxvk/dxvk_adapter.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+
 #include "./vulkan/dxvk_vulkan_extensions.h"
 
 #include "dxvk_include.h"
@@ -14,7 +16,7 @@ namespace dxvk {
    * \brief GPU vendors
    * Based on PCIe IDs.
    */
-  enum class DxvkGpuVendor : uint16_t {
+  enum DxvkGpuVendor : uint16_t {
     Amd    = 0x1002,
     Nvidia = 0x10de,
     Intel  = 0x8086,


### PR DESCRIPTION
This commit allows the user to configure a custom GPU Vendor and Device PCI ID

This is useful for getting programs to behave similarly on different graphics cards.