### PR TITLE
[clang-tidy] performance-for-range-copy fix

### DIFF
--- a/src/d3d11/d3d11_cmdlist.cpp
+++ b/src/d3d11/d3d11_cmdlist.cpp
@@ -52,7 +52,7 @@ namespace dxvk {
   void D3D11CommandList::EmitToCommandList(ID3D11CommandList* pCommandList) {
     auto cmdList = static_cast<D3D11CommandList*>(pCommandList);
     
-    for (auto chunk : m_chunks)
+    for (const auto& chunk : m_chunks)
       cmdList->m_chunks.push_back(chunk);
     
     cmdList->m_drawCount += m_drawCount;
@@ -60,7 +60,7 @@ namespace dxvk {
   
   
   void D3D11CommandList::EmitToCsThread(DxvkCsThread* CsThread) {
-    for (auto chunk : m_chunks)
+    for (const auto& chunk : m_chunks)
       CsThread->dispatchChunk(Rc<DxvkCsChunk>(chunk));
   }
   


### PR DESCRIPTION
> Finds C++11 for ranges where the loop variable is copied in each iteration but it would suffice to obtain it by const reference.

> The check is only applied to loop variables of types that are expensive to copy which means they are not trivially copyable or have a non-trivial copy constructor or destructor.

https://clang.llvm.org/extra/clang-tidy/checks/performance-for-range-copy.html