### PR TITLE
[d3d11, d3d10, dxgi] Fix return values and add nullptr checks

### DIFF
--- a/src/d3d10/d3d10_device.cpp
+++ b/src/d3d10/d3d10_device.cpp
@@ -515,18 +515,21 @@ namespace dxvk {
     InitReturnPtr(ppBlendState);
 
     D3D11_BLEND_DESC d3d11Desc;
-    d3d11Desc.AlphaToCoverageEnable   = pBlendStateDesc->AlphaToCoverageEnable;
-    d3d11Desc.IndependentBlendEnable  = TRUE;
 
-    for (uint32_t i = 0; i < 8; i++) {
-      d3d11Desc.RenderTarget[i].BlendEnable           = pBlendStateDesc->BlendEnable[i];
-      d3d11Desc.RenderTarget[i].SrcBlend              = D3D11_BLEND   (pBlendStateDesc->SrcBlend);
-      d3d11Desc.RenderTarget[i].DestBlend             = D3D11_BLEND   (pBlendStateDesc->DestBlend);
-      d3d11Desc.RenderTarget[i].BlendOp               = D3D11_BLEND_OP(pBlendStateDesc->BlendOp);
-      d3d11Desc.RenderTarget[i].SrcBlendAlpha         = D3D11_BLEND   (pBlendStateDesc->SrcBlendAlpha);
-      d3d11Desc.RenderTarget[i].DestBlendAlpha        = D3D11_BLEND   (pBlendStateDesc->DestBlendAlpha);
-      d3d11Desc.RenderTarget[i].BlendOpAlpha          = D3D11_BLEND_OP(pBlendStateDesc->BlendOpAlpha);
-      d3d11Desc.RenderTarget[i].RenderTargetWriteMask = pBlendStateDesc->RenderTargetWriteMask[i];
+    if (pBlendStateDesc != nullptr) {
+      d3d11Desc.AlphaToCoverageEnable   = pBlendStateDesc->AlphaToCoverageEnable;
+      d3d11Desc.IndependentBlendEnable  = TRUE;
+
+      for (uint32_t i = 0; i < 8; i++) {
+        d3d11Desc.RenderTarget[i].BlendEnable           = pBlendStateDesc->BlendEnable[i];
+        d3d11Desc.RenderTarget[i].SrcBlend              = D3D11_BLEND   (pBlendStateDesc->SrcBlend);
+        d3d11Desc.RenderTarget[i].DestBlend             = D3D11_BLEND   (pBlendStateDesc->DestBlend);
+        d3d11Desc.RenderTarget[i].BlendOp               = D3D11_BLEND_OP(pBlendStateDesc->BlendOp);
+        d3d11Desc.RenderTarget[i].SrcBlendAlpha         = D3D11_BLEND   (pBlendStateDesc->SrcBlendAlpha);
+        d3d11Desc.RenderTarget[i].DestBlendAlpha        = D3D11_BLEND   (pBlendStateDesc->DestBlendAlpha);
+        d3d11Desc.RenderTarget[i].BlendOpAlpha          = D3D11_BLEND_OP(pBlendStateDesc->BlendOpAlpha);
+        d3d11Desc.RenderTarget[i].RenderTargetWriteMask = pBlendStateDesc->RenderTargetWriteMask[i];
+      }
     }
 
     ID3D11BlendState* d3d11BlendState = nullptr;

--- a/src/d3d10/d3d10_device.cpp
+++ b/src/d3d10/d3d10_device.cpp
@@ -110,13 +110,12 @@ namespace dxvk {
       reinterpret_cast<const D3D11_SUBRESOURCE_DATA*>(pInitialData),
       ppBuffer != nullptr ? &d3d11Buffer : nullptr);
     
-    if (FAILED(hr))
+    if (FAILED(hr) || hr == S_FALSE)
       return hr;
     
-    if (ppBuffer != nullptr) {
-      *ppBuffer = static_cast<D3D11Buffer*>(d3d11Buffer)->GetD3D10Iface();
-      return S_OK;
-    } return S_FALSE;
+    *ppBuffer = static_cast<D3D11Buffer*>(d3d11Buffer)->GetD3D10Iface();
+
+    return S_OK;
   }
 
 
@@ -144,13 +143,12 @@ namespace dxvk {
       reinterpret_cast<const D3D11_SUBRESOURCE_DATA*>(pInitialData),
       ppTexture1D != nullptr ? &d3d11Texture1D : nullptr);
     
-    if (FAILED(hr))
+    if (FAILED(hr) || hr == S_FALSE)
       return hr;
 
-    if (ppTexture1D != nullptr) {
-      *ppTexture1D = static_cast<D3D11Texture1D*>(d3d11Texture1D)->GetD3D10Iface();
-      return S_OK;
-    } return S_FALSE;
+    *ppTexture1D = static_cast<D3D11Texture1D*>(d3d11Texture1D)->GetD3D10Iface();
+
+    return S_OK;
   }
 
 
@@ -180,13 +178,12 @@ namespace dxvk {
       reinterpret_cast<const D3D11_SUBRESOURCE_DATA*>(pInitialData),
       ppTexture2D != nullptr ? &d3d11Texture2D : nullptr);
 
-    if (FAILED(hr))
+    if (FAILED(hr) || hr == S_FALSE)
       return hr;
 
-    if (ppTexture2D != nullptr) {
-      *ppTexture2D = static_cast<D3D11Texture2D*>(d3d11Texture2D)->GetD3D10Iface();
-      return S_OK;
-    } return S_FALSE;
+    *ppTexture2D = static_cast<D3D11Texture2D*>(d3d11Texture2D)->GetD3D10Iface();
+
+    return S_OK;
   }
 
 
@@ -215,13 +212,12 @@ namespace dxvk {
       reinterpret_cast<const D3D11_SUBRESOURCE_DATA*>(pInitialData),
       ppTexture3D != nullptr ? &d3d11Texture3D : nullptr);
 
-    if (FAILED(hr))
+    if (FAILED(hr) || hr == S_FALSE)
       return hr;
 
-    if (ppTexture3D != nullptr) {
-      *ppTexture3D = static_cast<D3D11Texture3D*>(d3d11Texture3D)->GetD3D10Iface();
-      return S_OK;
-    } return S_FALSE;
+    *ppTexture3D = static_cast<D3D11Texture3D*>(d3d11Texture3D)->GetD3D10Iface();
+
+    return S_OK;
   }
 
 
@@ -242,13 +238,12 @@ namespace dxvk {
       reinterpret_cast<const D3D11_SHADER_RESOURCE_VIEW_DESC*>(pDesc),
       ppSRView ? &d3d11Srv : nullptr);
     
-    if (FAILED(hr))
+    if (FAILED(hr) || hr == S_FALSE)
       return hr;
     
-    if (ppSRView != nullptr) {
-      *ppSRView = static_cast<D3D11ShaderResourceView*>(d3d11Srv)->GetD3D10Iface();
-      return S_OK;
-    } return S_FALSE;
+    *ppSRView = static_cast<D3D11ShaderResourceView*>(d3d11Srv)->GetD3D10Iface();
+
+    return S_OK;
   }
 
 
@@ -269,13 +264,12 @@ namespace dxvk {
       reinterpret_cast<const D3D11_SHADER_RESOURCE_VIEW_DESC*>(pDesc),
       ppSRView ? &d3d11View : nullptr);
     
-    if (FAILED(hr))
+    if (FAILED(hr) || hr == S_FALSE)
       return hr;
     
-    if (ppSRView != nullptr) {
-      *ppSRView = static_cast<D3D11ShaderResourceView*>(d3d11View)->GetD3D10Iface();
-      return S_OK;
-    } return S_FALSE;
+    *ppSRView = static_cast<D3D11ShaderResourceView*>(d3d11View)->GetD3D10Iface();
+
+    return S_OK;
   }
 
 
@@ -296,13 +290,12 @@ namespace dxvk {
       reinterpret_cast<const D3D11_RENDER_TARGET_VIEW_DESC*>(pDesc),
       ppRTView ? &d3d11View : nullptr);
     
-    if (FAILED(hr))
+    if (FAILED(hr) || hr == S_FALSE)
       return hr;
     
-    if (ppRTView != nullptr) {
-      *ppRTView = static_cast<D3D11RenderTargetView*>(d3d11View)->GetD3D10Iface();
-      return S_OK;
-    } return S_FALSE;
+    *ppRTView = static_cast<D3D11RenderTargetView*>(d3d11View)->GetD3D10Iface();
+
+    return S_OK;
   }
 
 
@@ -366,13 +359,12 @@ namespace dxvk {
       d3d11Resource.ptr(), pDesc ? &d3d11Desc : nullptr,
       ppDepthStencilView ? &d3d11View : nullptr);
     
-    if (FAILED(hr))
+    if (FAILED(hr) || hr == S_FALSE)
       return hr;
     
-    if (ppDepthStencilView != nullptr) {
-      *ppDepthStencilView = static_cast<D3D11DepthStencilView*>(d3d11View)->GetD3D10Iface();
-      return S_OK;
-    } return S_FALSE;
+    *ppDepthStencilView = static_cast<D3D11DepthStencilView*>(d3d11View)->GetD3D10Iface();
+
+    return S_OK;
   }
 
 
@@ -396,8 +388,7 @@ namespace dxvk {
     if (FAILED(hr) || hr == S_FALSE)
       return hr;
     
-    if (ppInputLayout)
-      *ppInputLayout = static_cast<D3D11InputLayout*>(d3d11InputLayout)->GetD3D10Iface();
+    *ppInputLayout = static_cast<D3D11InputLayout*>(d3d11InputLayout)->GetD3D10Iface();
 
     return hr;
   }
@@ -415,13 +406,12 @@ namespace dxvk {
       pShaderBytecode, BytecodeLength, nullptr,
       ppVertexShader ? &d3d11Shader : nullptr);
     
-    if (FAILED(hr))
+    if (FAILED(hr) || hr == S_FALSE)
       return hr;
     
-    if (ppVertexShader != nullptr) {
-      *ppVertexShader = static_cast<D3D11VertexShader*>(d3d11Shader)->GetD3D10Iface();
-      return S_OK;
-    } return S_FALSE;
+    *ppVertexShader = static_cast<D3D11VertexShader*>(d3d11Shader)->GetD3D10Iface();
+
+    return S_OK;
   }
 
 
@@ -437,13 +427,12 @@ namespace dxvk {
       pShaderBytecode, BytecodeLength, nullptr,
       ppGeometryShader ? &d3d11Shader : nullptr);
     
-    if (FAILED(hr))
+    if (FAILED(hr) || hr == S_FALSE)
       return hr;
     
-    if (ppGeometryShader != nullptr) {
-      *ppGeometryShader = static_cast<D3D11GeometryShader*>(d3d11Shader)->GetD3D10Iface();
-      return S_OK;
-    } return S_FALSE;
+    *ppGeometryShader = static_cast<D3D11GeometryShader*>(d3d11Shader)->GetD3D10Iface();
+
+    return S_OK;
   }
 
 
@@ -477,13 +466,12 @@ namespace dxvk {
       D3D11_SO_NO_RASTERIZED_STREAM, nullptr,
       ppGeometryShader ? &d3d11Shader : nullptr);
     
-    if (FAILED(hr))
+    if (FAILED(hr) || hr == S_FALSE)
       return hr;
     
-    if (ppGeometryShader != nullptr) {
-      *ppGeometryShader = static_cast<D3D11GeometryShader*>(d3d11Shader)->GetD3D10Iface();
-      return S_OK;
-    } return S_FALSE;
+    *ppGeometryShader = static_cast<D3D11GeometryShader*>(d3d11Shader)->GetD3D10Iface();
+
+    return S_OK;
   }
 
 
@@ -499,13 +487,12 @@ namespace dxvk {
       pShaderBytecode, BytecodeLength, nullptr,
       ppPixelShader ? &d3d11Shader : nullptr);
     
-    if (FAILED(hr))
+    if (FAILED(hr) || hr == S_FALSE)
       return hr;
     
-    if (ppPixelShader != nullptr) {
-      *ppPixelShader = static_cast<D3D11PixelShader*>(d3d11Shader)->GetD3D10Iface();
-      return S_OK;
-    } return S_FALSE;
+    *ppPixelShader = static_cast<D3D11PixelShader*>(d3d11Shader)->GetD3D10Iface();
+
+    return S_OK;
   }
 
 
@@ -536,13 +523,12 @@ namespace dxvk {
     HRESULT hr = m_device->CreateBlendState(&d3d11Desc,
       ppBlendState ? &d3d11BlendState : nullptr);
     
-    if (FAILED(hr))
+    if (FAILED(hr) || hr == S_FALSE)
       return hr;
     
-    if (ppBlendState != nullptr) {
-      *ppBlendState = static_cast<D3D11BlendState*>(d3d11BlendState)->GetD3D10Iface();
-      return S_OK;
-    } return S_FALSE;
+    *ppBlendState = static_cast<D3D11BlendState*>(d3d11BlendState)->GetD3D10Iface();
+
+    return S_OK;
   }
 
 
@@ -556,13 +542,12 @@ namespace dxvk {
       reinterpret_cast<const D3D11_BLEND_DESC*>(pBlendStateDesc),
       ppBlendState ? &d3d11BlendState : nullptr);
     
-    if (FAILED(hr))
+    if (FAILED(hr) || hr == S_FALSE)
       return hr;
     
-    if (ppBlendState != nullptr) {
-      *ppBlendState = static_cast<D3D11BlendState*>(d3d11BlendState)->GetD3D10Iface();
-      return S_OK;
-    } return S_FALSE;
+    *ppBlendState = static_cast<D3D11BlendState*>(d3d11BlendState)->GetD3D10Iface();
+
+    return S_OK;
   }
 
 
@@ -576,13 +561,12 @@ namespace dxvk {
       reinterpret_cast<const D3D11_DEPTH_STENCIL_DESC*>(pDepthStencilDesc),
       ppDepthStencilState ? &d3d11DepthStencilState : nullptr);
     
-    if (FAILED(hr))
+    if (FAILED(hr) || hr == S_FALSE)
       return hr;
     
-    if (ppDepthStencilState != nullptr) {
-      *ppDepthStencilState = static_cast<D3D11DepthStencilState*>(d3d11DepthStencilState)->GetD3D10Iface();
-      return S_OK;
-    } return S_FALSE;
+    *ppDepthStencilState = static_cast<D3D11DepthStencilState*>(d3d11DepthStencilState)->GetD3D10Iface();
+
+    return S_OK;
   }
 
 
@@ -596,13 +580,12 @@ namespace dxvk {
       reinterpret_cast<const D3D11_RASTERIZER_DESC*>(pRasterizerDesc),
       ppRasterizerState ? &d3d11RasterizerState : nullptr);
     
-    if (FAILED(hr))
+    if (FAILED(hr) || hr == S_FALSE)
       return hr;
     
-    if (ppRasterizerState != nullptr) {
-      *ppRasterizerState = static_cast<D3D11RasterizerState*>(d3d11RasterizerState)->GetD3D10Iface();
-      return S_OK;
-    } return S_FALSE;
+    *ppRasterizerState = static_cast<D3D11RasterizerState*>(d3d11RasterizerState)->GetD3D10Iface();
+
+    return S_OK;
   }
 
 
@@ -632,13 +615,12 @@ namespace dxvk {
     HRESULT hr = m_device->CreateSamplerState(&d3d11Desc,
       ppSamplerState ? &d3d11SamplerState : nullptr);
     
-    if (FAILED(hr))
+    if (FAILED(hr) || hr == S_FALSE)
       return hr;
 
-    if (ppSamplerState) {
-      *ppSamplerState = static_cast<D3D11SamplerState*>(d3d11SamplerState)->GetD3D10Iface();
-      return S_OK;
-    } return S_FALSE;
+    *ppSamplerState = static_cast<D3D11SamplerState*>(d3d11SamplerState)->GetD3D10Iface();
+
+    return S_OK;
   }
 
 
@@ -658,13 +640,12 @@ namespace dxvk {
     HRESULT hr = m_device->CreateQuery(&d3d11Desc,
       ppQuery ? &d3d11Query : nullptr);
 
-    if (FAILED(hr))
+    if (FAILED(hr) || hr == S_FALSE)
       return hr;
-    
-    if (ppQuery != nullptr) {
-      *ppQuery = static_cast<D3D11Query*>(d3d11Query)->GetD3D10Iface();
-      return S_OK;
-    } return S_FALSE;
+
+    *ppQuery = static_cast<D3D11Query*>(d3d11Query)->GetD3D10Iface();
+
+     return S_OK;
   }
 
 
@@ -681,13 +662,12 @@ namespace dxvk {
     HRESULT hr = m_device->CreatePredicate(&d3d11Desc,
       ppPredicate ? &d3d11Predicate : nullptr);
 
-    if (FAILED(hr))
+    if (FAILED(hr) || hr == S_FALSE)
       return hr;
     
-    if (ppPredicate != nullptr) {
-      *ppPredicate = static_cast<D3D11Query*>(d3d11Predicate)->GetD3D10Iface();
-      return S_OK;
-    } return S_FALSE;
+    *ppPredicate = static_cast<D3D11Query*>(d3d11Predicate)->GetD3D10Iface();
+
+    return S_OK;
   }
 
 

--- a/src/d3d10/d3d10_device.cpp
+++ b/src/d3d10/d3d10_device.cpp
@@ -94,6 +94,9 @@ namespace dxvk {
           ID3D10Buffer**                    ppBuffer) {
     InitReturnPtr(ppBuffer);
 
+    if (pDesc == nullptr)
+      return E_INVALIDARG;
+
     D3D11_BUFFER_DESC d3d11Desc;
     d3d11Desc.ByteWidth       = pDesc->ByteWidth;
     d3d11Desc.Usage           = D3D11_USAGE(pDesc->Usage);
@@ -122,6 +125,9 @@ namespace dxvk {
     const D3D10_SUBRESOURCE_DATA*           pInitialData,
           ID3D10Texture1D**                 ppTexture1D) {
     InitReturnPtr(ppTexture1D);
+
+    if (pDesc == nullptr)
+      return E_INVALIDARG;
 
     D3D11_TEXTURE1D_DESC d3d11Desc;
     d3d11Desc.Width           = pDesc->Width;
@@ -153,6 +159,9 @@ namespace dxvk {
     const D3D10_SUBRESOURCE_DATA*           pInitialData,
           ID3D10Texture2D**                 ppTexture2D) {
     InitReturnPtr(ppTexture2D);
+
+    if (pDesc == nullptr)
+      return E_INVALIDARG;
 
     D3D11_TEXTURE2D_DESC d3d11Desc;
     d3d11Desc.Width           = pDesc->Width;
@@ -187,6 +196,9 @@ namespace dxvk {
           ID3D10Texture3D**                 ppTexture3D) {
     InitReturnPtr(ppTexture3D);
 
+    if (pDesc == nullptr)
+      return E_INVALIDARG;
+
     D3D11_TEXTURE3D_DESC d3d11Desc;
     d3d11Desc.Width           = pDesc->Width;
     d3d11Desc.Height          = pDesc->Height;
@@ -217,6 +229,11 @@ namespace dxvk {
           ID3D10Resource*                   pResource,
     const D3D10_SHADER_RESOURCE_VIEW_DESC*  pDesc,
           ID3D10ShaderResourceView**        ppSRView) {
+    InitReturnPtr(ppSRView);
+
+    if (pResource == nullptr)
+      return E_INVALIDARG;
+
     Com<ID3D11Resource> d3d11Resource;
     GetD3D11Resource(pResource, &d3d11Resource);
 
@@ -239,6 +256,11 @@ namespace dxvk {
           ID3D10Resource*                   pResource,
     const D3D10_SHADER_RESOURCE_VIEW_DESC1* pDesc,
           ID3D10ShaderResourceView1**       ppSRView) {
+    InitReturnPtr(ppSRView);
+
+    if (pResource == nullptr)
+      return E_INVALIDARG;
+
     Com<ID3D11Resource> d3d11Resource;
     GetD3D11Resource(pResource, &d3d11Resource);
 
@@ -261,6 +283,11 @@ namespace dxvk {
           ID3D10Resource*                   pResource,
     const D3D10_RENDER_TARGET_VIEW_DESC*    pDesc,
           ID3D10RenderTargetView**          ppRTView) {
+    InitReturnPtr(ppRTView);
+
+    if (pResource == nullptr)
+      return E_INVALIDARG;
+
     Com<ID3D11Resource> d3d11Resource;
     GetD3D11Resource(pResource, &d3d11Resource);
 
@@ -283,6 +310,11 @@ namespace dxvk {
           ID3D10Resource*                   pResource,
     const D3D10_DEPTH_STENCIL_VIEW_DESC*    pDesc,
           ID3D10DepthStencilView**          ppDepthStencilView) {
+    InitReturnPtr(ppDepthStencilView);
+
+    if (pResource == nullptr)
+      return E_INVALIDARG;
+
     Com<ID3D11Resource> d3d11Resource;
     GetD3D11Resource(pResource, &d3d11Resource);
 
@@ -361,13 +393,13 @@ namespace dxvk {
       NumElements, pShaderBytecodeWithInputSignature, BytecodeLength,
       ppInputLayout ? &d3d11InputLayout : nullptr);
     
-    if (FAILED(hr))
+    if (FAILED(hr) || hr == S_FALSE)
       return hr;
     
-    if (ppInputLayout) {
+    if (ppInputLayout)
       *ppInputLayout = static_cast<D3D11InputLayout*>(d3d11InputLayout)->GetD3D10Iface();
-      return S_OK;
-    } return S_FALSE;
+
+    return hr;
   }
 
 
@@ -576,6 +608,9 @@ namespace dxvk {
           ID3D10SamplerState**              ppSamplerState) {
     InitReturnPtr(ppSamplerState);
 
+    if (pSamplerDesc == nullptr)
+      return E_INVALIDARG;
+
     D3D11_SAMPLER_DESC d3d11Desc;
     d3d11Desc.Filter            = D3D11_FILTER(pSamplerDesc->Filter);
     d3d11Desc.AddressU          = D3D11_TEXTURE_ADDRESS_MODE(pSamplerDesc->AddressU);
@@ -608,6 +643,9 @@ namespace dxvk {
     const D3D10_QUERY_DESC*                 pQueryDesc,
           ID3D10Query**                     ppQuery) {
     InitReturnPtr(ppQuery);
+
+    if (pQueryDesc == nullptr)
+      return E_INVALIDARG;
 
     D3D11_QUERY_DESC d3d11Desc;
     d3d11Desc.Query      = D3D11_QUERY(pQueryDesc->Query);

--- a/src/d3d11/d3d11_device.cpp
+++ b/src/d3d11/d3d11_device.cpp
@@ -76,6 +76,9 @@ namespace dxvk {
           ID3D11Buffer**          ppBuffer) {
     InitReturnPtr(ppBuffer);
     
+    if (pDesc == nullptr)
+      return E_INVALIDARG;
+
     if (ppBuffer == nullptr)
       return S_FALSE;
     
@@ -88,7 +91,7 @@ namespace dxvk {
       return S_OK;
     } catch (const DxvkError& e) {
       Logger::err(e.message());
-      return E_FAIL;
+      return E_INVALIDARG;
     }
   }
   
@@ -98,6 +101,9 @@ namespace dxvk {
     const D3D11_SUBRESOURCE_DATA* pInitialData,
           ID3D11Texture1D**       ppTexture1D) {
     InitReturnPtr(ppTexture1D);
+
+    if (pDesc == nullptr)
+      return E_INVALIDARG;
     
     D3D11_COMMON_TEXTURE_DESC desc;
     desc.Width          = pDesc->Width;
@@ -125,7 +131,7 @@ namespace dxvk {
       return S_OK;
     } catch (const DxvkError& e) {
       Logger::err(e.message());
-      return E_FAIL;
+      return E_INVALIDARG;
     }
   }
   
@@ -135,6 +141,9 @@ namespace dxvk {
     const D3D11_SUBRESOURCE_DATA* pInitialData,
           ID3D11Texture2D**       ppTexture2D) {
     InitReturnPtr(ppTexture2D);
+
+    if (pDesc == nullptr)
+      return E_INVALIDARG;
     
     D3D11_COMMON_TEXTURE_DESC desc;
     desc.Width          = pDesc->Width;
@@ -162,7 +171,7 @@ namespace dxvk {
       return S_OK;
     } catch (const DxvkError& e) {
       Logger::err(e.message());
-      return E_FAIL;
+      return E_INVALIDARG;
     }
   }
   
@@ -172,6 +181,9 @@ namespace dxvk {
     const D3D11_SUBRESOURCE_DATA* pInitialData,
           ID3D11Texture3D**       ppTexture3D) {
     InitReturnPtr(ppTexture3D);
+
+    if (pDesc == nullptr)
+      return E_INVALIDARG;
     
     D3D11_COMMON_TEXTURE_DESC desc;
     desc.Width          = pDesc->Width;
@@ -199,7 +211,7 @@ namespace dxvk {
       return S_OK;
     } catch (const DxvkError& e) {
       Logger::err(e.message());
-      return E_FAIL;
+      return E_INVALIDARG;
     }
   }
   
@@ -247,7 +259,7 @@ namespace dxvk {
       return S_OK;
     } catch (const DxvkError& e) {
       Logger::err(e.message());
-      return E_FAIL;
+      return E_INVALIDARG;
     }
   }
   
@@ -295,7 +307,7 @@ namespace dxvk {
       return S_OK;
     } catch (const DxvkError& e) {
       Logger::err(e.message());
-      return E_FAIL;
+      return E_INVALIDARG;
     }
   }
   
@@ -349,7 +361,7 @@ namespace dxvk {
       return S_OK;
     } catch (const DxvkError& e) {
       Logger::err(e.message());
-      return E_FAIL;
+      return E_INVALIDARG;
     }
   }
   
@@ -397,7 +409,7 @@ namespace dxvk {
       return S_OK;
     } catch (const DxvkError& e) {
       Logger::err(e.message());
-      return E_FAIL;
+      return E_INVALIDARG;
     }
   }
   
@@ -409,6 +421,9 @@ namespace dxvk {
           SIZE_T                      BytecodeLength,
           ID3D11InputLayout**         ppInputLayout) {
     InitReturnPtr(ppInputLayout);
+
+    if (pInputElementDescs == nullptr)
+      return E_INVALIDARG;
     
     try {
       DxbcReader dxbcReader(reinterpret_cast<const char*>(
@@ -533,7 +548,7 @@ namespace dxvk {
       return S_OK;
     } catch (const DxvkError& e) {
       Logger::err(e.message());
-      return E_FAIL;
+      return E_INVALIDARG;
     }
   }
   
@@ -916,6 +931,10 @@ namespace dxvk {
     const D3D11_SAMPLER_DESC*         pSamplerDesc,
           ID3D11SamplerState**        ppSamplerState) {
     InitReturnPtr(ppSamplerState);
+
+    if (pSamplerDesc == nullptr)
+      return E_INVALIDARG;
+
     D3D11_SAMPLER_DESC desc = *pSamplerDesc;
     
     if (FAILED(D3D11SamplerState::NormalizeDesc(&desc)))
@@ -929,7 +948,7 @@ namespace dxvk {
       return S_OK;
     } catch (const DxvkError& e) {
       Logger::err(e.message());
-      return E_FAIL;
+      return E_INVALIDARG;
     }
   }
   
@@ -938,6 +957,9 @@ namespace dxvk {
     const D3D11_QUERY_DESC*           pQueryDesc,
           ID3D11Query**               ppQuery) {
     InitReturnPtr(ppQuery);
+
+    if (pQueryDesc == nullptr)
+      return E_INVALIDARG;
     
     if (ppQuery == nullptr)
       return S_FALSE;
@@ -947,7 +969,7 @@ namespace dxvk {
       return S_OK;
     } catch (const DxvkError& e) {
       Logger::err(e.message());
-      return E_FAIL;
+      return E_INVALIDARG;
     }
   }
   
@@ -957,7 +979,7 @@ namespace dxvk {
           ID3D11Predicate**           ppPredicate) {
     InitReturnPtr(ppPredicate);
     
-    if (pPredicateDesc->Query != D3D11_QUERY_OCCLUSION_PREDICATE)
+    if (pPredicateDesc == nullptr || pPredicateDesc->Query != D3D11_QUERY_OCCLUSION_PREDICATE)
       return E_INVALIDARG;
     
     if (ppPredicate == nullptr)
@@ -968,7 +990,7 @@ namespace dxvk {
       return S_OK;
     } catch (const DxvkError& e) {
       Logger::err(e.message());
-      return E_FAIL;
+      return E_INVALIDARG;
     }
   }
   
@@ -1478,7 +1500,7 @@ namespace dxvk {
       return S_OK;
     } catch (const DxvkError& e) {
       Logger::err(e.message());
-      return E_FAIL;
+      return E_INVALIDARG;
     }
   }
 

--- a/src/dxgi/dxgi_main.cpp
+++ b/src/dxgi/dxgi_main.cpp
@@ -11,7 +11,7 @@ namespace dxvk {
       HRESULT hr = factory->QueryInterface(riid, ppFactory);
 
       if (FAILED(hr))
-        return DXGI_ERROR_UNSUPPORTED;
+        return hr;
       
       return S_OK;
     } catch (const DxvkError& e) {


### PR DESCRIPTION
Based off tests on native d3d11's behaviour.

This also fixes a crash creating a default blend state in d3d10.