### PR TITLE
[util] Disable NvAPI hack for Mirror's Edge Catalyst

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -122,6 +122,14 @@ namespace dxvk {
     { "MassEffectAndromeda.exe", {{
       { "dxgi.nvapiHack",                   "False" },
     }} },
+    /* Mirror`s Edge Catalyst                     */
+    { "MirrorsEdgeCatalyst.exe", {{
+      { "dxgi.nvapiHack",                   "False" },
+    }} },
+    /* Mirror`s Edge Catalyst Trial               */
+    { "MirrorsEdgeCatalystTrial.exe", {{
+      { "dxgi.nvapiHack",                   "False" },
+    }} },
     /* Star Wars Battlefront (2015)               */
     { "starwarsbattlefront.exe", {{
       { "dxgi.nvapiHack",                   "False" },


### PR DESCRIPTION
Without this, game crashes at startup on nVidia cards.
#893