### PR TITLE
[d3d11, d3d10, dxgi] Handle null ppvObject in QueryInterface.

### DIFF
--- a/src/d3d10/d3d10_reflection.cpp
+++ b/src/d3d10/d3d10_reflection.cpp
@@ -173,6 +173,9 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE D3D10ShaderReflection::QueryInterface(
           REFIID              riid,
           void**              ppvObject) {
+    if (ppvObject == nullptr)
+      return E_POINTER;
+
     static const GUID IID_ID3D10ShaderReflection
       = {0xd40e20b6,0xf8f7,0x42ad,{0xab,0x20,0x4b,0xaf,0x8f,0x15,0xdf,0xaa}};
 

--- a/src/d3d11/d3d11_blend.cpp
+++ b/src/d3d11/d3d11_blend.cpp
@@ -38,6 +38,9 @@ namespace dxvk {
   
   
   HRESULT STDMETHODCALLTYPE D3D11BlendState::QueryInterface(REFIID riid, void** ppvObject) {
+    if (ppvObject == nullptr)
+      return E_POINTER;
+
     *ppvObject = nullptr;
     
     if (riid == __uuidof(IUnknown)

--- a/src/d3d11/d3d11_buffer.cpp
+++ b/src/d3d11/d3d11_buffer.cpp
@@ -113,6 +113,9 @@ namespace dxvk {
   
   
   HRESULT STDMETHODCALLTYPE D3D11Buffer::QueryInterface(REFIID riid, void** ppvObject) {
+    if (ppvObject == nullptr)
+      return E_POINTER;
+
     *ppvObject = nullptr;
     
     if (riid == __uuidof(IUnknown)

--- a/src/d3d11/d3d11_class_linkage.cpp
+++ b/src/d3d11/d3d11_class_linkage.cpp
@@ -16,6 +16,9 @@ namespace dxvk {
   
   
   HRESULT STDMETHODCALLTYPE D3D11ClassLinkage::QueryInterface(REFIID riid, void** ppvObject) {
+    if (ppvObject == nullptr)
+      return E_POINTER;
+
     *ppvObject = nullptr;
     
     if (riid == __uuidof(IUnknown)

--- a/src/d3d11/d3d11_cmdlist.cpp
+++ b/src/d3d11/d3d11_cmdlist.cpp
@@ -16,6 +16,9 @@ namespace dxvk {
   
   
   HRESULT STDMETHODCALLTYPE D3D11CommandList::QueryInterface(REFIID riid, void** ppvObject) {
+    if (ppvObject == nullptr)
+      return E_POINTER;
+
     *ppvObject = nullptr;
     
     if (riid == __uuidof(IUnknown)

--- a/src/d3d11/d3d11_context.cpp
+++ b/src/d3d11/d3d11_context.cpp
@@ -45,6 +45,9 @@ namespace dxvk {
   
   
   HRESULT STDMETHODCALLTYPE D3D11DeviceContext::QueryInterface(REFIID riid, void** ppvObject) {
+    if (ppvObject == nullptr)
+      return E_POINTER;
+
     *ppvObject = nullptr;
     
     if (riid == __uuidof(IUnknown)

--- a/src/d3d11/d3d11_depth_stencil.cpp
+++ b/src/d3d11/d3d11_depth_stencil.cpp
@@ -22,6 +22,9 @@ namespace dxvk {
   
   
   HRESULT STDMETHODCALLTYPE D3D11DepthStencilState::QueryInterface(REFIID riid, void** ppvObject) {
+    if (ppvObject == nullptr)
+      return E_POINTER;
+
     *ppvObject = nullptr;
     
     if (riid == __uuidof(IUnknown)

--- a/src/d3d11/d3d11_device.cpp
+++ b/src/d3d11/d3d11_device.cpp
@@ -1753,6 +1753,9 @@ namespace dxvk {
   
   
   HRESULT STDMETHODCALLTYPE D3D11DXGIDevice::QueryInterface(REFIID riid, void** ppvObject) {
+    if (ppvObject == nullptr)
+      return E_POINTER;
+
     *ppvObject = nullptr;
     
     if (riid == __uuidof(IUnknown)

--- a/src/d3d11/d3d11_input_layout.cpp
+++ b/src/d3d11/d3d11_input_layout.cpp
@@ -27,6 +27,9 @@ namespace dxvk {
   
   
   HRESULT STDMETHODCALLTYPE D3D11InputLayout::QueryInterface(REFIID riid, void** ppvObject) {
+    if (ppvObject == nullptr)
+      return E_POINTER;
+
     *ppvObject = nullptr;
     
     if (riid == __uuidof(IUnknown)

--- a/src/d3d11/d3d11_query.cpp
+++ b/src/d3d11/d3d11_query.cpp
@@ -78,6 +78,9 @@ namespace dxvk {
   
     
   HRESULT STDMETHODCALLTYPE D3D11Query::QueryInterface(REFIID  riid, void** ppvObject) {
+    if (ppvObject == nullptr)
+      return E_POINTER;
+
     *ppvObject = nullptr;
     
     if (riid == __uuidof(IUnknown)

--- a/src/d3d11/d3d11_rasterizer.cpp
+++ b/src/d3d11/d3d11_rasterizer.cpp
@@ -63,6 +63,9 @@ namespace dxvk {
   
   
   HRESULT STDMETHODCALLTYPE D3D11RasterizerState::QueryInterface(REFIID riid, void** ppvObject) {
+    if (ppvObject == nullptr)
+      return E_POINTER;
+
     *ppvObject = nullptr;
     
     if (riid == __uuidof(IUnknown)

--- a/src/d3d11/d3d11_sampler.cpp
+++ b/src/d3d11/d3d11_sampler.cpp
@@ -60,6 +60,9 @@ namespace dxvk {
   
   
   HRESULT STDMETHODCALLTYPE D3D11SamplerState::QueryInterface(REFIID riid, void** ppvObject) {
+    if (ppvObject == nullptr)
+      return E_POINTER;
+
     *ppvObject = nullptr;
     
     if (riid == __uuidof(IUnknown)

--- a/src/d3d11/d3d11_swapchain.cpp
+++ b/src/d3d11/d3d11_swapchain.cpp
@@ -50,6 +50,9 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE D3D11SwapChain::QueryInterface(
           REFIID                  riid,
           void**                  ppvObject) {
+    if (ppvObject == nullptr)
+      return E_POINTER;
+
     InitReturnPtr(ppvObject);
 
     if (riid == __uuidof(IUnknown)

--- a/src/d3d11/d3d11_texture.cpp
+++ b/src/d3d11/d3d11_texture.cpp
@@ -568,6 +568,9 @@ namespace dxvk {
   
   
   HRESULT STDMETHODCALLTYPE D3D11Texture1D::QueryInterface(REFIID riid, void** ppvObject) {
+    if (ppvObject == nullptr)
+      return E_POINTER;
+
     *ppvObject = nullptr;
     
     if (riid == __uuidof(IUnknown)
@@ -649,6 +652,9 @@ namespace dxvk {
   
   
   HRESULT STDMETHODCALLTYPE D3D11Texture2D::QueryInterface(REFIID riid, void** ppvObject) {
+    if (ppvObject == nullptr)
+      return E_POINTER;
+
     *ppvObject = nullptr;
     
     if (riid == __uuidof(IUnknown)
@@ -732,6 +738,9 @@ namespace dxvk {
   
   
   HRESULT STDMETHODCALLTYPE D3D11Texture3D::QueryInterface(REFIID riid, void** ppvObject) {
+    if (ppvObject == nullptr)
+      return E_POINTER;
+
     *ppvObject = nullptr;
     
     if (riid == __uuidof(IUnknown)

--- a/src/d3d11/d3d11_view_dsv.cpp
+++ b/src/d3d11/d3d11_view_dsv.cpp
@@ -90,6 +90,9 @@ namespace dxvk {
   
   
   HRESULT STDMETHODCALLTYPE D3D11DepthStencilView::QueryInterface(REFIID riid, void** ppvObject) {
+    if (ppvObject == nullptr)
+      return E_POINTER;
+
     *ppvObject = nullptr;
     
     if (riid == __uuidof(IUnknown)

--- a/src/d3d11/d3d11_view_rtv.cpp
+++ b/src/d3d11/d3d11_view_rtv.cpp
@@ -102,6 +102,9 @@ namespace dxvk {
   
   
   HRESULT STDMETHODCALLTYPE D3D11RenderTargetView::QueryInterface(REFIID riid, void** ppvObject) {
+    if (ppvObject == nullptr)
+      return E_POINTER;
+
     *ppvObject = nullptr;
     
     if (riid == __uuidof(IUnknown)

--- a/src/d3d11/d3d11_view_srv.cpp
+++ b/src/d3d11/d3d11_view_srv.cpp
@@ -167,6 +167,9 @@ namespace dxvk {
   
   
   HRESULT STDMETHODCALLTYPE D3D11ShaderResourceView::QueryInterface(REFIID riid, void** ppvObject) {
+    if (ppvObject == nullptr)
+      return E_POINTER;
+
     *ppvObject = nullptr;
     
     if (riid == __uuidof(IUnknown)

--- a/src/d3d11/d3d11_view_uav.cpp
+++ b/src/d3d11/d3d11_view_uav.cpp
@@ -114,6 +114,9 @@ namespace dxvk {
   
   
   HRESULT STDMETHODCALLTYPE D3D11UnorderedAccessView::QueryInterface(REFIID riid, void** ppvObject) {
+    if (ppvObject == nullptr)
+      return E_POINTER;
+
     *ppvObject = nullptr;
     
     if (riid == __uuidof(IUnknown)

--- a/src/dxgi/dxgi_adapter.cpp
+++ b/src/dxgi/dxgi_adapter.cpp
@@ -27,6 +27,9 @@ namespace dxvk {
   
   
   HRESULT STDMETHODCALLTYPE DxgiAdapter::QueryInterface(REFIID riid, void** ppvObject) {
+    if (ppvObject == nullptr)
+      return E_POINTER;
+
     *ppvObject = nullptr;
     
     if (riid == __uuidof(IUnknown)

--- a/src/dxgi/dxgi_factory.cpp
+++ b/src/dxgi/dxgi_factory.cpp
@@ -18,6 +18,9 @@ namespace dxvk {
   
   
   HRESULT STDMETHODCALLTYPE DxgiFactory::QueryInterface(REFIID riid, void** ppvObject) {
+    if (ppvObject == nullptr)
+      return E_POINTER;
+
     *ppvObject = nullptr;
     
     if (riid == __uuidof(IUnknown)

--- a/src/dxgi/dxgi_output.cpp
+++ b/src/dxgi/dxgi_output.cpp
@@ -41,6 +41,9 @@ namespace dxvk {
   
   
   HRESULT STDMETHODCALLTYPE DxgiOutput::QueryInterface(REFIID riid, void** ppvObject) {
+    if (ppvObject == nullptr)
+      return E_POINTER;
+
     *ppvObject = nullptr;
     
     if (riid == __uuidof(IUnknown)

--- a/src/dxgi/dxgi_swapchain.cpp
+++ b/src/dxgi/dxgi_swapchain.cpp
@@ -48,6 +48,9 @@ namespace dxvk {
   
   
   HRESULT STDMETHODCALLTYPE DxgiSwapChain::QueryInterface(REFIID riid, void** ppvObject) {
+    if (ppvObject == nullptr)
+      return E_POINTER;
+
     *ppvObject = nullptr;
     
     if (riid == __uuidof(IUnknown)


### PR DESCRIPTION
When a null ppvObject is passed into a QueryInterface on any IUnknown, a E_POINTER should be returned as the result (and it should not crash.)

This matches native d3d11/d3d10/dxgi behaviour and the documentation found here https://docs.microsoft.com/en-us/windows/desktop/api/unknwn/nf-unknwn-iunknown-queryinterface(q_) for IUnknown.