### PR TITLE
Only set 2D_ARRAY_COMPATIBLE on 3D textures that will be rendered to.

### DIFF
--- a/src/d3d11/d3d11_texture.cpp
+++ b/src/d3d11/d3d11_texture.cpp
@@ -101,7 +101,8 @@ namespace dxvk {
     if (m_desc.MiscFlags & D3D11_RESOURCE_MISC_TEXTURECUBE)
       imageInfo.flags |= VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT;
     
-    if (Dimension == D3D11_RESOURCE_DIMENSION_TEXTURE3D)
+    if (Dimension == D3D11_RESOURCE_DIMENSION_TEXTURE3D &&
+        (m_desc.BindFlags & D3D11_BIND_RENDER_TARGET))
       imageInfo.flags |= VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT_KHR;
     
     // Some image formats (i.e. the R32G32B32 ones) are


### PR DESCRIPTION
It is impossible to create a 2D or 2D array SRV or UAV from a 3D
texture. Nor is it possible to create a DSV from a 3D texture.
Therefore, the only time we ever need to create a 2D array view from a
3D texture is when we're going to render to it.

This is necessary to make 3D image views work with MoltenVK. Since
Metal doesn't natively support 2D array image views on 3D images,
MoltenVK doesn't allow creating Vulkan 2D array image views on a 3D
image unless it is known that the view will be used as a render target.
I'm aware this is technically in violation of the Vulkan spec, but we haven't
much of a choice here.