### PR TITLE
Move Custom PCI ID from DXVK to DXGI

### DIFF
--- a/src/dxgi/dxgi_adapter.cpp
+++ b/src/dxgi/dxgi_adapter.cpp
@@ -98,8 +98,24 @@ namespace dxvk {
     if (pDesc == nullptr)
       return DXGI_ERROR_INVALID_CALL;
     
-    const auto deviceProp = m_adapter->deviceProperties();
-    const auto memoryProp = m_adapter->memoryProperties();
+    auto deviceProp = m_adapter->deviceProperties();
+    auto memoryProp = m_adapter->memoryProperties();
+    
+    //Custom Vendor ID
+    const std::string customVendorID = env::getEnvVar(L"DXVK_CUSTOM_VENDOR_ID");
+    const std::string customDeviceID = env::getEnvVar(L"DXVK_CUSTOM_DEVICE_ID");
+    
+    if (!customVendorID.empty()) {
+      Logger::info("Using Custom PCI Vendor ID " + customVendorID + " instead of " + str::format(std::hex, deviceProp.vendorID));
+      
+      deviceProp.vendorID = std::stoul(customVendorID, nullptr, 16);
+    }
+    
+    if (!customDeviceID.empty()) {
+      Logger::info("Using Custom PCI Device ID " + customDeviceID + " instead of " + str::format(std::hex, deviceProp.deviceID));
+      
+      deviceProp.deviceID = std::stoul(customDeviceID, nullptr, 16);  
+    }
     
     std::memset(pDesc->Description, 0, sizeof(pDesc->Description));
     std::mbstowcs(pDesc->Description, deviceProp.deviceName, _countof(pDesc->Description) - 1);

--- a/src/dxgi/dxgi_adapter.h
+++ b/src/dxgi/dxgi_adapter.h
@@ -4,6 +4,7 @@
 #include <memory>
 #include <unordered_map>
 #include <vector>
+#include <string>
 
 #include <dxvk_adapter.h>
 

--- a/src/dxvk/dxvk_adapter.cpp
+++ b/src/dxvk/dxvk_adapter.cpp
@@ -32,21 +32,6 @@ namespace dxvk {
     VkPhysicalDeviceProperties properties;
     m_vki->vkGetPhysicalDeviceProperties(m_handle, &properties);
     
-    const std::string customVendorID = env::getEnvVar(L"DXVK_CUSTOM_VENDOR_ID");
-    const std::string customDeviceID = env::getEnvVar(L"DXVK_CUSTOM_DEVICE_ID");
-    
-    if (!customVendorID.empty()) {
-      Logger::info("Using Custom PCI Vendor ID " + customVendorID + " instead of " + str::format(std::hex, properties.vendorID));
-      
-      properties.vendorID = std::stoul(customVendorID, nullptr, 16);
-    }
-    
-    if (!customDeviceID.empty()) {
-      Logger::info("Using Custom PCI Device ID " + customDeviceID + " instead of " + str::format(std::hex, properties.deviceID));
-      
-      properties.deviceID = std::stoul(customDeviceID, nullptr, 16);  
-    }
-    
     if (DxvkGpuVendor(properties.vendorID) == DxvkGpuVendor::Nvidia) {
       properties.driverVersion = VK_MAKE_VERSION(
         VK_VERSION_MAJOR(properties.driverVersion),

--- a/src/dxvk/dxvk_adapter.h
+++ b/src/dxvk/dxvk_adapter.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <string>
-
 #include "./vulkan/dxvk_vulkan_extensions.h"
 
 #include "dxvk_include.h"


### PR DESCRIPTION
Previously, the custom set PCI IDs would interfere with DXVK's ability to apply vendor-specific driver workarounds, because it was using the custom IDs itself.  With this commit, only the application using DXVK is shown the custom ID, which is useful for workarounds.