### PR TITLE
[dxvk] Set VK_EXT_VERTEX_ATTRIBUTE_DIVISOR_EXTENSION_NAME as Desired

### DIFF
--- a/src/dxvk/dxvk_extensions.h
+++ b/src/dxvk/dxvk_extensions.h
@@ -130,7 +130,7 @@ namespace dxvk {
    */
   struct DxvkDeviceExtensions : public DxvkExtensionList {
     DxvkExtension extShaderViewportIndexLayer = { this, VK_EXT_SHADER_VIEWPORT_INDEX_LAYER_EXTENSION_NAME,  DxvkExtensionType::Desired  };
-    DxvkExtension extVertexAttributeDivisor   = { this, VK_EXT_VERTEX_ATTRIBUTE_DIVISOR_EXTENSION_NAME,     DxvkExtensionType::Required };
+    DxvkExtension extVertexAttributeDivisor   = { this, VK_EXT_VERTEX_ATTRIBUTE_DIVISOR_EXTENSION_NAME,     DxvkExtensionType::Desired };
     DxvkExtension khrDedicatedAllocation      = { this, VK_KHR_DEDICATED_ALLOCATION_EXTENSION_NAME,         DxvkExtensionType::Required };
     DxvkExtension khrDescriptorUpdateTemplate = { this, VK_KHR_DESCRIPTOR_UPDATE_TEMPLATE_EXTENSION_NAME,   DxvkExtensionType::Required };
     DxvkExtension khrGetMemoryRequirements2   = { this, VK_KHR_GET_MEMORY_REQUIREMENTS_2_EXTENSION_NAME,    DxvkExtensionType::Required };


### PR DESCRIPTION
With NVIDIA driver 390.48 on GTX 960, VK_EXT_vertex_attribute_divisor is
not available.
In Fallout4, when VK_EXT_VERTEX_ATTRIBUTE_DIVISOR_EXTENSION_NAME is set
as required the game stucks on startup with a black screen.

Signed-off-by: GORAND Charles <charles.gorand.dev@gmail.com>