### PR TITLE
[d3d11, d3d10] Init returnptrs for CreateDevice funcs.

### DIFF
--- a/src/d3d10/d3d10_main.cpp
+++ b/src/d3d10/d3d10_main.cpp
@@ -27,10 +27,9 @@ extern "C" {
           UINT                    Flags,
           D3D_FEATURE_LEVEL       FeatureLevel,
           ID3D10Device**          ppDevice) {
-    Com<ID3D11Device> d3d11Device;
+    InitReturnPtr(ppDevice);
 
-    if (ppDevice != nullptr)
-      *ppDevice = nullptr;
+    Com<ID3D11Device> d3d11Device;
 
     HRESULT hr = pAdapter->CheckInterfaceSupport(
       __uuidof(ID3D10Device), nullptr);

--- a/src/d3d11/d3d11_main.cpp
+++ b/src/d3d11/d3d11_main.cpp
@@ -22,6 +22,8 @@ extern "C" {
     const D3D_FEATURE_LEVEL*  pFeatureLevels,
           UINT                FeatureLevels,
           ID3D11Device**      ppDevice) {
+    InitReturnPtr(ppDevice);
+
     Rc<DxvkAdapter>  dxvkAdapter;
     Rc<DxvkInstance> dxvkInstance;
 
@@ -107,6 +109,9 @@ extern "C" {
           ID3D11Device**        ppDevice,
           D3D_FEATURE_LEVEL*    pFeatureLevel,
           ID3D11DeviceContext** ppImmediateContext) {
+    InitReturnPtr(ppDevice);
+    InitReturnPtr(ppImmediateContext);
+
     Com<IDXGIFactory> dxgiFactory = nullptr;
     Com<IDXGIAdapter> dxgiAdapter = pAdapter;
     
@@ -187,6 +192,10 @@ extern "C" {
           ID3D11Device**        ppDevice,
           D3D_FEATURE_LEVEL*    pFeatureLevel,
           ID3D11DeviceContext** ppImmediateContext) {
+    InitReturnPtr(ppDevice);
+    InitReturnPtr(ppSwapChain);
+    InitReturnPtr(ppImmediateContext);
+
     Com<ID3D11Device>        d3d11Device;
     Com<ID3D11DeviceContext> d3d11Context;
     


### PR DESCRIPTION
Matches native d3d11 behaviour on fail.