### PR TITLE
Spoof AMD card for GTA V

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -36,6 +36,11 @@ namespace dxvk {
     { "Frostpunk.exe", {{
       { "dxgi.deferSurfaceCreation",        "True" },
     }} },
+    /* Grand Theft Auto V                         */
+    { "GTA5.exe", {{
+      { "dxgi.customVendorId",              "1002" },
+      { "dxgi.customDeviceId",              "E366" },
+    }} },
     /* Mafia 3                                    */
     { "mafia3.exe", {{
       { "d3d11.fakeStreamOutSupport",       "True" },


### PR DESCRIPTION
GTA V working out of box on Proton for Nvidia users. Tested
#624
https://github.com/ValveSoftware/Proton/issues/37#issuecomment-415833819