### PR TITLE
[clang-tidy] performance-unnecessary-value-param fix

### DIFF
--- a/src/d3d11/d3d11_context.cpp
+++ b/src/d3d11/d3d11_context.cpp
@@ -1,4 +1,5 @@
 #include <cstring>
+#include <utility>
 
 #include "d3d11_context.h"
 #include "d3d11_device.h"
@@ -13,7 +14,7 @@ namespace dxvk {
       D3D11Device*    pParent,
       Rc<DxvkDevice>  Device)
   : m_parent  (pParent),
-    m_device  (Device),
+    m_device  (std::move(Device)),
     m_csChunk (new DxvkCsChunk()) {
     // Create default state objects. We won't ever return them
     // to the application, but we'll use them to apply state.

--- a/src/d3d11/d3d11_context_def.cpp
+++ b/src/d3d11/d3d11_context_def.cpp
@@ -1,12 +1,14 @@
 #include "d3d11_context_def.h"
 
+#include <utility>
+
 namespace dxvk {
   
   D3D11DeferredContext::D3D11DeferredContext(
     D3D11Device*    pParent,
     Rc<DxvkDevice>  Device,
     UINT            ContextFlags)
-  : D3D11DeviceContext(pParent, Device),
+  : D3D11DeviceContext(pParent, std::move(Device)),
     m_contextFlags(ContextFlags),
     m_commandList (CreateCommandList()) {
     ClearState();

--- a/src/d3d11/d3d11_context_imm.cpp
+++ b/src/d3d11/d3d11_context_imm.cpp
@@ -7,7 +7,7 @@ namespace dxvk {
   
   D3D11ImmediateContext::D3D11ImmediateContext(
     D3D11Device*    pParent,
-    Rc<DxvkDevice>  Device)
+    const Rc<DxvkDevice>&  Device)
   : D3D11DeviceContext(pParent, Device),
     m_csThread(Device->createContext()) {
     EmitCs([cDevice = m_device] (DxvkContext* ctx) {

--- a/src/d3d11/d3d11_context_imm.h
+++ b/src/d3d11/d3d11_context_imm.h
@@ -13,7 +13,7 @@ namespace dxvk {
     
     D3D11ImmediateContext(
       D3D11Device*    pParent,
-      Rc<DxvkDevice>  Device);
+      const Rc<DxvkDevice>&  Device);
     ~D3D11ImmediateContext();
     
     ULONG STDMETHODCALLTYPE AddRef() final;

--- a/src/dxvk/dxvk_memory.cpp
+++ b/src/dxvk/dxvk_memory.cpp
@@ -152,7 +152,7 @@ namespace dxvk {
   
   
   DxvkMemoryHeap::DxvkMemoryHeap(
-    const Rc<vk::DeviceFn>    vkd,
+    const Rc<vk::DeviceFn>&    vkd,
           uint32_t            memTypeId,
           VkMemoryType        memType)
   : m_vkd       (vkd),

--- a/src/dxvk/dxvk_memory.h
+++ b/src/dxvk/dxvk_memory.h
@@ -161,7 +161,7 @@ namespace dxvk {
   public:
     
     DxvkMemoryHeap(
-      const Rc<vk::DeviceFn>    vkd,
+      const Rc<vk::DeviceFn>&    vkd,
             uint32_t            memTypeId,
             VkMemoryType        memType);
     


### PR DESCRIPTION
> Flags value parameter declarations of expensive to copy types that are copied for each invocation but it would suffice to pass them by const reference.

> The check is only applied to parameters of types that are expensive to copy which means they are not trivially copyable or have a non-trivial copy constructor or destructor.

https://clang.llvm.org/extra/clang-tidy/checks/performance-unnecessary-value-param.html