### PR TITLE
fix old year (2018) in file (now 2019)

### DIFF
--- a/utils/setup_dxvk.verb
+++ b/utils/setup_dxvk.verb
@@ -1,7 +1,7 @@
 w_metadata setup_dxvk dlls \
     title="DXVK" \
     publisher="Philip Rebohle" \
-    year="2018" \
+    year="2019" \
     media="manual_download" \
     file1="dxgi.dll" \
     file2="d3d11.dll" \


### PR DESCRIPTION
hello mr. doitsujin

this makes it so the file setup_dxvk.verb doesn't have the old year (2018) but replaces it with the new year (2019)

the commit description is: update the year to the current year (2019)

thank you for your time and open code! 😄

