### PR TITLE
[util] correctly resolves the setup script's path

### DIFF
--- a/utils/setup_dxvk.sh.in
+++ b/utils/setup_dxvk.sh.in
@@ -2,7 +2,7 @@
 
 export WINEDEBUG=-all
 
-dlls_dir=`dirname "$(readlink -f $0)"`
+dlls_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 build_arch='@arch@'
 winelib='@winelib@'
 


### PR DESCRIPTION
If the setup script is called from another script, current code will return the path of the callee script, and not the setup script's one.