### PR TITLE
[WIP] [dxbc] partially implemented dcl_hs_max_tessfactor

### DIFF
--- a/src/dxbc/dxbc_compiler.cpp
+++ b/src/dxbc/dxbc_compiler.cpp
@@ -256,6 +256,9 @@ namespace dxvk {
       case DxbcOpcode::DclTessOutputPrimitive:
         return this->emitDclTessOutputPrimitive(ins);
       
+      case DxbcOpcode::DclHsMaxTessFactor:
+          return this->emitDclHsMaxTessFactor(ins);
+      
       case DxbcOpcode::DclThreadGroup:
         return this->emitDclThreadGroup(ins);
       
@@ -1158,6 +1161,18 @@ namespace dxvk {
       default:
         throw DxvkError("Dxbc: Invalid tess output primitive");
     }
+  }
+  
+  
+  void DxbcCompiler::emitDclHsMaxTessFactor(const DxbcShaderInstruction& ins) {
+      float maxTessFactor = ins.imm[0].f32;
+
+      if (maxTessFactor < 1.0f || maxTessFactor > 64.0f)
+          Logger::warn(str::format(
+              "DxbcCompiler: Invalid dcl_hs_max_tessfactor value: ",
+              maxTessFactor));
+      else
+          m_hs.maxTessFactor = maxTessFactor;
   }
   
   

--- a/src/dxbc/dxbc_compiler.h
+++ b/src/dxbc/dxbc_compiler.h
@@ -212,6 +212,9 @@ namespace dxvk {
     
     uint32_t invocationBlockBegin  = 0;
     uint32_t invocationBlockEnd    = 0;
+
+    /* TODO: use this value */
+    float maxTessFactor = 64.0f;
     
     DxbcCompilerHsControlPointPhase          cpPhase;
     std::vector<DxbcCompilerHsForkJoinPhase> forkPhases;
@@ -493,6 +496,9 @@ namespace dxvk {
     void emitDclTessOutputPrimitive(
       const DxbcShaderInstruction&  ins);
     
+    void emitDclHsMaxTessFactor(
+      const DxbcShaderInstruction&  ins);
+
     void emitDclThreadGroup(
       const DxbcShaderInstruction&  ins);
     

--- a/src/dxbc/dxbc_decoder.h
+++ b/src/dxbc/dxbc_decoder.h
@@ -273,11 +273,13 @@ namespace dxvk {
    * \brief Immediate value
    * 
    * Immediate argument represented either
-   * as a 32-bit or 64-bit unsigned integer.
+   * as a 32-bit or 64-bit unsigned integer
+   * or a 32-bit floating point number.
    */
   union DxbcImmediate {
     uint32_t u32;
     uint64_t u64;
+    float    f32;
   };
   
   

--- a/src/dxbc/dxbc_defs.cpp
+++ b/src/dxbc/dxbc_defs.cpp
@@ -726,7 +726,9 @@ namespace dxvk {
     /* DclTessOutputPrimitive               */
     { 0, DxbcInstClass::Declaration },
     /* DclHsMaxTessFactor                   */
-    { },
+    { 1, DxbcInstClass::Declaration, {
+      { DxbcOperandKind::Imm32, DxbcScalarType::Float32 },
+    } },
     /* DclHsForkPhaseInstanceCount          */
     { 1, DxbcInstClass::HullShaderInstCnt, {
       { DxbcOperandKind::Imm32, DxbcScalarType::Uint32  },


### PR DESCRIPTION
Implemented value reading but i am not sure where i should apply it. Looks like tessellation factors are set up in `DxbcCompiler::emitHsSystemValueStore`.

I'm confused with using of `uint32_t` type because tessellation factor has `float32` type in DXBC.
