### PR TITLE
[dxgi] Use GetMonitorInfoW function explicitly

### DIFF
--- a/src/dxgi/dxgi_output.cpp
+++ b/src/dxgi/dxgi_output.cpp
@@ -150,16 +150,15 @@ namespace dxvk {
     if (pDesc == nullptr)
       return DXGI_ERROR_INVALID_CALL;
     
-    ::MONITORINFOEX monInfo;
+    ::MONITORINFOEXW monInfo;
     monInfo.cbSize = sizeof(monInfo);
 
-    if (!::GetMonitorInfo(m_monitor, reinterpret_cast<MONITORINFO*>(&monInfo))) {
+    if (!::GetMonitorInfoW(m_monitor, reinterpret_cast<MONITORINFO*>(&monInfo))) {
       Logger::err("DxgiOutput: Failed to query monitor info");
       return E_FAIL;
     }
     
-    std::memset(pDesc->DeviceName, 0, sizeof(pDesc->DeviceName));
-    std::mbstowcs(pDesc->DeviceName, monInfo.szDevice, std::size(pDesc->DeviceName) - 1);
+    std::memcpy(pDesc->DeviceName, monInfo.szDevice, std::size(pDesc->DeviceName));
     
     pDesc->DesktopCoordinates = monInfo.rcMonitor;
     pDesc->AttachedToDesktop  = 1;
@@ -178,24 +177,24 @@ namespace dxvk {
       return DXGI_ERROR_INVALID_CALL;
     
     // Query monitor info to get the device name
-    ::MONITORINFOEX monInfo;
+    ::MONITORINFOEXW monInfo;
     monInfo.cbSize = sizeof(monInfo);
 
-    if (!::GetMonitorInfo(m_monitor, reinterpret_cast<MONITORINFO*>(&monInfo))) {
+    if (!::GetMonitorInfoW(m_monitor, reinterpret_cast<MONITORINFO*>(&monInfo))) {
       Logger::err("DxgiOutput: Failed to query monitor info");
       return E_FAIL;
     }
     
     // Walk over all modes that the display supports and
     // return those that match the requested format etc.
-    DEVMODE devMode;
+    DEVMODEW devMode;
     
     uint32_t srcModeId = 0;
     uint32_t dstModeId = 0;
     
     const bool includeStretchedModes = (Flags & DXGI_ENUM_MODES_SCALING);
     
-    while (::EnumDisplaySettings(monInfo.szDevice, srcModeId++, &devMode)) {
+    while (::EnumDisplaySettingsW(monInfo.szDevice, srcModeId++, &devMode)) {
       // Skip interlaced modes altogether
       if (devMode.dmDisplayFlags & DM_INTERLACED)
         continue;


### PR DESCRIPTION
No `std::mbstowcs` string conversion needed than.
W/o this change I have different output when running `dxgi-factory.exe` compiled with MinGW:
* `Output 0:`
  ```
  \\.\DISPLAY1 (default)
  \\.\DISPLAY1 (DXVK MinGW)
  \            (DXVK winebuild)
  ```

With this patch all three variants are identical (`\\.\DISPLAY1`)

p.s. same problem in dxgi_adapter.cpp, but `deviceProp.deviceName` is vulkan structure parameter (char deviceName[VK_MAX_PHYSICAL_DEVICE_NAME_SIZE]).