### PR TITLE
[d3d11] Make D3D11Device share DXGIDevice's refcount

### DIFF
--- a/src/d3d11/d3d11_device.cpp
+++ b/src/d3d11/d3d11_device.cpp
@@ -79,8 +79,19 @@ namespace dxvk {
     Logger::warn(str::format(riid));
     return E_NOINTERFACE;
   }
-    
-  
+
+
+  // D3D11Device shares DXGIDevice's refcount
+  ULONG STDMETHODCALLTYPE D3D11Device::AddRef(void) {
+    return m_dxgiDevice->AddRef();
+  }
+
+
+  ULONG STDMETHODCALLTYPE D3D11Device::Release(void) {
+    return m_dxgiDevice->Release();
+  }
+
+
   HRESULT STDMETHODCALLTYPE D3D11Device::CreateBuffer(
     const D3D11_BUFFER_DESC*      pDesc,
     const D3D11_SUBRESOURCE_DATA* pInitialData,

--- a/src/d3d11/d3d11_device.h
+++ b/src/d3d11/d3d11_device.h
@@ -29,7 +29,7 @@ namespace dxvk {
   class D3D11Texture2D;
   class D3D11Texture3D;
   
-  class D3D11Device : public ComObject<ID3D11Device1> {
+  class D3D11Device : public ID3D11Device1 {
     /// Maximum number of resource init commands per command buffer
     constexpr static uint64_t InitCommandThreshold = 50;
   public:
@@ -38,12 +38,15 @@ namespace dxvk {
             IDXGIDevicePrivate*     dxgiDevice,
             D3D_FEATURE_LEVEL       featureLevel,
             UINT                    featureFlags);
-    ~D3D11Device();
+    virtual ~D3D11Device();
     
     HRESULT STDMETHODCALLTYPE QueryInterface(
             REFIID                  riid,
             void**                  ppvObject) final;
     
+    ULONG STDMETHODCALLTYPE AddRef(void) final;
+    ULONG STDMETHODCALLTYPE Release(void) final;
+
     HRESULT STDMETHODCALLTYPE CreateBuffer(
       const D3D11_BUFFER_DESC*      pDesc,
       const D3D11_SUBRESOURCE_DATA* pInitialData,
@@ -298,7 +301,8 @@ namespace dxvk {
     
   private:
     
-    const Com<IDXGIDevicePrivate>   m_dxgiDevice;
+    IDXGIDevicePrivate* const       m_dxgiDevice = nullptr;
+
           Com<IDXGIAdapterPrivate>  m_dxgiAdapter;
     const Com<D3D11PresentDevice>   m_presentDevice;
     

--- a/src/dxgi/dxgi_device.cpp
+++ b/src/dxgi/dxgi_device.cpp
@@ -1,5 +1,6 @@
 #include "dxgi_device.h"
 #include "dxgi_factory.h"
+#include "../d3d11/d3d11_device.h"
 
 namespace dxvk {
   
@@ -12,7 +13,7 @@ namespace dxvk {
   
   
   DxgiDevice::~DxgiDevice() {
-    
+    delete static_cast<D3D11Device*>(m_layer);
   }
   
   


### PR DESCRIPTION
If we query IDXGIDevice interface from d3d11 device as follows:
  D3D11CreateDevice(..., &device, NULL, NULL);
  device->QueryInterface(IDXGIDevice, (void **)&dxgi_device);
then manipulating dxgi_device's refcount using AddRef()/Release() will
also change device's refcount (and vice versa). In fact they seem to match.

Also, according to wine's tests, code like
  D3D11CreateDevice(..., &device, NULL, NULL);
  device->QueryInterface(IDXGIDevice, (void **)&dxgi_device);
  device->Release();
does not destroy the device. Make the refcount shared to implement this.

---
Unsure if it's the right approach, but it makes wine's tests progress much further.