### PR TITLE
[build] Meson kwargs support (>=0.49)

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,4 @@
-project('dxvk', ['c', 'cpp'], version : 'v1.0.1', meson_version : '>= 0.43')
+project('dxvk', ['c', 'cpp'], version : 'v1.0.1', meson_version : '>= 0.49')
 
 cpu_family = target_machine.cpu_family()
 
@@ -61,6 +61,13 @@ else
   res_ext = '.o'
   def_spec_ext = '.def'
 endif
+
+# Common kwargs for targets
+common_opts = { 'override_options': ['cpp_std=' + dxvk_cpp_std] }
+
+common_exe_opts    = common_opts + { 'install': true }
+common_static_opts = common_opts + { 'include_directories': dxvk_include_path }
+common_shared_opts = common_opts + { 'include_directories': dxvk_include_path, 'name_prefix': '', 'install': true }
 
 glsl_compiler = find_program('glslangValidator')
 glsl_generator = generator(glsl_compiler,

--- a/src/d3d10/meson.build
+++ b/src/d3d10/meson.build
@@ -10,32 +10,21 @@ d3d10_main_src = [
 d3d10_deps = [ lib_d3dcompiler_43, lib_dxgi ]
 d3d10_deps += dxvk_winelib ? lib_d3d11 : d3d11_dep
 
-d3d10_core_dll = shared_library('d3d10core'+dll_ext, d3d10_main_src, d3d10_core_res,
-  name_prefix         : '',
-  dependencies        : [ d3d10_deps, dxbc_dep, dxvk_dep ],
-  include_directories : dxvk_include_path,
-  install             : true,
-  objects             : not dxvk_msvc ? 'd3d10core'+def_spec_ext : [],
-  vs_module_defs      : 'd3d10core'+def_spec_ext,
-  override_options    : ['cpp_std='+dxvk_cpp_std])
+d3d10_common_opts = common_shared_opts + { 'dependencies': [ d3d10_deps, dxbc_dep, dxvk_dep ] }
 
-d3d10_dll = shared_library('d3d10'+dll_ext, d3d10_main_src, d3d10_res,
-  name_prefix         : '',
-  dependencies        : [ d3d10_deps, dxbc_dep, dxvk_dep ],
-  include_directories : dxvk_include_path,
-  install             : true,
-  objects             : not dxvk_msvc ? 'd3d10'+def_spec_ext : [],
-  vs_module_defs      : 'd3d10'+def_spec_ext,
-  override_options    : ['cpp_std='+dxvk_cpp_std])
+d3d10_core_opts = d3d10_common_opts + { 'vs_module_defs': 'd3d10core' + def_spec_ext }
+d3d10_opts      = d3d10_common_opts + { 'vs_module_defs': 'd3d10'     + def_spec_ext }
+d3d10_1_opts    = d3d10_common_opts + { 'vs_module_defs': 'd3d10_1'   + def_spec_ext }
 
-d3d10_1_dll = shared_library('d3d10_1'+dll_ext, d3d10_main_src, d3d10_1_res,
-  name_prefix         : '',
-  dependencies        : [ d3d10_deps, dxbc_dep, dxvk_dep ],
-  include_directories : dxvk_include_path,
-  install             : true,
-  objects             : not dxvk_msvc ? 'd3d10_1'+def_spec_ext : [],
-  vs_module_defs      : 'd3d10_1'+def_spec_ext,
-  override_options    : ['cpp_std='+dxvk_cpp_std])
+if not dxvk_msvc
+  d3d10_core_opts += { 'objects': 'd3d10core' + def_spec_ext }
+  d3d10_opts      += { 'objects': 'd3d10'     + def_spec_ext }
+  d3d10_1_opts    += { 'objects': 'd3d10_1'   + def_spec_ext }
+endif
+
+d3d10_core_dll = shared_library('d3d10core'+dll_ext, d3d10_main_src, d3d10_core_res, kwargs: d3d10_core_opts)
+d3d10_dll      = shared_library('d3d10'+dll_ext,     d3d10_main_src, d3d10_res,      kwargs: d3d10_opts)
+d3d10_1_dll    = shared_library('d3d10_1'+dll_ext,   d3d10_main_src, d3d10_1_res,    kwargs: d3d10_1_opts)
 
 d3d10_dep = declare_dependency(
   link_with           : [ d3d10_dll, d3d10_1_dll, d3d10_core_dll ],

--- a/src/d3d11/meson.build
+++ b/src/d3d11/meson.build
@@ -56,14 +56,13 @@ d3d11_src = [
   'd3d11_view_uav.cpp',
 ]
 
-d3d11_dll = shared_library('d3d11'+dll_ext, dxgi_common_src + d3d11_src + d3d10_src, glsl_generator.process(dxgi_shaders), d3d11_res,
-  name_prefix         : '',
-  dependencies        : [ lib_dxgi, dxbc_dep, dxvk_dep ],
-  include_directories : dxvk_include_path,
-  install             : true,
-  objects             : not dxvk_msvc ? 'd3d11'+def_spec_ext : [],
-  vs_module_defs      : 'd3d11'+def_spec_ext,
-  override_options    : ['cpp_std='+dxvk_cpp_std])
+d3d11_opts = common_shared_opts + { 'dependencies': [ lib_dxgi, dxbc_dep, dxvk_dep ], 'vs_module_defs': 'd3d11' + def_spec_ext }
+
+if not dxvk_msvc
+  d3d11_opts += { 'objects': 'd3d11' + def_spec_ext }
+endif
+
+d3d11_dll = shared_library('d3d11'+dll_ext, dxgi_common_src + d3d11_src + d3d10_src, glsl_generator.process(dxgi_shaders), d3d11_res, kwargs: d3d11_opts)
 
 d3d11_dep = declare_dependency(
   link_with           : [ d3d11_dll ],

--- a/src/dxbc/meson.build
+++ b/src/dxbc/meson.build
@@ -14,9 +14,7 @@ dxbc_src = files([
   'dxbc_util.cpp',
 ])
 
-dxbc_lib = static_library('dxbc', dxbc_src,
-  include_directories : [ dxvk_include_path ],
-  override_options    : ['cpp_std='+dxvk_cpp_std])
+dxbc_lib = static_library('dxbc', dxbc_src, kwargs: common_static_opts)
 
 dxbc_dep = declare_dependency(
   link_with           : [ dxbc_lib ],

--- a/src/dxgi/meson.build
+++ b/src/dxgi/meson.build
@@ -17,14 +17,13 @@ dxgi_src = [
   'dxgi_swapchain.cpp',
 ]
 
-dxgi_dll = shared_library('dxgi'+dll_ext, dxgi_src, dxgi_res,
-  name_prefix         : '',
-  dependencies        : [ dxvk_dep ],
-  include_directories : dxvk_include_path,
-  install             : true,
-  vs_module_defs      : 'dxgi'+def_spec_ext,
-  objects             : not dxvk_msvc ? 'dxgi'+def_spec_ext : [],
-  override_options    : ['cpp_std='+dxvk_cpp_std])
+dxgi_opts = common_shared_opts + { 'dependencies': [ dxvk_dep ], 'vs_module_defs': 'dxgi' + def_spec_ext }
+
+if not dxvk_msvc
+  dxgi_opts += { 'objects': 'dxgi' + def_spec_ext }
+endif
+
+dxgi_dll = shared_library('dxgi'+dll_ext, dxgi_src, dxgi_res, kwargs: dxgi_opts)
 
 dxgi_dep = declare_dependency(
   link_with           : [ dxgi_dll ],

--- a/src/dxvk/meson.build
+++ b/src/dxvk/meson.build
@@ -97,11 +97,9 @@ dxvk_src = files([
 
 thread_dep = dependency('threads')
 
-dxvk_lib = static_library('dxvk', dxvk_src, glsl_generator.process(dxvk_shaders), dxvk_version,
-  link_with           : [ util_lib, spirv_lib ],
-  dependencies        : [ thread_dep, vkcommon_dep ] + dxvk_extradep,
-  include_directories : [ dxvk_include_path ],
-  override_options    : ['cpp_std='+dxvk_cpp_std])
+dxvk_opts = common_static_opts + { 'link_with': [ util_lib, spirv_lib ], 'dependencies': [ thread_dep, vkcommon_dep ] + dxvk_extradep }
+
+dxvk_lib = static_library('dxvk', dxvk_src, glsl_generator.process(dxvk_shaders), dxvk_version, kwargs: dxvk_opts)
 
 dxvk_dep = declare_dependency(
   link_with           : [ dxvk_lib ],

--- a/src/spirv/meson.build
+++ b/src/spirv/meson.build
@@ -4,6 +4,4 @@ spirv_src = files([
   'spirv_module.cpp',
 ])
 
-spirv_lib = static_library('spirv', spirv_src,
-  include_directories : [ dxvk_include_path ],
-  override_options    : ['cpp_std='+dxvk_cpp_std])
+spirv_lib = static_library('spirv', spirv_src, kwargs: common_static_opts)

--- a/src/util/meson.build
+++ b/src/util/meson.build
@@ -14,9 +14,7 @@ util_src = files([
   'sha1/sha1_util.cpp',
 ])
 
-util_lib = static_library('util', util_src,
-  include_directories : [ dxvk_include_path ],
-  override_options    : ['cpp_std='+dxvk_cpp_std])
+util_lib = static_library('util', util_src, kwargs: common_static_opts)
 
 util_dep = declare_dependency(
   link_with           : [ util_lib ])

--- a/src/vulkan/meson.build
+++ b/src/vulkan/meson.build
@@ -6,10 +6,9 @@ vkcommon_src = files([
 
 thread_dep = dependency('threads')
 
-vkcommon_lib = static_library('vkcommon', vkcommon_src,
-  dependencies        : [ thread_dep, lib_vulkan ],
-  override_options    : ['cpp_std='+dxvk_cpp_std],
-  include_directories : [ dxvk_include_path ])
+vkcommon_opts = common_static_opts + { 'dependencies': [ thread_dep, lib_vulkan ] }
+
+vkcommon_lib = static_library('vkcommon', vkcommon_src, kwargs: vkcommon_opts)
 
 vkcommon_dep = declare_dependency(
   link_with           : [ vkcommon_lib ],

--- a/tests/d3d11/meson.build
+++ b/tests/d3d11/meson.build
@@ -1,7 +1,7 @@
-test_d3d11_deps = [ util_dep, lib_dxgi, lib_d3d11, lib_d3dcompiler_47 ]
+test_d3d11_opts = common_exe_opts + { 'dependencies': [ util_dep, lib_dxgi, lib_d3d11, lib_d3dcompiler_47 ] }
 
-executable('d3d11-compute'+exe_ext,   files('test_d3d11_compute.cpp'),   dependencies : test_d3d11_deps, install : true, override_options: ['cpp_std='+dxvk_cpp_std])
-executable('d3d11-formats'+exe_ext,   files('test_d3d11_formats.cpp'),   dependencies : test_d3d11_deps, install : true, override_options: ['cpp_std='+dxvk_cpp_std])
-executable('d3d11-map-read'+exe_ext,  files('test_d3d11_map_read.cpp'),  dependencies : test_d3d11_deps, install : true, override_options: ['cpp_std='+dxvk_cpp_std])
-executable('d3d11-streamout'+exe_ext, files('test_d3d11_streamout.cpp'), dependencies : test_d3d11_deps, install : true, override_options: ['cpp_std='+dxvk_cpp_std])
-executable('d3d11-triangle'+exe_ext,  files('test_d3d11_triangle.cpp'),  dependencies : test_d3d11_deps, install : true, override_options: ['cpp_std='+dxvk_cpp_std])
+executable('d3d11-compute'+exe_ext,   files('test_d3d11_compute.cpp'),   kwargs: test_d3d11_opts)
+executable('d3d11-formats'+exe_ext,   files('test_d3d11_formats.cpp'),   kwargs: test_d3d11_opts)
+executable('d3d11-map-read'+exe_ext,  files('test_d3d11_map_read.cpp'),  kwargs: test_d3d11_opts)
+executable('d3d11-streamout'+exe_ext, files('test_d3d11_streamout.cpp'), kwargs: test_d3d11_opts)
+executable('d3d11-triangle'+exe_ext,  files('test_d3d11_triangle.cpp'),  kwargs: test_d3d11_opts)

--- a/tests/dxbc/meson.build
+++ b/tests/dxbc/meson.build
@@ -1,6 +1,6 @@
-test_dxbc_deps = [ dxbc_dep, dxvk_dep ]
+test_dxbc_opts     = common_exe_opts + { 'dependencies': [ dxbc_dep, dxvk_dep ] }
+test_dxbc_ext_opts = common_exe_opts + { 'dependencies': [ dxbc_dep, dxvk_dep, lib_d3dcompiler_47 ] }
 
-executable('dxbc-compiler'+exe_ext, files('test_dxbc_compiler.cpp'), dependencies : test_dxbc_deps, install : true, override_options: ['cpp_std='+dxvk_cpp_std])
-executable('dxbc-disasm'+exe_ext,   files('test_dxbc_disasm.cpp'),   dependencies : [ test_dxbc_deps, lib_d3dcompiler_47 ], install : true, override_options: ['cpp_std='+dxvk_cpp_std])
-executable('hlsl-compiler'+exe_ext, files('test_hlsl_compiler.cpp'), dependencies : [ test_dxbc_deps, lib_d3dcompiler_47 ], install : true, override_options: ['cpp_std='+dxvk_cpp_std])
-
+executable('dxbc-compiler'+exe_ext, files('test_dxbc_compiler.cpp'), kwargs: test_dxbc_opts)
+executable('dxbc-disasm'+exe_ext,   files('test_dxbc_disasm.cpp'),   kwargs: test_dxbc_ext_opts)
+executable('hlsl-compiler'+exe_ext, files('test_hlsl_compiler.cpp'), kwargs: test_dxbc_ext_opts)

--- a/tests/dxgi/meson.build
+++ b/tests/dxgi/meson.build
@@ -1,3 +1,3 @@
-test_dxgi_deps = [ util_dep, lib_dxgi ]
+test_dxgi_opts = common_exe_opts + { 'dependencies': [ util_dep, lib_dxgi ] }
 
-executable('dxgi-factory'+exe_ext, files('test_dxgi_factory.cpp'), dependencies : test_dxgi_deps, install: true, override_options: ['cpp_std='+dxvk_cpp_std])
+executable('dxgi-factory'+exe_ext, files('test_dxgi_factory.cpp'), kwargs: test_dxgi_opts)


### PR DESCRIPTION
http://mesonbuild.com/Release-notes-for-0-49-0.html#can-specify-keyword-arguments-with-a-dictionary

Changes nothing, but keyword arguments became more maintainable.

e.g. #945 could be something like
```patch
--- a/meson.build
+++ b/meson.build
@@ -69,6 +69,10 @@ common_exe_opts    = common_opts + { 'install': true }
 common_static_opts = common_opts + { 'include_directories': dxvk_include_path }
 common_shared_opts = common_opts + { 'include_directories': dxvk_include_path, 'name_prefix': '', 'install': true }
 
+if dxvk_compiler.get_id() == 'msvc'
+  common_exe_opts  += { 'gui_app' : true }
+endif
+
 glsl_compiler = find_program('glslangValidator')
 glsl_generator = generator(glsl_compiler,
   output    : [ '@BASENAME@.h' ],
```

_Started this just for fun, to check how those `kwargs` works. I'm sharing this, since patch already exists.
Feel free to reject this PR, and use it's parts as a guide when/if DXVK will support Meson 0.49._