### PR TITLE
Update DXVK_FILTER_DEVICE_NAME to support matching substrings

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Additionally, `DXVK_HUD=1` has the same effect as `DXVK_HUD=devinfo,fps`, and `D
 
 ### Device filter
 Some applications do not provide a method to select a different GPU. In that case, DXVK can be forced to use a given device:
-- `DXVK_FILTER_DEVICE_NAME="Device Name"` Selects devices with a matching Vulkan device name, which can be retrieved with tools such as `vulkaninfo`.
+- `DXVK_FILTER_DEVICE_NAME="Device Name"` Selects devices with a matching Vulkan device name, which can be retrieved with tools such as `vulkaninfo`. Matches on substrings, so "VEGA" or "AMD RADV VEGA10" is supported if the full device name is "AMD RADV VEGA10 (LLVM 9.0.0)", for example. If the substring matches more than one device, the first device matched will be used.
 
 **Note:** If the device filter is configured incorrectly, it may filter out all devices and applications will be unable to create a D3D device.
 

--- a/src/dxvk/dxvk_device_filter.cpp
+++ b/src/dxvk/dxvk_device_filter.cpp
@@ -20,7 +20,7 @@ namespace dxvk {
     const auto& deviceProps = adapter->deviceProperties();
     
     if (m_flags.test(DxvkDeviceFilterFlag::MatchDeviceName)) {
-      if (deviceProps.deviceName != m_matchDeviceName)
+      if (std::string (deviceProps.deviceName).find(m_matchDeviceName) == std::string::npos)
         return false;
     }
       


### PR DESCRIPTION
Why? RADV device names include the LLVM version, which means that on every LLVM upgrade, the device name needs to be changed to match. This change allows setting something like "AMD RADV VEGA10" which should remain persistent over time.