### PR TITLE
 dxbc_compiler: use arithmetic shift to calculate offset 

### DIFF
--- a/src/dxbc/dxbc_compiler.cpp
+++ b/src/dxbc/dxbc_compiler.cpp
@@ -5122,13 +5122,9 @@ namespace dxvk {
     
     const uint32_t typeId = getVectorTypeId(result.type);
     
-    uint32_t offset = m_moduleInfo.options.useSdivForBufferIndex
-      ? m_module.opSDiv             (typeId, structOffset.id, m_module.consti32(4))
-      : m_module.opShiftRightLogical(typeId, structOffset.id, m_module.consti32(2));
-    
     result.id = m_module.opIAdd(typeId,
       m_module.opIMul(typeId, structId.id, m_module.consti32(structStride / 4)),
-      offset);
+      m_module.opShiftRightLogical(typeId, structOffset.id, m_module.consti32(2)));
     return result;
   }
   
@@ -5138,12 +5134,10 @@ namespace dxvk {
     DxbcRegisterValue result;
     result.type.ctype  = DxbcScalarType::Sint32;
     result.type.ccount = 1;
-    
-    uint32_t typeId = getVectorTypeId(result.type);
-    
-    result.id = m_moduleInfo.options.useSdivForBufferIndex
-      ? m_module.opSDiv             (typeId, byteOffset.id, m_module.consti32(4))
-      : m_module.opShiftRightLogical(typeId, byteOffset.id, m_module.consti32(2));
+    result.id = m_module.opShiftRightLogical(
+      getVectorTypeId(result.type),
+      byteOffset.id,
+      m_module.consti32(2));
     return result;
   }
   

--- a/src/dxbc/dxbc_compiler.cpp
+++ b/src/dxbc/dxbc_compiler.cpp
@@ -5124,7 +5124,7 @@ namespace dxvk {
     
     result.id = m_module.opIAdd(typeId,
       m_module.opIMul(typeId, structId.id, m_module.consti32(structStride / 4)),
-      m_module.opShiftRightLogical(typeId, structOffset.id, m_module.consti32(2)));
+      m_module.opShiftRightArithmetic(typeId, structOffset.id, m_module.consti32(2)));
     return result;
   }
   
@@ -5134,7 +5134,7 @@ namespace dxvk {
     DxbcRegisterValue result;
     result.type.ctype  = DxbcScalarType::Sint32;
     result.type.ccount = 1;
-    result.id = m_module.opShiftRightLogical(
+    result.id = m_module.opShiftRightArithmetic(
       getVectorTypeId(result.type),
       byteOffset.id,
       m_module.consti32(2));

--- a/src/dxbc/dxbc_options.cpp
+++ b/src/dxbc/dxbc_options.cpp
@@ -25,8 +25,6 @@ namespace dxvk {
      && (devInfo.coreSubgroup.supportedOperations & VK_SUBGROUP_FEATURE_BALLOT_BIT);
     useRawSsbo
       = (devInfo.core.properties.limits.minStorageBufferOffsetAlignment <= sizeof(uint32_t));
-    useSdivForBufferIndex
-      = adapter->matchesDriver(DxvkGpuVendor::Nvidia, VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR, 0, 0);
     
     strictDivision          = options.strictDivision;
     zeroInitWorkgroupMemory = options.zeroInitWorkgroupMemory;

--- a/src/dxbc/dxbc_options.h
+++ b/src/dxbc/dxbc_options.h
@@ -24,10 +24,6 @@ namespace dxvk {
     /// Use SSBOs instead of texel buffers
     /// for raw and structured buffers.
     bool useRawSsbo = false;
-    
-    /// Use SDiv instead of SHR to converte byte offsets to
-    /// dword offsets. Fixes RE2 and DMC5 on Nvidia drivers.
-    bool useSdivForBufferIndex = false;
 
     /// Enables sm4-compliant division-by-zero behaviour
     bool strictDivision = false;


### PR DESCRIPTION
there's nothing preventing the offset from being negative. according to the SPIR-V spec logical shift will fill MSB with zeros which is invalid here.