### PR TITLE
[dxgi] Fix compilation with WINE headers

### DIFF
--- a/src/dxgi/dxgi_output.cpp
+++ b/src/dxgi/dxgi_output.cpp
@@ -138,7 +138,7 @@ namespace dxvk {
     ::MONITORINFOEX monInfo;
     monInfo.cbSize = sizeof(monInfo);
 
-    if (!::GetMonitorInfo(m_monitor, (MONITORINFO *)&monInfo)) {
+    if (!::GetMonitorInfo(m_monitor, reinterpret_cast<MONITORINFO*>(&monInfo))) {
       Logger::err("DxgiOutput: Failed to query monitor info");
       return E_FAIL;
     }
@@ -166,7 +166,7 @@ namespace dxvk {
     ::MONITORINFOEX monInfo;
     monInfo.cbSize = sizeof(monInfo);
 
-    if (!::GetMonitorInfo(m_monitor, (MONITORINFO *)&monInfo)) {
+    if (!::GetMonitorInfo(m_monitor, reinterpret_cast<MONITORINFO*>(&monInfo))) {
       Logger::err("DxgiOutput: Failed to query monitor info");
       return E_FAIL;
     }

--- a/src/dxgi/dxgi_output.cpp
+++ b/src/dxgi/dxgi_output.cpp
@@ -138,7 +138,7 @@ namespace dxvk {
     ::MONITORINFOEX monInfo;
     monInfo.cbSize = sizeof(monInfo);
 
-    if (!::GetMonitorInfo(m_monitor, &monInfo)) {
+    if (!::GetMonitorInfo(m_monitor, (MONITORINFO *)&monInfo)) {
       Logger::err("DxgiOutput: Failed to query monitor info");
       return E_FAIL;
     }
@@ -166,7 +166,7 @@ namespace dxvk {
     ::MONITORINFOEX monInfo;
     monInfo.cbSize = sizeof(monInfo);
 
-    if (!::GetMonitorInfo(m_monitor, &monInfo)) {
+    if (!::GetMonitorInfo(m_monitor, (MONITORINFO *)&monInfo)) {
       Logger::err("DxgiOutput: Failed to query monitor info");
       return E_FAIL;
     }


### PR DESCRIPTION
```gcc
error: cannot convert 'MONITORINFOEX* {aka tagMONITORINFOEXA*}' to 'LPMONITORINFO {aka tagMONITORINFO*}' for argument '2' to 'BOOL GetMonitorInfoA(HMONITOR, LPMONITORINFO)'
```
```clang
cannot initialize a parameter of type 'LPMONITORINFO' (aka 'tagMONITORINFO *') with an rvalue of type '::MONITORINFOEX *' (aka 'tagMONITORINFOEXA *')
```

This can be WINE bug but I don't want to dig now, firs suggestion is wrong "tag":
wine variant
```c
typedef struct tagMONITORINFO
{
...
} MONITORINFO, *LPMONITORINFO;

typedef struct tagMONITORINFOEXA
{   /* the 4 first entries are the same as MONITORINFO */
...
} MONITORINFOEXA, *LPMONITORINFOEXA;

typedef struct tagMONITORINFOEXW
{   /* the 4 first entries are the same as MONITORINFO */
...
} MONITORINFOEXW, *LPMONITORINFOEXW;

DECL_WINELIB_TYPE_AW(MONITORINFOEX)
DECL_WINELIB_TYPE_AW(LPMONITORINFOEX)
```  
VS
MinGW variant
```c
  typedef struct tagMONITORINFO {
...
  } MONITORINFO,*LPMONITORINFO;

  typedef struct tagMONITORINFOEXA : public tagMONITORINFO {
    CHAR szDevice[CCHDEVICENAME];
  } MONITORINFOEXA,*LPMONITORINFOEXA;

  typedef struct tagMONITORINFOEXW : public tagMONITORINFO {
    WCHAR szDevice[CCHDEVICENAME];
  } MONITORINFOEXW,*LPMONITORINFOEXW;

  __MINGW_TYPEDEF_AW(MONITORINFOEX)
  __MINGW_TYPEDEF_AW(LPMONITORINFOEX)
```