### PR TITLE
[build] Mark tests as gui apps in Meson

### DIFF
--- a/tests/d3d11/meson.build
+++ b/tests/d3d11/meson.build
@@ -1,7 +1,7 @@
 test_d3d11_deps = [ util_dep, lib_dxgi, lib_d3d11, lib_d3dcompiler_47 ]
 
-executable('d3d11-compute'+exe_ext,   files('test_d3d11_compute.cpp'),   dependencies : test_d3d11_deps, install : true, override_options: ['cpp_std='+dxvk_cpp_std])
-executable('d3d11-formats'+exe_ext,   files('test_d3d11_formats.cpp'),   dependencies : test_d3d11_deps, install : true, override_options: ['cpp_std='+dxvk_cpp_std])
-executable('d3d11-map-read'+exe_ext,  files('test_d3d11_map_read.cpp'),  dependencies : test_d3d11_deps, install : true, override_options: ['cpp_std='+dxvk_cpp_std])
-executable('d3d11-streamout'+exe_ext, files('test_d3d11_streamout.cpp'), dependencies : test_d3d11_deps, install : true, override_options: ['cpp_std='+dxvk_cpp_std])
-executable('d3d11-triangle'+exe_ext,  files('test_d3d11_triangle.cpp'),  dependencies : test_d3d11_deps, install : true, override_options: ['cpp_std='+dxvk_cpp_std])
+executable('d3d11-compute'+exe_ext,   files('test_d3d11_compute.cpp'),   dependencies : test_d3d11_deps, install : true, gui_app : true, override_options: ['cpp_std='+dxvk_cpp_std])
+executable('d3d11-formats'+exe_ext,   files('test_d3d11_formats.cpp'),   dependencies : test_d3d11_deps, install : true, gui_app : true, override_options: ['cpp_std='+dxvk_cpp_std])
+executable('d3d11-map-read'+exe_ext,  files('test_d3d11_map_read.cpp'),  dependencies : test_d3d11_deps, install : true, gui_app : true, override_options: ['cpp_std='+dxvk_cpp_std])
+executable('d3d11-streamout'+exe_ext, files('test_d3d11_streamout.cpp'), dependencies : test_d3d11_deps, install : true, gui_app : true, override_options: ['cpp_std='+dxvk_cpp_std])
+executable('d3d11-triangle'+exe_ext,  files('test_d3d11_triangle.cpp'),  dependencies : test_d3d11_deps, install : true, gui_app : true, override_options: ['cpp_std='+dxvk_cpp_std])

--- a/tests/dxbc/meson.build
+++ b/tests/dxbc/meson.build
@@ -1,6 +1,6 @@
 test_dxbc_deps = [ dxbc_dep, dxvk_dep ]
 
-executable('dxbc-compiler'+exe_ext, files('test_dxbc_compiler.cpp'), dependencies : test_dxbc_deps, install : true, override_options: ['cpp_std='+dxvk_cpp_std])
-executable('dxbc-disasm'+exe_ext,   files('test_dxbc_disasm.cpp'),   dependencies : [ test_dxbc_deps, lib_d3dcompiler_47 ], install : true, override_options: ['cpp_std='+dxvk_cpp_std])
-executable('hlsl-compiler'+exe_ext, files('test_hlsl_compiler.cpp'), dependencies : [ test_dxbc_deps, lib_d3dcompiler_47 ], install : true, override_options: ['cpp_std='+dxvk_cpp_std])
+executable('dxbc-compiler'+exe_ext, files('test_dxbc_compiler.cpp'), dependencies : test_dxbc_deps, install : true, gui_app : true, override_options: ['cpp_std='+dxvk_cpp_std])
+executable('dxbc-disasm'+exe_ext,   files('test_dxbc_disasm.cpp'),   dependencies : [ test_dxbc_deps, lib_d3dcompiler_47 ], install : true, gui_app : true, override_options: ['cpp_std='+dxvk_cpp_std])
+executable('hlsl-compiler'+exe_ext, files('test_hlsl_compiler.cpp'), dependencies : [ test_dxbc_deps, lib_d3dcompiler_47 ], install : true, gui_app : true, override_options: ['cpp_std='+dxvk_cpp_std])
 

--- a/tests/dxgi/meson.build
+++ b/tests/dxgi/meson.build
@@ -1,3 +1,3 @@
 test_dxgi_deps = [ util_dep, lib_dxgi ]
 
-executable('dxgi-factory'+exe_ext, files('test_dxgi_factory.cpp'), dependencies : test_dxgi_deps, install: true, override_options: ['cpp_std='+dxvk_cpp_std])
+executable('dxgi-factory'+exe_ext, files('test_dxgi_factory.cpp'), dependencies : test_dxgi_deps, install: true, gui_app : true, override_options: ['cpp_std='+dxvk_cpp_std])


### PR DESCRIPTION
Fixes building the tests on Windows and uses the right entrypoint and linker subsystem.