### PR TITLE
Make build_arch and winelib variables externally configurable in setup_dxvk.sh

### DIFF
--- a/utils/setup_dxvk.sh.in
+++ b/utils/setup_dxvk.sh.in
@@ -3,8 +3,8 @@
 export WINEDEBUG=-all
 
 dlls_dir=`dirname "$(readlink -f $0)"`
-build_arch='@arch@'
-winelib='@winelib@'
+build_arch=${build_arch:-'@arch@'}
+winelib=${winelib:-'@winelib@'}
 
 if [ $winelib == 'True' ]; then
     dll_ext='dll.so'


### PR DESCRIPTION
Allows reusing the same setup_dxvk.sh for both winelib (so) and windowns (dll) cases.

This allows conveniently placing both dxvk builds into the same directory structure instead of into two distinct locations and then using one script with external variable setting, to enable/disable either of them.

Example how I made it look in my case:

```
dxvk
dxvk/bin
dxvk/bin/dxgi.dll
dxvk/bin/d3d11.dll
dxvk/bin/d3d10core.dll
dxvk/bin/d3d10.dll
dxvk/bin/d3d10_1.dll
dxvk/bin/setup_dxvk.sh
dxvk/lib
dxvk/lib/x86_64-linux-gnu
dxvk/lib/x86_64-linux-gnu/libdxgi.dll.a
dxvk/lib/x86_64-linux-gnu/libd3d11.dll.a
dxvk/lib/x86_64-linux-gnu/libd3d10core.dll.a
dxvk/lib/x86_64-linux-gnu/libd3d10.dll.a
dxvk/lib/x86_64-linux-gnu/libd3d10_1.dll.a
dxvk/lib/x86_64-linux-gnu/d3d10.dll.so
dxvk/lib/x86_64-linux-gnu/d3d10_1.dll.so
dxvk/lib/x86_64-linux-gnu/d3d10core.dll.so
dxvk/lib/x86_64-linux-gnu/d3d11.dll.so
dxvk/lib/x86_64-linux-gnu/dxgi.dll.so
```

Then I can call the same `dxvk/bin/setup_dxvk.sh` as follows:

```winelib=True dxvk/bin/setup_dxvk.sh install```
or
```winelib=False dxvk/bin/setup_dxvk.sh install```