### PR TITLE
[d3d10] Implement Get/SetTextFilterSize using the behaviour D3D10 exhibits

### DIFF
--- a/src/d3d10/d3d10_device.cpp
+++ b/src/d3d10/d3d10_device.cpp
@@ -1568,7 +1568,8 @@ namespace dxvk {
   void STDMETHODCALLTYPE D3D10Device::SetTextFilterSize(
           UINT                              Width,
           UINT                              Height) {
-    // Although a bit strange, this is the behaviour D3D10 exhibits.
+    // D3D10 doesn't seem to actually store or do anything with these values,
+    // as when calling GetTextFilterSize, it just makes the values 0.
   }
 
 

--- a/src/d3d10/d3d10_device.cpp
+++ b/src/d3d10/d3d10_device.cpp
@@ -1564,18 +1564,21 @@ namespace dxvk {
       Logger::warn("D3D10: SOGetTargets: Reporting buffer offsets not supported");
   }
 
-
+  // Although a bit strange, this is the behaviour D3D10 exhibits.
   void STDMETHODCALLTYPE D3D10Device::SetTextFilterSize(
           UINT                              Width,
           UINT                              Height) {
-    Logger::err("D3D10Device::SetTextFilterSize: Not implemented");
   }
 
 
   void STDMETHODCALLTYPE D3D10Device::GetTextFilterSize(
           UINT*                             pWidth,
           UINT*                             pHeight) {
-    Logger::err("D3D10Device::GetTextFilterSize: Not implemented");
+    if (pWidth)
+        *pWidth = 0;
+
+    if (pHeight)
+        *pHeight = 0;
   }
 
 }

--- a/src/d3d10/d3d10_device.cpp
+++ b/src/d3d10/d3d10_device.cpp
@@ -1564,10 +1564,11 @@ namespace dxvk {
       Logger::warn("D3D10: SOGetTargets: Reporting buffer offsets not supported");
   }
 
-  // Although a bit strange, this is the behaviour D3D10 exhibits.
+
   void STDMETHODCALLTYPE D3D10Device::SetTextFilterSize(
           UINT                              Width,
           UINT                              Height) {
+    // Although a bit strange, this is the behaviour D3D10 exhibits.
   }
 
 


### PR DESCRIPTION
Despite this function being deprecated before D3D10's release and not used anywhere, when I got bored, I tested the actual functionality of this function.
```
m_device->SetTextFilterSize(10, 10);

UINT textFilterX = 20;
UINT textFilterY = 20;
m_device->GetTextFilterSize(&textFilterX, &textFilterY);

if (textFilterX == 0 && textFilterY == 0)
	return 0;
	
if (textFilterX == 20 && textFilterY == 20)
	return 1;
	
return 2;
```

This will return 0.
There's no practical use for this, but it's probably a good idea to be authentic to the current implementation, just in case some random pre-release tech demo or something uses it.