### PR TITLE
Make hashes use correct types and fix narrowing warnings in spirv module.

### DIFF
--- a/src/d3d11/d3d11_sampler.cpp
+++ b/src/d3d11/d3d11_sampler.cpp
@@ -25,7 +25,7 @@ namespace dxvk {
     info.mipmapLodBias = desc.MipLODBias;
     info.mipmapLodMin  = desc.MinLOD;
     info.mipmapLodMax  = desc.MaxLOD;
-    info.maxAnisotropy = desc.MaxAnisotropy;
+    info.maxAnisotropy = static_cast<float>(desc.MaxAnisotropy);
     info.addressModeU  = DecodeAddressMode(desc.AddressU);
     info.addressModeV  = DecodeAddressMode(desc.AddressV);
     info.addressModeW  = DecodeAddressMode(desc.AddressW);

--- a/src/d3d11/d3d11_state.cpp
+++ b/src/d3d11/d3d11_state.cpp
@@ -47,13 +47,15 @@ namespace dxvk {
   
   size_t D3D11StateDescHash::operator () (
     const D3D11_RASTERIZER_DESC1& desc) const {
+    std::hash<float> fhash;
+
     DxvkHashState hash;
     hash.add(desc.FillMode);
     hash.add(desc.CullMode);
     hash.add(desc.FrontCounterClockwise);
     hash.add(desc.DepthBias);
-    hash.add(desc.SlopeScaledDepthBias);
-    hash.add(desc.DepthBiasClamp);
+    hash.add(fhash(desc.SlopeScaledDepthBias));
+    hash.add(fhash(desc.DepthBiasClamp));
     hash.add(desc.DepthClipEnable);
     hash.add(desc.ScissorEnable);
     hash.add(desc.MultisampleEnable);
@@ -90,7 +92,7 @@ namespace dxvk {
     hash.add(desc.AddressV);
     hash.add(desc.AddressW);
     hash.add(fhash(desc.MipLODBias));
-    hash.add(fhash(desc.MaxAnisotropy));
+    hash.add(desc.MaxAnisotropy);
     hash.add(desc.ComparisonFunc);
     for (uint32_t i = 0; i < 4; i++)
       hash.add(fhash(desc.BorderColor[i]));

--- a/src/spirv/spirv_module.cpp
+++ b/src/spirv/spirv_module.cpp
@@ -569,7 +569,7 @@ namespace dxvk {
           uint32_t                variableType,
           spv::StorageClass       storageClass) {
     std::array<uint32_t, 2> args = {{
-      storageClass,
+      static_cast<uint32_t>(storageClass),
       variableType,
     }};
     
@@ -593,11 +593,11 @@ namespace dxvk {
           spv::ImageFormat        format) {
     std::array<uint32_t, 7> args = {{
       sampledType,
-      dimensionality,
+	  static_cast<uint32_t>(dimensionality),
       depth, arrayed,
       multisample,
       sampled,
-      format
+	  static_cast<uint32_t>(format)
     }};
     
     return this->defType(spv::OpTypeImage,


### PR DESCRIPTION
In d3d11_state.cpp there were several implicit casts of floats to size_t which were then being hashed. I do not believe this is intentional. I have made them use the hash functions of their respective types. There was also one the other way around.

In spirv_module.cpp several enums were being narrowly casted implicitly as their type width was 64 bits wide and they were going to a uint32. This has been resolved with a static cast before their usage in the std::array.

