### PR TITLE
Use std::string for util::getEnvVar input

### DIFF
--- a/src/d3d11/d3d11_shader.cpp
+++ b/src/d3d11/d3d11_shader.cpp
@@ -24,7 +24,7 @@ namespace dxvk {
     
     // If requested by the user, dump both the raw DXBC
     // shader and the compiled SPIR-V module to a file.
-    const std::string dumpPath = env::getEnvVar(L"DXVK_SHADER_DUMP_PATH");
+    const std::string dumpPath = env::getEnvVar("DXVK_SHADER_DUMP_PATH");
     
     if (dumpPath.size() != 0) {
       reader.store(std::ofstream(str::format(dumpPath, "/", name, ".dxbc"),

--- a/src/dxvk/dxvk_device_filter.cpp
+++ b/src/dxvk/dxvk_device_filter.cpp
@@ -3,7 +3,7 @@
 namespace dxvk {
   
   DxvkDeviceFilter::DxvkDeviceFilter() {
-    m_matchDeviceName = env::getEnvVar(L"DXVK_FILTER_DEVICE_NAME");
+    m_matchDeviceName = env::getEnvVar("DXVK_FILTER_DEVICE_NAME");
     
     if (m_matchDeviceName.size() != 0)
       m_flags.set(DxvkDeviceFilterFlag::MatchDeviceName);

--- a/src/dxvk/dxvk_openvr.cpp
+++ b/src/dxvk/dxvk_openvr.cpp
@@ -115,7 +115,7 @@ namespace dxvk {
   
   vr::IVRCompositor* VrInstance::getCompositor() {
     // Skip OpenVR initialization if requested
-    if (env::getEnvVar(L"DXVK_NO_VR") == "1")
+    if (env::getEnvVar("DXVK_NO_VR") == "1")
       return nullptr;
     
     // Locate the OpenVR DLL if loaded by the process. Some

--- a/src/dxvk/dxvk_pipemanager.cpp
+++ b/src/dxvk/dxvk_pipemanager.cpp
@@ -44,7 +44,7 @@ namespace dxvk {
           DxvkRenderPassPool* passManager)
   : m_device    (device),
     m_cache     (new DxvkPipelineCache(device->vkd())) {
-    std::string useStateCache = env::getEnvVar(L"DXVK_STATE_CACHE");
+    std::string useStateCache = env::getEnvVar("DXVK_STATE_CACHE");
     
     if (useStateCache != "0")
       m_stateCache = new DxvkStateCache(device, this, passManager);

--- a/src/dxvk/dxvk_state_cache.cpp
+++ b/src/dxvk/dxvk_state_cache.cpp
@@ -418,7 +418,7 @@ namespace dxvk {
 
 
   std::string DxvkStateCache::getCacheFileName() const {
-    std::string path = env::getEnvVar(L"DXVK_STATE_CACHE_PATH");
+    std::string path = env::getEnvVar("DXVK_STATE_CACHE_PATH");
 
     if (!path.empty() && *path.rbegin() != '/')
       path += '/';

--- a/src/dxvk/hud/dxvk_hud.cpp
+++ b/src/dxvk/hud/dxvk_hud.cpp
@@ -62,7 +62,7 @@ namespace dxvk::hud {
   
   
   Rc<Hud> Hud::createHud(const Rc<DxvkDevice>& device) {
-    HudConfig config(env::getEnvVar(L"DXVK_HUD"));
+    HudConfig config(env::getEnvVar("DXVK_HUD"));
     
     return !config.elements.isClear()
       ? new Hud(device, config)

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -244,7 +244,7 @@ namespace dxvk {
     Config config;
 
     // Load either $DXVK_CONFIG_FILE or $PWD/dxvk.conf
-    std::string filePath = env::getEnvVar(L"DXVK_CONFIG_FILE");
+    std::string filePath = env::getEnvVar("DXVK_CONFIG_FILE");
 
     if (filePath == "")
       filePath = "dxvk.conf";

--- a/src/util/log/log.cpp
+++ b/src/util/log/log.cpp
@@ -68,7 +68,7 @@ namespace dxvk {
       { "none",  LogLevel::None  },
     }};
     
-    const std::string logLevelStr = env::getEnvVar(L"DXVK_LOG_LEVEL");
+    const std::string logLevelStr = env::getEnvVar("DXVK_LOG_LEVEL");
     
     for (const auto& pair : logLevels) {
       if (logLevelStr == pair.first)
@@ -80,7 +80,7 @@ namespace dxvk {
   
   
   std::string Logger::getFileName(const std::string& base) {
-    std::string path = env::getEnvVar(L"DXVK_LOG_PATH");
+    std::string path = env::getEnvVar("DXVK_LOG_PATH");
     
     if (!path.empty() && *path.rbegin() != '/')
       path += '/';

--- a/src/util/util_env.cpp
+++ b/src/util/util_env.cpp
@@ -5,15 +5,21 @@
 
 namespace dxvk::env {
 
-  std::string getEnvVar(const wchar_t* name) {
-    DWORD len = ::GetEnvironmentVariableW(name, nullptr, 0);
+  std::string getEnvVar(const std::string& name) {
+    int nameLen = ::MultiByteToWideChar(CP_ACP, 0, name.c_str(), name.length() + 1, nullptr, 0);
+
+    std::vector<WCHAR> wideName(nameLen);
+
+    ::MultiByteToWideChar(CP_ACP, 0, name.c_str(), name.length() + 1, wideName.data(), nameLen);
+
+    DWORD len = ::GetEnvironmentVariableW(wideName.data(), nullptr, 0);
     
     std::vector<WCHAR> result;
     
     while (len > result.size()) {
       result.resize(len);
       len = ::GetEnvironmentVariableW(
-        name, result.data(), result.size());
+        wideName.data(), result.data(), result.size());
     }
     
     result.resize(len);

--- a/src/util/util_env.h
+++ b/src/util/util_env.h
@@ -13,7 +13,7 @@ namespace dxvk::env {
    * \param [in] name Name of the variable
    * \returns Value of the variable
    */
-  std::string getEnvVar(const wchar_t* name);
+  std::string getEnvVar(const std::string& name);
   
   /**
    * \brief Gets the executable name


### PR DESCRIPTION
This cleans up the code for a potential native library port, where wide strings shouldn't be used.