### PR TITLE
[util] Spoof AMD GPU for Assetto Corsa Competizione

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -81,6 +81,11 @@ namespace dxvk {
       { "dxgi.customVendorId",              "1002" },
       { "dxgi.customDeviceId",              "e366" },
     }} },
+    /* Assetto Corsa Competizione                 */
+    { "AC2-Win64-Shipping.exe", {{
+      { "dxgi.customVendorId",              "1002" },
+      { "dxgi.customDeviceId",              "e366" },
+    }} },
   }};
 
 


### PR DESCRIPTION
Another spoof for UE4. This gets frames up from 15-30 to 55-60 and also seems to fix a minor startup issue where you'd get a black screen until you click anywhere.