### PR TITLE
[util] Spoof AMD card for Star Citizen

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -70,6 +70,11 @@ namespace dxvk {
     { "Overwatch.exe", {{
       { "d3d11.fakeStreamOutSupport",       "True" },
     }} },
+    /* Star Citizen                               */
+    { "StarCitizen.exe", {{
+      { "dxgi.customVendorId",              "1002" },
+      { "dxgi.customDeviceId",              "e366" },
+    }} },
   }};
 
 


### PR DESCRIPTION
Star Citizen spams the log output with NvAPI errors.
```
00bb:fixme:nvapi:NvAPI_D3D_GetObjectHandleForResource (0x7ff0adc59970, 0x7ff08d1c6ab0, 0x7ff0ae70f510): stub
00bb:err:nvapi:NvAPI_D3D11_SetDepthBoundsTest Failed to get wined3d device handle!
```

This results in a log larger than 6 MiB in less then 2-4 minutes. Spoofing an AMD card reduces the log amount to about 100 KiB in the same amount of time.