### PR TITLE
cross build cleanup

### DIFF
--- a/build-win32.txt
+++ b/build-win32.txt
@@ -3,13 +3,13 @@ c = 'i686-w64-mingw32-gcc'
 cpp = 'i686-w64-mingw32-g++'
 ar = 'i686-w64-mingw32-ar'
 strip = 'i686-w64-mingw32-strip'
-exe_wrapper = 'wine'
 
 [properties]
 c_args=['-msse', '-msse2']
 cpp_args=['-msse', '-msse2']
 c_link_args = ['-static', '-static-libgcc']
 cpp_link_args = ['-static', '-static-libgcc', '-static-libstdc++', '-Wl,--add-stdcall-alias,--enable-stdcall-fixup']
+needs_exe_wrapper = true
 
 [host_machine]
 system = 'windows'

--- a/build-win64.txt
+++ b/build-win64.txt
@@ -3,11 +3,11 @@ c = 'x86_64-w64-mingw32-gcc'
 cpp = 'x86_64-w64-mingw32-g++'
 ar = 'x86_64-w64-mingw32-ar'
 strip = 'x86_64-w64-mingw32-strip'
-exe_wrapper = 'wine'
 
 [properties]
 c_link_args = ['-static', '-static-libgcc']
 cpp_link_args = ['-static', '-static-libgcc', '-static-libstdc++']
+needs_exe_wrapper = true
 
 [host_machine]
 system = 'windows'

--- a/build-wine32.txt
+++ b/build-wine32.txt
@@ -9,7 +9,7 @@ needs_exe_wrapper = true
 winelib = true
 
 c_args=['-m32', '-msse', '-msse2']
-cpp_args=['-m32', '--no-gnu-unique', '-Wno-attributes', '-msse', '-msse2']
+cpp_args=['-m32', '--no-gnu-unique', '-msse', '-msse2']
 cpp_link_args=['-m32', '-mwindows', '-ldl']
 
 [host_machine]

--- a/build-wine32.txt
+++ b/build-wine32.txt
@@ -9,7 +9,7 @@ needs_exe_wrapper = true
 
 c_args=['-m32', '-msse', '-msse2']
 cpp_args=['-m32', '--no-gnu-unique', '-msse', '-msse2']
-cpp_link_args=['-m32', '-mwindows', '-ldl']
+cpp_link_args=['-m32', '-mwindows']
 
 [host_machine]
 system = 'linux'

--- a/build-wine32.txt
+++ b/build-wine32.txt
@@ -6,7 +6,6 @@ strip = 'strip'
 
 [properties]
 needs_exe_wrapper = true
-winelib = true
 
 c_args=['-m32', '-msse', '-msse2']
 cpp_args=['-m32', '--no-gnu-unique', '-msse', '-msse2']

--- a/build-wine64.txt
+++ b/build-wine64.txt
@@ -6,7 +6,6 @@ strip = 'strip'
 
 [properties]
 needs_exe_wrapper = true
-winelib = true
 
 c_args=['-m64']
 cpp_args=['-m64', '--no-gnu-unique']

--- a/build-wine64.txt
+++ b/build-wine64.txt
@@ -9,7 +9,7 @@ needs_exe_wrapper = true
 
 c_args=['-m64']
 cpp_args=['-m64', '--no-gnu-unique']
-cpp_link_args=['-m64', '-mwindows', '-ldl']
+cpp_link_args=['-m64', '-mwindows']
 
 [host_machine]
 system = 'linux'

--- a/build-wine64.txt
+++ b/build-wine64.txt
@@ -9,7 +9,7 @@ needs_exe_wrapper = true
 winelib = true
 
 c_args=['-m64']
-cpp_args=['-m64', '--no-gnu-unique', '-Wno-attributes']
+cpp_args=['-m64', '--no-gnu-unique']
 cpp_link_args=['-m64', '-mwindows', '-ldl']
 
 [host_machine]

--- a/meson.build
+++ b/meson.build
@@ -37,6 +37,7 @@ if dxvk_winelib
   lib_dxgi    = declare_dependency(link_args: [ '-ldxgi' ])
   lib_d3dcompiler_43 = declare_dependency(link_args: [ '-L'+dxvk_library_path, '-ld3dcompiler_43' ])
   lib_d3dcompiler_47 = declare_dependency(link_args: [ '-ld3dcompiler' ])
+  lib_dl = declare_dependency(link_args: [ '-ldl' ])
   exe_ext = '.exe.so'
   dll_ext = '.dll'
   def_spec_ext = '.spec'
@@ -45,6 +46,7 @@ else
   lib_d3d11   = dxvk_compiler.find_library('d3d11')
   lib_dxgi    = dxvk_compiler.find_library('dxgi')
   lib_d3dcompiler_43 = dxvk_compiler.find_library('d3dcompiler_43', dirs : dxvk_library_path)
+  lib_dl = dependency('', required : false)
   
   if dxvk_compiler.get_id() == 'msvc'
     lib_d3dcompiler_47 = dxvk_compiler.find_library('d3dcompiler')

--- a/meson.build
+++ b/meson.build
@@ -25,7 +25,13 @@ else
   dxvk_library_path = meson.source_root() + '/lib32'
 endif
 
-if meson.get_cross_property('winelib', false)
+code = '''#ifndef __WINE__
+#error 1
+#endif'''
+
+dxvk_winelib = dxvk_compiler.compiles(code, name: 'winelib check')
+
+if dxvk_winelib
   lib_vulkan  = declare_dependency(link_args: [ '-lwinevulkan' ])
   lib_d3d11   = declare_dependency(link_args: [ '-ld3d11' ])
   lib_dxgi    = declare_dependency(link_args: [ '-ldxgi' ])

--- a/src/d3d10/meson.build
+++ b/src/d3d10/meson.build
@@ -4,7 +4,7 @@ d3d10_main_src = [
 ]
 
 d3d10_deps = [ lib_d3dcompiler_43, lib_dxgi ]
-d3d10_deps += meson.get_cross_property('winelib', false) ? lib_d3d11 : d3d11_dep
+d3d10_deps += dxvk_winelib ? lib_d3d11 : d3d11_dep
 
 d3d10_core_dll = shared_library('d3d10core'+dll_ext, d3d10_main_src,
   name_prefix         : '',

--- a/src/dxgi/dxgi_include.h
+++ b/src/dxgi/dxgi_include.h
@@ -1,7 +1,7 @@
 #pragma once
 
 //for some reason we need to specify __declspec(dllexport) for MinGW
-#ifdef _MSC_VER
+#if defined(_MSC_VER) || defined(__WINE__)
   #define DLLEXPORT
 #else
   #define DLLEXPORT __declspec(dllexport)

--- a/src/dxvk/meson.build
+++ b/src/dxvk/meson.build
@@ -102,7 +102,7 @@ thread_dep = dependency('threads')
 
 dxvk_lib = static_library('dxvk', dxvk_src, glsl_generator.process(dxvk_shaders), dxvk_version,
   link_with           : [ util_lib, spirv_lib ],
-  dependencies        : [ thread_dep, vkcommon_dep ],
+  dependencies        : [ thread_dep, vkcommon_dep, lib_dl ],
   include_directories : [ dxvk_include_path ],
   override_options    : ['cpp_std='+dxvk_cpp_std])
 

--- a/utils/meson.build
+++ b/utils/meson.build
@@ -2,7 +2,7 @@ conf = configuration_data()
 conf.set('bindir', get_option('bindir'))
 conf.set('libdir', get_option('libdir'))
 conf.set('arch', target_machine.cpu_family())
-conf.set('winelib', meson.get_cross_property('winelib', false))
+conf.set('winelib', dxvk_winelib)
 configure_file(
   configuration : conf,
   input         : 'setup_dxvk.sh.in',


### PR DESCRIPTION
Move non-generic stuff out of the meson cross files.

This allows reusing private cross files without dxvk specific switches.