### PR TITLE
[build] Mute dllexport GCC warnings for winelib

### DIFF
--- a/build-wine64.txt
+++ b/build-wine64.txt
@@ -8,7 +8,7 @@ strip = 'strip'
 winelib = true
 
 c_args=['-m64']
-cpp_args=['-m64', '--no-gnu-unique']
+cpp_args=['-m64', '--no-gnu-unique', '-Wno-attributes']
 cpp_link_args=['-m64', '-mwindows']
 
 [host_machine]


### PR DESCRIPTION
GCC produces a lot of warnings about ignored dllimport/dllexport attributes.
Detecting real problems from build output will be easier with this warnings turned off.
 
`man winegcc`
```
The dllimport/dllexport attributes are not supported at the moment,
due to lack of support for these features in the ELF version of gcc.
```

`man gcc`
```
-Wno-attributes
Do not warn if an unexpected "__attribute__" is used,
such as unrecognized attributes, function attributes applied to variables, etc.
This does not stop errors for incorrect use of supported attributes.
```
