### PR TITLE
[util] Enable constant buffer range check for NieR:Automata

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -138,6 +138,10 @@ namespace dxvk {
     { "Grim Dawn.exe", {{
       { "d3d11.constantBufferRangeCheck",   "True" },
     }} },
+    /* NieR:Automata                              */
+    { "NieRAutomata.exe", {{
+      { "d3d11.constantBufferRangeCheck",   "True" },
+    }} },
   }};
 
 


### PR DESCRIPTION
This fixes a graphical corruption issue where Operator 6O's portrait
displays as a large flashing circle due to uninitialized buffer reads.

Fixes issue: https://github.com/ValveSoftware/Proton/issues/1543

Reviewed-by: Liam Middlebrook <lmiddlebrook@nvidia.com>