### PR TITLE
[dxvk] Include vector inheaders that use it.

### DIFF
--- a/src/dxvk/dxvk_descriptor.h
+++ b/src/dxvk/dxvk_descriptor.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <vector>
+
 #include "dxvk_include.h"
 
 namespace dxvk {

--- a/src/dxvk/dxvk_event_tracker.h
+++ b/src/dxvk/dxvk_event_tracker.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <vector>
+
 #include "dxvk_event.h"
 
 namespace dxvk {

--- a/src/dxvk/dxvk_extensions.h
+++ b/src/dxvk/dxvk_extensions.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <set>
+#include <vector>
 
 #include "dxvk_include.h"
 

--- a/src/dxvk/dxvk_query_pool.h
+++ b/src/dxvk/dxvk_query_pool.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <vector>
+
 #include "dxvk_query.h"
 
 namespace dxvk {


### PR DESCRIPTION
Fixes winelib compilation after recent changes.