### PR TITLE
Some changes to the packaging script

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -32,7 +32,13 @@ glsl_generator = generator(glsl_compiler,
   arguments : [ '-V', '--vn', '@BASENAME@', '@INPUT@', '-o', '@OUTPUT@' ])
 
 subdir('src')
-if dxvk_compiler.get_id() != 'msvc'
+
+enable_tests = get_option('enable_tests')
+
+if enable_tests
   subdir('tests')
+endif
+
+if dxvk_compiler.get_id() != 'msvc'
   subdir('wine_utils')
 endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,1 @@
+option('enable_tests', type : 'boolean', value : false)

--- a/package-release.sh
+++ b/package-release.sh
@@ -8,7 +8,7 @@ fi
 DXVK_VERSION="$1"
 DXVK_SRC_DIR=`dirname $(readlink -f $0)`
 DXVK_TMP_DIR="/tmp/dxvk-$DXVK_VERSION"
-DXVK_ARCHIVE_PATH="$2/dxvk-$DXVK_VERSION.tar.gz"
+DXVK_ARCHIVE_PATH=$(realpath "$2")"/dxvk-$DXVK_VERSION.tar.gz"
 
 function build_arch {
   cd "$DXVK_SRC_DIR"

--- a/package-release.sh
+++ b/package-release.sh
@@ -18,6 +18,7 @@ function build_arch {
         --prefix "$DXVK_TMP_DIR/install.$1"           \
 	--unity on                                    \
         --strip                                       \
+        -Denable_tests=false                          \
         "$DXVK_TMP_DIR/build.$1"
 
   cd "$DXVK_TMP_DIR/build.$1"

--- a/package-release.sh
+++ b/package-release.sh
@@ -16,6 +16,7 @@ function build_arch {
   meson --cross-file "$DXVK_SRC_DIR/build-win$1.txt"  \
         --buildtype "release"                         \
         --prefix "$DXVK_TMP_DIR/install.$1"           \
+	--unity on                                    \
         --strip                                       \
         "$DXVK_TMP_DIR/build.$1"
 

--- a/package-release.sh
+++ b/package-release.sh
@@ -16,7 +16,7 @@ function build_arch {
   meson --cross-file "$DXVK_SRC_DIR/build-win$1.txt"  \
         --buildtype "release"                         \
         --prefix "$DXVK_TMP_DIR/install.$1"           \
-	--unity on                                    \
+	--unity off                                   \
         --strip                                       \
         -Denable_tests=false                          \
         "$DXVK_TMP_DIR/build.$1"


### PR DESCRIPTION
I've added an option for skipping the building of test binaries, and I've added that to the packaging script.
I really didn't want to add the meson_options.txt file... but it seems there's no way around it (that I could find, at least...).

I've also enabled "unity builds" there, as recommended by the Meson documentation. This makes a couple of warnings appear, but so far it seems to work (not tested extensively, though)

I've also added support for relative output directory paths to the packaging script.