### PR TITLE
Fix tests for MSVC

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -22,7 +22,9 @@ lib_vulkan  = dxvk_compiler.find_library('vulkan-1', dirs : dxvk_library_path)
 lib_d3d11   = dxvk_compiler.find_library('d3d11')
 lib_dxgi    = dxvk_compiler.find_library('dxgi')
 
-if dxvk_compiler.get_id() != 'msvc'
+if dxvk_compiler.get_id() == 'msvc'
+  lib_d3dcompiler_47 = dxvk_compiler.find_library('d3dcompiler')
+else
   lib_d3dcompiler_47 = dxvk_compiler.find_library('d3dcompiler_47')
 endif
 

--- a/tests/d3d11/test_d3d11_compute.cpp
+++ b/tests/d3d11/test_d3d11_compute.cpp
@@ -30,10 +30,7 @@ const std::string g_computeShaderCode =
   "    buf_out[0] = tmp[0];\n"
   "}\n";
   
-int WINAPI WinMain(HINSTANCE hInstance,
-                   HINSTANCE hPrevInstance,
-                   LPSTR lpCmdLine,
-                   int nCmdShow) {
+int main() {
   Com<ID3D11Device>         device;
   Com<ID3D11DeviceContext>  context;
   Com<ID3D11ComputeShader>  computeShader;

--- a/tests/dxbc/test_dxbc_compiler.cpp
+++ b/tests/dxbc/test_dxbc_compiler.cpp
@@ -14,14 +14,7 @@ namespace dxvk {
 
 using namespace dxvk;
 
-int WINAPI WinMain(HINSTANCE hInstance,
-                   HINSTANCE hPrevInstance,
-                   LPSTR lpCmdLine,
-                   int nCmdShow) {
-  int     argc = 0;
-  LPWSTR* argv = CommandLineToArgvW(
-    GetCommandLineW(), &argc);  
-  
+int wmain(int argc, wchar_t *argv[], wchar_t *envp[]) {
   if (argc < 3) {
     Logger::err("Usage: dxbc-compiler input.dxbc output.spv");
     return 1;

--- a/tests/dxbc/test_dxbc_disasm.cpp
+++ b/tests/dxbc/test_dxbc_disasm.cpp
@@ -1,4 +1,5 @@
 #include <iostream>
+#include <string>
 
 #include <d3dcompiler.h>
 

--- a/tests/dxbc/test_dxbc_disasm.cpp
+++ b/tests/dxbc/test_dxbc_disasm.cpp
@@ -10,14 +10,7 @@
 
 using namespace dxvk;
 
-int WINAPI WinMain(HINSTANCE hInstance,
-                   HINSTANCE hPrevInstance,
-                   LPSTR lpCmdLine,
-                   int nCmdShow) {
-  int     argc = 0;
-  LPWSTR* argv = CommandLineToArgvW(
-    GetCommandLineW(), &argc);
-
+int wmain(int argc, wchar_t *argv[], wchar_t *envp[]) {
   if (argc < 2 || argc > 3) {
     std::cerr << "Usage: dxbc-disasm input.dxbc [output]" << std::endl;
     return 1;

--- a/tests/dxbc/test_hlsl_compiler.cpp
+++ b/tests/dxbc/test_hlsl_compiler.cpp
@@ -12,14 +12,7 @@
 
 using namespace dxvk;
 
-int WINAPI WinMain(HINSTANCE hInstance,
-                   HINSTANCE hPrevInstance,
-                   LPSTR lpCmdLine,
-                   int nCmdShow) {
-  int     argc = 0;
-  LPWSTR* argv = CommandLineToArgvW(
-    GetCommandLineW(), &argc);  
-  
+int wmain(int argc, wchar_t *argv[], wchar_t *envp[]) {
   if (argc < 5) {
     std::cerr << "Usage: hlsl-compiler target entrypoint input.hlsl output.dxbc" << std::endl;
     return 1;

--- a/tests/dxgi/test_dxgi_factory.cpp
+++ b/tests/dxgi/test_dxgi_factory.cpp
@@ -9,10 +9,7 @@
 
 using namespace dxvk;
 
-int WINAPI WinMain(HINSTANCE hInstance,
-                   HINSTANCE hPrevInstance,
-                   LPSTR lpCmdLine,
-                   int nCmdShow) {
+int main() {
   Com<IDXGIFactory> factory;
   
   if (CreateDXGIFactory(__uuidof(IDXGIFactory),


### PR DESCRIPTION
* replaced `WinMain()` with `main()`/`wmain()` for console applications.
* added missing `<string>` header in test_dxbc_disasm
* fixed `d3dcompiler` detection for MSVC