### PR TITLE
Create separate log files for each d3d10 module

### DIFF
--- a/src/d3d10/d3d10_main.cpp
+++ b/src/d3d10/d3d10_main.cpp
@@ -5,8 +5,10 @@
 
 #include "../dxgi/dxgi_adapter.h"
 
+#include "../util/util_str.h"
+
 namespace dxvk {
-  Logger Logger::s_instance("d3d10.log");
+  Logger Logger::s_instance(xstr(LOGGER_FILENAME));
 }
 
 extern "C" {

--- a/src/d3d10/meson.build
+++ b/src/d3d10/meson.build
@@ -13,6 +13,7 @@ d3d10_core_dll = shared_library('d3d10core'+dll_ext, d3d10_main_src,
   install             : true,
   objects             : not dxvk_msvc ? 'd3d10core'+def_spec_ext : [],
   vs_module_defs      : 'd3d10core'+def_spec_ext,
+  cpp_args            : '-DLOGGER_FILENAME=d3d10core.log',
   override_options    : ['cpp_std='+dxvk_cpp_std])
 
 d3d10_dll = shared_library('d3d10'+dll_ext, d3d10_main_src,
@@ -22,6 +23,7 @@ d3d10_dll = shared_library('d3d10'+dll_ext, d3d10_main_src,
   install             : true,
   objects             : not dxvk_msvc ? 'd3d10'+def_spec_ext : [],
   vs_module_defs      : 'd3d10'+def_spec_ext,
+  cpp_args            : '-DLOGGER_FILENAME=d3d10.log',
   override_options    : ['cpp_std='+dxvk_cpp_std])
 
 d3d10_1_dll = shared_library('d3d10_1'+dll_ext, d3d10_main_src,
@@ -31,6 +33,7 @@ d3d10_1_dll = shared_library('d3d10_1'+dll_ext, d3d10_main_src,
   install             : true,
   objects             : not dxvk_msvc ? 'd3d10_1'+def_spec_ext : [],
   vs_module_defs      : 'd3d10_1'+def_spec_ext,
+  cpp_args            : '-DLOGGER_FILENAME=d3d10_1.log',
   override_options    : ['cpp_std='+dxvk_cpp_std])
 
 d3d10_dep = declare_dependency(

--- a/src/d3d11/d3d11_main.cpp
+++ b/src/d3d11/d3d11_main.cpp
@@ -9,8 +9,10 @@
 #include "d3d11_interop.h"
 #include "d3d11_present.h"
 
+#include "../util/util_str.h"
+
 namespace dxvk {
-  Logger Logger::s_instance("d3d11.log");
+  Logger Logger::s_instance(xstr(LOGGER_FILENAME));
 }
   
 extern "C" {

--- a/src/d3d11/meson.build
+++ b/src/d3d11/meson.build
@@ -62,6 +62,7 @@ d3d11_dll = shared_library('d3d11'+dll_ext, dxgi_common_src + d3d11_src + d3d10_
   install             : true,
   objects             : not dxvk_msvc ? 'd3d11'+def_spec_ext : [],
   vs_module_defs      : 'd3d11'+def_spec_ext,
+  cpp_args            : '-DLOGGER_FILENAME=d3d11.log',
   override_options    : ['cpp_std='+dxvk_cpp_std])
 
 d3d11_dep = declare_dependency(

--- a/src/dxgi/dxgi_main.cpp
+++ b/src/dxgi/dxgi_main.cpp
@@ -1,9 +1,11 @@
 #include "dxgi_factory.h"
 #include "dxgi_include.h"
 
+#include "../util/util_str.h"
+
 namespace dxvk {
   
-  Logger Logger::s_instance("dxgi.log");
+  Logger Logger::s_instance(xstr(LOGGER_FILENAME));
   
   HRESULT createDxgiFactory(UINT Flags, REFIID riid, void **ppFactory) {
     try {

--- a/src/dxgi/meson.build
+++ b/src/dxgi/meson.build
@@ -22,6 +22,7 @@ dxgi_dll = shared_library('dxgi'+dll_ext, dxgi_src,
   install             : true,
   vs_module_defs      : 'dxgi'+def_spec_ext,
   objects             : not dxvk_msvc ? 'dxgi'+def_spec_ext : [],
+  cpp_args            : '-DLOGGER_FILENAME=dxgi.log',
   override_options    : ['cpp_std='+dxvk_cpp_std])
 
 dxgi_dep = declare_dependency(

--- a/src/util/util_str.h
+++ b/src/util/util_str.h
@@ -1,0 +1,2 @@
+#define str(s) #s
+#define xstr(s) str(s)


### PR DESCRIPTION
Hi there,

While playing a little bit with a d3d10 application I stumbled over some inconsistencies between the content of the log files and the log output on the console for d3d10 log statements. When digging into it I recognized that every d3d10 module (d3d10, d3d10_1, d3d10core) creates a logger for d3d10.log. These loggers can then overwrite each others content since every logger create its own stream to the log file.

This PR aims to create a separate logger for each d3d10 module by passing the file name for the logger as compiler argument into the compilation step. I did the same for the d3d11 and dxgi module for consistency.

Let me know what you think and where I could improve, _if_ you like this approach. I could actually go even further and determine the file name solemnly within the constructor the the logger. On the other hand I could also revert the changes for d3d11 and dxgi to handle only the problematic d3d10 modules with this way. I haven't touched the logger initialization of the test executable's, e.g. dxbc-compiler (yet).

PS: This is actually my third attempt to set the logger file name for each module sepately. I naively tried to use a static map of streams per logger file name, but that obviously didn't work because the logger sources are compiled into each module separately. (This took me quite some time to figure this out ;)) My second attempt was to get the module name at runtime using 'dllmain' and 'getmodulefilename'. That actually worked but felt a little bit tricky since the logger _must_ be initialized after 'dllmain' in this case. Using a compiler argument seemed the sanest solution imho.