### PR TITLE
Fixed for a05c93dd178de722c4e1d257a138fc94c4b877d6

### DIFF
--- a/package-release.sh
+++ b/package-release.sh
@@ -41,7 +41,6 @@ function build_arch {
   cp "$DXVK_BUILD_DIR/install.$1/bin/d3d11.dll" "$DXVK_BUILD_DIR/x$1/d3d11.dll"
   cp "$DXVK_BUILD_DIR/install.$1/bin/dxgi.dll" "$DXVK_BUILD_DIR/x$1/dxgi.dll"
   
-  rm -R "$DXVK_BUILD_DIR/wine.$1"
   rm -R "$DXVK_BUILD_DIR/build.$1"
   rm -R "$DXVK_BUILD_DIR/install.$1"
 }


### PR DESCRIPTION
package-release.sh script fails in that it tries to remove non-existing wine folder (since this is no longer creater after a05c93dd178de722c4e1d257a138fc94c4b877d6)