### PR TITLE
[vulkan] Recreate the surface on surface loss.

### DIFF
--- a/src/vulkan/vulkan_presenter.cpp
+++ b/src/vulkan/vulkan_presenter.cpp
@@ -106,8 +106,8 @@ namespace dxvk::vk {
     
     if ((status = m_vki->vkGetPhysicalDeviceSurfaceCapabilitiesKHR(
         m_device.adapter, m_surface, &caps)) != VK_SUCCESS) {
-      while (status == VK_ERROR_SURFACE_LOST_KHR) {
-        // Recreate the surface and try again.
+      for (uint32_t i = 0; i < 5 && status == VK_ERROR_SURFACE_LOST_KHR; i++) {
+        // Recreate the surface and try again. Give up after 5 tries.
         if (m_surface)
           destroySurface();
         if ((status = createSurface()) != VK_SUCCESS)

--- a/src/vulkan/vulkan_presenter.cpp
+++ b/src/vulkan/vulkan_presenter.cpp
@@ -106,15 +106,14 @@ namespace dxvk::vk {
     
     if ((status = m_vki->vkGetPhysicalDeviceSurfaceCapabilitiesKHR(
         m_device.adapter, m_surface, &caps)) != VK_SUCCESS) {
-      for (uint32_t i = 0; i < 5 && status == VK_ERROR_SURFACE_LOST_KHR; i++) {
-        // Recreate the surface and try again. Give up after 5 tries.
+      if (status == VK_ERROR_SURFACE_LOST_KHR) {
+        // Recreate the surface and try again.
         if (m_surface)
           destroySurface();
         if ((status = createSurface()) != VK_SUCCESS)
-          continue;
-        if ((status = m_vki->vkGetPhysicalDeviceSurfaceCapabilitiesKHR(
-            m_device.adapter, m_surface, &caps)) != VK_SUCCESS)
-          continue;
+          return status;
+        status = m_vki->vkGetPhysicalDeviceSurfaceCapabilitiesKHR(
+            m_device.adapter, m_surface, &caps);
       }
       if (status != VK_SUCCESS)
         return status;

--- a/src/vulkan/vulkan_presenter.h
+++ b/src/vulkan/vulkan_presenter.h
@@ -174,6 +174,7 @@ namespace dxvk::vk {
     PresenterDevice   m_device;
     PresenterInfo     m_info;
 
+    HWND              m_window      = nullptr;
     VkSurfaceKHR      m_surface     = VK_NULL_HANDLE;
     VkSwapchainKHR    m_swapchain   = VK_NULL_HANDLE;
 
@@ -213,7 +214,7 @@ namespace dxvk::vk {
             VkPresentModeKHR          presentMode,
             uint32_t                  desired);
 
-    VkResult createSurface(HWND window);
+    VkResult createSurface();
 
     void destroySwapchain();
 


### PR DESCRIPTION
According to the Vulkan spec:

> Several WSI functions return `VK_ERROR_SURFACE_LOST_KHR` if the
> surface becomes no longer available. After such an error, the surface
> (and any child swapchain, if one exists) **should** be destroyed, as
> there is no way to restore them to a not-lost state.

So if we get this error, we need to recreate the surface in addition to
the swapchain.