### PR TITLE
[build] Fix version info generation for winelib builds

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -25,8 +25,6 @@ else
   dxvk_library_path = meson.source_root() + '/lib32'
 endif
 
-wrc = cpu_family == 'x86_64' ? find_program('x86_64-w64-mingw32-windres') : find_program('i686-w64-mingw32-windres')
-
 code = '''#ifndef __WINE__
 #error 1
 #endif'''
@@ -35,6 +33,7 @@ dxvk_winelib = dxvk_compiler.compiles(code, name: 'winelib check')
 dxvk_extradep = [ ]
 
 if dxvk_winelib
+  wrc = find_program('wrc')
   lib_vulkan  = declare_dependency(link_args: [ '-lwinevulkan' ])
   lib_d3d11   = declare_dependency(link_args: [ '-ld3d11' ])
   lib_dxgi    = declare_dependency(link_args: [ '-ldxgi' ])
@@ -45,6 +44,7 @@ if dxvk_winelib
   dll_ext = '.dll'
   def_spec_ext = '.spec'
 else
+  wrc = cpu_family == 'x86_64' ? find_program('x86_64-w64-mingw32-windres') : find_program('i686-w64-mingw32-windres')
   lib_vulkan  = dxvk_compiler.find_library('vulkan-1', dirs : dxvk_library_path)
   lib_d3d11   = dxvk_compiler.find_library('d3d11')
   lib_dxgi    = dxvk_compiler.find_library('dxgi')

--- a/meson.build
+++ b/meson.build
@@ -42,6 +42,7 @@ if dxvk_winelib
   dxvk_extradep += [ declare_dependency(link_args: [ '-ldl' ]) ]
   exe_ext = '.exe.so'
   dll_ext = '.dll'
+  res_ext = '.res'
   def_spec_ext = '.spec'
 else
   wrc = cpu_family == 'x86_64' ? find_program('x86_64-w64-mingw32-windres') : find_program('i686-w64-mingw32-windres')
@@ -57,6 +58,7 @@ else
   endif
   exe_ext = ''
   dll_ext = ''
+  res_ext = '.o'
   def_spec_ext = '.def'
 endif
 
@@ -64,6 +66,10 @@ glsl_compiler = find_program('glslangValidator')
 glsl_generator = generator(glsl_compiler,
   output    : [ '@BASENAME@.h' ],
   arguments : [ '-V', '--vn', '@BASENAME@', '@INPUT@', '-o', '@OUTPUT@' ])
+
+wrc_generator = generator(wrc,
+  output    : [ '@BASENAME@' + res_ext ],
+  arguments : [ '-i', '@INPUT@', '-o', '@OUTPUT@' ])
 
 dxvk_version = vcs_tag(
   command: ['git', 'describe', '--dirty=+'],

--- a/src/d3d10/meson.build
+++ b/src/d3d10/meson.build
@@ -1,23 +1,6 @@
-d3d10_res = custom_target(
-  'version10.res',
-  input   : 'version10.rc',
-  output  : 'version10.o',
-  command : [ wrc, '@INPUT@', '@OUTPUT@' ],
-)
-
-d3d10_1_res = custom_target(
-  'version10_1.res',
-  input   : 'version10_1.rc',
-  output  : 'version10_1.o',
-  command : [ wrc, '@INPUT@', '@OUTPUT@' ],
-)
-
-d3d10_core_res = custom_target(
-  'version10_core.res',
-  input   : 'version10_core.rc',
-  output  : 'version10_core.o',
-  command : [ wrc, '@INPUT@', '@OUTPUT@' ],
-)
+d3d10_res      = wrc_generator.process('version10.rc')
+d3d10_1_res    = wrc_generator.process('version10_1.rc')
+d3d10_core_res = wrc_generator.process('version10_core.rc')
 
 d3d10_main_src = [
   'd3d10_main.cpp',
@@ -27,7 +10,7 @@ d3d10_main_src = [
 d3d10_deps = [ lib_d3dcompiler_43, lib_dxgi ]
 d3d10_deps += dxvk_winelib ? lib_d3d11 : d3d11_dep
 
-d3d10_core_dll = shared_library('d3d10core'+dll_ext, d3d10_main_src, not dxvk_winelib ? d3d10_core_res : [],
+d3d10_core_dll = shared_library('d3d10core'+dll_ext, d3d10_main_src, d3d10_core_res,
   name_prefix         : '',
   dependencies        : [ d3d10_deps, dxbc_dep, dxvk_dep ],
   include_directories : dxvk_include_path,
@@ -36,7 +19,7 @@ d3d10_core_dll = shared_library('d3d10core'+dll_ext, d3d10_main_src, not dxvk_wi
   vs_module_defs      : 'd3d10core'+def_spec_ext,
   override_options    : ['cpp_std='+dxvk_cpp_std])
 
-d3d10_dll = shared_library('d3d10'+dll_ext, d3d10_main_src, not dxvk_winelib ? d3d10_res : [],
+d3d10_dll = shared_library('d3d10'+dll_ext, d3d10_main_src, d3d10_res,
   name_prefix         : '',
   dependencies        : [ d3d10_deps, dxbc_dep, dxvk_dep ],
   include_directories : dxvk_include_path,
@@ -45,7 +28,7 @@ d3d10_dll = shared_library('d3d10'+dll_ext, d3d10_main_src, not dxvk_winelib ? d
   vs_module_defs      : 'd3d10'+def_spec_ext,
   override_options    : ['cpp_std='+dxvk_cpp_std])
 
-d3d10_1_dll = shared_library('d3d10_1'+dll_ext, d3d10_main_src, not dxvk_winelib ? d3d10_1_res : [],
+d3d10_1_dll = shared_library('d3d10_1'+dll_ext, d3d10_main_src, d3d10_1_res,
   name_prefix         : '',
   dependencies        : [ d3d10_deps, dxbc_dep, dxvk_dep ],
   include_directories : dxvk_include_path,

--- a/src/d3d11/meson.build
+++ b/src/d3d11/meson.build
@@ -1,9 +1,4 @@
-d3d11_res = custom_target(
-  'version_11.res',
-  input   : 'version.rc',
-  output  : 'version.o',
-  command : [ wrc, '@INPUT@', '@OUTPUT@' ],
-)
+d3d11_res = wrc_generator.process('version.rc')
 
 dxgi_common_src = [
   '../dxgi/dxgi_format.cpp',
@@ -61,7 +56,7 @@ d3d11_src = [
   'd3d11_view_uav.cpp',
 ]
 
-d3d11_dll = shared_library('d3d11'+dll_ext, dxgi_common_src + d3d11_src + d3d10_src, glsl_generator.process(dxgi_shaders), not dxvk_winelib ? d3d11_res : [],
+d3d11_dll = shared_library('d3d11'+dll_ext, dxgi_common_src + d3d11_src + d3d10_src, glsl_generator.process(dxgi_shaders), d3d11_res,
   name_prefix         : '',
   dependencies        : [ lib_dxgi, dxbc_dep, dxvk_dep ],
   include_directories : dxvk_include_path,

--- a/src/dxgi/meson.build
+++ b/src/dxgi/meson.build
@@ -1,9 +1,4 @@
-dxgi_res = custom_target(
-  'version_dxgi.res',
-  input   : 'version.rc',
-  output  : 'version.o',
-  command : [ wrc, '@INPUT@', '@OUTPUT@' ],
-)
+dxgi_res = wrc_generator.process('version.rc')
 
 dxgi_shaders = files([
   'shaders/dxgi_presenter_frag.frag',
@@ -22,7 +17,7 @@ dxgi_src = [
   'dxgi_swapchain.cpp',
 ]
 
-dxgi_dll = shared_library('dxgi'+dll_ext, dxgi_src, not dxvk_winelib ? dxgi_res : [],
+dxgi_dll = shared_library('dxgi'+dll_ext, dxgi_src, dxgi_res,
   name_prefix         : '',
   dependencies        : [ dxvk_dep ],
   include_directories : dxvk_include_path,


### PR DESCRIPTION
`*.res` extensions used for winelib, in case there is "magic" in `winegcc`.