### PR TITLE
setup_dxvk: don't install by default

### DIFF
--- a/utils/setup_dxvk.sh.in
+++ b/utils/setup_dxvk.sh.in
@@ -133,15 +133,15 @@ function createOverride {
 }
 
 case "$1" in
-reset)
+uninstall)
     fun=removeOverride
     ;;
-'')
+install)
     fun=createOverride
     ;;
 *)
     echo "Unrecognized option: $1"
-    echo "Usage: $0 [reset] [-q|--quiet] [-y|-n]"
+    echo "Usage: $0 [install|uninstall] [-q|--quiet] [-y|-n]"
     exit 1
     ;;
 esac


### PR DESCRIPTION
Hello!

Not sure if you are willing to break the API here, but allow me to make my case.

I'd like to install this script to the user's path.

Not defaulting to "install" is a great way to educate the user that "reset" is available.

What do you think?

I also think that reset could be renamed to "remove" or "uninstall". What would you think about that? (this is much less important, however).

Cheers,