### PR TITLE
[util] Enable deferred surface creation for "Dissidia Final Fantasy NT Free Edition".

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -19,6 +19,10 @@ namespace dxvk {
     { "Dishonored2.exe", {{
       { "d3d11.allowMapFlagNoWait",         "True" }
     }} },
+    /* Dissidia Final Fantasy NT Free Edition */
+    { "dffnt.exe", {{
+      { "dxgi.deferSurfaceCreation",        "True" },
+    }} },
     /* Elite Dangerous: Compiles weird shaders    *
      * when running on AMD hardware               */
     { "EliteDangerous64.exe", {{


### PR DESCRIPTION

Avoid white screen, "D3D11Device: No such vertex shader semantic: COLOR0"...
[Screenshot](https://www.reddit.com/r/archlinux/comments/b7e38x/protondxvk_dissidia_nt/)
If you find more cleaner to add the option in "dxvk.conf". I could edit the Wiki then with the config.

PS: Thanks to the creator(s) of the project, its amazing .