### PR TITLE
[WIP] Added Pipeline Cache Size to DXVK HUD info

### DIFF
--- a/src/dxvk/dxvk_device.h
+++ b/src/dxvk/dxvk_device.h
@@ -77,6 +77,16 @@ namespace dxvk {
     }
     
     /**
+     * \brief The pipeline cache
+     * 
+     * The device's pipeline cache
+     * \returns Pipeline Cache
+     */
+    Rc<DxvkPipelineCache> pipelineCache() const {
+      return m_pipelineCache;
+    }
+    
+    /**
      * \brief Checks whether an option is enabled
      * 
      * \param [in] option The option to check for

--- a/src/dxvk/dxvk_pipecache.cpp
+++ b/src/dxvk/dxvk_pipecache.cpp
@@ -5,6 +5,7 @@ namespace dxvk {
   DxvkPipelineCache::DxvkPipelineCache(
     const Rc<vk::DeviceFn>& vkd)
   : m_vkd           (vkd),
+    m_cacheSize     (0),
     m_fileName      (getFileName()),
     m_updateStop    (0),
     m_updateCounter (0),
@@ -106,7 +107,7 @@ namespace dxvk {
   }
   
   
-  std::vector<char> DxvkPipelineCache::loadPipelineCache() const {
+  std::vector<char> DxvkPipelineCache::loadPipelineCache(){
     std::vector<char> cacheData;
     
     if (m_fileName.size() == 0) {
@@ -131,6 +132,8 @@ namespace dxvk {
       cacheData.resize(0);
     }
     
+    m_cacheSize = cacheData.size();
+    
     Logger::debug(str::format(
       "DxvkPipelineCache: Read ", cacheData.size(),
       " bytes from ", m_fileName));
@@ -138,7 +141,7 @@ namespace dxvk {
   }
   
   
-  void DxvkPipelineCache::storePipelineCache(const std::vector<char>& cacheData) const {
+  void DxvkPipelineCache::storePipelineCache(const std::vector<char>& cacheData){
     if (m_fileName.size() == 0) {
       Logger::warn("DxvkPipelineCache: Failed to locate cache file");
       return;
@@ -158,6 +161,8 @@ namespace dxvk {
       Logger::warn("DxvkPipelineCache: Failed to write shader cache file");
       return;
     }
+    
+    m_cacheSize = cacheData.size();
     
     Logger::debug(str::format(
       "DxvkPipelineCache: Wrote ", cacheData.size(),

--- a/src/dxvk/dxvk_pipecache.h
+++ b/src/dxvk/dxvk_pipecache.h
@@ -32,6 +32,14 @@ namespace dxvk {
      */
     VkPipelineCache handle() const {
       return m_handle;
+    }     
+    
+    /**
+     * \brief returns cache size in bytes
+     * \returns size of the Pipeline cache
+     */
+    size_t getPipelineCacheSize() const {
+      return m_cacheSize;
     }
     
     /**
@@ -42,10 +50,13 @@ namespace dxvk {
      */
     void update();
     
+
+    
   private:
     
     Rc<vk::DeviceFn>        m_vkd;
     VkPipelineCache         m_handle;
+    size_t                  m_cacheSize;
     
     std::string             m_fileName;
     
@@ -60,10 +71,10 @@ namespace dxvk {
     
     std::vector<char> getPipelineCache() const;
     
-    std::vector<char> loadPipelineCache() const;
+    std::vector<char> loadPipelineCache();
     
     void storePipelineCache(
-      const std::vector<char>& cacheData) const;
+      const std::vector<char>& cacheData);
     
     static std::string getFileName();
     

--- a/src/dxvk/hud/dxvk_hud.cpp
+++ b/src/dxvk/hud/dxvk_hud.cpp
@@ -9,7 +9,8 @@ namespace dxvk::hud {
     m_context       (m_device->createContext()),
     m_textRenderer  (m_device, m_context),
     m_uniformBuffer (createUniformBuffer()),
-    m_hudDeviceInfo (device) {
+    m_hudDeviceInfo (device),
+    m_hudCacheSize  (m_device->pipelineCache()) {
     this->setupConstantState();
   }
   
@@ -68,6 +69,8 @@ namespace dxvk::hud {
     position = m_hudDeviceInfo.renderText(
       m_context, m_textRenderer, position);
     position = m_hudFps.renderText(
+      m_context, m_textRenderer, position);
+    position = m_hudCacheSize.renderText(
       m_context, m_textRenderer, position);
   }
   

--- a/src/dxvk/hud/dxvk_hud.h
+++ b/src/dxvk/hud/dxvk_hud.h
@@ -6,10 +6,11 @@
 
 #include "dxvk_hud_devinfo.h"
 #include "dxvk_hud_fps.h"
+#include "dxvk_hud_cachesize.h"
 #include "dxvk_hud_text.h"
 
 namespace dxvk::hud {
-  
+    
   struct HudUniformData {
     VkExtent2D surfaceSize;
   };
@@ -75,6 +76,7 @@ namespace dxvk::hud {
     
     HudDeviceInfo         m_hudDeviceInfo;
     HudFps                m_hudFps;
+    HudCacheSize          m_hudCacheSize;
     
     void renderText();
     

--- a/src/dxvk/hud/dxvk_hud_cachesize.cpp
+++ b/src/dxvk/hud/dxvk_hud_cachesize.cpp
@@ -1,0 +1,29 @@
+#include "dxvk_hud_cachesize.h"
+
+namespace dxvk::hud {
+  
+  HudCacheSize::HudCacheSize(const Rc<DxvkPipelineCache>& cache)
+  : m_cache(cache),
+    m_cacheSizeString("Pipeline Cache Size: ") {
+    
+  }
+  
+  
+  HudCacheSize::~HudCacheSize() {
+    
+  }
+  
+  
+  HudPos HudCacheSize::renderText(
+    const Rc<DxvkContext>&  context,
+          HudTextRenderer&  renderer,
+          HudPos            position) {
+    renderer.drawText(context, 16.0f,
+      { position.x, position.y },
+      { 1.0f, 1.0f, 1.0f, 1.0f },
+      m_cacheSizeString + str::makeSizeReadable(m_cache->getPipelineCacheSize()) );
+    
+    return HudPos { position.x, position.y + 20 };
+  }
+  
+}

--- a/src/dxvk/hud/dxvk_hud_cachesize.h
+++ b/src/dxvk/hud/dxvk_hud_cachesize.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "dxvk_hud_text.h"
+
+#include "../dxvk_pipecache.h"
+#include "../util/util_string.h"
+
+namespace dxvk::hud {
+    
+  /**
+   * \brief Pipeline cache size display for the HUD
+   * 
+   * Displays the current size of the cache.
+   */
+  class HudCacheSize {
+  public:
+    
+    HudCacheSize(const Rc<DxvkPipelineCache>& cache);
+    ~HudCacheSize();
+    
+    HudPos renderText(
+      const Rc<DxvkContext>&  context,
+            HudTextRenderer&  renderer,
+            HudPos            position);
+    
+  private:
+    
+    Rc<DxvkPipelineCache> m_cache;
+    
+    std::string m_cacheSizeString;
+    
+  };
+  
+}

--- a/src/dxvk/meson.build
+++ b/src/dxvk/meson.build
@@ -48,6 +48,7 @@ dxvk_src = files([
   
   'hud/dxvk_hud.cpp',
   'hud/dxvk_hud_devinfo.cpp',
+  'hud/dxvk_hud_cachesize.cpp',
   'hud/dxvk_hud_font.cpp',
   'hud/dxvk_hud_fps.cpp',
   'hud/dxvk_hud_text.cpp',

--- a/src/util/meson.build
+++ b/src/util/meson.build
@@ -1,5 +1,6 @@
 util_src = files([
   'util_env.cpp',
+  'util_string.cpp',
   
   'com/com_guid.cpp',
   'com/com_private_data.cpp',

--- a/src/util/util_string.cpp
+++ b/src/util/util_string.cpp
@@ -1,0 +1,11 @@
+#include "util_string.h"
+
+namespace dxvk::str {
+
+  //TODO: Actually make the string readable
+  std::string makeSizeReadable(size_t bytes)
+  {
+    return std::to_string(bytes);
+  }
+  
+}

--- a/src/util/util_string.h
+++ b/src/util/util_string.h
@@ -26,4 +26,6 @@ namespace dxvk::str {
     return std::wstring_convert<std::codecvt_utf8<wchar_t>>().to_bytes(ws);
   }
   
+  std::string makeSizeReadable(size_t bytes);
+  
 }


### PR DESCRIPTION
This can be useful to both alarm people of a abnormally large pipeline cache, and also potentially help them confirm the cause of stutters.
Currently, the size only shows what is written on disk, but this could be easily changed.
Also, there is a framework to output in a more readable format, but right now it outputs a large number of bytes.