### PR TITLE
[dxgi] Don't use std::mbstowcs.

### DIFF
--- a/src/dxgi/dxgi_adapter.cpp
+++ b/src/dxgi/dxgi_adapter.cpp
@@ -165,7 +165,8 @@ namespace dxvk {
     }
     
     std::memset(pDesc->Description, 0, sizeof(pDesc->Description));
-    std::mbstowcs(pDesc->Description, deviceProp.deviceName, std::size(pDesc->Description) - 1);
+    ::MultiByteToWideChar(CP_UTF8, 0, deviceProp.deviceName, -1, pDesc->Description,
+                          sizeof(pDesc->Description));
     
     VkDeviceSize deviceMemory = 0;
     VkDeviceSize sharedMemory = 0;


### PR DESCRIPTION
This will not work in winelib build.

This is in reply to https://github.com/doitsujin/dxvk/pull/520#issuecomment-412507895
Only compile-tested.