### PR TITLE
[dxgi] SetFullscreenState succeeds if not changing state

### DIFF
--- a/src/dxgi/dxgi_swapchain.cpp
+++ b/src/dxgi/dxgi_swapchain.cpp
@@ -410,9 +410,6 @@ namespace dxvk {
           IDXGIOutput*  pTarget) {
     std::lock_guard<std::mutex> lock(m_lockWindow);
     
-    if (!IsWindow(m_window))
-      return DXGI_ERROR_INVALID_CALL;
-    
     if (m_descFs.Windowed && Fullscreen)
       return this->EnterFullscreenMode(pTarget);
     else if (!m_descFs.Windowed && !Fullscreen)
@@ -522,6 +519,9 @@ namespace dxvk {
   
   HRESULT DxgiSwapChain::EnterFullscreenMode(IDXGIOutput* pTarget) {
     Com<IDXGIOutput> output = static_cast<DxgiOutput*>(pTarget);
+
+    if (!IsWindow(m_window))
+      return DXGI_ERROR_NOT_CURRENTLY_AVAILABLE;
     
     if (output == nullptr) {
       if (FAILED(GetContainingOutput(&output))) {
@@ -581,6 +581,9 @@ namespace dxvk {
   
   HRESULT DxgiSwapChain::LeaveFullscreenMode() {
     Com<IDXGIOutput> output;
+
+    if (!IsWindow(m_window))
+      return DXGI_ERROR_NOT_CURRENTLY_AVAILABLE;
     
     if (FAILED(m_adapter->GetOutputFromMonitor(m_monitor, &output))
      || FAILED(RestoreDisplayMode(output.ptr())))


### PR DESCRIPTION
This fixes an error dialog on exiting Unreal Engine 4 games.

This diff to current Wine tests demonstrates the behavior on Windows 7:

```
diff --git a/dlls/dxgi/tests/device.c b/dlls/dxgi/tests/device.c
index 2e68511137..96e5125758 100644
--- a/dlls/dxgi/tests/device.c
+++ b/dlls/dxgi/tests/device.c
@@ -2055,10 +2055,14 @@ static void test_set_fullscreen(void)
     }
     hr = IDXGISwapChain_SetFullscreenState(swapchain, FALSE, NULL);
     ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+    DestroyWindow(swapchain_desc.OutputWindow);
+    hr = IDXGISwapChain_SetFullscreenState(swapchain, FALSE, NULL);
+    ok(hr == S_OK, "Got unexpected hr %#x.\n", hr);
+    hr = IDXGISwapChain_SetFullscreenState(swapchain, TRUE, NULL);
+    ok(hr == DXGI_ERROR_NOT_CURRENTLY_AVAILABLE, "Got unexpected hr %#x.\n", hr);
     refcount = IDXGISwapChain_Release(swapchain);
     ok(!refcount, "IDXGISwapChain has %u references left.\n", refcount);
 
-    DestroyWindow(swapchain_desc.OutputWindow);
     swapchain_desc.OutputWindow = CreateWindowA("static", "dxgi_test", 0, 0, 0, 400, 200, 0, 0, 0, 0);
     check_window_fullscreen_state(swapchain_desc.OutputWindow, &initial_state.fullscreen_state);
     hr = IDXGIFactory_CreateSwapChain(factory, (IUnknown *)device, &swapchain_desc, &swapchain);
```