### PR TITLE
[d3d11] Improve CreatePredicate logging

### DIFF
--- a/src/d3d11/d3d11_device.cpp
+++ b/src/d3d11/d3d11_device.cpp
@@ -991,8 +991,13 @@ namespace dxvk {
           ID3D11Predicate**           ppPredicate) {
     InitReturnPtr(ppPredicate);
     
-    if (pPredicateDesc == nullptr || pPredicateDesc->Query != D3D11_QUERY_OCCLUSION_PREDICATE)
+    if (pPredicateDesc == nullptr)
       return E_INVALIDARG;
+
+    if (pPredicateDesc->Query != D3D11_QUERY_OCCLUSION_PREDICATE) {
+      Logger::warn("D3D11: Unhandled predicate type: ", pPredicateDesc->Query);
+      return E_INVALIDARG;
+    }
     
     if (ppPredicate == nullptr)
       return S_FALSE;


### PR DESCRIPTION
Although I know nothing uses D3D11_QUERY_SO_OVERFLOW_PREDICATE, it may be a good idea to log if the game tries to do something unsupported by us.