### PR TITLE
[vr] Cosmetic code cleanup, again

### DIFF
--- a/src/dxvk/dxvk_openvr.h
+++ b/src/dxvk/dxvk_openvr.h
@@ -5,6 +5,12 @@
 
 #include "dxvk_include.h"
 
+#ifdef __WINE__
+using SoHandle = void*;
+#else
+using SoHandle = HMODULE;
+#endif
+
 namespace vr {
   class IVRCompositor;
   class IVRSystem;
@@ -66,11 +72,7 @@ namespace dxvk {
 
     std::mutex            m_mutex;
     vr::IVRCompositor*    m_compositor = nullptr;
-#ifdef __WINE__
-    void*                 m_ovrApi     = nullptr;
-#else
-    HMODULE               m_ovrApi     = nullptr;
-#endif
+    SoHandle              m_ovrApi     = nullptr;
 
     bool m_loadedOvrApi      = false;
     bool m_initializedOpenVr = false;
@@ -91,6 +93,12 @@ namespace dxvk {
     vr::IVRCompositor* getCompositor();
 
     void shutdown();
+
+    SoHandle loadLibrary();
+
+    void freeLibrary();
+
+    void* getSym(const char* sym);
     
   };
 


### PR DESCRIPTION
This reverts commit 20353f6f62f802bab9618b19940748af19cc1812, but fixes
openvr_api module refcounting.

The problem was we were releasing the module after calling GetModuleHandle, which does not increase the module refcount. We should only release if we used LoadLibrary (or dlopen in the winelib path).

To see the diff from the original cosmetic code cleanup, run:

    git diff a3bf90f5a3fe050ffae353f80bc5608c7c9a1244..f8e434e6bbade62de203911a1495dcb0c08529a5 -- :/src/dxvk/dxvk_openvr.cpp
