### PR TITLE
[util] Fix compilation with WINE headers 

### DIFF
--- a/src/util/com/com_guid.h
+++ b/src/util/com/com_guid.h
@@ -6,8 +6,13 @@
 #include "com_include.h"
 
 #ifndef _MSC_VER
-#define DXVK_DEFINE_GUID(iface) \
-  template<> inline GUID const& __mingw_uuidof<iface> () { return iface::guid; }
+# ifdef __WINE__
+#   define DXVK_DEFINE_GUID(iface) \
+      template<> inline GUID const& __wine_uuidof<iface> () { return iface::guid; }
+# else
+#   define DXVK_DEFINE_GUID(iface) \
+      template<> inline GUID const& __mingw_uuidof<iface> () { return iface::guid; }
+# endif
 #endif
 
 std::ostream& operator << (std::ostream& os, REFIID guid);

--- a/src/util/com/com_include.h
+++ b/src/util/com/com_include.h
@@ -9,3 +9,9 @@
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #include <unknwn.h>
+
+// GCC: -std options disable certain keywords
+// https://gcc.gnu.org/onlinedocs/gcc/Alternate-Keywords.html
+#if defined(__WINE__) && !defined(typeof)
+#define typeof __typeof
+#endif


### PR DESCRIPTION
* [util] Define typeof keyword for WINE guiddef.h
  GCC: `-std options disable certain keywords`
  https://gcc.gnu.org/onlinedocs/gcc/Alternate-Keywords.html
  https://gcc.gnu.org/onlinedocs/gcc/Typeof.html#Typeof

  MinGW: `#define __uuidof(type) __mingw_uuidof<__typeof(type)>()`
  WINE: `#define __uuidof(type) __wine_uuidof<typeof(type)>()`

* [util] Fix compilation with WINE headers
  Use `__wine_uuidof` for WINE.
  Overall definitions are the same but `__wine_` prefix used in .

  MinGW: `_mingw.h` + `guiddef.h`
  WINE: `guiddef.h`