### PR TITLE
Enable SSE/SSE2 ISA extensions on 32-bit x86

### DIFF
--- a/build-win32.txt
+++ b/build-win32.txt
@@ -6,6 +6,8 @@ strip = 'i686-w64-mingw32-strip'
 exe_wrapper = 'wine'
 
 [properties]
+c_args=['-msse', '-msse2']
+cpp_args=['-msse', '-msse2']
 c_link_args = ['-static', '-static-libgcc']
 cpp_link_args = ['-static', '-static-libgcc', '-static-libstdc++', '-Wl,--add-stdcall-alias,--enable-stdcall-fixup']
 

--- a/build-wine32.txt
+++ b/build-wine32.txt
@@ -8,8 +8,8 @@ strip = 'strip'
 needs_exe_wrapper = true
 winelib = true
 
-c_args=['-m32']
-cpp_args=['-m32', '--no-gnu-unique', '-Wno-attributes']
+c_args=['-m32', '-msse', '-msse2']
+cpp_args=['-m32', '--no-gnu-unique', '-Wno-attributes', '-msse', '-msse2']
 cpp_link_args=['-m32', '-mwindows']
 
 [host_machine]


### PR DESCRIPTION
The SSE/SSE2 extensions to x86 are so beneficial to performance that
telling the compiler to use other ISA extensions typically does not have
much of a performance impact in general. They were made part of the base
64-bit amd64 instruction set, such that 64-bit software can always use
them while 32-bit software typically omits them lest the software run on
older processors that lack them.  This handicaps DXVK on 32-bit
software, which represents the majority of D3D10/D3D11 software.

Processors that lack SSE/SSE2 pre-date the original Pentium 4. It is
non-trivial to use Vulkan on such hardware, such that SSE/SSE2 are
safe to include in the minimum specifications for hardware using DXVK
without risk of breaking compatibility with people's systems.

If anyone is using DXVK with anything older than a Pentium 4 (or even a
Pentium 4), they would need to use either a PCI-E to PCI adapter or
PCI-E to AGP bridge chip to use a modern graphics card whose drivers
support Vulkan. There are a multitude of reasons why that will not work
well for anything graphically intensive, so DXVK can safely disregard
this use case.

This likely violates the policies of multiple Linux distributions
(including Gentoo). However, if downstream distributors disagree, they
are free to revert this change in their builds. Even if they do not, I
doubt any user will ever file a bug report concerning a crash because
any of SSE/SSE2 were used on a CPU that does not support it.

Signed-off-by: Richard Yao <ryao@gentoo.org>