### PR TITLE
[dxvk] Add adapterCount function to DXVKInstance.

### DIFF
--- a/src/dxvk/dxvk_instance.h
+++ b/src/dxvk/dxvk_instance.h
@@ -38,6 +38,15 @@ namespace dxvk {
     VkInstance handle() {
       return m_vki->instance();
     }
+
+     /**
+     * \brief Number of adapters
+     * 
+     * \returns The number of adapters
+     */
+    size_t adapterCount() {
+      return m_adapters.size();
+    }
     
     /**
      * \brief Retrieves an adapter


### PR DESCRIPTION
Will be needed in the Direct3D9 interface as you can query the number of adapters.