### PR TITLE
[util] don't exit when setup script is successful

### DIFF
--- a/utils/setup_dxvk.sh.in
+++ b/utils/setup_dxvk.sh.in
@@ -191,4 +191,7 @@ echo '[4/5] d3d10core:'
 $fun d3d10core
 echo '[5/5] d3d11:'
 $fun d3d11
-exit $ret
+
+if [ $ret -ne 0 ]; then
+    exit $ret
+fi


### PR DESCRIPTION
If dxvk's setup script is called inside another script, it prevents the code following the call from running.