### PR TITLE
Reworked patch from https://github.com/jomihaka/dxvk-poe-hack for discard shaders until they be compiled

### DIFF
--- a/src/dxvk/dxvk_graphics.h
+++ b/src/dxvk/dxvk_graphics.h
@@ -236,6 +236,8 @@ namespace dxvk {
     Rc<DxvkShaderModule>  m_tes;
     Rc<DxvkShaderModule>  m_gs;
     Rc<DxvkShaderModule>  m_fs;
+    Rc<DxvkShaderModule>  m_vs_placeholder;
+    Rc<DxvkShaderModule>  m_fs_placeholder;
     
     uint32_t m_vsIn  = 0;
     uint32_t m_fsOut = 0;

--- a/src/dxvk/dxvk_options.cpp
+++ b/src/dxvk/dxvk_options.cpp
@@ -5,6 +5,7 @@ namespace dxvk {
   DxvkOptions::DxvkOptions(const Config& config) {
     allowMemoryOvercommit = config.getOption<bool>("dxvk.allowMemoryOvercommit", false);
     useAsyncPipeCompiler  = config.getOption<bool>("dxvk.useAsyncPipeCompiler",  false);
+    usePlaceholderShaders = config.getOption<bool>("dxvk.usePlaceholderShaders", false);
   }
 
 }

--- a/src/dxvk/dxvk_options.h
+++ b/src/dxvk/dxvk_options.h
@@ -13,6 +13,9 @@ namespace dxvk {
 
     /// Enable asynchronous pipeline compilation.
     bool useAsyncPipeCompiler;
+
+    /// Enable placeholder shaders.
+    bool usePlaceholderShaders;
   };
 
 }

--- a/src/dxvk/dxvk_shader.cpp
+++ b/src/dxvk/dxvk_shader.cpp
@@ -1,4 +1,6 @@
 #include "dxvk_shader.h"
+#include "vs_placeholder.h"
+#include "fs_placeholder.h"
 
 namespace dxvk {
   
@@ -35,6 +37,25 @@ namespace dxvk {
 
   DxvkShaderConstData::~DxvkShaderConstData() {
     delete[] m_data;
+  }
+
+
+  void getPlaceholderShaders(DxvkShader*& vert, DxvkShader*& frag, bool enabled) {
+    static bool init;
+    static DxvkShader* vs;
+    static DxvkShader* fs;
+
+    if (!init) {
+      if (enabled) {
+        vs = new DxvkShader(VK_SHADER_STAGE_VERTEX_BIT  , 0, nullptr, {1,1}, SpirvCodeBuffer(vs_placeholder), DxvkShaderConstData());
+        fs = new DxvkShader(VK_SHADER_STAGE_FRAGMENT_BIT, 0, nullptr, {1,1}, SpirvCodeBuffer(fs_placeholder), DxvkShaderConstData());
+        Logger::info("Using placeholder shaders");
+      }
+      init = true;
+    }
+
+    vert = vs;
+    frag = fs;
   }
 
 

--- a/src/dxvk/dxvk_shader.h
+++ b/src/dxvk/dxvk_shader.h
@@ -259,4 +259,6 @@ namespace dxvk {
     
   };
   
+  void getPlaceholderShaders(DxvkShader*& vert, DxvkShader*& frag, bool enabled);
+
 }

--- a/src/dxvk/meson.build
+++ b/src/dxvk/meson.build
@@ -27,6 +27,9 @@ dxvk_shaders = files([
   'hud/shaders/hud_line.frag',
   'hud/shaders/hud_text.frag',
   'hud/shaders/hud_vert.vert',
+
+  'placeholders/vs_placeholder.vert',
+  'placeholders/fs_placeholder.frag',
 ])
 
 dxvk_src = files([

--- a/src/dxvk/placeholders/fs_placeholder.frag
+++ b/src/dxvk/placeholders/fs_placeholder.frag
@@ -1,0 +1,5 @@
+#version 450
+
+void main() {
+  discard;
+}

--- a/src/dxvk/placeholders/vs_placeholder.vert
+++ b/src/dxvk/placeholders/vs_placeholder.vert
@@ -1,0 +1,5 @@
+#version 450
+
+void main() {
+  gl_Position = vec4(0.0, 0.0, 0.0, 0.0);
+}

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -39,9 +39,19 @@ namespace dxvk {
     { "mafia3.exe", {{
       { "d3d11.fakeStreamOutSupport",       "True" },
     }} },
+    /* No Man's Sky                               */
+    { "NMS.exe", {{
+      { "dxvk.useAsyncPipeCompiler",        "True" },
+      { "dxvk.usePlaceholderShaders",       "True" },
+    }} },
     /* Overwatch                                  */
     { "Overwatch.exe", {{
       { "d3d11.fakeStreamOutSupport",       "True" },
+    }} },
+    /* Path of Exile                              */
+    { "PathOfExile_x64.exe", {{
+      { "dxvk.useAsyncPipeCompiler",        "True" },
+      { "dxvk.usePlaceholderShaders",       "True" },
     }} },
     /* Sleeping Dogs                              */
     { "HKShip.exe", {{


### PR DESCRIPTION
Adopted to dxvk master branch (new options in config file) and tested with games:
- Path of Exile - playing without this patch just a pain in the ass, especially bosses with many visual effects (elder and his guardians, uber elder)
- No Man's Sky - some shutters while compiling shaders can cause sound glitches and sometimes need to restart game to fix audio (maybe hardware or wine dependent, but this patch fixed it)