### PR TITLE
mingw-w64 build .dll version creation

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -21,8 +21,10 @@ dxvk_include_path = include_directories('./include')
 
 if (cpu_family == 'x86_64')
   dxvk_library_path = meson.source_root() + '/lib'
+  target_arch = '-m64'
 else
   dxvk_library_path = meson.source_root() + '/lib32'
+  target_arch = '-m32'
 endif
 
 code = '''#ifndef __WINE__
@@ -42,7 +44,6 @@ if dxvk_winelib
   exe_ext = '.exe.so'
   dll_ext = '.dll'
   def_spec_ext = '.spec'
-  wrc = [ find_program('wrc'), '-i', '@INPUT@', '-o', '@OUTPUT@' ]
 else
   lib_vulkan  = dxvk_compiler.find_library('vulkan-1', dirs : dxvk_library_path)
   lib_d3d11   = dxvk_compiler.find_library('d3d11')

--- a/meson.build
+++ b/meson.build
@@ -21,11 +21,11 @@ dxvk_include_path = include_directories('./include')
 
 if (cpu_family == 'x86_64')
   dxvk_library_path = meson.source_root() + '/lib'
-  target_arch = '-m64'
 else
   dxvk_library_path = meson.source_root() + '/lib32'
-  target_arch = '-m32'
 endif
+
+wrc = cpu_family == 'x86_64' ? find_program('x86_64-w64-mingw32-windres') : find_program('i686-w64-mingw32-windres')
 
 code = '''#ifndef __WINE__
 #error 1
@@ -52,14 +52,8 @@ else
   
   if dxvk_compiler.get_id() == 'msvc'
     lib_d3dcompiler_47 = dxvk_compiler.find_library('d3dcompiler')
-    wrc = [ find_program('windres'), '-i', '@INPUT@', '-o', '@OUTPUT@' ]
   else
     lib_d3dcompiler_47 = dxvk_compiler.find_library('d3dcompiler_47')
-    if (cpu_family == 'x86_64')
-      wrc = [ find_program('x86_64-w64-mingw32-windres'), '-i', '@INPUT@', '-o', '@OUTPUT@' ]
-    else
-      wrc = [ find_program('i686-w64-mingw32-windres'), '-i', '@INPUT@', '-o', '@OUTPUT@' ]
-    endif
   endif
   exe_ext = ''
   dll_ext = ''

--- a/meson.build
+++ b/meson.build
@@ -42,6 +42,7 @@ if dxvk_winelib
   exe_ext = '.exe.so'
   dll_ext = '.dll'
   def_spec_ext = '.spec'
+  wrc = [ find_program('wrc'), '-i', '@INPUT@', '-o', '@OUTPUT@' ]
 else
   lib_vulkan  = dxvk_compiler.find_library('vulkan-1', dirs : dxvk_library_path)
   lib_d3d11   = dxvk_compiler.find_library('d3d11')
@@ -50,8 +51,14 @@ else
   
   if dxvk_compiler.get_id() == 'msvc'
     lib_d3dcompiler_47 = dxvk_compiler.find_library('d3dcompiler')
+    wrc = [ find_program('windres'), '-i', '@INPUT@', '-o', '@OUTPUT@' ]
   else
     lib_d3dcompiler_47 = dxvk_compiler.find_library('d3dcompiler_47')
+    if (cpu_family == 'x86_64')
+      wrc = [ find_program('x86_64-w64-mingw32-windres'), '-i', '@INPUT@', '-o', '@OUTPUT@' ]
+    else
+      wrc = [ find_program('i686-w64-mingw32-windres'), '-i', '@INPUT@', '-o', '@OUTPUT@' ]
+    endif
   endif
   exe_ext = ''
   dll_ext = ''

--- a/package-release.sh
+++ b/package-release.sh
@@ -71,9 +71,6 @@ function build_arch {
       rm "$DXVK_BUILD_DIR/x$1/"*.!(dll)
     fi
     rm -R "$DXVK_BUILD_DIR/build.$1"
-    if [ $opt_winelib -eq 1 ]; then
-      mv "$DXVK_BUILD_DIR/fakedlls" "$DXVK_BUILD_DIR/fakedlls$1"
-    fi
   fi
 }
 

--- a/package-release.sh
+++ b/package-release.sh
@@ -71,6 +71,9 @@ function build_arch {
       rm "$DXVK_BUILD_DIR/x$1/"*.!(dll)
     fi
     rm -R "$DXVK_BUILD_DIR/build.$1"
+    if [ $opt_winelib -eq 1 ]; then
+      mv "$DXVK_BUILD_DIR/fakedlls" "$DXVK_BUILD_DIR/fakedlls$1"
+    fi
   fi
 }
 

--- a/src/d3d10/meson.build
+++ b/src/d3d10/meson.build
@@ -1,23 +1,46 @@
-d3d10_res = custom_target(
-  'version10.res',
-  input   : 'version10.rc',
-  output  : 'version10.o',
-  command : wrc,
-)
+if dxvk_winelib
+  d3d10_res = custom_target('version_10.res',
+    input   : 'version10.rc',
+    output  : 'version10.res',
+    command : [ find_program('wrc'), '-o', '@OUTPUT@', '@INPUT@' ],
+    install : false,
+  )
 
-d3d10_1_res = custom_target(
-  'version10_1.res',
-  input   : 'version10_1.rc',
-  output  : 'version10_1.o',
-  command : wrc,
-)
+  d3d10_1_res = custom_target('version_1_10.res',
+    input   : 'version10_1.rc',
+    output  : 'version10_1.res',
+    command : [ find_program('wrc'), '-o', '@OUTPUT@', '@INPUT@' ],
+    install : false,
+  )
 
-d3d10_core_res = custom_target(
-  'version10_core.res',
-  input   : 'version10_core.rc',
-  output  : 'version10_core.o',
-  command : wrc,
-)
+  d3d10_core_res = custom_target('version10_core.res',
+    input   : 'version10_core.rc',
+    output  : 'version10_core.res',
+    command : [ find_program('wrc'), '-o', '@OUTPUT@', '@INPUT@' ],
+    install : false,
+  )
+else
+  d3d10_res = custom_target(
+    'version10.res',
+    input   : 'version10.rc',
+    output  : 'version10.o',
+    command : wrc,
+  )
+
+  d3d10_1_res = custom_target(
+    'version10_1.res',
+    input   : 'version10_1.rc',
+    output  : 'version10_1.o',
+    command : wrc,
+  )
+
+  d3d10_core_res = custom_target(
+    'version10_core.res',
+    input   : 'version10_core.rc',
+    output  : 'version10_core.o',
+    command : wrc,
+  )
+endif
 
 d3d10_main_src = [
   'd3d10_main.cpp',
@@ -53,6 +76,30 @@ d3d10_1_dll = shared_library('d3d10_1'+dll_ext, d3d10_main_src, not dxvk_winelib
   objects             : not dxvk_msvc ? 'd3d10_1'+def_spec_ext : [],
   vs_module_defs      : 'd3d10_1'+def_spec_ext,
   override_options    : ['cpp_std='+dxvk_cpp_std])
+
+if dxvk_winelib
+  d3d10_dll_target = custom_target('d3d10.dll',
+    output  : 'd3d10.dll',
+    input   : [ 'd3d10.spec', d3d10_res ],
+    command : [ find_program('winebuild'), target_arch, '--dll', '--fake-module', '-E', '@INPUT@', '-o', '@OUTPUT@', '-F', 'd3d10.dll' ],
+    install : true,
+    install_dir : 'fakedlls')
+
+  d3d10_1_dll_target = custom_target('d3d10_1.dll',
+    output  : 'd3d10_1.dll',
+    input   : [ 'd3d10_1.spec', d3d10_1_res ],
+    command : [ find_program('winebuild'), target_arch, '--dll', '--fake-module', '-E', '@INPUT@', '-o', '@OUTPUT@', '-F', 'd3d10_1.dll' ],
+    install : true,
+    install_dir : 'fakedlls')
+
+  d3d10_core_dll_target = custom_target('d3d10core.dll',
+    output  : 'd3d10core.dll',
+    input   : [ 'd3d10core.spec', d3d10_core_res ],
+    command : [ find_program('winebuild'), target_arch, '--dll', '--fake-module', '-E', '@INPUT@', '-o', '@OUTPUT@', '-F', 'd3d10core.dll' ],
+    install : true,
+    install_dir : 'fakedlls')
+endif
+
 
 d3d10_dep = declare_dependency(
   link_with           : [ d3d10_dll, d3d10_1_dll, d3d10_core_dll ],

--- a/src/d3d10/meson.build
+++ b/src/d3d10/meson.build
@@ -1,3 +1,24 @@
+d3d10_res = custom_target(
+  'version10.res',
+  input   : 'version10.rc',
+  output  : 'version10.o',
+  command : wrc,
+)
+
+d3d10_1_res = custom_target(
+  'version10_1.res',
+  input   : 'version10_1.rc',
+  output  : 'version10_1.o',
+  command : wrc,
+)
+
+d3d10_core_res = custom_target(
+  'version10_core.res',
+  input   : 'version10_core.rc',
+  output  : 'version10_core.o',
+  command : wrc,
+)
+
 d3d10_main_src = [
   'd3d10_main.cpp',
   'd3d10_reflection.cpp',
@@ -6,7 +27,7 @@ d3d10_main_src = [
 d3d10_deps = [ lib_d3dcompiler_43, lib_dxgi ]
 d3d10_deps += dxvk_winelib ? lib_d3d11 : d3d11_dep
 
-d3d10_core_dll = shared_library('d3d10core'+dll_ext, d3d10_main_src,
+d3d10_core_dll = shared_library('d3d10core'+dll_ext, d3d10_main_src, not dxvk_winelib ? d3d10_core_res : [],
   name_prefix         : '',
   dependencies        : [ d3d10_deps, dxbc_dep, dxvk_dep ],
   include_directories : dxvk_include_path,
@@ -15,7 +36,7 @@ d3d10_core_dll = shared_library('d3d10core'+dll_ext, d3d10_main_src,
   vs_module_defs      : 'd3d10core'+def_spec_ext,
   override_options    : ['cpp_std='+dxvk_cpp_std])
 
-d3d10_dll = shared_library('d3d10'+dll_ext, d3d10_main_src,
+d3d10_dll = shared_library('d3d10'+dll_ext, d3d10_main_src, not dxvk_winelib ? d3d10_res : [],
   name_prefix         : '',
   dependencies        : [ d3d10_deps, dxbc_dep, dxvk_dep ],
   include_directories : dxvk_include_path,
@@ -24,7 +45,7 @@ d3d10_dll = shared_library('d3d10'+dll_ext, d3d10_main_src,
   vs_module_defs      : 'd3d10'+def_spec_ext,
   override_options    : ['cpp_std='+dxvk_cpp_std])
 
-d3d10_1_dll = shared_library('d3d10_1'+dll_ext, d3d10_main_src,
+d3d10_1_dll = shared_library('d3d10_1'+dll_ext, d3d10_main_src, not dxvk_winelib ? d3d10_1_res : [],
   name_prefix         : '',
   dependencies        : [ d3d10_deps, dxbc_dep, dxvk_dep ],
   include_directories : dxvk_include_path,

--- a/src/d3d10/meson.build
+++ b/src/d3d10/meson.build
@@ -1,46 +1,23 @@
-if dxvk_winelib
-  d3d10_res = custom_target('version_10.res',
-    input   : 'version10.rc',
-    output  : 'version10.res',
-    command : [ find_program('wrc'), '-o', '@OUTPUT@', '@INPUT@' ],
-    install : false,
-  )
+d3d10_res = custom_target(
+  'version10.res',
+  input   : 'version10.rc',
+  output  : 'version10.o',
+  command : [ wrc, '@INPUT@', '@OUTPUT@' ],
+)
 
-  d3d10_1_res = custom_target('version_1_10.res',
-    input   : 'version10_1.rc',
-    output  : 'version10_1.res',
-    command : [ find_program('wrc'), '-o', '@OUTPUT@', '@INPUT@' ],
-    install : false,
-  )
+d3d10_1_res = custom_target(
+  'version10_1.res',
+  input   : 'version10_1.rc',
+  output  : 'version10_1.o',
+  command : [ wrc, '@INPUT@', '@OUTPUT@' ],
+)
 
-  d3d10_core_res = custom_target('version10_core.res',
-    input   : 'version10_core.rc',
-    output  : 'version10_core.res',
-    command : [ find_program('wrc'), '-o', '@OUTPUT@', '@INPUT@' ],
-    install : false,
-  )
-else
-  d3d10_res = custom_target(
-    'version10.res',
-    input   : 'version10.rc',
-    output  : 'version10.o',
-    command : wrc,
-  )
-
-  d3d10_1_res = custom_target(
-    'version10_1.res',
-    input   : 'version10_1.rc',
-    output  : 'version10_1.o',
-    command : wrc,
-  )
-
-  d3d10_core_res = custom_target(
-    'version10_core.res',
-    input   : 'version10_core.rc',
-    output  : 'version10_core.o',
-    command : wrc,
-  )
-endif
+d3d10_core_res = custom_target(
+  'version10_core.res',
+  input   : 'version10_core.rc',
+  output  : 'version10_core.o',
+  command : [ wrc, '@INPUT@', '@OUTPUT@' ],
+)
 
 d3d10_main_src = [
   'd3d10_main.cpp',
@@ -76,30 +53,6 @@ d3d10_1_dll = shared_library('d3d10_1'+dll_ext, d3d10_main_src, not dxvk_winelib
   objects             : not dxvk_msvc ? 'd3d10_1'+def_spec_ext : [],
   vs_module_defs      : 'd3d10_1'+def_spec_ext,
   override_options    : ['cpp_std='+dxvk_cpp_std])
-
-if dxvk_winelib
-  d3d10_dll_target = custom_target('d3d10.dll',
-    output  : 'd3d10.dll',
-    input   : [ 'd3d10.spec', d3d10_res ],
-    command : [ find_program('winebuild'), target_arch, '--dll', '--fake-module', '-E', '@INPUT@', '-o', '@OUTPUT@', '-F', 'd3d10.dll' ],
-    install : true,
-    install_dir : 'fakedlls')
-
-  d3d10_1_dll_target = custom_target('d3d10_1.dll',
-    output  : 'd3d10_1.dll',
-    input   : [ 'd3d10_1.spec', d3d10_1_res ],
-    command : [ find_program('winebuild'), target_arch, '--dll', '--fake-module', '-E', '@INPUT@', '-o', '@OUTPUT@', '-F', 'd3d10_1.dll' ],
-    install : true,
-    install_dir : 'fakedlls')
-
-  d3d10_core_dll_target = custom_target('d3d10core.dll',
-    output  : 'd3d10core.dll',
-    input   : [ 'd3d10core.spec', d3d10_core_res ],
-    command : [ find_program('winebuild'), target_arch, '--dll', '--fake-module', '-E', '@INPUT@', '-o', '@OUTPUT@', '-F', 'd3d10core.dll' ],
-    install : true,
-    install_dir : 'fakedlls')
-endif
-
 
 d3d10_dep = declare_dependency(
   link_with           : [ d3d10_dll, d3d10_1_dll, d3d10_core_dll ],

--- a/src/d3d10/version10.rc
+++ b/src/d3d10/version10.rc
@@ -2,10 +2,10 @@
 
 // DLL version information.
 VS_VERSION_INFO    VERSIONINFO
-FILEVERSION 10,0,17763,1
-PRODUCTVERSION 10,0,17763,1
+FILEVERSION        10,0,17763,1
+PRODUCTVERSION     10,0,17763,1
 FILEFLAGSMASK      VS_FFI_FILEFLAGSMASK
-FILEFLAGS        0
+FILEFLAGS          0
 FILEOS VOS_NT_WINDOWS32
 FILETYPE VFT_DLL
 FILESUBTYPE VFT2_UNKNOWN
@@ -14,14 +14,14 @@ BEGIN
   BEGIN
     BLOCK "080904b0"
     BEGIN
-      VALUE "CompanyName", "Microsoft Corporation"
-      VALUE "FileDescription", "Direct3D 10 Runtime"
-      VALUE "FileVersion", "10.0.17763.1 (WinBuild.160101.0800)"
-      VALUE "InternalName", "D3D10.dll"
-      VALUE "LegalCopyright", "2019 It's FOSS!"
+      VALUE "CompanyName",      "DXVK"
+      VALUE "FileDescription",  "Direct3D 10 Runtime"
+      VALUE "FileVersion",      "10.0.17763.1 (WinBuild.160101.0800)"
+      VALUE "InternalName",     "D3D10.dll"
+      VALUE "LegalCopyright",   "zlib/libpng license"
       VALUE "OriginalFilename", "D3D10.dll"
-      VALUE "ProductName", "Microsoft\xAE Windows\xAE Operating System"
-      VALUE "ProductVersion", "10.0.17763.1"
+      VALUE "ProductName",      "DXVK"
+      VALUE "ProductVersion",   "10.0.17763.1"
     END
   END
   BLOCK "VarFileInfo"

--- a/src/d3d10/version10.rc
+++ b/src/d3d10/version10.rc
@@ -1,0 +1,32 @@
+#include <windows.h>
+
+// DLL version information.
+VS_VERSION_INFO    VERSIONINFO
+FILEVERSION 10,0,17763,1
+PRODUCTVERSION 10,0,17763,1
+FILEFLAGSMASK      VS_FFI_FILEFLAGSMASK
+FILEFLAGS        0
+FILEOS VOS_NT_WINDOWS32
+FILETYPE VFT_DLL
+FILESUBTYPE VFT2_UNKNOWN
+BEGIN
+  BLOCK "StringFileInfo"
+  BEGIN
+    BLOCK "080904b0"
+    BEGIN
+      VALUE "CompanyName", "Microsoft Corporation"
+      VALUE "FileDescription", "Direct3D 10 Runtime"
+      VALUE "FileVersion", "10.0.17763.1 (WinBuild.160101.0800)"
+      VALUE "InternalName", "D3D10.dll"
+      VALUE "LegalCopyright", "2019 It's FOSS!"
+      VALUE "OriginalFilename", "D3D10.dll"
+      VALUE "ProductName", "Microsoft\xAE Windows\xAE Operating System"
+      VALUE "ProductVersion", "10.0.17763.1"
+    END
+  END
+  BLOCK "VarFileInfo"
+  BEGIN
+    VALUE "Translation", 0x0809, 1200
+  END
+END
+

--- a/src/d3d10/version10_1.rc
+++ b/src/d3d10/version10_1.rc
@@ -1,0 +1,32 @@
+#include <windows.h>
+
+// DLL version information.
+VS_VERSION_INFO    VERSIONINFO
+FILEVERSION 10,0,17763,1
+PRODUCTVERSION 10,0,17763,1
+FILEFLAGSMASK      VS_FFI_FILEFLAGSMASK
+FILEFLAGS        0
+FILEOS VOS_NT_WINDOWS32
+FILETYPE VFT_DLL
+FILESUBTYPE VFT2_UNKNOWN
+BEGIN
+  BLOCK "StringFileInfo"
+  BEGIN
+    BLOCK "080904b0"
+    BEGIN
+      VALUE "CompanyName", "Microsoft Corporation"
+      VALUE "FileDescription", "Direct3D 10.1 Runtime"
+      VALUE "FileVersion", "10.0.17763.1 (WinBuild.160101.0800)"
+      VALUE "InternalName", "D3D10_1.dll"
+      VALUE "LegalCopyright", "2019 It's FOSS!"
+      VALUE "OriginalFilename", "D3D10_1.dll"
+      VALUE "ProductName", "Microsoft\xAE Windows\xAE Operating System"
+      VALUE "ProductVersion", "10.0.17763.1"
+    END
+  END
+  BLOCK "VarFileInfo"
+  BEGIN
+    VALUE "Translation", 0x0809, 1200
+  END
+END
+

--- a/src/d3d10/version10_1.rc
+++ b/src/d3d10/version10_1.rc
@@ -2,10 +2,10 @@
 
 // DLL version information.
 VS_VERSION_INFO    VERSIONINFO
-FILEVERSION 10,0,17763,1
-PRODUCTVERSION 10,0,17763,1
+FILEVERSION        10,0,17763,1
+PRODUCTVERSION     10,0,17763,1
 FILEFLAGSMASK      VS_FFI_FILEFLAGSMASK
-FILEFLAGS        0
+FILEFLAGS          0
 FILEOS VOS_NT_WINDOWS32
 FILETYPE VFT_DLL
 FILESUBTYPE VFT2_UNKNOWN
@@ -14,14 +14,14 @@ BEGIN
   BEGIN
     BLOCK "080904b0"
     BEGIN
-      VALUE "CompanyName", "Microsoft Corporation"
-      VALUE "FileDescription", "Direct3D 10.1 Runtime"
-      VALUE "FileVersion", "10.0.17763.1 (WinBuild.160101.0800)"
-      VALUE "InternalName", "D3D10_1.dll"
-      VALUE "LegalCopyright", "2019 It's FOSS!"
+      VALUE "CompanyName",      "DXVK"
+      VALUE "FileDescription",  "Direct3D 10.1 Runtime"
+      VALUE "FileVersion",      "10.0.17763.1 (WinBuild.160101.0800)"
+      VALUE "InternalName",     "D3D10_1.dll"
+      VALUE "LegalCopyright",   "zlib/libpng license"
       VALUE "OriginalFilename", "D3D10_1.dll"
-      VALUE "ProductName", "Microsoft\xAE Windows\xAE Operating System"
-      VALUE "ProductVersion", "10.0.17763.1"
+      VALUE "ProductName",      "DXVK"
+      VALUE "ProductVersion",   "10.0.17763.1"
     END
   END
   BLOCK "VarFileInfo"

--- a/src/d3d10/version10_core.rc
+++ b/src/d3d10/version10_core.rc
@@ -1,0 +1,32 @@
+#include <windows.h>
+
+// DLL version information.
+VS_VERSION_INFO    VERSIONINFO
+FILEVERSION 10,0,17763,1
+PRODUCTVERSION 10,0,17763,1
+FILEFLAGSMASK      VS_FFI_FILEFLAGSMASK
+FILEFLAGS        0
+FILEOS VOS_NT_WINDOWS32
+FILETYPE VFT_DLL
+FILESUBTYPE VFT2_UNKNOWN
+BEGIN
+  BLOCK "StringFileInfo"
+  BEGIN
+    BLOCK "080904b0"
+    BEGIN
+      VALUE "CompanyName", "Microsoft Corporation"
+      VALUE "FileDescription", "Direct3D 10 Runtime"
+      VALUE "FileVersion", "10.0.17763.1 (WinBuild.160101.0800)"
+      VALUE "InternalName", "D3D10Core.dll"
+      VALUE "LegalCopyright", "2019 It's FOSS!"
+      VALUE "OriginalFilename", "D3D10Core.dll"
+      VALUE "ProductName", "Microsoft\xAE Windows\xAE Operating System"
+      VALUE "ProductVersion", "10.0.17763.1"
+    END
+  END
+  BLOCK "VarFileInfo"
+  BEGIN
+    VALUE "Translation", 0x0809, 1200
+  END
+END
+

--- a/src/d3d10/version10_core.rc
+++ b/src/d3d10/version10_core.rc
@@ -2,10 +2,10 @@
 
 // DLL version information.
 VS_VERSION_INFO    VERSIONINFO
-FILEVERSION 10,0,17763,1
-PRODUCTVERSION 10,0,17763,1
+FILEVERSION        10,0,17763,1
+PRODUCTVERSION     10,0,17763,1
 FILEFLAGSMASK      VS_FFI_FILEFLAGSMASK
-FILEFLAGS        0
+FILEFLAGS          0
 FILEOS VOS_NT_WINDOWS32
 FILETYPE VFT_DLL
 FILESUBTYPE VFT2_UNKNOWN
@@ -14,14 +14,14 @@ BEGIN
   BEGIN
     BLOCK "080904b0"
     BEGIN
-      VALUE "CompanyName", "Microsoft Corporation"
-      VALUE "FileDescription", "Direct3D 10 Runtime"
-      VALUE "FileVersion", "10.0.17763.1 (WinBuild.160101.0800)"
-      VALUE "InternalName", "D3D10Core.dll"
-      VALUE "LegalCopyright", "2019 It's FOSS!"
+      VALUE "CompanyName",      "DXVK"
+      VALUE "FileDescription",  "Direct3D 10 Runtime"
+      VALUE "FileVersion",      "10.0.17763.1 (WinBuild.160101.0800)"
+      VALUE "InternalName",     "D3D10Core.dll"
+      VALUE "LegalCopyright",   "zlib/libpng license"
       VALUE "OriginalFilename", "D3D10Core.dll"
-      VALUE "ProductName", "Microsoft\xAE Windows\xAE Operating System"
-      VALUE "ProductVersion", "10.0.17763.1"
+      VALUE "ProductName",      "DXVK"
+      VALUE "ProductVersion",   "10.0.17763.1"
     END
   END
   BLOCK "VarFileInfo"

--- a/src/d3d11/meson.build
+++ b/src/d3d11/meson.build
@@ -1,3 +1,10 @@
+d3d11_res = custom_target(
+  'version_11.res',
+  input   : 'version.rc',
+  output  : 'version.o',
+  command : wrc,
+)
+
 dxgi_common_src = [
   '../dxgi/dxgi_format.cpp',
   '../dxgi/dxgi_monitor.cpp',
@@ -54,7 +61,7 @@ d3d11_src = [
   'd3d11_view_uav.cpp',
 ]
 
-d3d11_dll = shared_library('d3d11'+dll_ext, dxgi_common_src + d3d11_src + d3d10_src, glsl_generator.process(dxgi_shaders),
+d3d11_dll = shared_library('d3d11'+dll_ext, dxgi_common_src + d3d11_src + d3d10_src, glsl_generator.process(dxgi_shaders), not dxvk_winelib ? d3d11_res : [],
   name_prefix         : '',
   dependencies        : [ lib_dxgi, dxbc_dep, dxvk_dep ],
   include_directories : dxvk_include_path,

--- a/src/d3d11/meson.build
+++ b/src/d3d11/meson.build
@@ -1,9 +1,17 @@
-d3d11_res = custom_target(
-  'version_11.res',
+if dxvk_winelib
+  d3d11_res = custom_target('version_11.res',
   input   : 'version.rc',
-  output  : 'version.o',
-  command : wrc,
-)
+  output  : 'version.res',
+  command : [ find_program('wrc'), '-o', '@OUTPUT@', '@INPUT@' ],
+  install : false)
+else
+  d3d11_res = custom_target(
+    'version_11.res',
+    input   : 'version.rc',
+    output  : 'version.o',
+    command : wrc,
+  )
+endif
 
 dxgi_common_src = [
   '../dxgi/dxgi_format.cpp',
@@ -69,6 +77,15 @@ d3d11_dll = shared_library('d3d11'+dll_ext, dxgi_common_src + d3d11_src + d3d10_
   objects             : not dxvk_msvc ? 'd3d11'+def_spec_ext : [],
   vs_module_defs      : 'd3d11'+def_spec_ext,
   override_options    : ['cpp_std='+dxvk_cpp_std])
+
+if dxvk_winelib
+  d3d11_dll_target = custom_target('d3d11.dll',
+    output  : 'd3d11.dll',
+    input   : [ 'd3d11.spec', d3d11_res ],
+    command : [ find_program('winebuild'), target_arch, '--dll', '--fake-module', '-E', '@INPUT@', '-o', '@OUTPUT@', '-F', 'd3d11.dll' ],
+    install : true,
+    install_dir : 'fakedlls')
+endif
 
 d3d11_dep = declare_dependency(
   link_with           : [ d3d11_dll ],

--- a/src/d3d11/meson.build
+++ b/src/d3d11/meson.build
@@ -1,17 +1,9 @@
-if dxvk_winelib
-  d3d11_res = custom_target('version_11.res',
+d3d11_res = custom_target(
+  'version_11.res',
   input   : 'version.rc',
-  output  : 'version.res',
-  command : [ find_program('wrc'), '-o', '@OUTPUT@', '@INPUT@' ],
-  install : false)
-else
-  d3d11_res = custom_target(
-    'version_11.res',
-    input   : 'version.rc',
-    output  : 'version.o',
-    command : wrc,
-  )
-endif
+  output  : 'version.o',
+  command : [ wrc, '@INPUT@', '@OUTPUT@' ],
+)
 
 dxgi_common_src = [
   '../dxgi/dxgi_format.cpp',
@@ -77,15 +69,6 @@ d3d11_dll = shared_library('d3d11'+dll_ext, dxgi_common_src + d3d11_src + d3d10_
   objects             : not dxvk_msvc ? 'd3d11'+def_spec_ext : [],
   vs_module_defs      : 'd3d11'+def_spec_ext,
   override_options    : ['cpp_std='+dxvk_cpp_std])
-
-if dxvk_winelib
-  d3d11_dll_target = custom_target('d3d11.dll',
-    output  : 'd3d11.dll',
-    input   : [ 'd3d11.spec', d3d11_res ],
-    command : [ find_program('winebuild'), target_arch, '--dll', '--fake-module', '-E', '@INPUT@', '-o', '@OUTPUT@', '-F', 'd3d11.dll' ],
-    install : true,
-    install_dir : 'fakedlls')
-endif
 
 d3d11_dep = declare_dependency(
   link_with           : [ d3d11_dll ],

--- a/src/d3d11/version.rc
+++ b/src/d3d11/version.rc
@@ -1,0 +1,32 @@
+#include <windows.h>
+
+// DLL version information.
+VS_VERSION_INFO    VERSIONINFO
+FILEVERSION 10,0,17763,1
+PRODUCTVERSION 10,0,17763,1
+FILEFLAGSMASK      VS_FFI_FILEFLAGSMASK
+FILEFLAGS        0
+FILEOS VOS_NT_WINDOWS32
+FILETYPE VFT_DLL
+FILESUBTYPE VFT2_UNKNOWN
+BEGIN
+  BLOCK "StringFileInfo"
+  BEGIN
+    BLOCK "080904b0"
+    BEGIN
+      VALUE "CompanyName", "Microsoft Corporation"
+      VALUE "FileDescription", "Direct3D 11 Runtime"
+      VALUE "FileVersion", "10.0.17763.1 (WinBuild.160101.0800)"
+      VALUE "InternalName", "D3D11.dll"
+      VALUE "LegalCopyright", "2019 It's FOSS!"
+      VALUE "OriginalFilename", "D3D11.dll"
+      VALUE "ProductName", "Microsoft\xAE Windows\xAE Operating System"
+      VALUE "ProductVersion", "10.0.17763.1"
+    END
+  END
+  BLOCK "VarFileInfo"
+  BEGIN
+    VALUE "Translation", 0x0809, 1200
+  END
+END
+

--- a/src/d3d11/version.rc
+++ b/src/d3d11/version.rc
@@ -2,10 +2,10 @@
 
 // DLL version information.
 VS_VERSION_INFO    VERSIONINFO
-FILEVERSION 10,0,17763,1
-PRODUCTVERSION 10,0,17763,1
+FILEVERSION        10,0,17763,1
+PRODUCTVERSION     10,0,17763,1
 FILEFLAGSMASK      VS_FFI_FILEFLAGSMASK
-FILEFLAGS        0
+FILEFLAGS          0
 FILEOS VOS_NT_WINDOWS32
 FILETYPE VFT_DLL
 FILESUBTYPE VFT2_UNKNOWN
@@ -14,14 +14,14 @@ BEGIN
   BEGIN
     BLOCK "080904b0"
     BEGIN
-      VALUE "CompanyName", "Microsoft Corporation"
-      VALUE "FileDescription", "Direct3D 11 Runtime"
-      VALUE "FileVersion", "10.0.17763.1 (WinBuild.160101.0800)"
-      VALUE "InternalName", "D3D11.dll"
-      VALUE "LegalCopyright", "2019 It's FOSS!"
+      VALUE "CompanyName",      "DXVK"
+      VALUE "FileDescription",  "Direct3D 11 Runtime"
+      VALUE "FileVersion",      "10.0.17763.1 (WinBuild.160101.0800)"
+      VALUE "InternalName",     "D3D11.dll"
+      VALUE "LegalCopyright",   "zlib/libpng license"
       VALUE "OriginalFilename", "D3D11.dll"
-      VALUE "ProductName", "Microsoft\xAE Windows\xAE Operating System"
-      VALUE "ProductVersion", "10.0.17763.1"
+      VALUE "ProductName",      "DXVK"
+      VALUE "ProductVersion",   "10.0.17763.1"
     END
   END
   BLOCK "VarFileInfo"

--- a/src/dxgi/meson.build
+++ b/src/dxgi/meson.build
@@ -1,17 +1,9 @@
-if dxvk_winelib
-  dxgi_res = custom_target('dxgi.res',
+dxgi_res = custom_target(
+  'version_dxgi.res',
   input   : 'version.rc',
-  output  : 'version.res',
-  command : [ find_program('wrc'), '-o', '@OUTPUT@', '@INPUT@' ],
-  install : false)
-else
-  dxgi_res = custom_target(
-    'version_dxgi.res',
-    input   : 'version.rc',
-    output  : 'version.o',
-    command : wrc,
-  )
-endif
+  output  : 'version.o',
+  command : [ wrc, '@INPUT@', '@OUTPUT@' ],
+)
 
 dxgi_shaders = files([
   'shaders/dxgi_presenter_frag.frag',
@@ -38,15 +30,6 @@ dxgi_dll = shared_library('dxgi'+dll_ext, dxgi_src, not dxvk_winelib ? dxgi_res 
   vs_module_defs      : 'dxgi'+def_spec_ext,
   objects             : not dxvk_msvc ? 'dxgi'+def_spec_ext : [],
   override_options    : ['cpp_std='+dxvk_cpp_std])
-
-if dxvk_winelib
-  dxgi_dll_target = custom_target('dxgi.dll',
-    output  : 'dxgi.dll',
-    input   : [ 'dxgi.spec', dxgi_res ],
-    command : [ find_program('winebuild'), target_arch, '--dll', '--fake-module', '-E', '@INPUT@', '-o', '@OUTPUT@', '-F', 'dxgi.dll' ],
-    install : true,
-    install_dir : 'fakedlls')
-endif
 
 dxgi_dep = declare_dependency(
   link_with           : [ dxgi_dll ],

--- a/src/dxgi/meson.build
+++ b/src/dxgi/meson.build
@@ -1,3 +1,10 @@
+dxgi_res = custom_target(
+  'version_dxgi.res',
+  input   : 'version.rc',
+  output  : 'version.o',
+  command : wrc,
+)
+
 dxgi_shaders = files([
   'shaders/dxgi_presenter_frag.frag',
   'shaders/dxgi_presenter_vert.vert',
@@ -15,7 +22,7 @@ dxgi_src = [
   'dxgi_swapchain.cpp',
 ]
 
-dxgi_dll = shared_library('dxgi'+dll_ext, dxgi_src,
+dxgi_dll = shared_library('dxgi'+dll_ext, dxgi_src, not dxvk_winelib ? dxgi_res : [],
   name_prefix         : '',
   dependencies        : [ dxvk_dep ],
   include_directories : dxvk_include_path,

--- a/src/dxgi/meson.build
+++ b/src/dxgi/meson.build
@@ -1,9 +1,17 @@
-dxgi_res = custom_target(
-  'version_dxgi.res',
+if dxvk_winelib
+  dxgi_res = custom_target('dxgi.res',
   input   : 'version.rc',
-  output  : 'version.o',
-  command : wrc,
-)
+  output  : 'version.res',
+  command : [ find_program('wrc'), '-o', '@OUTPUT@', '@INPUT@' ],
+  install : false)
+else
+  dxgi_res = custom_target(
+    'version_dxgi.res',
+    input   : 'version.rc',
+    output  : 'version.o',
+    command : wrc,
+  )
+endif
 
 dxgi_shaders = files([
   'shaders/dxgi_presenter_frag.frag',
@@ -30,6 +38,15 @@ dxgi_dll = shared_library('dxgi'+dll_ext, dxgi_src, not dxvk_winelib ? dxgi_res 
   vs_module_defs      : 'dxgi'+def_spec_ext,
   objects             : not dxvk_msvc ? 'dxgi'+def_spec_ext : [],
   override_options    : ['cpp_std='+dxvk_cpp_std])
+
+if dxvk_winelib
+  dxgi_dll_target = custom_target('dxgi.dll',
+    output  : 'dxgi.dll',
+    input   : [ 'dxgi.spec', dxgi_res ],
+    command : [ find_program('winebuild'), target_arch, '--dll', '--fake-module', '-E', '@INPUT@', '-o', '@OUTPUT@', '-F', 'dxgi.dll' ],
+    install : true,
+    install_dir : 'fakedlls')
+endif
 
 dxgi_dep = declare_dependency(
   link_with           : [ dxgi_dll ],

--- a/src/dxgi/version.rc
+++ b/src/dxgi/version.rc
@@ -2,10 +2,10 @@
 
 // DLL version information.
 VS_VERSION_INFO    VERSIONINFO
-FILEVERSION 10,0,17763,1
-PRODUCTVERSION 10,0,17763,1
+FILEVERSION        10,0,17763,1
+PRODUCTVERSION     10,0,17763,1
 FILEFLAGSMASK      VS_FFI_FILEFLAGSMASK
-FILEFLAGS        0
+FILEFLAGS          0
 FILEOS VOS_NT_WINDOWS32
 FILETYPE VFT_DLL
 FILESUBTYPE VFT2_UNKNOWN
@@ -14,14 +14,14 @@ BEGIN
   BEGIN
     BLOCK "080904b0"
     BEGIN
-      VALUE "CompanyName", "Microsoft Corporation"
-      VALUE "FileDescription", "DirectX Graphics Infrastructure"
-      VALUE "FileVersion", "10.0.17763.1 (WinBuild.160101.0800)"
-      VALUE "InternalName", "dxgi.dll"
-      VALUE "LegalCopyright", "2019 It's FOSS!"
+      VALUE "CompanyName",      "DXVK"
+      VALUE "FileDescription",  "DirectX Graphics Infrastructure"
+      VALUE "FileVersion",      "10.0.17763.1 (WinBuild.160101.0800)"
+      VALUE "InternalName",     "dxgi.dll"
+      VALUE "LegalCopyright",   "zlib/libpng license"
       VALUE "OriginalFilename", "dxgi.dll"
-      VALUE "ProductName", "Microsoft\xAE Windows\xAE Operating System"
-      VALUE "ProductVersion", "10.0.17763.1"
+      VALUE "ProductName",      "DXVK"
+      VALUE "ProductVersion",   "10.0.17763.1"
     END
   END
   BLOCK "VarFileInfo"

--- a/src/dxgi/version.rc
+++ b/src/dxgi/version.rc
@@ -1,0 +1,32 @@
+#include <windows.h>
+
+// DLL version information.
+VS_VERSION_INFO    VERSIONINFO
+FILEVERSION 10,0,17763,1
+PRODUCTVERSION 10,0,17763,1
+FILEFLAGSMASK      VS_FFI_FILEFLAGSMASK
+FILEFLAGS        0
+FILEOS VOS_NT_WINDOWS32
+FILETYPE VFT_DLL
+FILESUBTYPE VFT2_UNKNOWN
+BEGIN
+  BLOCK "StringFileInfo"
+  BEGIN
+    BLOCK "080904b0"
+    BEGIN
+      VALUE "CompanyName", "Microsoft Corporation"
+      VALUE "FileDescription", "DirectX Graphics Infrastructure"
+      VALUE "FileVersion", "10.0.17763.1 (WinBuild.160101.0800)"
+      VALUE "InternalName", "dxgi.dll"
+      VALUE "LegalCopyright", "2019 It's FOSS!"
+      VALUE "OriginalFilename", "dxgi.dll"
+      VALUE "ProductName", "Microsoft\xAE Windows\xAE Operating System"
+      VALUE "ProductVersion", "10.0.17763.1"
+    END
+  END
+  BLOCK "VarFileInfo"
+  BEGIN
+    VALUE "Translation", 0x0809, 1200
+  END
+END
+


### PR DESCRIPTION
This will create .dll version information for d3d11, d3d10, d3d10.1, d3d10core and dxgi dll's.

I used the version that was on the files in my Windows 10 VM installed box - 10.0.17763.1
The only thing changed vs "the original" is really Copyright note, cos I don't think its proper to use Microsoft there, so i set: `2019 It's FOSS!`

Take a look at it, and do some tests.

OBS! This will NOT create version info for a winelib build, as the version info is really tied to the "fakedlls" and the dll.so will not show this if used. So for now this is just "disabled" with a `not dxvk_winelib ?` statement.

If "fakedlls" are to be created some day, this could be enabled when compiling those i guess.

Customize at will :)