### PR TITLE
[d3d11] add some resource validation for copying resources

### DIFF
--- a/src/d3d11/d3d11_context.cpp
+++ b/src/d3d11/d3d11_context.cpp
@@ -365,7 +365,7 @@ namespace dxvk {
       // Copies are only supported on size-compatible formats
       if (dstFormatInfo->elementSize != srcFormatInfo->elementSize) {
         Logger::err(str::format(
-          "D3D11: Cannot perform image copy:"
+          "D3D11: CopySubresourceRegion: Incompatible texel size"
           "\n  Dst texel size: ", dstFormatInfo->elementSize,
           "\n  Src texel size: ", srcFormatInfo->elementSize));
         return;
@@ -374,7 +374,7 @@ namespace dxvk {
       // Copies are only supported if the sample count matches
       if (dstImage->info().sampleCount != srcImage->info().sampleCount) {
         Logger::err(str::format(
-          "D3D11: Cannot perform image copy:",
+          "D3D11: CopySubresourceRegion: Incompatible sample count",
           "\n  Dst sample count: ", dstImage->info().sampleCount,
           "\n  Src sample count: ", srcImage->info().sampleCount));
         return;
@@ -433,7 +433,7 @@ namespace dxvk {
       // Don't perform the copy if the offsets aren't aligned
       if (!util::isBlockAligned(srcOffset, srcFormatInfo->blockSize)
        || !util::isBlockAligned(dstOffset, dstFormatInfo->blockSize)) {
-        Logger::err("D3D11: Cannot perform copy: Unaligned block offset");
+        Logger::err("D3D11: CopySubresourceRegion: Unaligned block offset");
         return;
       }
       
@@ -451,7 +451,7 @@ namespace dxvk {
       // if it does not touch the image border for unaligned dimensons
       if (!util::isBlockAligned(srcOffset, regExtent, srcFormatInfo->blockSize, srcExtent)
        || !util::isBlockAligned(dstOffset, regExtent, dstFormatInfo->blockSize, dstExtent)) {
-        Logger::err("D3D11: Cannot perform copy: Unaligned block size");
+        Logger::err("D3D11: CopySubresourceRegion: Unaligned block size");
         return;
       }
       
@@ -537,7 +537,7 @@ namespace dxvk {
       // Copies are only supported on size-compatible formats
       if (dstFormatInfo->elementSize != srcFormatInfo->elementSize) {
         Logger::err(str::format(
-          "D3D11: Cannot perform image copy:"
+          "D3D11: CopyResource: Incompatible texel size"
           "\n  Dst texel size: ", dstFormatInfo->elementSize,
           "\n  Src texel size: ", srcFormatInfo->elementSize));
         return;
@@ -548,7 +548,7 @@ namespace dxvk {
        || srcImage->info().mipLevels != dstImage->info().mipLevels
        || srcImage->info().sampleCount != dstImage->info().sampleCount) {
         Logger::err(str::format(
-          "D3D11: Cannot perform image copy:"
+          "D3D11: CopyResource: Incompatible images"
           "\n  Dst: (", dstImage->info().numLayers,
                    ",", dstImage->info().mipLevels,
                    ",", dstImage->info().sampleCount, ")",

--- a/src/d3d11/d3d11_context.cpp
+++ b/src/d3d11/d3d11_context.cpp
@@ -2910,12 +2910,13 @@ namespace dxvk {
           const VkOffset3D& dstOffset,
           const VkExtent3D& extent) const {
     
+    
     //It's undefined behavior to have a src copy region outside 
     //of the src resource extent
     if (srcOffset.x + extent.width > srcExtent.width
       || srcOffset.y + extent.height > srcExtent.height
       || srcOffset.z + extent.depth > srcExtent.depth)
-      return;
+      return false;
 
     bool dstCompressed = dstFormatInfo->flags.test(DxvkFormatFlag::BlockCompressed);
     bool srcCompressed = srcFormatInfo->flags.test(DxvkFormatFlag::BlockCompressed);
@@ -2926,15 +2927,15 @@ namespace dxvk {
       //must match the source resource dimensions
       if (extent.width % srcFormatInfo->blockSize.width != 0
         || srcOffset.x + extent.width != srcExtent.width)
-        return;
+        return false;
 
       if (extent.height % srcFormatInfo->blockSize.height != 0
         || srcOffset.y + extent.height != srcExtent.height)
-        return;
+        return false;
 
       if (extent.depth % srcFormatInfo->blockSize.depth != 0
         || srcOffset.z + extent.depth != srcExtent.depth)
-        return;
+        return false;
 
       VkExtent3D uncompressedExtent = {
         extent.width / srcFormatInfo->blockSize.width,
@@ -2945,7 +2946,7 @@ namespace dxvk {
       if (uncompressedExtent.width > dstExtent.width - dstOffset.x
         || uncompressedExtent.height > dstExtent.height - dstOffset.y
         || uncompressedExtent.depth > dstExtent.depth - dstOffset.z)
-        return;
+        return false;
 
 
     } else if (!srcCompressed && dstCompressed) {
@@ -2961,22 +2962,22 @@ namespace dxvk {
       //must match the destination resource dimensions
       if (extent.width % dstFormatInfo->blockSize.width != 0
         || dstOffset.x + compressedExtent.width != dstExtent.width)
-        return;
+        return false;
 
       if (extent.height % dstFormatInfo->blockSize.height != 0
         || dstOffset.y + compressedExtent.height != dstExtent.height)
-        return;
+        return false;
 
       if (extent.depth % dstFormatInfo->blockSize.depth != 0
         || dstOffset.z + compressedExtent.depth != dstExtent.depth)
-        return;
+        return false;
 
 
 
       if (compressedExtent.width > dstExtent.width - dstOffset.x
         || compressedExtent.height > dstExtent.height - dstOffset.y
         || compressedExtent.depth > dstExtent.depth - dstOffset.z)
-        return;
+        return false;
 
       //for everything else. uncompressed to uncompressed 
       //or compressed to compressed
@@ -2985,11 +2986,11 @@ namespace dxvk {
       if (extent.width > dstExtent.width - dstOffset.x
         || extent.height > dstExtent.height - dstOffset.y
         || extent.depth > dstExtent.depth - dstOffset.z)
-        return;
+        return false;
     }
     
     
-    return false;
+    return true;
   }
   
 }

--- a/src/d3d11/d3d11_context.cpp
+++ b/src/d3d11/d3d11_context.cpp
@@ -2926,15 +2926,15 @@ namespace dxvk {
       //if it's not then the srcOffset + Extent 
       //must match the source resource dimensions
       if (extent.width % srcFormatInfo->blockSize.width != 0
-        || srcOffset.x + extent.width != srcExtent.width)
+        && srcOffset.x + extent.width != srcExtent.width)
         return false;
 
       if (extent.height % srcFormatInfo->blockSize.height != 0
-        || srcOffset.y + extent.height != srcExtent.height)
+        && srcOffset.y + extent.height != srcExtent.height)
         return false;
 
       if (extent.depth % srcFormatInfo->blockSize.depth != 0
-        || srcOffset.z + extent.depth != srcExtent.depth)
+        && srcOffset.z + extent.depth != srcExtent.depth)
         return false;
 
       VkExtent3D uncompressedExtent = {
@@ -2961,15 +2961,15 @@ namespace dxvk {
       //block dimensions if it's not then the dstOffset + Extent 
       //must match the destination resource dimensions
       if (extent.width % dstFormatInfo->blockSize.width != 0
-        || dstOffset.x + compressedExtent.width != dstExtent.width)
+        && dstOffset.x + compressedExtent.width != dstExtent.width)
         return false;
 
       if (extent.height % dstFormatInfo->blockSize.height != 0
-        || dstOffset.y + compressedExtent.height != dstExtent.height)
+        && dstOffset.y + compressedExtent.height != dstExtent.height)
         return false;
 
       if (extent.depth % dstFormatInfo->blockSize.depth != 0
-        || dstOffset.z + compressedExtent.depth != dstExtent.depth)
+        && dstOffset.z + compressedExtent.depth != dstExtent.depth)
         return false;
 
 

--- a/src/d3d11/d3d11_context.h
+++ b/src/d3d11/d3d11_context.h
@@ -771,14 +771,14 @@ namespace dxvk {
     
     DxvkDataSlice AllocUpdateBufferSlice(size_t Size);
 
-    bool ValidCopyExtents(
+    bool SetValidCopyExtents(
             const DxvkFormatInfo* const srcFormatInfo, 
             const DxvkFormatInfo* const dstFormatInfo,
             const VkExtent3D& srcExtent,
             const VkOffset3D& srcOffset,
             const VkExtent3D& dstExtent,
             const VkOffset3D& dstOffset,
-            const VkExtent3D& extent) const;
+                  VkExtent3D& extent) const;
     
     template<typename Cmd>
     void EmitCs(Cmd&& command) {

--- a/src/d3d11/d3d11_context.h
+++ b/src/d3d11/d3d11_context.h
@@ -770,6 +770,15 @@ namespace dxvk {
             D3D11UnorderedAccessBindings&     Bindings);
     
     DxvkDataSlice AllocUpdateBufferSlice(size_t Size);
+
+    bool ValidCopyExtents(
+            const DxvkFormatInfo* const srcFormatInfo, 
+            const DxvkFormatInfo* const dstFormatInfo,
+            const VkExtent3D& srcExtent,
+            const VkOffset3D& srcOffset,
+            const VkExtent3D& dstExtent,
+            const VkOffset3D& dstOffset,
+            const VkExtent3D& extent) const;
     
     template<typename Cmd>
     void EmitCs(Cmd&& command) {

--- a/src/d3d11/d3d11_context.h
+++ b/src/d3d11/d3d11_context.h
@@ -770,15 +770,6 @@ namespace dxvk {
             D3D11UnorderedAccessBindings&     Bindings);
     
     DxvkDataSlice AllocUpdateBufferSlice(size_t Size);
-
-    bool SetValidCopyExtents(
-            const DxvkFormatInfo* const srcFormatInfo, 
-            const DxvkFormatInfo* const dstFormatInfo,
-            const VkExtent3D& srcExtent,
-            const VkOffset3D& srcOffset,
-            const VkExtent3D& dstExtent,
-            const VkOffset3D& dstOffset,
-                  VkExtent3D& extent) const;
     
     template<typename Cmd>
     void EmitCs(Cmd&& command) {

--- a/src/dxvk/dxvk_util.h
+++ b/src/dxvk/dxvk_util.h
@@ -40,19 +40,114 @@ namespace dxvk::util {
           VkDeviceSize      pitchPerLayer);
   
   /**
+   * \brief Computes minimum extent
+   * 
+   * \param [in] a First value
+   * \param [in] b Second value
+   * \returns Component-wise \c min
+   */
+  inline VkExtent3D minExtent3D(VkExtent3D a, VkExtent3D b) {
+    return VkExtent3D {
+      std::min(a.width,  b.width),
+      std::min(a.height, b.height),
+      std::min(a.depth,  b.depth) };
+  }
+  
+  /**
+   * \brief Checks whether an offset is block-aligned
+   * 
+   * An offset is considered block-aligned if it is
+   * a multiple of the block size. Only non-negative
+   * offset values are valid.
+   * \param [in] offset The offset to check
+   * \param [in] blockSize Block size
+   * \returns \c true if \c offset is aligned
+   */
+  inline bool isBlockAligned(VkOffset3D offset, VkExtent3D blockSize) {
+    return (offset.x % blockSize.width  == 0)
+        && (offset.y % blockSize.height == 0)
+        && (offset.z % blockSize.depth  == 0);
+  }
+  
+  /**
+   * \brief Checks whether an extent is block-aligned
+   * 
+   * A block-aligned extent can be used for image copy
+   * operations that involve block-compressed images.
+   * \param [in] offset The base offset
+   * \param [in] extent The extent to check
+   * \param [in] blockSize Compressed block size
+   * \param [in] imageSize Image size
+   * \returns \c true if all components of \c extent
+   *          are aligned or touch the image border.
+   */
+  inline bool isBlockAligned(VkOffset3D offset, VkExtent3D extent, VkExtent3D blockSize, VkExtent3D imageSize) {
+    return ((extent.width  % blockSize.width  == 0) || (uint32_t(offset.x + extent.width)  == imageSize.width))
+        && ((extent.height % blockSize.height == 0) || (uint32_t(offset.y + extent.height) == imageSize.height))
+        && ((extent.depth  % blockSize.depth  == 0) || (uint32_t(offset.z + extent.depth)  == imageSize.depth));
+  }
+  
+  /**
+   * \brief Computes block offset for compressed images
+   * 
+   * Convenience function to compute the block position
+   * within a compressed image based on the block size.
+   * \param [in] offset The offset
+   * \param [in] blockSize Size of a pixel block
+   * \returns The block offset
+   */
+  inline VkOffset3D computeBlockOffset(VkOffset3D offset, VkExtent3D blockSize) {
+    return VkOffset3D {
+      offset.x / int32_t(blockSize.width),
+      offset.y / int32_t(blockSize.height),
+      offset.z / int32_t(blockSize.depth) };
+  }
+  
+  /**
    * \brief Computes block count for compressed images
    * 
    * Convenience function to compute the size, in
    * blocks, of compressed images subresources.
-   * \param [in] imageSize The image size
-   * \param [in] blockSize Size per pixel block
+   * \param [in] extent The image size
+   * \param [in] blockSize Size of a pixel block
    * \returns Number of blocks in the image
    */
-  inline VkExtent3D computeBlockCount(VkExtent3D imageSize, VkExtent3D blockSize) {
+  inline VkExtent3D computeBlockCount(VkExtent3D extent, VkExtent3D blockSize) {
     return VkExtent3D {
-      (imageSize.width  + blockSize.width  - 1) / blockSize.width,
-      (imageSize.height + blockSize.height - 1) / blockSize.height,
-      (imageSize.depth  + blockSize.depth  - 1) / blockSize.depth };
+      (extent.width  + blockSize.width  - 1) / blockSize.width,
+      (extent.height + blockSize.height - 1) / blockSize.height,
+      (extent.depth  + blockSize.depth  - 1) / blockSize.depth };
+  }
+  
+  /**
+   * \brief Computes block count for compressed images
+   * 
+   * Given an aligned offset, this computes 
+   * Convenience function to compute the size, in
+   * blocks, of compressed images subresources.
+   * \param [in] extent The image size
+   * \param [in] blockSize Size of a pixel block
+   * \returns Number of blocks in the image
+   */
+  inline VkExtent3D computeMaxBlockCount(VkOffset3D offset, VkExtent3D extent, VkExtent3D blockSize) {
+    return VkExtent3D {
+      (extent.width  + blockSize.width  - offset.x - 1) / blockSize.width,
+      (extent.height + blockSize.height - offset.y - 1) / blockSize.height,
+      (extent.depth  + blockSize.depth  - offset.z - 1) / blockSize.depth };
+  }
+  
+  /**
+   * \brief Computes block extent for compressed images
+   * 
+   * \param [in] blockCount The number of blocks
+   * \param [in] blockSize Size of a pixel block
+   * \returns Extent of the given blocks
+   */
+  inline VkExtent3D computeBlockExtent(VkExtent3D blockCount, VkExtent3D blockSize) {
+    return VkExtent3D {
+      blockCount.width  * blockSize.width,
+      blockCount.height * blockSize.height,
+      blockCount.depth  * blockSize.depth };
   }
   
   /**


### PR DESCRIPTION
Some games, such as Saints Row IV and Star Citizen, use invalid parameters for resource copying. These invalid parameters can cause Device Lost errors and other undefined problems.