### PR TITLE
Workaround for C++ STD not being set on MSVC/Visual Studio 2017

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -10,6 +10,10 @@ else
   dxvk_cpp_std='c++1z'
 endif
 
+if dxvk_compiler.get_id() == 'msvc'
+	add_global_arguments('/std:' + dxvk_cpp_std, language : 'cpp')
+endif
+
 dxvk_include_path = include_directories('./include')
 
 if (cpu_family == 'x86_64')


### PR DESCRIPTION
When building (in Visual Studio 2017) the standard doesn't set properly which causes it to error on the nested namespaces.

This pr adds a slight workaround as a global compiler argument to fix it based on the currently selected standard.