### PR TITLE
[dxvk] Fix native build on *nix x86_64 systems

### DIFF
--- a/src/dxvk/hud/dxvk_hud_stats.cpp
+++ b/src/dxvk/hud/dxvk_hud_stats.cpp
@@ -47,7 +47,7 @@ namespace dxvk::hud {
     const Rc<DxvkContext>&  context,
           HudRenderer&      renderer,
           HudPos            position) {
-    const uint64_t frameCount = std::max(m_diffCounters.getCtr(DxvkStatCounter::QueuePresentCount), 1ull);
+    const uint64_t frameCount = std::max(m_diffCounters.getCtr(DxvkStatCounter::QueuePresentCount), UINT64_C(1));
     
     const uint64_t gpCalls = m_diffCounters.getCtr(DxvkStatCounter::CmdDrawCalls)       / frameCount;
     const uint64_t cpCalls = m_diffCounters.getCtr(DxvkStatCounter::CmdDispatchCalls)   / frameCount;
@@ -80,7 +80,7 @@ namespace dxvk::hud {
     const Rc<DxvkContext>&  context,
           HudRenderer&      renderer,
           HudPos            position) {
-    const uint64_t frameCount = std::max(m_diffCounters.getCtr(DxvkStatCounter::QueuePresentCount), 1ull);
+    const uint64_t frameCount = std::max(m_diffCounters.getCtr(DxvkStatCounter::QueuePresentCount), UINT64_C(1));
     const uint64_t numSubmits = m_diffCounters.getCtr(DxvkStatCounter::QueueSubmitCount) / frameCount;
     
     const std::string strSubmissions = str::format("Queue submissions: ", numSubmits);

--- a/src/dxvk/hud/dxvk_hud_stats.cpp
+++ b/src/dxvk/hud/dxvk_hud_stats.cpp
@@ -47,7 +47,7 @@ namespace dxvk::hud {
     const Rc<DxvkContext>&  context,
           HudRenderer&      renderer,
           HudPos            position) {
-    const uint64_t frameCount = std::max(m_diffCounters.getCtr(DxvkStatCounter::QueuePresentCount), UINT64_C(1));
+    const uint64_t frameCount = std::max<uint64_t>(m_diffCounters.getCtr(DxvkStatCounter::QueuePresentCount), 1);
     
     const uint64_t gpCalls = m_diffCounters.getCtr(DxvkStatCounter::CmdDrawCalls)       / frameCount;
     const uint64_t cpCalls = m_diffCounters.getCtr(DxvkStatCounter::CmdDispatchCalls)   / frameCount;
@@ -80,7 +80,7 @@ namespace dxvk::hud {
     const Rc<DxvkContext>&  context,
           HudRenderer&      renderer,
           HudPos            position) {
-    const uint64_t frameCount = std::max(m_diffCounters.getCtr(DxvkStatCounter::QueuePresentCount), UINT64_C(1));
+    const uint64_t frameCount = std::max<uint64_t>(m_diffCounters.getCtr(DxvkStatCounter::QueuePresentCount), 1);
     const uint64_t numSubmits = m_diffCounters.getCtr(DxvkStatCounter::QueueSubmitCount) / frameCount;
     
     const std::string strSubmissions = str::format("Queue submissions: ", numSubmits);


### PR DESCRIPTION
> /usr/include/c++/v1/algorithm:2633:1:
> note: candidate template ignored: deduced conflicting types for parameter '_Tp' ('unsigned long' vs. 'unsigned long long')

winegcc, clang-tidy and other native build types/tools are affected.

http://en.cppreference.com/w/cpp/language/types#Data_models
> 64 bit systems:
> * LLP64 or 4/4/8 (int and long are 32-bit, pointer is 64-bit) 
>    * Win64 API 
> * LP64 or 4/8/8 (int is 32-bit, long and pointer are 64-bit) 
>    * Unix and Unix-like systems (Linux, Mac OS X) 

http://en.cppreference.com/w/cpp/types/integer#Function_macros_for_minimum-width_integer_constants
Macro `UINT64_C(1)` from `stdint.h` should literally interpret `1` to `1UL` or `1ULL`
```c
# if __WORDSIZE == 64
#  define UINT64_C(c)	c ## UL
# else
#  define UINT64_C(c)	c ## ULL
# endif
```