### PR TITLE
[dxvk] Zero-Initialize SpecConstantData

### DIFF
--- a/src/dxvk/dxvk_compute.cpp
+++ b/src/dxvk/dxvk_compute.cpp
@@ -101,7 +101,7 @@ namespace dxvk {
 
     auto csm = m_cs->createShaderModule(m_vkd, m_slotMapping, moduleInfo);
 
-    DxvkSpecConstantData specData;
+    DxvkSpecConstantData specData = { };
     
     for (uint32_t i = 0; i < MaxNumActiveBindings; i++)
       specData.activeBindings[i] = state.bsBindingMask.isBound(i) ? VK_TRUE : VK_FALSE;

--- a/src/dxvk/dxvk_graphics.cpp
+++ b/src/dxvk/dxvk_graphics.cpp
@@ -184,7 +184,7 @@ namespace dxvk {
       sampleCount = VkSampleCountFlagBits(state.rsSampleCount);
     
     // Set up some specialization constants
-    DxvkSpecConstantData specData;
+    DxvkSpecConstantData specData = { };
     specData.rasterizerSampleCount = uint32_t(sampleCount);
     specData.alphaTestEnable       = state.xsAlphaCompareOp != VK_COMPARE_OP_ALWAYS;
     specData.alphaCompareOp        = state.xsAlphaCompareOp;


### PR DESCRIPTION
Ensure that specialization constant data passed into the driver is
zero-initialized.

Having the pData field in VkSpecializationInfo be zero-initialized helps
to create more deterministic input to the driver, which is particularly
useful when debugging shader issues.