### PR TITLE
[util] Spoof AMD GPU for Dauntless and Redout.

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -75,6 +75,16 @@ namespace dxvk {
       { "dxgi.customVendorId",              "1002" },
       { "dxgi.customDeviceId",              "e366" },
     }} },
+    /* Dauntless                                  */
+    { "Dauntless-Win64-Shipping.exe", {{
+      { "dxgi.customVendorId",              "1002" },
+      { "dxgi.customDeviceId",              "e366" },
+    }} },
+    /* Redout                                     */
+    { "redout-Win64-Shipping.exe", {{
+      { "dxgi.customVendorId",              "1002" },
+      { "dxgi.customDeviceId",              "e366" },
+    }} },
   }};
 
 


### PR DESCRIPTION
It silences some nvapi related warnings and improves performance on both titles by up to 10%.
Also fixes a random crash on Redout.