### PR TITLE
Spoof AMD card for Batman: Arkham Knight

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -41,6 +41,11 @@ namespace dxvk {
       { "dxgi.customVendorId",              "1002" },
       { "dxgi.customDeviceId",              "E366" },
     }} },
+    /* Batman: Arkham Knight                      */
+    { "BatmanAK.exe", {{
+      { "dxgi.customVendorId",              "1002" },
+      { "dxgi.customDeviceId",              "E366" },
+    }} },
     /* Mafia 3                                    */
     { "mafia3.exe", {{
       { "d3d11.fakeStreamOutSupport",       "True" },


### PR DESCRIPTION
This prevents game crashes in "Detective Mode" for NVidia cards.
Fixes https://github.com/doitsujin/dxvk/issues/580