### PR TITLE
[build] Don't run wine during winelib build process

### DIFF
--- a/build-wine32.txt
+++ b/build-wine32.txt
@@ -3,13 +3,13 @@ c = 'winegcc'
 cpp = 'wineg++'
 ar = 'ar'
 strip = 'strip'
-exe_wrapper = 'wine'
 
 [properties]
+needs_exe_wrapper = true
 winelib = true
 
 c_args=['-m32']
-cpp_args=['-m32', '--no-gnu-unique']
+cpp_args=['-m32', '--no-gnu-unique', '-Wno-attributes']
 cpp_link_args=['-m32', '-mwindows']
 
 [host_machine]

--- a/build-wine64.txt
+++ b/build-wine64.txt
@@ -5,6 +5,7 @@ ar = 'ar'
 strip = 'strip'
 
 [properties]
+needs_exe_wrapper = true
 winelib = true
 
 c_args=['-m64']


### PR DESCRIPTION
This will tell meson to not run initial compiler test on binaries generated by `winegcc`.
http://mesonbuild.com/Cross-compilation.html#defining-the-environment

Since `winegcc` produces `sanitycheckc_cross.exe` wrapper script, which will run command like `wine sanitycheckc_cross.exe.so` to test generated binary, we can skip this test and don't summon `wine` at all during build process.

This also can help to package DXVK in some distribution (like gentoo), where running wine in sandboxed environment can be a problem.