### PR TITLE
Constant Buffer Bounds check option

### DIFF
--- a/src/d3d11/d3d11_options.cpp
+++ b/src/d3d11/d3d11_options.cpp
@@ -10,6 +10,7 @@ namespace dxvk {
     this->strictDivision          = config.getOption<bool>("d3d11.strictDivision", false);
     this->zeroInitWorkgroupMemory = config.getOption<bool>("d3d11.zeroInitWorkgroupMemory", false);
     this->relaxedBarriers       = config.getOption<bool>("d3d11.relaxedBarriers", false);
+    this->checkConstantBufferBounds = config.getOption<bool>("d3d11.checkConstantBufferBounds", false);
     this->maxTessFactor         = config.getOption<int32_t>("d3d11.maxTessFactor", 0);
     this->samplerAnisotropy     = config.getOption<int32_t>("d3d11.samplerAnisotropy", -1);
     this->deferSurfaceCreation  = config.getOption<bool>("dxgi.deferSurfaceCreation", false);

--- a/src/d3d11/d3d11_options.h
+++ b/src/d3d11/d3d11_options.h
@@ -7,11 +7,11 @@
 #include "d3d11_include.h"
 
 namespace dxvk {
-  
+
   struct D3D11Options {
     D3D11Options(const Config& config);
     /// Handle D3D11_MAP_FLAG_DO_NOT_WAIT properly.
-    /// 
+    ///
     /// This can offer substantial speedups, but some games
     /// (The Witcher 3, Elder Scrolls Online, possibly others)
     /// seem to make incorrect assumptions about when a map
@@ -42,6 +42,13 @@ namespace dxvk {
     /// but might also cause rendering issues.
     bool relaxedBarriers;
 
+    /// Check dynamic constant buffer index bounds
+    ///
+    /// Comes with a performance penalty and is not
+    /// completely accurate to D3D11 but fixes an
+    /// issue in Dark Souls Remastered
+    bool checkConstantBufferBounds = false;
+
     /// Maximum tessellation factor.
     ///
     /// Limits tessellation factors in tessellation
@@ -54,7 +61,7 @@ namespace dxvk {
     /// Enforces anisotropic filtering with the
     /// given anisotropy value for all samplers.
     int32_t samplerAnisotropy;
-    
+
     /// Back buffer count for the Vulkan swap chain.
     /// Overrides DXGI_SWAP_CHAIN_DESC::BufferCount.
     int32_t numBackBuffers;
@@ -72,5 +79,5 @@ namespace dxvk {
     /// for a single window that may interfere with each other.
     bool deferSurfaceCreation;
   };
-  
+
 }

--- a/src/dxbc/dxbc_compiler.cpp
+++ b/src/dxbc/dxbc_compiler.cpp
@@ -5236,7 +5236,7 @@ namespace dxvk {
     const DxbcRegisterValue constId = emitIndexLoad(reg.idx[1]);
     
     const uint32_t ptrTypeId = getPointerTypeId(info);
-    
+
     const std::array<uint32_t, 2> indices =
       {{ m_module.consti32(0), constId.id }};
     
@@ -5289,12 +5289,12 @@ namespace dxvk {
 
     // For dynamically indexed constant buffers, we should
     // return a vec4(0.0f) if the index is out of bounds
-    if (reg.idx[1].relReg != nullptr) {
+    if (m_moduleInfo.options.checkConstantBufferBounds && reg.idx[1].relReg != nullptr) {
       DxbcRegisterValue cbSize;
       cbSize.type = { DxbcScalarType::Uint32, 1 };
       cbSize.id   = m_module.constu32(m_constantBuffers.at(regId).size);
-      DxbcRegisterValue inBounds = emitRegisterExtend(emitIndexBoundCheck(constId, cbSize), 4);
 
+      DxbcRegisterValue inBounds = emitRegisterExtend(emitIndexBoundCheck(constId, cbSize), 4);
       result.type = ptr.type;
       result.id = m_module.opSelect(
         getVectorTypeId(result.type), inBounds.id, result.id,

--- a/src/dxbc/dxbc_compiler.h
+++ b/src/dxbc/dxbc_compiler.h
@@ -958,6 +958,10 @@ namespace dxvk {
     
     //////////////////////////////
     // Operand load/store methods
+    DxbcRegisterValue emitIndexBoundCheck(
+          DxbcRegisterValue       index,
+            DxbcRegisterValue       count);
+
     DxbcRegisterValue emitIndexLoad(
             DxbcRegIndex            index);
     

--- a/src/dxbc/dxbc_options.cpp
+++ b/src/dxbc/dxbc_options.cpp
@@ -27,10 +27,11 @@ namespace dxvk {
       = (devInfo.core.properties.limits.minStorageBufferOffsetAlignment <= sizeof(uint32_t));
     useSdivForBufferIndex
       = adapter->matchesDriver(DxvkGpuVendor::Nvidia, VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR, 0, 0);
-    
+
     strictDivision          = options.strictDivision;
     zeroInitWorkgroupMemory = options.zeroInitWorkgroupMemory;
-    
+    checkConstantBufferBounds = options.checkConstantBufferBounds;
+
     // Disable early discard on RADV due to GPU hangs
     // Disable early discard on Nvidia because it may hurt performance
     if (adapter->matchesDriver(DxvkGpuVendor::Amd,    VK_DRIVER_ID_MESA_RADV_KHR,          0, 0)

--- a/src/dxbc/dxbc_options.h
+++ b/src/dxbc/dxbc_options.h
@@ -5,7 +5,7 @@
 namespace dxvk {
 
   struct D3D11Options;
-  
+
   struct DxbcOptions {
     DxbcOptions();
     DxbcOptions(const Rc<DxvkDevice>& device, const D3D11Options& options);
@@ -34,6 +34,9 @@ namespace dxvk {
 
     /// Clear thread-group shared memory to zero
     bool zeroInitWorkgroupMemory = false;
+
+    /// Check dynamic constant buffer index bounds
+    bool checkConstantBufferBounds = false;
   };
-  
+
 }

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -122,6 +122,10 @@ namespace dxvk {
     { "DarkSoulsRemastered.exe", {{
       { "d3d11.checkConstantBufferBounds",  "True" },
     }} },
+    /* Grim Dawn                                  */
+    { "Grim Dawn.exe", {{
+      { "d3d11.checkConstantBufferBounds",  "True" },
+    }} },
   }};
 
 

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -118,6 +118,10 @@ namespace dxvk {
     { "starwarsbattlefronttrial.exe", {{
       { "dxgi.nvapiHack",                   "False" },
     }} },
+    /* Dark Souls Remastered                      */
+    { "DarkSoulsRemastered.exe", {{
+      { "d3d11.checkConstantBufferBounds",  "True" },
+    }} },
   }};
 
 


### PR DESCRIPTION
This brings back 621aed5fdbaf92764944be7b3a27cbb3df63ba94 but disables it for everything other than Dark Souls Remastered.