### PR TITLE
[d3d11/d3d10] Store stream output offsets and return in d3d10 if requested

### DIFF
--- a/src/d3d10/d3d10_device.cpp
+++ b/src/d3d10/d3d10_device.cpp
@@ -1561,7 +1561,7 @@ namespace dxvk {
     }
 
     if (pOffsets != nullptr)
-      Logger::warn("D3D10: SOGetTargets: Reporting buffer offsets not supported");
+      m_context->SOGetOffsets(NumBuffers, pOffsets);
   }
 
 

--- a/src/d3d11/d3d11_context.cpp
+++ b/src/d3d11/d3d11_context.cpp
@@ -2472,6 +2472,7 @@ namespace dxvk {
       m_state.so.targets[i] = (ppSOTargets != nullptr && i < NumBuffers)
         ? static_cast<D3D11Buffer*>(ppSOTargets[i])
         : nullptr;
+      m_state.so.offsets[i] = pOffsets ? pOffsets[i] : 0;
     }
   }
   
@@ -2483,6 +2484,14 @@ namespace dxvk {
       ppSOTargets[i] = m_state.so.targets[i].ref();
   }
   
+
+  void STDMETHODCALLTYPE D3D11DeviceContext::SOGetOffsets(
+          UINT                              NumBuffers,
+          UINT*                             pOffsets) {
+    for (uint32_t i = 0; i < NumBuffers; i++)
+      pOffsets[i] = m_state.so.offsets[i];
+  }
+
   
   void STDMETHODCALLTYPE D3D11DeviceContext::TransitionSurfaceLayout(
           IDXGIVkInteropSurface*    pSurface,

--- a/src/d3d11/d3d11_context.h
+++ b/src/d3d11/d3d11_context.h
@@ -630,6 +630,13 @@ namespace dxvk {
     void STDMETHODCALLTYPE SOGetTargets(
             UINT                              NumBuffers,
             ID3D11Buffer**                    ppSOTargets) final;
+
+    // This is not a D3D11 method. It serves to return offsets as is
+    // needed by D3D10's SOGetTargets implementation.
+    void STDMETHODCALLTYPE SOGetOffsets(
+            UINT                              NumBuffers,
+            UINT*                             pOffsets
+    );
     
     void STDMETHODCALLTYPE TransitionSurfaceLayout(
             IDXGIVkInteropSurface*    pSurface,

--- a/src/d3d11/d3d11_context_state.h
+++ b/src/d3d11/d3d11_context_state.h
@@ -138,6 +138,7 @@ namespace dxvk {
   
   struct D3D11ContextStateSO {
     std::array<Com<D3D11Buffer>, D3D11_SO_STREAM_COUNT> targets;
+    std::array<UINT, D3D11_SO_STREAM_COUNT> offsets;
   };
   
   


### PR DESCRIPTION
D3D10's SOGetTargets has the parameter to return the offsets of each SO.

I know SO support isn't there in DXVK yet but it should at least get it prepared for D3D10.

I have added the offsets to the SO context state (which may be useful for when SO gets implemented anyway) and made it return them in the function SOGetTargets on d3d10.