### PR TITLE
[dxvk] Use more threads for pipeline compilation

### DIFF
--- a/src/dxvk/dxvk_state_cache.cpp
+++ b/src/dxvk/dxvk_state_cache.cpp
@@ -57,11 +57,9 @@ namespace dxvk {
         writeCacheEntry(file, e);
     }
 
-    // Use half the available CPU cores for pipeline compilation
+    // Use 3/4 the available CPU cores for pipeline compilation
     uint32_t numCpuCores = dxvk::thread::hardware_concurrency();
-    uint32_t numWorkers  = numCpuCores > 8
-      ? numCpuCores * 3 / 4
-      : numCpuCores * 1 / 2;
+    uint32_t numWorkers  = numCpuCores * 3 / 4;
 
     if (numWorkers <  1) numWorkers =  1;
     if (numWorkers > 16) numWorkers = 16;


### PR DESCRIPTION
This will report 2 worker threads for 3 core CPUs.

Also, changes behaviour for 4, 6 and 8 cores/threads, and for cases when
non-power-of-2 concurrent threads reported (`taskset`,`cgroups`, ... ?).