### PR TITLE
split the package-release.sh script into 2 scripts to allow building without making a tarball

### DIFF
--- a/package.sh
+++ b/package.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+source release.sh
+
+function package {
+  tar -czf "$DXVK_ARCHIVE_PATH" -C "$DXVK_TARGET_DIR"/.. dxvk-$DXVK_VERSION
+  rm -R "$DXVK_TARGET_DIR"
+}
+
+package

--- a/release.sh
+++ b/release.sh
@@ -1,14 +1,15 @@
 #!/bin/bash
 
 if [ -z "$1" ] || [ -z "$2" ]; then
-  echo "Usage: package-release.sh version destdir"
+  echo "Usage: $(basename $0) version destdir"
   exit 1
 fi
-
+CWD=$(pwd)
 DXVK_VERSION="$1"
 DXVK_SRC_DIR=`dirname $(readlink -f $0)`
 DXVK_TMP_DIR="/tmp/dxvk-$DXVK_VERSION"
-DXVK_ARCHIVE_PATH=$(realpath "$2")"/dxvk-$DXVK_VERSION.tar.gz"
+DXVK_TARGET_DIR=$(realpath "$2")/dxvk-$DXVK_VERSION
+DXVK_ARCHIVE_PATH="$DXVK_TARGET_DIR/../dxvk-$DXVK_VERSION.tar.gz"
 
 function build_arch {
   cd "$DXVK_SRC_DIR"
@@ -24,22 +25,16 @@ function build_arch {
   cd "$DXVK_TMP_DIR/build.$1"
   ninja install
 
-  mkdir "$DXVK_TMP_DIR/x$1"
+  mkdir -p "$DXVK_TARGET_DIR/x$1"
 
-  cp "$DXVK_TMP_DIR/install.$1/bin/d3d11.dll" "$DXVK_TMP_DIR/x$1/d3d11.dll"
-  cp "$DXVK_TMP_DIR/install.$1/bin/dxgi.dll" "$DXVK_TMP_DIR/x$1/dxgi.dll"
-  cp "$DXVK_TMP_DIR/install.$1/bin/setup_dxvk.sh" "$DXVK_TMP_DIR/x$1/setup_dxvk.sh"
+  cp "$DXVK_TMP_DIR/install.$1/bin/d3d11.dll" "$DXVK_TARGET_DIR/x$1/d3d11.dll"
+  cp "$DXVK_TMP_DIR/install.$1/bin/dxgi.dll" "$DXVK_TARGET_DIR/x$1/dxgi.dll"
+  cp "$DXVK_TMP_DIR/install.$1/bin/setup_dxvk.sh" "$DXVK_TARGET_DIR/x$1/setup_dxvk.sh"
   
   rm -R "$DXVK_TMP_DIR/build.$1"
   rm -R "$DXVK_TMP_DIR/install.$1"
 }
 
-function package {
-  cd "$DXVK_TMP_DIR/.."
-  tar -czf "$DXVK_ARCHIVE_PATH" "dxvk-$DXVK_VERSION"
-  rm -R "dxvk-$DXVK_VERSION"
-}
-
 build_arch 64
 build_arch 32
-package
+cd $CWD


### PR DESCRIPTION
The script 'package.sh' can be used in the same way the previous single script was, and does the same; but using the script 'release.sh' alone creates a directory with the built libraries instead of a tarball