### PR TITLE
[d3d11] Allow FarCry 5 to use D3D11_MAP_FLAG_DO_NOT_WAIT

### DIFF
--- a/src/d3d11/d3d11_options.cpp
+++ b/src/d3d11/d3d11_options.cpp
@@ -6,6 +6,7 @@ namespace dxvk {
   
   const static std::unordered_map<std::string, D3D11OptionSet> g_d3d11AppOptions = {{
     { "Dishonored2.exe", D3D11OptionSet(D3D11Option::AllowMapFlagNoWait)           },
+    { "FarCry5.exe",     D3D11OptionSet(D3D11Option::AllowMapFlagNoWait)           },
     { "Fallout4.exe",    D3D11OptionSet(D3D11Option::DisableGetDataFlagDoNotFlush) },
     { "Overwatch.exe",   D3D11OptionSet(D3D11Option::FakeStreamOutSupport)         },
   }};


### PR DESCRIPTION
This helps with some frame rate stability and stuttering issues with the benchmark/game.