### PR TITLE
Stop cross-compile attempting to change rpath

### DIFF
--- a/src/d3d10/meson.build
+++ b/src/d3d10/meson.build
@@ -4,7 +4,8 @@ d3d10_main_src = [
 ]
 
 d3d10_deps = [ lib_d3dcompiler_43, lib_dxgi ]
-d3d10_deps += meson.get_cross_property('winelib', false) ? lib_d3d11 : d3d11_dep
+cross_build = meson.get_cross_property('winelib', false) ? true : meson.is_cross_build()
+d3d10_deps += cross_build ? lib_d3d11 : d3d11_dep
 
 d3d10_core_dll = shared_library('d3d10core'+dll_ext, d3d10_main_src,
   name_prefix         : '',


### PR DESCRIPTION
Attempts to fix cross-compilation when using macOS.

Meson tries to change the rpath when using `d3d11_dep` on macOS. This results in an error since the tool is being used on a non-native build.