### PR TITLE
Implement dedicated allocation

### DIFF
--- a/src/dxvk/dxvk_buffer_res.cpp
+++ b/src/dxvk/dxvk_buffer_res.cpp
@@ -52,7 +52,8 @@ namespace dxvk {
        m_vkd->device(), &memReqInfo, &memReq);
 
     bool useDedicated = dedicatedRequirements.prefersDedicatedAllocation;
-    m_memory = memAlloc.alloc(memReq, useDedicated ? &dedMemoryAllocInfo : nullptr, memFlags);
+    m_memory = memAlloc.alloc(&memReq.memoryRequirements,
+      useDedicated ? &dedMemoryAllocInfo : nullptr, memFlags);
     
     if (m_vkd->vkBindBufferMemory(m_vkd->device(), m_handle,
         m_memory.memory(), m_memory.offset()) != VK_SUCCESS)

--- a/src/dxvk/dxvk_buffer_res.cpp
+++ b/src/dxvk/dxvk_buffer_res.cpp
@@ -27,22 +27,20 @@ namespace dxvk {
         "\n  usage: ", info.usage));
     }
     
-    VkMemoryDedicatedRequirementsKHR dedicatedRequirements =
-    {
-      VK_STRUCTURE_TYPE_MEMORY_DEDICATED_REQUIREMENTS_KHR,
-      VK_NULL_HANDLE,
-      VK_FALSE,
-      VK_FALSE
-    };
+    VkMemoryDedicatedRequirementsKHR dedicatedRequirements;
+    dedicatedRequirements.sType                       = VK_STRUCTURE_TYPE_MEMORY_DEDICATED_REQUIREMENTS_KHR;
+    dedicatedRequirements.pNext                       = VK_NULL_HANDLE;
+    dedicatedRequirements.prefersDedicatedAllocation  = VK_FALSE;
+    dedicatedRequirements.requiresDedicatedAllocation = VK_FALSE;
     
     VkMemoryRequirements2KHR memReq;
     memReq.sType = VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2_KHR;
     memReq.pNext = &dedicatedRequirements;
     
     VkBufferMemoryRequirementsInfo2KHR memReqInfo;
-    memReqInfo.sType = VK_STRUCTURE_TYPE_BUFFER_MEMORY_REQUIREMENTS_INFO_2_KHR;
+    memReqInfo.sType  = VK_STRUCTURE_TYPE_BUFFER_MEMORY_REQUIREMENTS_INFO_2_KHR;
     memReqInfo.buffer = m_handle;
-    memReqInfo.pNext = VK_NULL_HANDLE;
+    memReqInfo.pNext  = VK_NULL_HANDLE;
     
     m_vkd->vkGetBufferMemoryRequirements2KHR(
        m_vkd->device(), &memReqInfo, &memReq);

--- a/src/dxvk/dxvk_buffer_res.cpp
+++ b/src/dxvk/dxvk_buffer_res.cpp
@@ -42,9 +42,17 @@ namespace dxvk {
     memReqInfo.buffer = m_handle;
     memReqInfo.pNext  = VK_NULL_HANDLE;
     
+    VkMemoryDedicatedAllocateInfoKHR dedMemoryAllocInfo;
+    dedMemoryAllocInfo.sType  = VK_STRUCTURE_TYPE_MEMORY_DEDICATED_ALLOCATE_INFO_KHR;
+    dedMemoryAllocInfo.pNext  = VK_NULL_HANDLE;
+    dedMemoryAllocInfo.buffer = m_handle;
+    dedMemoryAllocInfo.image  = VK_NULL_HANDLE;
+
     m_vkd->vkGetBufferMemoryRequirements2KHR(
        m_vkd->device(), &memReqInfo, &memReq);
-    m_memory = memAlloc.alloc(memReq, dedicatedRequirements, memFlags, VK_NULL_HANDLE, m_handle);
+
+    bool useDedicated = dedicatedRequirements.prefersDedicatedAllocation;
+    m_memory = memAlloc.alloc(memReq, useDedicated ? &dedMemoryAllocInfo : nullptr, memFlags);
     
     if (m_vkd->vkBindBufferMemory(m_vkd->device(), m_handle,
         m_memory.memory(), m_memory.offset()) != VK_SUCCESS)

--- a/src/dxvk/dxvk_buffer_res.cpp
+++ b/src/dxvk/dxvk_buffer_res.cpp
@@ -27,10 +27,26 @@ namespace dxvk {
         "\n  usage: ", info.usage));
     }
     
-    VkMemoryRequirements memReq;
-    m_vkd->vkGetBufferMemoryRequirements(
-      m_vkd->device(), m_handle, &memReq);
-    m_memory = memAlloc.alloc(memReq, memFlags);
+    VkMemoryDedicatedRequirementsKHR dedicatedRequirements =
+    {
+      VK_STRUCTURE_TYPE_MEMORY_DEDICATED_REQUIREMENTS_KHR,
+      VK_NULL_HANDLE,
+      VK_FALSE,
+      VK_FALSE
+    };
+    
+    VkMemoryRequirements2KHR memReq;
+    memReq.sType = VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2_KHR;
+    memReq.pNext = &dedicatedRequirements;
+    
+    VkBufferMemoryRequirementsInfo2KHR memReqInfo;
+    memReqInfo.sType = VK_STRUCTURE_TYPE_BUFFER_MEMORY_REQUIREMENTS_INFO_2_KHR;
+    memReqInfo.buffer = m_handle;
+    memReqInfo.pNext = VK_NULL_HANDLE;
+    
+    m_vkd->vkGetBufferMemoryRequirements2KHR(
+       m_vkd->device(), &memReqInfo, &memReq);
+    m_memory = memAlloc.alloc(memReq, dedicatedRequirements, memFlags, VK_NULL_HANDLE, m_handle);
     
     if (m_vkd->vkBindBufferMemory(m_vkd->device(), m_handle,
         m_memory.memory(), m_memory.offset()) != VK_SUCCESS)

--- a/src/dxvk/dxvk_extensions.h
+++ b/src/dxvk/dxvk_extensions.h
@@ -131,14 +131,14 @@ namespace dxvk {
   struct DxvkDeviceExtensions : public DxvkExtensionList {
     DxvkExtension extShaderViewportIndexLayer = { this, VK_EXT_SHADER_VIEWPORT_INDEX_LAYER_EXTENSION_NAME,  DxvkExtensionType::Desired  };
     DxvkExtension extVertexAttributeDivisor   = { this, VK_EXT_VERTEX_ATTRIBUTE_DIVISOR_EXTENSION_NAME,     DxvkExtensionType::Required };
+    DxvkExtension khrDedicatedAllocation      = { this, VK_KHR_DEDICATED_ALLOCATION_EXTENSION_NAME,         DxvkExtensionType::Required };
     DxvkExtension khrDescriptorUpdateTemplate = { this, VK_KHR_DESCRIPTOR_UPDATE_TEMPLATE_EXTENSION_NAME,   DxvkExtensionType::Required };
-    DxvkExtension khrSamplerMirrorClampToEdge = { this, VK_KHR_SAMPLER_MIRROR_CLAMP_TO_EDGE_EXTENSION_NAME, DxvkExtensionType::Desired  };
+    DxvkExtension khrGetMemoryRequirements2   = { this, VK_KHR_GET_MEMORY_REQUIREMENTS_2_EXTENSION_NAME,    DxvkExtensionType::Required };
     DxvkExtension khrMaintenance1             = { this, VK_KHR_MAINTENANCE1_EXTENSION_NAME,                 DxvkExtensionType::Required };
     DxvkExtension khrMaintenance2             = { this, VK_KHR_MAINTENANCE2_EXTENSION_NAME,                 DxvkExtensionType::Required };
+    DxvkExtension khrSamplerMirrorClampToEdge = { this, VK_KHR_SAMPLER_MIRROR_CLAMP_TO_EDGE_EXTENSION_NAME, DxvkExtensionType::Desired  };
     DxvkExtension khrShaderDrawParameters     = { this, VK_KHR_SHADER_DRAW_PARAMETERS_EXTENSION_NAME,       DxvkExtensionType::Required };
     DxvkExtension khrSwapchain                = { this, VK_KHR_SWAPCHAIN_EXTENSION_NAME,                    DxvkExtensionType::Required };
-    DxvkExtension khrGetMemoryRequirements2   = { this, VK_KHR_GET_MEMORY_REQUIREMENTS_2_EXTENSION_NAME,    DxvkExtensionType::Required };
-    DxvkExtension khrDedicatedAllocation      = { this, VK_KHR_DEDICATED_ALLOCATION_EXTENSION_NAME,         DxvkExtensionType::Required };
   };
   
   /**

--- a/src/dxvk/dxvk_extensions.h
+++ b/src/dxvk/dxvk_extensions.h
@@ -137,6 +137,8 @@ namespace dxvk {
     DxvkExtension khrMaintenance2             = { this, VK_KHR_MAINTENANCE2_EXTENSION_NAME,                 DxvkExtensionType::Required };
     DxvkExtension khrShaderDrawParameters     = { this, VK_KHR_SHADER_DRAW_PARAMETERS_EXTENSION_NAME,       DxvkExtensionType::Required };
     DxvkExtension khrSwapchain                = { this, VK_KHR_SWAPCHAIN_EXTENSION_NAME,                    DxvkExtensionType::Required };
+    DxvkExtension khrGetMemoryRequirements2   = { this, VK_KHR_GET_MEMORY_REQUIREMENTS_2_EXTENSION_NAME,    DxvkExtensionType::Required };
+    DxvkExtension khrDedicatedAllocation      = { this, VK_KHR_DEDICATED_ALLOCATION_EXTENSION_NAME,         DxvkExtensionType::Required };
   };
   
   /**

--- a/src/dxvk/dxvk_image.cpp
+++ b/src/dxvk/dxvk_image.cpp
@@ -46,13 +46,11 @@ namespace dxvk {
     // alignment on non-linear images in order not to violate the
     // bufferImageGranularity limit, which may be greater than the
     // required resource memory alignment on some GPUs.
-    VkMemoryDedicatedRequirementsKHR dedicatedRequirements =
-    {
-      VK_STRUCTURE_TYPE_MEMORY_DEDICATED_REQUIREMENTS_KHR,
-      VK_NULL_HANDLE,
-      VK_FALSE,
-      VK_FALSE
-    };
+    VkMemoryDedicatedRequirementsKHR dedicatedRequirements;
+    dedicatedRequirements.sType                       = VK_STRUCTURE_TYPE_MEMORY_DEDICATED_REQUIREMENTS_KHR;
+    dedicatedRequirements.pNext                       = VK_NULL_HANDLE;
+    dedicatedRequirements.prefersDedicatedAllocation  = VK_FALSE;
+    dedicatedRequirements.requiresDedicatedAllocation = VK_FALSE;
     
     VkMemoryRequirements2KHR memReq;
     memReq.sType = VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2_KHR;

--- a/src/dxvk/dxvk_image.cpp
+++ b/src/dxvk/dxvk_image.cpp
@@ -76,7 +76,8 @@ namespace dxvk {
     }
 
     bool useDedicated = dedicatedRequirements.prefersDedicatedAllocation;
-    m_memory = memAlloc.alloc(memReq, useDedicated ? &dedMemoryAllocInfo : nullptr, memFlags);
+    m_memory = memAlloc.alloc(&memReq.memoryRequirements,
+      useDedicated ? &dedMemoryAllocInfo : nullptr, memFlags);
     
     // Try to bind the allocated memory slice to the image
     if (m_vkd->vkBindImageMemory(m_vkd->device(),

--- a/src/dxvk/dxvk_image.cpp
+++ b/src/dxvk/dxvk_image.cpp
@@ -46,17 +46,34 @@ namespace dxvk {
     // alignment on non-linear images in order not to violate the
     // bufferImageGranularity limit, which may be greater than the
     // required resource memory alignment on some GPUs.
-    VkMemoryRequirements memReq;
+    VkMemoryDedicatedRequirementsKHR dedicatedRequirements =
+    {
+      VK_STRUCTURE_TYPE_MEMORY_DEDICATED_REQUIREMENTS_KHR,
+      VK_NULL_HANDLE,
+      VK_FALSE,
+      VK_FALSE
+    };
     
-    m_vkd->vkGetImageMemoryRequirements(
-      m_vkd->device(), m_image, &memReq);
+    VkMemoryRequirements2KHR memReq;
+    memReq.sType = VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2_KHR;
+    memReq.pNext = &dedicatedRequirements;
+    
+    
+    VkImageMemoryRequirementsInfo2KHR memReqInfo;
+    memReqInfo.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_REQUIREMENTS_INFO_2_KHR;
+    memReqInfo.image = m_image;
+    memReqInfo.pNext = VK_NULL_HANDLE;
+    
+    m_vkd->vkGetImageMemoryRequirements2KHR(
+      m_vkd->device(), &memReqInfo, &memReq);
+ 
     
     if (info.tiling != VK_IMAGE_TILING_LINEAR) {
-      memReq.size      = align(memReq.size,       memAlloc.bufferImageGranularity());
-      memReq.alignment = align(memReq.alignment , memAlloc.bufferImageGranularity());
+      memReq.memoryRequirements.size      = align(memReq.memoryRequirements.size,       memAlloc.bufferImageGranularity());
+      memReq.memoryRequirements.alignment = align(memReq.memoryRequirements.alignment , memAlloc.bufferImageGranularity());
     }
     
-    m_memory = memAlloc.alloc(memReq, memFlags);
+    m_memory = memAlloc.alloc(memReq, dedicatedRequirements, memFlags, m_image, VK_NULL_HANDLE);
     
     // Try to bind the allocated memory slice to the image
     if (m_vkd->vkBindImageMemory(m_vkd->device(),

--- a/src/dxvk/dxvk_memory.cpp
+++ b/src/dxvk/dxvk_memory.cpp
@@ -166,22 +166,25 @@ namespace dxvk {
   
   
   DxvkMemory DxvkMemoryAllocator::alloc(
-    const VkMemoryRequirements& req,
-    const VkMemoryPropertyFlags flags) {
+    const VkMemoryRequirements2KHR& req,
+    const VkMemoryDedicatedRequirementsKHR& dedReq,
+    const VkMemoryPropertyFlags flags,
+    VkImage               image,
+    VkBuffer              buffer) {
     std::lock_guard<std::mutex> lock(m_mutex);
 
-    DxvkMemory result = this->tryAlloc(req, flags);
+    DxvkMemory result = this->tryAlloc(req, dedReq, flags, image, buffer);
     
     if (!result && (flags & VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT))
-      result = this->tryAlloc(req, flags & ~VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+      result = this->tryAlloc(req, dedReq, flags & ~VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, image, buffer);
     
     if (!result) {
       Logger::err(str::format(
         "DxvkMemoryAllocator: Memory allocation failed",
-        "\n  Size:      ", req.size,
-        "\n  Alignment: ", req.alignment,
+        "\n  Size:      ", req.memoryRequirements.size,
+        "\n  Alignment: ", req.memoryRequirements.alignment,
         "\n  Mem flags: ", "0x", std::hex, flags,
-        "\n  Mem types: ", "0x", std::hex, req.memoryTypeBits));
+        "\n  Mem types: ", "0x", std::hex, req.memoryRequirements.memoryTypeBits));
       throw DxvkError("DxvkMemoryAllocator: Memory allocation failed");
     }
     
@@ -204,17 +207,21 @@ namespace dxvk {
   
   
   DxvkMemory DxvkMemoryAllocator::tryAlloc(
-    const VkMemoryRequirements& req,
-    const VkMemoryPropertyFlags flags) {
+    const VkMemoryRequirements2KHR& req,
+    const VkMemoryDedicatedRequirementsKHR& dedicatedReq,
+    const VkMemoryPropertyFlags flags,
+    VkImage               image,
+    VkBuffer              buffer) {
     DxvkMemory result;
-    
+    bool dedicatedAllocation = dedicatedReq.prefersDedicatedAllocation || dedicatedReq.requiresDedicatedAllocation;
+
     for (uint32_t i = 0; i < m_memProps.memoryTypeCount && !result; i++) {
-      const bool supported = (req.memoryTypeBits & (1u << i)) != 0;
+      const bool supported = (req.memoryRequirements.memoryTypeBits & (1u << i)) != 0;
       const bool adequate  = (m_memTypes[i].memType.propertyFlags & flags) == flags;
       
       if (supported && adequate) {
         result = this->tryAllocFromType(
-          &m_memTypes[i], req.size, req.alignment);
+          &m_memTypes[i], req.memoryRequirements.size, req.memoryRequirements.alignment, dedicatedAllocation, image, buffer);
       }
     }
     
@@ -225,11 +232,14 @@ namespace dxvk {
   DxvkMemory DxvkMemoryAllocator::tryAllocFromType(
           DxvkMemoryType*       type,
           VkDeviceSize          size,
-          VkDeviceSize          align) {
+          VkDeviceSize          align,
+          bool                  dedicatedAllocation,
+          VkImage               image,
+          VkBuffer              buffer) {
     DxvkMemory memory;
 
-    if (size >= ChunkSize / 4) {
-      DxvkDeviceMemory devMem = this->tryAllocDeviceMemory(type, size);
+    if ((size >= ChunkSize / 4) || dedicatedAllocation) {
+      DxvkDeviceMemory devMem = this->tryAllocDeviceMemory(type, size, dedicatedAllocation, image, buffer);
 
       if (devMem.memHandle != VK_NULL_HANDLE)
         memory = DxvkMemory(this, nullptr, type, devMem.memHandle, 0, size, devMem.memPointer);
@@ -238,7 +248,7 @@ namespace dxvk {
         memory = type->chunks[i]->alloc(size, align);
       
       if (!memory) {
-        DxvkDeviceMemory devMem = tryAllocDeviceMemory(type, ChunkSize);
+        DxvkDeviceMemory devMem = tryAllocDeviceMemory(type, ChunkSize, false, image, buffer);
 
         if (devMem.memHandle == VK_NULL_HANDLE)
           return DxvkMemory();
@@ -259,7 +269,10 @@ namespace dxvk {
   
   DxvkDeviceMemory DxvkMemoryAllocator::tryAllocDeviceMemory(
           DxvkMemoryType*       type,
-          VkDeviceSize          size) {
+          VkDeviceSize          size,
+          bool                  dedicatedAllocation,
+          VkImage               image,
+          VkBuffer              buffer) {
     if ((type->memType.propertyFlags & VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT)
      && (type->heap->stats.memoryAllocated + size > type->heap->properties.size))
       return DxvkDeviceMemory();
@@ -267,9 +280,16 @@ namespace dxvk {
     DxvkDeviceMemory result;
     result.memSize = size;
     
+    
+    VkMemoryDedicatedAllocateInfoKHR dedicatedInfo;
+    dedicatedInfo.sType = VK_STRUCTURE_TYPE_MEMORY_DEDICATED_ALLOCATE_INFO_KHR;
+    dedicatedInfo.pNext = VK_NULL_HANDLE;
+    dedicatedInfo.buffer = buffer;
+    dedicatedInfo.image = image;
+
     VkMemoryAllocateInfo info;
     info.sType            = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
-    info.pNext            = nullptr;
+    info.pNext            = dedicatedAllocation ? &dedicatedInfo : VK_NULL_HANDLE;
     info.allocationSize   = size;
     info.memoryTypeIndex  = type->memTypeId;
 

--- a/src/dxvk/dxvk_memory.h
+++ b/src/dxvk/dxvk_memory.h
@@ -237,8 +237,11 @@ namespace dxvk {
      * \returns Allocated memory slice
      */
     DxvkMemory alloc(
-      const VkMemoryRequirements& req,
-      const VkMemoryPropertyFlags flags);
+      const VkMemoryRequirements2KHR& req,
+      const VkMemoryDedicatedRequirementsKHR& dedReq,
+      const VkMemoryPropertyFlags flags,
+      VkImage               image,
+      VkBuffer              buffer);
     
     /**
      * \brief Queries memory stats
@@ -262,17 +265,26 @@ namespace dxvk {
     std::array<DxvkMemoryType, VK_MAX_MEMORY_TYPES> m_memTypes;
     
     DxvkMemory tryAlloc(
-      const VkMemoryRequirements& req,
-      const VkMemoryPropertyFlags flags);
+      const VkMemoryRequirements2KHR& req,
+      const VkMemoryDedicatedRequirementsKHR& dedReq,
+      const VkMemoryPropertyFlags flags,
+      VkImage               image,
+      VkBuffer              buffer);
     
     DxvkMemory tryAllocFromType(
             DxvkMemoryType*       type,
             VkDeviceSize          size,
-            VkDeviceSize          align);
+            VkDeviceSize          align,
+            bool                  dedicatedAllocation,
+            VkImage               image,
+            VkBuffer              buffer);
     
     DxvkDeviceMemory tryAllocDeviceMemory(
             DxvkMemoryType*       type,
-            VkDeviceSize          size);
+            VkDeviceSize          size,
+            bool                  dedicatedAllocation,
+            VkImage               image,
+            VkBuffer              buffer);
     
     void free(
       const DxvkMemory&           memory);

--- a/src/dxvk/dxvk_memory.h
+++ b/src/dxvk/dxvk_memory.h
@@ -237,9 +237,9 @@ namespace dxvk {
      * \returns Allocated memory slice
      */
     DxvkMemory alloc(
-      const VkMemoryRequirements2KHR&               req,
-            VkMemoryDedicatedAllocateInfoKHR* const dedAllocInfo,
-      const VkMemoryPropertyFlags                   flags);
+      const VkMemoryRequirements*             req,
+      const VkMemoryDedicatedAllocateInfoKHR* dedAllocInfo,
+            VkMemoryPropertyFlags             flags);
     
     /**
      * \brief Queries memory stats
@@ -263,20 +263,20 @@ namespace dxvk {
     std::array<DxvkMemoryType, VK_MAX_MEMORY_TYPES> m_memTypes;
     
     DxvkMemory tryAlloc(
-      const VkMemoryRequirements2KHR&               req,
-            VkMemoryDedicatedAllocateInfoKHR* const dedAllocInfo,
-      const VkMemoryPropertyFlags                   flags);
+      const VkMemoryRequirements*             req,
+      const VkMemoryDedicatedAllocateInfoKHR* dedAllocInfo,
+            VkMemoryPropertyFlags             flags);
     
     DxvkMemory tryAllocFromType(
-            DxvkMemoryType*                         type,
-            VkDeviceSize                            size,
-            VkDeviceSize                            align,
-            VkMemoryDedicatedAllocateInfoKHR* const dedAllocInfo);
+            DxvkMemoryType*                   type,
+            VkDeviceSize                      size,
+            VkDeviceSize                      align,
+      const VkMemoryDedicatedAllocateInfoKHR* dedAllocInfo);
     
     DxvkDeviceMemory tryAllocDeviceMemory(
-            DxvkMemoryType*       type,
-            VkDeviceSize          size,
-            VkMemoryDedicatedAllocateInfoKHR* const dedAllocInfo);
+            DxvkMemoryType*                   type,
+            VkDeviceSize                      size,
+      const VkMemoryDedicatedAllocateInfoKHR* dedAllocInfo);
     
     void free(
       const DxvkMemory&           memory);

--- a/src/dxvk/dxvk_memory.h
+++ b/src/dxvk/dxvk_memory.h
@@ -237,11 +237,9 @@ namespace dxvk {
      * \returns Allocated memory slice
      */
     DxvkMemory alloc(
-      const VkMemoryRequirements2KHR& req,
-      const VkMemoryDedicatedRequirementsKHR& dedReq,
-      const VkMemoryPropertyFlags flags,
-      VkImage               image,
-      VkBuffer              buffer);
+      const VkMemoryRequirements2KHR&               req,
+            VkMemoryDedicatedAllocateInfoKHR* const dedAllocInfo,
+      const VkMemoryPropertyFlags                   flags);
     
     /**
      * \brief Queries memory stats
@@ -265,26 +263,20 @@ namespace dxvk {
     std::array<DxvkMemoryType, VK_MAX_MEMORY_TYPES> m_memTypes;
     
     DxvkMemory tryAlloc(
-      const VkMemoryRequirements2KHR& req,
-      const VkMemoryDedicatedRequirementsKHR& dedReq,
-      const VkMemoryPropertyFlags flags,
-      VkImage               image,
-      VkBuffer              buffer);
+      const VkMemoryRequirements2KHR&               req,
+            VkMemoryDedicatedAllocateInfoKHR* const dedAllocInfo,
+      const VkMemoryPropertyFlags                   flags);
     
     DxvkMemory tryAllocFromType(
-            DxvkMemoryType*       type,
-            VkDeviceSize          size,
-            VkDeviceSize          align,
-            bool                  dedicatedAllocation,
-            VkImage               image,
-            VkBuffer              buffer);
+            DxvkMemoryType*                         type,
+            VkDeviceSize                            size,
+            VkDeviceSize                            align,
+            VkMemoryDedicatedAllocateInfoKHR* const dedAllocInfo);
     
     DxvkDeviceMemory tryAllocDeviceMemory(
             DxvkMemoryType*       type,
             VkDeviceSize          size,
-            bool                  dedicatedAllocation,
-            VkImage               image,
-            VkBuffer              buffer);
+            VkMemoryDedicatedAllocateInfoKHR* const dedAllocInfo);
     
     void free(
       const DxvkMemory&           memory);

--- a/src/dxvk/vulkan/dxvk_vulkan_loader.h
+++ b/src/dxvk/vulkan/dxvk_vulkan_loader.h
@@ -269,6 +269,11 @@ namespace dxvk::vk {
     VULKAN_FN(vkAcquireNextImageKHR);
     VULKAN_FN(vkQueuePresentKHR);
     #endif
+
+    #ifdef VK_KHR_get_memory_requirements2
+    VULKAN_FN(vkGetBufferMemoryRequirements2KHR);
+    VULKAN_FN(vkGetImageMemoryRequirements2KHR);
+    #endif
   };
   
 }


### PR DESCRIPTION
Implements the `VK_KHR_DEDICATED_ALLOCATION` extension. Nvidia GPU's seem to need this to use Delta Color Compression and other optimizations.  You **_may_** see increase of performance up to 20% depending on the GPU and game. This extension seems to be more effective on Maxwell and Kepler architectures.