### PR TITLE
[dxgi] Replace MSVC _countof macro with std::size

### DIFF
--- a/src/dxgi/dxgi_adapter.cpp
+++ b/src/dxgi/dxgi_adapter.cpp
@@ -118,7 +118,7 @@ namespace dxvk {
     }
     
     std::memset(pDesc->Description, 0, sizeof(pDesc->Description));
-    std::mbstowcs(pDesc->Description, deviceProp.deviceName, _countof(pDesc->Description) - 1);
+    std::mbstowcs(pDesc->Description, deviceProp.deviceName, std::size(pDesc->Description) - 1);
     
     VkDeviceSize deviceMemory = 0;
     VkDeviceSize sharedMemory = 0;

--- a/src/dxgi/dxgi_output.cpp
+++ b/src/dxgi/dxgi_output.cpp
@@ -139,7 +139,7 @@ namespace dxvk {
     }
     
     std::memset(pDesc->DeviceName, 0, sizeof(pDesc->DeviceName));
-    std::mbstowcs(pDesc->DeviceName, monInfo.szDevice, _countof(pDesc->DeviceName) - 1);
+    std::mbstowcs(pDesc->DeviceName, monInfo.szDevice, std::size(pDesc->DeviceName) - 1);
     
     pDesc->DesktopCoordinates = monInfo.rcMonitor;
     pDesc->AttachedToDesktop  = 1;


### PR DESCRIPTION
`std::size` (**c++17**) support required

**pro**: portable
**con**: may not work for older clang/gcc/mingw

http://en.cppreference.com/w/cpp/iterator/size
For example `Run this code` mode produces errors for GCC-5.2(C++17) and clang-3.8(C++17). Local GCC-7.3 and clang-7 versions are ok. 
Not tested w/ MinGW64.