### PR TITLE
[dxgi] Replace UINT_MAX with std::numeric_limits

### DIFF
--- a/src/dxgi/dxgi_output.cpp
+++ b/src/dxgi/dxgi_output.cpp
@@ -115,7 +115,7 @@ namespace dxvk {
       return DXGI_ERROR_NOT_FOUND;
 
     // Select mode with minimal height+width difference
-    UINT minDifference = UINT_MAX;
+    UINT minDifference = std::numeric_limits<unsigned int>::max();
     
     for (auto& mode : modes) {
       UINT currDifference = std::abs(int(pModeToMatch->Width  - mode.Width))


### PR DESCRIPTION
`limits.h` required for `UINT_MAX` and not always used, so better to use standard C++ variant from `<limits>`.

Some compilers may simply return `UINT_MAX` value, gcc version: `max() _GLIBCXX_USE_NOEXCEPT { return __INT_MAX__ * 2U + 1; }`.