### PR TITLE
Copy staging textures to their mapped buffers after every write

### DIFF
--- a/src/d3d11/d3d11_context.h
+++ b/src/d3d11/d3d11_context.h
@@ -857,6 +857,8 @@ namespace dxvk {
         m_cmdData = nullptr;
       }
     }
+
+    void CopyTextureToMappedBuffer(const D3D11CommonTexture* pTexture, uint32_t subresourceIndex);
     
     virtual void EmitCsChunk(DxvkCsChunkRef&& chunk) = 0;
     

--- a/src/d3d11/d3d11_context_imm.cpp
+++ b/src/d3d11/d3d11_context_imm.cpp
@@ -383,11 +383,14 @@ namespace dxvk {
         // When using any map mode which requires the image contents
         // to be preserved, and if the GPU has write access to the
         // image, copy the current image contents into the buffer.
-        if (pResource->Desc()->Usage == D3D11_USAGE_STAGING && !pResource->SupportsEarlyBufferCopy()) {
+        bool copyToBuffer = pResource->Desc()->Usage == D3D11_USAGE_STAGING && !pResource->SupportsEarlyBufferCopy();
+        if (copyToBuffer) {
           CopyTextureToMappedBuffer(pResource, Subresource);
         }
 
-        WaitForResource(mappedBuffer, 0);
+        if (!WaitForResource(mappedBuffer, copyToBuffer ? 0 : MapFlags))
+          return DXGI_ERROR_WAS_STILL_DRAWING;
+
         physSlice = mappedBuffer->getSliceHandle();
       }
       

--- a/src/d3d11/d3d11_texture.h
+++ b/src/d3d11/d3d11_texture.h
@@ -185,6 +185,10 @@ namespace dxvk {
      */
     static HRESULT NormalizeTextureProperties(
             D3D11_COMMON_TEXTURE_DESC* pDesc);
+
+    bool SupportsEarlyBufferCopy() const {
+      return m_mapMode == D3D11_COMMON_TEXTURE_MAP_MODE_BUFFER && m_desc.Usage == D3D11_USAGE_STAGING && m_desc.MipLevels == 1 && m_desc.ArraySize == 1;
+    }
     
   private:
     

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -150,6 +150,10 @@ namespace dxvk {
     { "NieRAutomata.exe", {{
       { "d3d11.constantBufferRangeCheck",   "True" },
     }} },
+    /* The Surge                                  */
+    { "TheSurge.exe", {{
+      { "d3d11.allowMapFlagNoWait",         "True" },
+    }} }
   }};
 
 


### PR DESCRIPTION
GPU access to staging textures is limited to CopySubresourceRegion and CopyResource, so if the texture uses a buffer for mapping we can also copy to that in those methods. This removes the need to sync with the GPU when the texture gets mapped.

There's a caveat: This only works for textures with a single subresource because there's only one mapped buffer.

This improves GPU utilization in The Surge by 20-40% (its >95% now for me). Performance is improved by similar numbers.