### PR TITLE
[build] Improve winelib builds.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -26,7 +26,11 @@ else
 endif
 
 if meson.get_cross_property('winelib', false)
-  add_project_link_arguments('-mwindows', language : 'cpp')
+  arch_arg = cpu_family == 'x86_64' ? '-m64' : '-m32'
+  add_project_arguments(arch_arg, '--no-gnu-unique', language : 'cpp')
+  add_project_arguments(arch_arg, language : 'c')
+  add_project_link_arguments(arch_arg, '-mwindows', language : 'cpp')
+
   lib_vulkan  = declare_dependency(link_args: [ '-lvulkan-1' ])
   lib_d3d11   = declare_dependency(link_args: [ '-ld3d11' ])
   lib_dxgi    = declare_dependency(link_args: [ '-ldxgi' ])


### PR DESCRIPTION
Specifying -m32/-m64 explicitly is mostly needed for 32-bit builds with 64-bit Wine. -m32 currently does not work on many distros, mostly because winegcc can't find 32-bit libraries. Some configs should be fixed in recent Wine:
https://source.winehq.org/git/wine.git/commitdiff/551d0971c54896f286e41a39217094a477363d49
others may need this:
https://source.winehq.org/patches/data/148834
Both this and changes required to build tests:
https://source.winehq.org/patches/data/148767
will have to wait for a while, as Wine maintainer is on vacations for three weeks.

Above problems may be worked around by using 32-bit-only Wine for 32-bit dxvk builds or specifying library paths explicitly with -L....

Although 32-bit builds will succeed, they won't work. There are struct alignment problems with Vulkan structures. I have some hacks for this, but it's not ready yet.

Also --no-gnu-unique is needed because g++ decides to emit STB_GNU_UNIQUE symbols for dxvk uuidof declarations. This prevents .so files from being unloaded and leads to a behaviour that Wine doesn't expects when applications tries to load again dxgi.dll after it was previously unloaded. With this patch, such cases work as expected.