### PR TITLE
[build] Don't use full paths in build files.

### DIFF
--- a/build-win32.txt
+++ b/build-win32.txt
@@ -1,8 +1,8 @@
 [binaries]
-c = '/usr/bin/i686-w64-mingw32-gcc'
-cpp = '/usr/bin/i686-w64-mingw32-g++'
-ar = '/usr/bin/i686-w64-mingw32-ar'
-strip = '/usr/bin/i686-w64-mingw32-strip'
+c = 'i686-w64-mingw32-gcc'
+cpp = 'i686-w64-mingw32-g++'
+ar = 'i686-w64-mingw32-ar'
+strip = 'i686-w64-mingw32-strip'
 exe_wrapper = 'wine'
 
 [properties]

--- a/build-win64.txt
+++ b/build-win64.txt
@@ -1,8 +1,8 @@
 [binaries]
-c = '/usr/bin/x86_64-w64-mingw32-gcc'
-cpp = '/usr/bin/x86_64-w64-mingw32-g++'
-ar = '/usr/bin/x86_64-w64-mingw32-ar'
-strip = '/usr/bin/x86_64-w64-mingw32-strip'
+c = 'x86_64-w64-mingw32-gcc'
+cpp = 'x86_64-w64-mingw32-g++'
+ar = 'x86_64-w64-mingw32-ar'
+strip = 'x86_64-w64-mingw32-strip'
 exe_wrapper = 'wine'
 
 [properties]


### PR DESCRIPTION
They don't seem needed at all and specifying them makes working with installation in another place harder. For example, I use my own builds of mingw-w64 and I don't want them in /usr/