### PR TITLE
[build] Moved git command into the command list

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -35,7 +35,8 @@ glsl_generator = generator(glsl_compiler,
   output    : [ '@BASENAME@.h' ],
   arguments : [ '-V', '--vn', '@BASENAME@', '@INPUT@', '-o', '@OUTPUT@' ])
 
-dxvk_version = vcs_tag(['git', 'describe'],
+dxvk_version = vcs_tag(
+  command: ['git', 'describe'],
   input:  'version.h.in',
   output: 'version.h')
 


### PR DESCRIPTION
According to the meson documentation, vcs commands need to be a part
of the command string list. Right now, it pulls the version number no
matter what.