### PR TITLE
package-release.sh: exit on errors

### DIFF
--- a/package-release.sh
+++ b/package-release.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 if [ -z "$1" ] || [ -z "$2" ]; then
   echo "Usage: package-release.sh version destdir [--no-package]"
   exit 1


### PR DESCRIPTION
Reading logs can be confusing if the script does not exit on error.