### PR TITLE
[build] Use native vuilkan ABI in winelib builds

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -26,7 +26,7 @@ else
 endif
 
 if meson.get_cross_property('winelib', false)
-  lib_vulkan  = declare_dependency(link_args: [ '-lvulkan-1' ])
+  lib_vulkan  = declare_dependency(link_args: [ '-lwinevulkan' ])
   lib_d3d11   = declare_dependency(link_args: [ '-ld3d11' ])
   lib_dxgi    = declare_dependency(link_args: [ '-ldxgi' ])
   lib_d3dcompiler_43 = declare_dependency(link_args: [ '-L'+dxvk_library_path, '-ld3dcompiler_43' ])

--- a/src/dxvk/vulkan/dxvk_vulkan_loader.cpp
+++ b/src/dxvk/vulkan/dxvk_vulkan_loader.cpp
@@ -1,9 +1,21 @@
 #include "dxvk_vulkan_loader.h"
 
 namespace dxvk::vk {
-  
+
+#if defined(__WINE__)
+
+  extern "C"
+  PFN_vkVoidFunction native_vkGetInstanceProcAddrWINE(VkInstance instance, const char *name);
+  static const PFN_vkGetInstanceProcAddr GetInstanceProcAddr = native_vkGetInstanceProcAddrWINE;
+
+#else
+
+  static const PFN_vkGetInstanceProcAddr GetInstanceProcAddr = vkGetInstanceProcAddr;
+
+#endif
+
   PFN_vkVoidFunction LibraryLoader::sym(const char* name) const {
-    return ::vkGetInstanceProcAddr(nullptr, name);
+    return dxvk::vk::GetInstanceProcAddr(nullptr, name);
   }
   
   
@@ -12,13 +24,13 @@ namespace dxvk::vk {
   
   
   PFN_vkVoidFunction InstanceLoader::sym(const char* name) const {
-    return ::vkGetInstanceProcAddr(m_instance, name);
+    return dxvk::vk::GetInstanceProcAddr(m_instance, name);
   }
   
   
   DeviceLoader::DeviceLoader(VkInstance instance, VkDevice device)
   : m_getDeviceProcAddr(reinterpret_cast<PFN_vkGetDeviceProcAddr>(
-      ::vkGetInstanceProcAddr(instance, "vkGetDeviceProcAddr"))),
+      dxvk::vk::GetInstanceProcAddr(instance, "vkGetDeviceProcAddr"))),
     m_device(device) { }
   
   

--- a/src/dxvk/vulkan/dxvk_vulkan_loader_fn.h
+++ b/src/dxvk/vulkan/dxvk_vulkan_loader_fn.h
@@ -1,7 +1,22 @@
 #pragma once
 
+/*
+ * In 32-bit winelib build, alignment of Vulkan structures may be different than what
+ * native C++ compiler expects. Wine exposes an extension, intended for winelib
+ * applications, that exposes native Vulkan APIs with win32 additions, but using
+ * native ABI.
+ */
+#ifdef __WINE__
+#pragma push_macro("_WIN32")
+#undef _WIN32
+#endif
+
 #define VK_USE_PLATFORM_WIN32_KHR 1
 #include <vulkan/vulkan.h>
+
+#ifdef __WINE__
+#pragma pop_macro("_WIN32")
+#endif
 
 #define VULKAN_FN(name) \
   VulkanFn<::PFN_ ## name> name = sym(#name)


### PR DESCRIPTION
This uses Wine extension that's not yet in Wine:
https://source.winehq.org/patches/data/148981
I submit it mostly for feedback so far, so I'd appreciate an opinion on it.

The idea is that we can use native Vulkan almost directly. Wine intercepts only vkGetInstanceProcAddr to expose win32-specific extensions, but otherwise it exposes functions from native Vulkan loader. This means native calling conventions and structure layouts are the same as native (and what native g++ expects). This fixes win32 builds (that previously didn't  work due to different structure layout).

I created a fork of Wine containing required patches:
https://github.com/jacekcw/wine/commits/master
as well as dxvk fork containing required changes:
https://github.com/jacekcw/dxvk/commits/master

With those two repos, both 32-bit and 64-bit winelib dxvk builds work.