### PR TITLE
[d3d11] Fix bad check in DrawInstancedIndirect

### DIFF
--- a/src/d3d11/d3d11_context.cpp
+++ b/src/d3d11/d3d11_context.cpp
@@ -1439,7 +1439,7 @@ namespace dxvk {
     constexpr VkDeviceSize stride = sizeof(VkDrawIndirectCommand);
     auto cmdData = static_cast<D3D11CmdDrawIndirectData*>(m_cmdData);
 
-    bool useMultiDraw = cmdData && cmdData->type == D3D11CmdType::DrawIndirectIndexed
+    bool useMultiDraw = cmdData && cmdData->type == D3D11CmdType::DrawIndirect
       && cmdData->offset + cmdData->count * stride == AlignedByteOffsetForArgs
       && m_device->features().core.features.multiDrawIndirect;
     


### PR DESCRIPTION
The code in DrawInstancedIndirect would reuse the cmdData if it was of type
DrawIndirectIndexed, which does not look correct. It looks like copy-paste
mistake - the same code is in DrawIndexedInstancedIndirect.