### PR TITLE
[Untested] [Feedback Wanted] Add option on whether or not to advertise command list support

### DIFF
--- a/src/d3d11/d3d11_context.h
+++ b/src/d3d11/d3d11_context.h
@@ -7,6 +7,7 @@
 #include "d3d11_annotation.h"
 #include "d3d11_context_state.h"
 #include "d3d11_device_child.h"
+#include "d3d11_options.h"
 #include "d3d11_texture.h"
 
 namespace dxvk {

--- a/src/d3d11/d3d11_device.cpp
+++ b/src/d3d11/d3d11_device.cpp
@@ -1173,7 +1173,7 @@ namespace dxvk {
         // https://msdn.microsoft.com/en-us/library/windows/desktop/ff476486(v=vs.85).aspx)
         auto info = static_cast<D3D11_FEATURE_DATA_THREADING*>(pFeatureSupportData);
         info->DriverConcurrentCreates = TRUE;
-        info->DriverCommandLists      = TRUE;
+        info->DriverCommandLists      = m_d3d11Options.reportCommandListSupport ? TRUE : FALSE;
       } return S_OK;
       
       case D3D11_FEATURE_DOUBLES: {

--- a/src/d3d11/d3d11_options.cpp
+++ b/src/d3d11/d3d11_options.cpp
@@ -11,6 +11,7 @@ namespace dxvk {
     this->maxTessFactor         = config.getOption<int32_t>("d3d11.maxTessFactor",      0);
     this->samplerAnisotropy     = config.getOption<int32_t>("d3d11.samplerAnisotropy",  -1);
     this->deferSurfaceCreation  = config.getOption<bool>("dxgi.deferSurfaceCreation",   false);
+    this->reportCommandListSupport = config.getOption<bool>("d3d11.reportCommandListSupport", true);
     this->numBackBuffers        = config.getOption<int32_t>("dxgi.numBackBuffers", 0);
     this->syncInterval          = config.getOption<int32_t>("dxgi.syncInterval", -1);
     this->syncMode              = D3D11SwapChainSyncMode(config.getOption<int32_t>("dxgi.syncMode", 0));

--- a/src/d3d11/d3d11_options.h
+++ b/src/d3d11/d3d11_options.h
@@ -69,6 +69,10 @@ namespace dxvk {
 
     /// Vsync mode
     D3D11SwapChainSyncMode syncMode;
+
+    /// Reports whether the implementation utilizes hardware command lists
+    bool reportCommandListSupport;
+
   };
   
 }


### PR DESCRIPTION
In the VKx discord, I heard that DXVK has to emulate deferred contexts, and that games which use them are slower on DXVK.  Because of this, I thought not advertising support for a hardware implementation may trigger some applications to use an alternative codepath that doesn't involve deferred contexts.  I haven't tested this PR with any applications yet, but I would like to know whether I'm doing anything wrong before I proceed.