### PR TITLE
[build] Partially fix tests for winelib build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -30,7 +30,7 @@ if meson.get_cross_property('winelib', false)
   lib_d3d11   = declare_dependency(link_args: [ '-ld3d11' ])
   lib_dxgi    = declare_dependency(link_args: [ '-ldxgi' ])
   lib_d3dcompiler_43 = declare_dependency(link_args: [ '-L'+dxvk_library_path, '-ld3dcompiler_43' ])
-  lib_d3dcompiler_47 = declare_dependency(link_args: [ '-ld3dcompiler_47' ])
+  lib_d3dcompiler_47 = declare_dependency(link_args: [ '-ld3dcompiler' ])
   exe_ext = '.exe.so'
   dll_ext = '.dll'
   def_spec_ext = '.spec'


### PR DESCRIPTION
This change was present in initial winelib patch, but was missed.

The only broken test is ` hlsl-compiler`.