### PR TITLE
[util] improve dxvk::thread compatibility with std::thread

### DIFF
--- a/src/util/thread.h
+++ b/src/util/thread.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <chrono>
 #include <functional>
 
 #include "util_error.h"
@@ -143,6 +144,14 @@ namespace dxvk {
     
     inline DWORD get_id() {
       return GetCurrentThreadId();
+    }
+
+    inline void sleep_for(const std::chrono::nanoseconds& ns) {
+      using namespace std::chrono;
+      if (ns > nanoseconds::zero()) {
+        milliseconds ms = duration_cast<milliseconds>(ns + nanoseconds(999999));
+        ::Sleep(ms.count());
+      }
     }
   }
 }

--- a/src/util/thread.h
+++ b/src/util/thread.h
@@ -110,6 +110,10 @@ namespace dxvk {
       m_thread->join();
     }
 
+    void swap(thread& other) noexcept {
+      std::swap(m_thread, other.m_thread);
+    }
+
     bool joinable() const {
       return m_thread != nullptr
           && m_thread->joinable();
@@ -140,5 +144,11 @@ namespace dxvk {
     inline DWORD get_id() {
       return GetCurrentThreadId();
     }
+  }
+}
+
+namespace std {
+  inline void swap(dxvk::thread& left, dxvk::thread& right) noexcept {	
+    left.swap(right);
   }
 }

--- a/src/util/thread.h
+++ b/src/util/thread.h
@@ -56,6 +56,10 @@ namespace dxvk {
       return m_handle != nullptr;
     }
 
+    DWORD get_id() const {
+      return GetThreadId(m_handle);
+    }
+
   private:
 
     Proc    m_proc;
@@ -111,6 +115,10 @@ namespace dxvk {
           && m_thread->joinable();
     }
 
+    DWORD get_id() {
+      return m_thread->get_id();
+    }
+
   private:
 
     Rc<ThreadFn> m_thread;
@@ -121,6 +129,10 @@ namespace dxvk {
   namespace this_thread {
     inline void yield() {
       Sleep(0);
+    }
+    
+    inline DWORD get_id() {
+      return GetCurrentThreadId();
     }
   }
 }

--- a/src/util/thread.h
+++ b/src/util/thread.h
@@ -83,11 +83,15 @@ namespace dxvk {
 
     thread() { }
 
+    thread(const thread&) = delete;
+
     explicit thread(std::function<void()>&& func)
     : m_thread(new ThreadFn(std::move(func))) { }
 
     thread(thread&& other)
     : m_thread(std::move(other.m_thread)) { }
+
+    thread& operator=(const thread&) = delete;
 
     thread& operator = (thread&& other) {
       m_thread = std::move(other.m_thread);

--- a/src/util/thread.h
+++ b/src/util/thread.h
@@ -115,6 +115,12 @@ namespace dxvk {
           && m_thread->joinable();
     }
 
+    static DWORD hardware_concurrency() {
+      SYSTEM_INFO info {};
+      GetSystemInfo(&info);
+      return info.dwNumberOfProcessors;
+    }
+
     DWORD get_id() {
       return m_thread->get_id();
     }


### PR DESCRIPTION
* **delete copy assignment**
* implemented `dxvk::thread::get_id()` and `dxvk::this_thread::get_id()`
* implemented `dxvk::thread::hardware_concurrency()`
* implemented `dxvk::thread::swap()` and `std::swap(dxvk::thread&, dxvk::thread&)`
* implemented `dxvk::this_thread::sleep_for()`
