### PR TITLE
[build] Use -mtune=core2 to generate better assembly

### DIFF
--- a/build-win32.txt
+++ b/build-win32.txt
@@ -6,8 +6,8 @@ strip = 'i686-w64-mingw32-strip'
 exe_wrapper = 'wine'
 
 [properties]
-c_args=['-msse', '-msse2']
-cpp_args=['-msse', '-msse2']
+c_args=['-msse', '-msse2', '-mtune=core2']
+cpp_args=['-msse', '-msse2', '-mtune=core2']
 c_link_args = ['-static', '-static-libgcc']
 cpp_link_args = ['-static', '-static-libgcc', '-static-libstdc++', '-Wl,--add-stdcall-alias,--enable-stdcall-fixup']
 

--- a/build-win64.txt
+++ b/build-win64.txt
@@ -6,8 +6,8 @@ strip = 'x86_64-w64-mingw32-strip'
 exe_wrapper = 'wine'
 
 [properties]
-c_link_args = ['-static', '-static-libgcc']
-cpp_link_args = ['-static', '-static-libgcc', '-static-libstdc++']
+c_link_args = ['-static', '-static-libgcc', '-mtune=core2']
+cpp_link_args = ['-static', '-static-libgcc', '-static-libstdc++', '-mtune=core2']
 
 [host_machine]
 system = 'windows'

--- a/build-wine32.txt
+++ b/build-wine32.txt
@@ -8,8 +8,8 @@ strip = 'strip'
 needs_exe_wrapper = true
 winelib = true
 
-c_args=['-m32', '-msse', '-msse2']
-cpp_args=['-m32', '--no-gnu-unique', '-Wno-attributes', '-msse', '-msse2']
+c_args=['-m32', '-msse', '-msse2', '-mtune=core2']
+cpp_args=['-m32', '--no-gnu-unique', '-Wno-attributes', '-msse', '-msse2', '-mtune=core2']
 cpp_link_args=['-m32', '-mwindows']
 
 [host_machine]

--- a/build-wine64.txt
+++ b/build-wine64.txt
@@ -8,8 +8,8 @@ strip = 'strip'
 needs_exe_wrapper = true
 winelib = true
 
-c_args=['-m64']
-cpp_args=['-m64', '--no-gnu-unique', '-Wno-attributes']
+c_args=['-m64', '-mtune=core2']
+cpp_args=['-m64', '--no-gnu-unique', '-Wno-attributes', '-mtune=core2']
 cpp_link_args=['-m64', '-mwindows']
 
 [host_machine]


### PR DESCRIPTION
This gives me roughly a 10% improvement in FPS on the `Rise of Nations: Extended Edition` title screen according to the DXVK HUD. This game is CPU bound when vsync is off with a single thread using 100% of the CPU. It also is a 32-bit title and uses Direct3D 11. I tested on a Xeon E5-1650 v2, which is an Ivy Bridge processor. Having the compiler tune for the core2 should give a generic performance improvement on modern processors.