### PR TITLE
Change getEnvVar to use the standard library

### DIFF
--- a/src/util/util_env.cpp
+++ b/src/util/util_env.cpp
@@ -1,29 +1,16 @@
 #include "util_env.h"
 #include <vector>
+#include <cstdlib>
 
 #include "./com/com_include.h"
 
 namespace dxvk::env {
 
-  std::string getEnvVar(const std::string& name) {
-    int nameLen = ::MultiByteToWideChar(CP_ACP, 0, name.c_str(), name.length() + 1, nullptr, 0);
-
-    std::vector<WCHAR> wideName(nameLen);
-
-    ::MultiByteToWideChar(CP_ACP, 0, name.c_str(), name.length() + 1, wideName.data(), nameLen);
-
-    DWORD len = ::GetEnvironmentVariableW(wideName.data(), nullptr, 0);
-    
-    std::vector<WCHAR> result;
-    
-    while (len > result.size()) {
-      result.resize(len);
-      len = ::GetEnvironmentVariableW(
-        wideName.data(), result.data(), result.size());
-    }
-    
-    result.resize(len);
-    return str::fromws(result.data());
+  std::string getEnvVar(const char* name) {
+    char* result = std::getenv(name);
+    return (result)
+      ? result
+      : "";
   }
   
   

--- a/src/util/util_env.h
+++ b/src/util/util_env.h
@@ -13,7 +13,7 @@ namespace dxvk::env {
    * \param [in] name Name of the variable
    * \returns Value of the variable
    */
-  std::string getEnvVar(const std::string& name);
+  std::string getEnvVar(const char* name);
   
   /**
    * \brief Gets the executable name


### PR DESCRIPTION
The standard library already provides a function to retrieve the content of environment variables that both works on mingw and winelib applications so I believe it should be preferred over the Windows one, especially as it doesn't require to change back and forth between encodings.
I didn't just replace the function with std::getenv because it returns a char* instead of a std::string, that would possibly mess with some comparisons where getEnvVar is called, and by spec it returns a null pointer if the searched environment variable does not exists, breaking several std::string constructors in such scenario and therefore it has to be checked to return an empty string there.