### PR TITLE
Lock the d3d10 device during presentation

### DIFF
--- a/src/d3d10/d3d10_buffer.cpp
+++ b/src/d3d10/d3d10_buffer.cpp
@@ -73,8 +73,6 @@ namespace dxvk {
           D3D10_MAP                 MapType,
           UINT                      MapFlags,
           void**                    ppData) {
-    D3D10DeviceLock lock = m_device->LockDevice();
-
     Com<ID3D11DeviceContext> ctx;
     GetD3D11Context(m_d3d11, &ctx);
 
@@ -92,9 +90,7 @@ namespace dxvk {
   }
 
 
-  void STDMETHODCALLTYPE D3D10Buffer::Unmap() {
-    D3D10DeviceLock lock = m_device->LockDevice();
-    
+  void STDMETHODCALLTYPE D3D10Buffer::Unmap() {    
     Com<ID3D11DeviceContext> ctx;
     GetD3D11Context(m_d3d11, &ctx);
 

--- a/src/d3d10/d3d10_device.cpp
+++ b/src/d3d10/d3d10_device.cpp
@@ -8,9 +8,7 @@ namespace dxvk {
   D3D10Device::D3D10Device(
           D3D11Device*                      pDevice,
           D3D11ImmediateContext*            pContext)
-  : m_device(pDevice), m_context(pContext),
-    m_multithread(this, !(pDevice->GetCreationFlags() & D3D10_CREATE_DEVICE_SINGLETHREADED)) {
-    
+  : m_device(pDevice), m_context(pContext) {
   }
 
   
@@ -716,8 +714,6 @@ namespace dxvk {
   void STDMETHODCALLTYPE D3D10Device::ClearRenderTargetView(
           ID3D10RenderTargetView*           pRenderTargetView,
     const FLOAT                             ColorRGBA[4]) {
-    D3D10DeviceLock lock = LockDevice();
-
     D3D10RenderTargetView* d3d10View = static_cast<D3D10RenderTargetView*>(pRenderTargetView);
     D3D11RenderTargetView* d3d11View = d3d10View ? d3d10View->GetD3D11Iface() : nullptr;
 
@@ -730,8 +726,6 @@ namespace dxvk {
           UINT                              ClearFlags,
           FLOAT                             Depth,
           UINT8                             Stencil) {
-    D3D10DeviceLock lock = LockDevice();
-
     D3D10DepthStencilView* d3d10View = static_cast<D3D10DepthStencilView*>(pDepthStencilView);
     D3D11DepthStencilView* d3d11View = d3d10View ? d3d10View->GetD3D11Iface() : nullptr;
 
@@ -742,8 +736,6 @@ namespace dxvk {
   void STDMETHODCALLTYPE D3D10Device::SetPredication(
           ID3D10Predicate*                  pPredicate,
           BOOL                              PredicateValue) {
-    D3D10DeviceLock lock = LockDevice();
-
     D3D10Query* d3d10Predicate = static_cast<D3D10Query*>(pPredicate);
     D3D11Query* d3d11Predicate = d3d10Predicate ? d3d10Predicate->GetD3D11Iface() : nullptr;
 
@@ -754,7 +746,6 @@ namespace dxvk {
   void STDMETHODCALLTYPE D3D10Device::GetPredication(
           ID3D10Predicate**                 ppPredicate,
           BOOL*                             pPredicateValue) {
-    D3D10DeviceLock lock = LockDevice();
     ID3D11Predicate* d3d11Predicate = nullptr;
 
     m_context->GetPredication(
@@ -775,8 +766,6 @@ namespace dxvk {
           ID3D10Resource*                   pSrcResource,
           UINT                              SrcSubresource,
     const D3D10_BOX*                        pSrcBox) {
-    D3D10DeviceLock lock = LockDevice();
-
     Com<ID3D11Resource> d3d11DstResource;
     Com<ID3D11Resource> d3d11SrcResource;
     
@@ -793,8 +782,6 @@ namespace dxvk {
   void STDMETHODCALLTYPE D3D10Device::CopyResource(
           ID3D10Resource*                   pDstResource,
           ID3D10Resource*                   pSrcResource) {
-    D3D10DeviceLock lock = LockDevice();
-
     Com<ID3D11Resource> d3d11DstResource;
     Com<ID3D11Resource> d3d11SrcResource;
     
@@ -814,8 +801,6 @@ namespace dxvk {
     const void*                             pSrcData,
           UINT                              SrcRowPitch,
           UINT                              SrcDepthPitch) {
-    D3D10DeviceLock lock = LockDevice();
-
     Com<ID3D11Resource> d3d11DstResource;
     GetD3D11Resource(pDstResource, &d3d11DstResource);
 
@@ -828,8 +813,6 @@ namespace dxvk {
 
   void STDMETHODCALLTYPE D3D10Device::GenerateMips(
           ID3D10ShaderResourceView*         pShaderResourceView) {
-    D3D10DeviceLock lock = LockDevice();
-
     D3D10ShaderResourceView* d3d10View = static_cast<D3D10ShaderResourceView*>(pShaderResourceView);
     D3D11ShaderResourceView* d3d11View = d3d10View ? d3d10View->GetD3D11Iface() : nullptr;
 
@@ -843,8 +826,6 @@ namespace dxvk {
           ID3D10Resource*                   pSrcResource,
           UINT                              SrcSubresource,
           DXGI_FORMAT                       Format) {
-    D3D10DeviceLock lock = LockDevice();
-
     Com<ID3D11Resource> d3d11DstResource;
     Com<ID3D11Resource> d3d11SrcResource;
     
@@ -861,8 +842,6 @@ namespace dxvk {
   void STDMETHODCALLTYPE D3D10Device::Draw(
           UINT                              VertexCount,
           UINT                              StartVertexLocation) {
-    D3D10DeviceLock lock = LockDevice();
-
     m_context->Draw(VertexCount,
       StartVertexLocation);
   }
@@ -872,8 +851,6 @@ namespace dxvk {
           UINT                              IndexCount,
           UINT                              StartIndexLocation,
           INT                               BaseVertexLocation) {
-    D3D10DeviceLock lock = LockDevice();
-
     m_context->DrawIndexed(IndexCount,
       StartIndexLocation,
       BaseVertexLocation);
@@ -885,8 +862,6 @@ namespace dxvk {
           UINT                              InstanceCount,
           UINT                              StartVertexLocation,
           UINT                              StartInstanceLocation) {
-    D3D10DeviceLock lock = LockDevice();
-
     m_context->DrawInstanced(
       VertexCountPerInstance,
       InstanceCount,
@@ -901,8 +876,6 @@ namespace dxvk {
           UINT                              StartIndexLocation,
           INT                               BaseVertexLocation,
           UINT                              StartInstanceLocation) {
-    D3D10DeviceLock lock = LockDevice();
-
     m_context->DrawIndexedInstanced(
       IndexCountPerInstance,
       InstanceCount,
@@ -913,16 +886,12 @@ namespace dxvk {
 
 
   void STDMETHODCALLTYPE D3D10Device::DrawAuto() {
-    D3D10DeviceLock lock = LockDevice();
-
     m_context->DrawAuto();
   }
 
 
   void STDMETHODCALLTYPE D3D10Device::IASetInputLayout(
           ID3D10InputLayout*                pInputLayout) {
-    D3D10DeviceLock lock = LockDevice();
-
     D3D10InputLayout* d3d10InputLayout = static_cast<D3D10InputLayout*>(pInputLayout);
     D3D11InputLayout* d3d11InputLayout = d3d10InputLayout ? d3d10InputLayout->GetD3D11Iface() : nullptr;
 
@@ -932,8 +901,6 @@ namespace dxvk {
 
   void STDMETHODCALLTYPE D3D10Device::IASetPrimitiveTopology(
           D3D10_PRIMITIVE_TOPOLOGY          Topology) {
-    D3D10DeviceLock lock = LockDevice();
-
     m_context->IASetPrimitiveTopology(
       D3D11_PRIMITIVE_TOPOLOGY(Topology));
   }
@@ -945,8 +912,6 @@ namespace dxvk {
           ID3D10Buffer* const*              ppVertexBuffers,
     const UINT*                             pStrides,
     const UINT*                             pOffsets) {
-    D3D10DeviceLock lock = LockDevice();
-    
     ID3D11Buffer* d3d11Buffers[D3D10_IA_VERTEX_INPUT_RESOURCE_SLOT_COUNT];
 
     if (NumBuffers > D3D10_IA_VERTEX_INPUT_RESOURCE_SLOT_COUNT)
@@ -968,8 +933,6 @@ namespace dxvk {
           ID3D10Buffer*                     pIndexBuffer,
           DXGI_FORMAT                       Format,
           UINT                              Offset) {
-    D3D10DeviceLock lock = LockDevice();
-
     D3D10Buffer* d3d10Buffer = static_cast<D3D10Buffer*>(pIndexBuffer);
     D3D11Buffer* d3d11Buffer = d3d10Buffer ? d3d10Buffer->GetD3D11Iface() : nullptr;
 
@@ -980,8 +943,6 @@ namespace dxvk {
   void STDMETHODCALLTYPE D3D10Device::IAGetInputLayout(
           ID3D10InputLayout**               ppInputLayout) {
     ID3D11InputLayout* d3d11InputLayout = nullptr;
-    D3D10DeviceLock lock = LockDevice();
-
     m_context->IAGetInputLayout(&d3d11InputLayout);
 
     *ppInputLayout = static_cast<D3D11InputLayout*>(
@@ -991,8 +952,6 @@ namespace dxvk {
 
   void STDMETHODCALLTYPE D3D10Device::IAGetPrimitiveTopology(
           D3D10_PRIMITIVE_TOPOLOGY*         pTopology) {
-    D3D10DeviceLock lock = LockDevice();
-
     D3D11_PRIMITIVE_TOPOLOGY d3d11Topology;
     m_context->IAGetPrimitiveTopology(&d3d11Topology);
 
@@ -1008,15 +967,13 @@ namespace dxvk {
           ID3D10Buffer**                    ppVertexBuffers,
           UINT*                             pStrides,
           UINT*                             pOffsets) {
-    D3D10DeviceLock lock = LockDevice();
-
     ID3D11Buffer* d3d11Buffers[D3D10_IA_VERTEX_INPUT_RESOURCE_SLOT_COUNT];
 
     m_context->IAGetVertexBuffers(
       StartSlot, NumBuffers,
       ppVertexBuffers ? d3d11Buffers : nullptr,
       pStrides, pOffsets);
-    
+
     if (ppVertexBuffers != nullptr) {
       for (uint32_t i = 0; i < NumBuffers; i++) {
         ppVertexBuffers[i] = d3d11Buffers[i]
@@ -1031,14 +988,12 @@ namespace dxvk {
           ID3D10Buffer**                    pIndexBuffer,
           DXGI_FORMAT*                      Format,
           UINT*                             Offset) {
-    D3D10DeviceLock lock = LockDevice();
-    
     ID3D11Buffer* d3d11Buffer = nullptr;
 
     m_context->IAGetIndexBuffer(
       pIndexBuffer ? &d3d11Buffer : nullptr,
       Format, Offset);
-    
+
     if (pIndexBuffer != nullptr)
       *pIndexBuffer = static_cast<D3D11Buffer*>(d3d11Buffer)->GetD3D10Iface();
   }
@@ -1046,8 +1001,6 @@ namespace dxvk {
 
   void STDMETHODCALLTYPE D3D10Device::VSSetShader(
           ID3D10VertexShader*               pVertexShader) {
-    D3D10DeviceLock lock = LockDevice();
-
     D3D10VertexShader* d3d10Shader = static_cast<D3D10VertexShader*>(pVertexShader);
     D3D11VertexShader* d3d11Shader = d3d10Shader ? d3d10Shader->GetD3D11Iface() : nullptr;
 
@@ -1059,8 +1012,6 @@ namespace dxvk {
           UINT                              StartSlot,
           UINT                              NumBuffers,
           ID3D10Buffer* const*              ppConstantBuffers) {
-    D3D10DeviceLock lock = LockDevice();
-
     ID3D11Buffer* d3d11Buffers[D3D11_COMMONSHADER_CONSTANT_BUFFER_API_SLOT_COUNT];
 
     if (NumBuffers > D3D11_COMMONSHADER_CONSTANT_BUFFER_API_SLOT_COUNT)
@@ -1080,13 +1031,11 @@ namespace dxvk {
           UINT                              StartSlot,
           UINT                              NumViews,
           ID3D10ShaderResourceView* const*  ppShaderResourceViews) {
-    D3D10DeviceLock lock = LockDevice();
-
     ID3D11ShaderResourceView* d3d11Views[D3D10_COMMONSHADER_INPUT_RESOURCE_SLOT_COUNT];
 
     if (NumViews > D3D10_COMMONSHADER_INPUT_RESOURCE_SLOT_COUNT)
       return;
-    
+
     for (uint32_t i = 0; i < NumViews; i++) {
       d3d11Views[i] = ppShaderResourceViews && ppShaderResourceViews[i]
         ? static_cast<D3D10ShaderResourceView*>(ppShaderResourceViews[i])->GetD3D11Iface()
@@ -1101,8 +1050,6 @@ namespace dxvk {
           UINT                              StartSlot,
           UINT                              NumSamplers,
           ID3D10SamplerState* const*        ppSamplers) {
-    D3D10DeviceLock lock = LockDevice();
-
     ID3D11SamplerState* d3d11Samplers[D3D10_COMMONSHADER_SAMPLER_SLOT_COUNT];
 
     if (NumSamplers > D3D10_COMMONSHADER_SAMPLER_SLOT_COUNT)
@@ -1120,8 +1067,6 @@ namespace dxvk {
 
   void STDMETHODCALLTYPE D3D10Device::VSGetShader(
           ID3D10VertexShader**              ppVertexShader) {
-    D3D10DeviceLock lock = LockDevice();
-
     ID3D11VertexShader* d3d11Shader = nullptr;
     m_context->VSGetShader(&d3d11Shader, nullptr, nullptr);
 
@@ -1133,8 +1078,6 @@ namespace dxvk {
           UINT                              StartSlot,
           UINT                              NumBuffers,
           ID3D10Buffer**                    ppConstantBuffers) {
-    D3D10DeviceLock lock = LockDevice();
-
     ID3D11Buffer* d3d11Buffers[D3D11_COMMONSHADER_CONSTANT_BUFFER_API_SLOT_COUNT];
     m_context->VSGetConstantBuffers(StartSlot, NumBuffers, d3d11Buffers);
 
@@ -1150,8 +1093,6 @@ namespace dxvk {
           UINT                              StartSlot,
           UINT                              NumViews,
           ID3D10ShaderResourceView**        ppShaderResourceViews) {
-    D3D10DeviceLock lock = LockDevice();
-    
     ID3D11ShaderResourceView* d3d11Views[D3D10_COMMONSHADER_INPUT_RESOURCE_SLOT_COUNT];
     m_context->VSGetShaderResources(StartSlot, NumViews, d3d11Views);
 
@@ -1167,8 +1108,6 @@ namespace dxvk {
           UINT                              StartSlot,
           UINT                              NumSamplers,
           ID3D10SamplerState**              ppSamplers) {
-    D3D10DeviceLock lock = LockDevice();
-    
     ID3D11SamplerState* d3d11Samplers[D3D10_COMMONSHADER_SAMPLER_SLOT_COUNT];
     m_context->VSGetSamplers(StartSlot, NumSamplers, d3d11Samplers);
 
@@ -1182,8 +1121,6 @@ namespace dxvk {
 
   void STDMETHODCALLTYPE D3D10Device::GSSetShader(
           ID3D10GeometryShader*             pShader) {
-    D3D10DeviceLock lock = LockDevice();
-    
     D3D10GeometryShader* d3d10Shader = static_cast<D3D10GeometryShader*>(pShader);
     D3D11GeometryShader* d3d11Shader = d3d10Shader ? d3d10Shader->GetD3D11Iface() : nullptr;
 
@@ -1195,8 +1132,6 @@ namespace dxvk {
           UINT                              StartSlot,
           UINT                              NumBuffers,
           ID3D10Buffer* const*              ppConstantBuffers) {
-    D3D10DeviceLock lock = LockDevice();
-    
     ID3D11Buffer* d3d11Buffers[D3D11_COMMONSHADER_CONSTANT_BUFFER_API_SLOT_COUNT];
 
     if (NumBuffers > D3D11_COMMONSHADER_CONSTANT_BUFFER_API_SLOT_COUNT)
@@ -1216,8 +1151,6 @@ namespace dxvk {
           UINT                              StartSlot,
           UINT                              NumViews,
           ID3D10ShaderResourceView* const*  ppShaderResourceViews) {
-    D3D10DeviceLock lock = LockDevice();
-    
     ID3D11ShaderResourceView* d3d11Views[D3D10_COMMONSHADER_INPUT_RESOURCE_SLOT_COUNT];
 
     if (NumViews > D3D10_COMMONSHADER_INPUT_RESOURCE_SLOT_COUNT)
@@ -1237,8 +1170,6 @@ namespace dxvk {
           UINT                              StartSlot,
           UINT                              NumSamplers,
           ID3D10SamplerState* const*        ppSamplers) {
-    D3D10DeviceLock lock = LockDevice();
-    
     ID3D11SamplerState* d3d11Samplers[D3D10_COMMONSHADER_SAMPLER_SLOT_COUNT];
 
     if (NumSamplers > D3D10_COMMONSHADER_SAMPLER_SLOT_COUNT)
@@ -1256,8 +1187,6 @@ namespace dxvk {
 
   void STDMETHODCALLTYPE D3D10Device::GSGetShader(
           ID3D10GeometryShader**            ppGeometryShader) {
-    D3D10DeviceLock lock = LockDevice();
-    
     ID3D11GeometryShader* d3d11Shader = nullptr;
     m_context->GSGetShader(&d3d11Shader, nullptr, nullptr);
 
@@ -1269,8 +1198,6 @@ namespace dxvk {
           UINT                              StartSlot,
           UINT                              NumBuffers,
           ID3D10Buffer**                    ppConstantBuffers) {
-    D3D10DeviceLock lock = LockDevice();
-    
     ID3D11Buffer* d3d11Buffers[D3D11_COMMONSHADER_CONSTANT_BUFFER_API_SLOT_COUNT];
     m_context->GSGetConstantBuffers(StartSlot, NumBuffers, d3d11Buffers);
 
@@ -1286,8 +1213,6 @@ namespace dxvk {
           UINT                              StartSlot,
           UINT                              NumViews,
           ID3D10ShaderResourceView**        ppShaderResourceViews) {
-    D3D10DeviceLock lock = LockDevice();
-    
     ID3D11ShaderResourceView* d3d11Views[D3D10_COMMONSHADER_INPUT_RESOURCE_SLOT_COUNT];
     m_context->GSGetShaderResources(StartSlot, NumViews, d3d11Views);
 
@@ -1303,8 +1228,6 @@ namespace dxvk {
           UINT                              StartSlot,
           UINT                              NumSamplers,
           ID3D10SamplerState**              ppSamplers) {
-    D3D10DeviceLock lock = LockDevice();
-    
     ID3D11SamplerState* d3d11Samplers[D3D10_COMMONSHADER_SAMPLER_SLOT_COUNT];
     m_context->GSGetSamplers(StartSlot, NumSamplers, d3d11Samplers);
 
@@ -1318,8 +1241,6 @@ namespace dxvk {
 
   void STDMETHODCALLTYPE D3D10Device::PSSetShader(
           ID3D10PixelShader*                pPixelShader) {
-    D3D10DeviceLock lock = LockDevice();
-    
     D3D10PixelShader* d3d10Shader = static_cast<D3D10PixelShader*>(pPixelShader);
     D3D11PixelShader* d3d11Shader = d3d10Shader ? d3d10Shader->GetD3D11Iface() : nullptr;
 
@@ -1331,8 +1252,6 @@ namespace dxvk {
           UINT                              StartSlot,
           UINT                              NumBuffers,
           ID3D10Buffer* const*              ppConstantBuffers) {
-    D3D10DeviceLock lock = LockDevice();
-    
     ID3D11Buffer* d3d11Buffers[D3D11_COMMONSHADER_CONSTANT_BUFFER_API_SLOT_COUNT];
 
     if (NumBuffers > D3D11_COMMONSHADER_CONSTANT_BUFFER_API_SLOT_COUNT)
@@ -1352,8 +1271,6 @@ namespace dxvk {
           UINT                              StartSlot,
           UINT                              NumViews,
           ID3D10ShaderResourceView* const*  ppShaderResourceViews) {
-    D3D10DeviceLock lock = LockDevice();
-    
     ID3D11ShaderResourceView* d3d11Views[D3D10_COMMONSHADER_INPUT_RESOURCE_SLOT_COUNT];
 
     if (NumViews > D3D10_COMMONSHADER_INPUT_RESOURCE_SLOT_COUNT)
@@ -1373,8 +1290,6 @@ namespace dxvk {
           UINT                              StartSlot,
           UINT                              NumSamplers,
           ID3D10SamplerState* const*        ppSamplers) {
-    D3D10DeviceLock lock = LockDevice();
-    
     ID3D11SamplerState* d3d11Samplers[D3D10_COMMONSHADER_SAMPLER_SLOT_COUNT];
 
     if (NumSamplers > D3D10_COMMONSHADER_SAMPLER_SLOT_COUNT)
@@ -1392,8 +1307,6 @@ namespace dxvk {
 
   void STDMETHODCALLTYPE D3D10Device::PSGetShader(
           ID3D10PixelShader**               ppPixelShader) {
-    D3D10DeviceLock lock = LockDevice();
-    
     ID3D11PixelShader* d3d11Shader = nullptr;
     m_context->PSGetShader(&d3d11Shader, nullptr, nullptr);
 
@@ -1405,8 +1318,6 @@ namespace dxvk {
           UINT                              StartSlot,
           UINT                              NumBuffers,
           ID3D10Buffer**                    ppConstantBuffers) {
-    D3D10DeviceLock lock = LockDevice();
-    
     ID3D11Buffer* d3d11Buffers[D3D11_COMMONSHADER_CONSTANT_BUFFER_API_SLOT_COUNT];
     m_context->PSGetConstantBuffers(StartSlot, NumBuffers, d3d11Buffers);
 
@@ -1422,8 +1333,6 @@ namespace dxvk {
           UINT                              StartSlot,
           UINT                              NumViews,
           ID3D10ShaderResourceView**        ppShaderResourceViews) {
-    D3D10DeviceLock lock = LockDevice();
-    
     ID3D11ShaderResourceView* d3d11Views[D3D10_COMMONSHADER_INPUT_RESOURCE_SLOT_COUNT];
     m_context->PSGetShaderResources(StartSlot, NumViews, d3d11Views);
 
@@ -1439,8 +1348,6 @@ namespace dxvk {
           UINT                              StartSlot,
           UINT                              NumSamplers,
           ID3D10SamplerState**              ppSamplers) {
-    D3D10DeviceLock lock = LockDevice();
-    
     ID3D11SamplerState* d3d11Samplers[D3D10_COMMONSHADER_SAMPLER_SLOT_COUNT];
     m_context->PSGetSamplers(StartSlot, NumSamplers, d3d11Samplers);
 
@@ -1456,8 +1363,6 @@ namespace dxvk {
           UINT                              NumViews,
           ID3D10RenderTargetView* const*    ppRenderTargetViews,
           ID3D10DepthStencilView*           pDepthStencilView) {
-    D3D10DeviceLock lock = LockDevice();
-    
     ID3D11RenderTargetView* d3d11Rtv[D3D10_SIMULTANEOUS_RENDER_TARGET_COUNT];
 
     if (NumViews > D3D10_SIMULTANEOUS_RENDER_TARGET_COUNT)
@@ -1480,8 +1385,6 @@ namespace dxvk {
           ID3D10BlendState*                 pBlendState,
     const FLOAT                             BlendFactor[4],
           UINT                              SampleMask) {
-    D3D10DeviceLock lock = LockDevice();
-    
     D3D10BlendState* d3d10BlendState = static_cast<D3D10BlendState*>(pBlendState);
     D3D11BlendState* d3d11BlendState = d3d10BlendState ? d3d10BlendState->GetD3D11Iface() : nullptr;
 
@@ -1503,15 +1406,13 @@ namespace dxvk {
           UINT                              NumViews,
           ID3D10RenderTargetView**          ppRenderTargetViews,
           ID3D10DepthStencilView**          ppDepthStencilView) {
-    D3D10DeviceLock lock = LockDevice();
-    
     ID3D11RenderTargetView* d3d11Rtv[D3D10_SIMULTANEOUS_RENDER_TARGET_COUNT];
     ID3D11DepthStencilView* d3d11Dsv = nullptr;
 
     m_context->OMGetRenderTargets(NumViews,
       ppRenderTargetViews ? d3d11Rtv : nullptr,
       ppDepthStencilView ? &d3d11Dsv : nullptr);
-    
+
     if (ppRenderTargetViews != nullptr) {
       for (uint32_t i = 0; i < NumViews; i++) {
         ppRenderTargetViews[i] = d3d11Rtv[i]
@@ -1529,8 +1430,6 @@ namespace dxvk {
           ID3D10BlendState**                ppBlendState,
           FLOAT                             BlendFactor[4],
           UINT*                             pSampleMask) {
-    D3D10DeviceLock lock = LockDevice();
-    
     ID3D11BlendState* d3d11BlendState = nullptr;
 
     m_context->OMGetBlendState(
@@ -1545,8 +1444,6 @@ namespace dxvk {
   void STDMETHODCALLTYPE D3D10Device::OMGetDepthStencilState(
           ID3D10DepthStencilState**         ppDepthStencilState,
           UINT*                             pStencilRef) {
-    D3D10DeviceLock lock = LockDevice();
-    
     ID3D11DepthStencilState* d3d11DepthStencilState = nullptr;
 
     m_context->OMGetDepthStencilState(
@@ -1560,8 +1457,6 @@ namespace dxvk {
 
   void STDMETHODCALLTYPE D3D10Device::RSSetState(
           ID3D10RasterizerState*            pRasterizerState) {
-    D3D10DeviceLock lock = LockDevice();
-    
     D3D10RasterizerState* d3d10RasterizerState = static_cast<D3D10RasterizerState*>(pRasterizerState);
     D3D11RasterizerState* d3d11RasterizerState = d3d10RasterizerState ? d3d10RasterizerState->GetD3D11Iface() : nullptr;
 
@@ -1572,8 +1467,6 @@ namespace dxvk {
   void STDMETHODCALLTYPE D3D10Device::RSSetViewports(
           UINT                              NumViewports,
     const D3D10_VIEWPORT*                   pViewports) {
-    D3D10DeviceLock lock = LockDevice();
-    
     D3D11_VIEWPORT vp[D3D10_VIEWPORT_AND_SCISSORRECT_OBJECT_COUNT_PER_PIPELINE];
 
     if (NumViewports > D3D10_VIEWPORT_AND_SCISSORRECT_OBJECT_COUNT_PER_PIPELINE)
@@ -1595,16 +1488,12 @@ namespace dxvk {
   void STDMETHODCALLTYPE D3D10Device::RSSetScissorRects(
           UINT                              NumRects,
     const D3D10_RECT*                       pRects) {
-    D3D10DeviceLock lock = LockDevice();
-    
     m_context->RSSetScissorRects(NumRects, pRects);
   }
 
 
   void STDMETHODCALLTYPE D3D10Device::RSGetState(
           ID3D10RasterizerState**           ppRasterizerState) {
-    D3D10DeviceLock lock = LockDevice();
-    
     ID3D11RasterizerState* d3d11RasterizerState = nullptr;
     m_context->RSGetState(&d3d11RasterizerState);
 
@@ -1615,8 +1504,6 @@ namespace dxvk {
   void STDMETHODCALLTYPE D3D10Device::RSGetViewports(
           UINT*                             NumViewports,
           D3D10_VIEWPORT*                   pViewports) {
-    D3D10DeviceLock lock = LockDevice();
-    
     D3D11_VIEWPORT vp[D3D10_VIEWPORT_AND_SCISSORRECT_OBJECT_COUNT_PER_PIPELINE];
     m_context->RSGetViewports(NumViewports, pViewports != nullptr ? vp : nullptr);
 
@@ -1636,8 +1523,6 @@ namespace dxvk {
   void STDMETHODCALLTYPE D3D10Device::RSGetScissorRects(
           UINT*                             NumRects,
           D3D10_RECT*                       pRects) {
-    D3D10DeviceLock lock = LockDevice();
-    
     m_context->RSGetScissorRects(NumRects, pRects);
   }
 
@@ -1646,8 +1531,6 @@ namespace dxvk {
           UINT                              NumBuffers,
           ID3D10Buffer* const*              ppSOTargets,
     const UINT*                             pOffsets) {
-    D3D10DeviceLock lock = LockDevice();
-    
     ID3D11Buffer* d3d11Buffers[D3D10_SO_BUFFER_SLOT_COUNT];
 
     if (NumBuffers > D3D10_SO_BUFFER_SLOT_COUNT)
@@ -1662,13 +1545,11 @@ namespace dxvk {
     m_context->SOSetTargets(NumBuffers, d3d11Buffers, pOffsets);
   }
 
-  
+
   void STDMETHODCALLTYPE D3D10Device::SOGetTargets(
           UINT                              NumBuffers,
           ID3D10Buffer**                    ppSOTargets,
           UINT*                             pOffsets) {
-    D3D10DeviceLock lock = LockDevice();
-    
     ID3D11Buffer* d3d11Buffers[D3D10_SO_BUFFER_SLOT_COUNT];
 
     m_context->SOGetTargetsWithOffsets(NumBuffers,

--- a/src/d3d10/d3d10_device.h
+++ b/src/d3d10/d3d10_device.h
@@ -469,20 +469,11 @@ namespace dxvk {
     void STDMETHODCALLTYPE GetTextFilterSize(
             UINT*                             pWidth,
             UINT*                             pHeight);
-    
-    D3D10DeviceLock LockDevice() {
-      return m_multithread.AcquireLock();
-    }
 
-    D3D10Multithread* GetMultithread() {
-      return &m_multithread;
-    }
-    
   private:
 
     D3D11Device*            m_device;
     D3D11ImmediateContext*  m_context;
-    D3D10Multithread        m_multithread;
 
   };
 

--- a/src/d3d10/d3d10_main.cpp
+++ b/src/d3d10/d3d10_main.cpp
@@ -40,9 +40,13 @@ extern "C" {
 
     hr = D3D11CoreCreateDevice(pFactory, pAdapter,
       Flags, &FeatureLevel, 1, &d3d11Device);
-    
+
     if (FAILED(hr))
       return hr;
+    
+    Com<ID3D10Multithread> multithread;
+    d3d11Device->QueryInterface(__uuidof(ID3D10Multithread), reinterpret_cast<void**>(&multithread));
+    multithread->SetMultithreadProtected(!(Flags & D3D10_CREATE_DEVICE_SINGLETHREADED));
     
     if (FAILED(d3d11Device->QueryInterface(
         __uuidof(ID3D10Device), reinterpret_cast<void**>(ppDevice))))

--- a/src/d3d10/d3d10_query.cpp
+++ b/src/d3d10/d3d10_query.cpp
@@ -54,8 +54,6 @@ namespace dxvk {
 
 
   void STDMETHODCALLTYPE D3D10Query::Begin() {
-    D3D10DeviceLock lock = m_device->LockDevice();
-    
     Com<ID3D11DeviceContext> ctx;
     GetD3D11Context(m_d3d11, &ctx);
 
@@ -64,8 +62,6 @@ namespace dxvk {
 
 
   void STDMETHODCALLTYPE D3D10Query::End() {
-    D3D10DeviceLock lock = m_device->LockDevice();
-    
     Com<ID3D11DeviceContext> ctx;
     GetD3D11Context(m_d3d11, &ctx);
 
@@ -77,8 +73,6 @@ namespace dxvk {
           void*                     pData,
           UINT                      DataSize,
           UINT                      GetDataFlags) {
-    D3D10DeviceLock lock = m_device->LockDevice();
-    
     Com<ID3D11DeviceContext> ctx;
     GetD3D11Context(m_d3d11, &ctx);
 

--- a/src/d3d10/d3d10_texture.cpp
+++ b/src/d3d10/d3d10_texture.cpp
@@ -75,8 +75,6 @@ namespace dxvk {
           D3D10_MAP                 MapType,
           UINT                      MapFlags,
           void**                    ppData) {
-    D3D10DeviceLock lock = m_device->LockDevice();
-
     Com<ID3D11DeviceContext> ctx;
     GetD3D11Context(m_d3d11, &ctx);
 
@@ -96,8 +94,6 @@ namespace dxvk {
 
   void STDMETHODCALLTYPE D3D10Texture1D::Unmap(
           UINT                      Subresource) {
-    D3D10DeviceLock lock = m_device->LockDevice();
-
     Com<ID3D11DeviceContext> ctx;
     GetD3D11Context(m_d3d11, &ctx);
 
@@ -189,8 +185,6 @@ namespace dxvk {
           D3D10_MAP                 MapType,
           UINT                      MapFlags,
           D3D10_MAPPED_TEXTURE2D*   pMappedTex2D) {
-    D3D10DeviceLock lock = m_device->LockDevice();
-
     Com<ID3D11DeviceContext> ctx;
     GetD3D11Context(m_d3d11, &ctx);
 
@@ -211,8 +205,6 @@ namespace dxvk {
 
   void STDMETHODCALLTYPE D3D10Texture2D::Unmap(
           UINT                      Subresource) {
-    D3D10DeviceLock lock = m_device->LockDevice();
-    
     Com<ID3D11DeviceContext> ctx;
     GetD3D11Context(m_d3d11, &ctx);
 
@@ -306,8 +298,6 @@ namespace dxvk {
           D3D10_MAP                 MapType,
           UINT                      MapFlags,
           D3D10_MAPPED_TEXTURE3D*   pMappedTex3D) {
-    D3D10DeviceLock lock = m_device->LockDevice();
-
     Com<ID3D11DeviceContext> ctx;
     GetD3D11Context(m_d3d11, &ctx);
 
@@ -329,8 +319,6 @@ namespace dxvk {
 
   void STDMETHODCALLTYPE D3D10Texture3D::Unmap(
           UINT                      Subresource) {
-    D3D10DeviceLock lock = m_device->LockDevice();
-    
     Com<ID3D11DeviceContext> ctx;
     GetD3D11Context(m_d3d11, &ctx);
 

--- a/src/d3d11/d3d11_context.h
+++ b/src/d3d11/d3d11_context.h
@@ -644,7 +644,7 @@ namespace dxvk {
       const VkImageSubresourceRange*  pSubresources,
             VkImageLayout             OldLayout,
             VkImageLayout             NewLayout);
-    
+
   protected:
     
     D3D11Device* const          m_parent;

--- a/src/d3d11/d3d11_context_imm.cpp
+++ b/src/d3d11/d3d11_context_imm.cpp
@@ -547,6 +547,8 @@ namespace dxvk {
   
   
   void D3D11ImmediateContext::SynchronizeCsThread() {
+    D3D10DeviceLock lock = LockContext();
+
     // Dispatch current chunk so that all commands
     // recorded prior to this function will be run
     FlushCsChunk();

--- a/src/d3d11/d3d11_device.cpp
+++ b/src/d3d11/d3d11_device.cpp
@@ -1779,8 +1779,9 @@ namespace dxvk {
     }
 
     if (riid == __uuidof(ID3D10Multithread)) {
-      *ppvObject = ref(m_d3d11Device.GetD3D10Multithread());
-      return S_OK;
+      Com<ID3D11DeviceContext> context;
+      m_d3d11Device.GetImmediateContext(&context);
+      return context->QueryInterface(riid, ppvObject);
     }
     
     if (riid == __uuidof(ID3D11Debug))

--- a/src/d3d11/d3d11_device.h
+++ b/src/d3d11/d3d11_device.h
@@ -318,10 +318,6 @@ namespace dxvk {
     D3D10Device* GetD3D10Interface() const {
       return m_d3d10Device;
     }
-
-    D3D10Multithread* GetD3D10Multithread() const {
-      return m_d3d10Device->GetMultithread();
-    }
     
     DxvkBufferSlice AllocUavCounterSlice() { return m_uavCounters->AllocSlice(); }
     DxvkBufferSlice AllocXfbCounterSlice() { return m_xfbCounters->AllocSlice(); }


### PR DESCRIPTION
The D3D10Device uses a mutex to avoid accessing the D3D11ImmediateContext from multiple threads at the same time. The new D3D11Swapchain needs to be locked as well because with D3D10 it's not guaranteed that the game only accesses the ImmediateContext from the render thread.

This fixes Just Cause 2 for me. I haven't done that much testing, just 5 minutes of running around an shooting things.

In theory D3D11VkInterop has the same issue because it also accesses the ImmediateContext.
But that is only used with VR and thus D3D11, right?
