### PR TITLE
[d3d11] In D3D11CreateDevice, create DXGI factory with IDXGIFactory1 support

### DIFF
--- a/src/d3d11/d3d11_main.cpp
+++ b/src/d3d11/d3d11_main.cpp
@@ -118,7 +118,7 @@ extern "C" {
         Logger::warn("D3D11CreateDevice: Unsupported driver type");
       
       // We'll use the first adapter returned by a DXGI factory
-      if (FAILED(CreateDXGIFactory(__uuidof(IDXGIFactory), reinterpret_cast<void**>(&dxgiFactory)))) {
+      if (FAILED(CreateDXGIFactory1(__uuidof(IDXGIFactory), reinterpret_cast<void**>(&dxgiFactory)))) {
         Logger::err("D3D11CreateDevice: Failed to create a DXGI factory");
         return E_FAIL;
       }


### PR DESCRIPTION
Fixes running the Resident Evil 2 demo against Wine's DXGI.

Tests are here: https://source.winehq.org/git/wine.git/blob/b353d7c9148414be7c928e3925f4075b1578c0a8:/dlls/d3d11/tests/d3d11.c#l2019