### PR TITLE
[clang-tidy] performance-move-const-arg fix

### DIFF
--- a/src/d3d11/d3d11_context.cpp
+++ b/src/d3d11/d3d11_context.cpp
@@ -2577,7 +2577,7 @@ namespace dxvk {
     }
     
     // Create and bind the framebuffer object to the context
-    EmitCs([cAttachments = std::move(attachments)] (DxvkContext* ctx) {
+    EmitCs([cAttachments = attachments] (DxvkContext* ctx) {
       ctx->bindRenderTargets(cAttachments);
     });
   }

--- a/src/d3d11/d3d11_device.cpp
+++ b/src/d3d11/d3d11_device.cpp
@@ -1025,7 +1025,7 @@ namespace dxvk {
       return S_FALSE;
     
     *ppVertexShader = ref(new D3D11VertexShader(
-      this, std::move(module)));
+      this, module));
     return S_OK;
   }
   
@@ -1047,7 +1047,7 @@ namespace dxvk {
       return S_FALSE;
     
     *ppGeometryShader = ref(new D3D11GeometryShader(
-      this, std::move(module)));
+      this, module));
     return S_OK;
   }
   
@@ -1085,7 +1085,7 @@ namespace dxvk {
       return S_FALSE;
     
     *ppPixelShader = ref(new D3D11PixelShader(
-      this, std::move(module)));
+      this, module));
     return S_OK;
   }
   
@@ -1107,7 +1107,7 @@ namespace dxvk {
       return S_FALSE;
     
     *ppHullShader = ref(new D3D11HullShader(
-      this, std::move(module)));
+      this, module));
     return S_OK;
   }
   
@@ -1129,7 +1129,7 @@ namespace dxvk {
       return S_FALSE;
     
     *ppDomainShader = ref(new D3D11DomainShader(
-      this, std::move(module)));
+      this, module));
     return S_OK;
   }
   
@@ -1151,7 +1151,7 @@ namespace dxvk {
       return S_FALSE;
     
     *ppComputeShader = ref(new D3D11ComputeShader(
-      this, std::move(module)));
+      this, module));
     return S_OK;
   }
   

--- a/src/d3d11/d3d11_shader.h
+++ b/src/d3d11/d3d11_shader.h
@@ -104,7 +104,7 @@ namespace dxvk {
   public:
     
     D3D11Shader(D3D11Device* device, const D3D11ShaderModule& module)
-    : m_device(device), m_module(std::move(module)) { }
+    : m_device(device), m_module(module) { }
     
     ~D3D11Shader() { }
     


### PR DESCRIPTION
> The check warns
> *    if std::move() is called with a constant argument,
> *    if std::move() is called with an argument of a trivially-copyable type,
> *    if the result of std::move() is passed as a const reference argument.
>
> In all three cases, the check will suggest a fix that removes the std::move().

https://clang.llvm.org/extra/clang-tidy/checks/performance-move-const-arg.html