### PR TITLE
[dxbc] Fix xfb passthrough for system values

### DIFF
--- a/src/dxbc/dxbc_compiler.cpp
+++ b/src/dxbc/dxbc_compiler.cpp
@@ -189,7 +189,7 @@ namespace dxvk {
 
     for (auto e = m_isgn->begin(); e != m_isgn->end(); e++) {
       emitDclInput(e->registerId, 1,
-        e->componentMask, e->systemValue,
+        e->componentMask, DxbcSystemValue::None,
         DxbcInterpolationMode::Undefined);
     }
 


### PR DESCRIPTION
vReg should be always allocated for system values which is necessary for emitXfbOutputSetup and is already done for hull shader passthrough.

Resulting spirv was crashing Mesa in spirv to nir translator and didn't pass spirv validation.

This fixes one of the crashes when working with RenderDoc and D3D11 under wine.