### PR TITLE
Add visibility flags on the winelib build to behave more like MinGW

### DIFF
--- a/build-wine32.txt
+++ b/build-wine32.txt
@@ -7,8 +7,8 @@ strip = 'strip'
 [properties]
 needs_exe_wrapper = true
 
-c_args=['-m32', '-msse', '-msse2']
-cpp_args=['-m32', '--no-gnu-unique', '-msse', '-msse2']
+c_args=['-m32', '-msse', '-msse2', '-fvisibility=hidden']
+cpp_args=['-m32', '--no-gnu-unique', '-msse', '-msse2', '-fvisibility=hidden', '-fvisibility-inlines-hidden']
 cpp_link_args=['-m32', '-mwindows']
 
 [host_machine]

--- a/build-wine64.txt
+++ b/build-wine64.txt
@@ -7,8 +7,8 @@ strip = 'strip'
 [properties]
 needs_exe_wrapper = true
 
-c_args=['-m64']
-cpp_args=['-m64', '--no-gnu-unique']
+c_args=['-m64', '-fvisibility=hidden']
+cpp_args=['-m64', '--no-gnu-unique', '-fvisibility=hidden', '-fvisibility-inlines-hidden']
 cpp_link_args=['-m64', '-mwindows']
 
 [host_machine]

--- a/src/dxgi/dxgi_include.h
+++ b/src/dxgi/dxgi_include.h
@@ -1,7 +1,9 @@
 #pragma once
 
 //for some reason we need to specify __declspec(dllexport) for MinGW
-#if defined(_MSC_VER) || defined(__WINE__)
+#if defined(__WINE__)
+  #define DLLEXPORT __attribute__((visibility("default")))
+#elif defined(_MSC_VER)
   #define DLLEXPORT
 #else
   #define DLLEXPORT __declspec(dllexport)


### PR DESCRIPTION
When compiling .so files, GCC exports _everything_ by default (while MinGW because of the PE DLL format does the opposite by having everything hidden by default and needing the dllexport specifier to be explicitly stated). This is inconvenient because the linker forgoes some optimizations assuming that everything is going to be exported, the executable are bigger than needed because of the very large symbol table, that also impacts the dynamic loading of the shared library and its symbols.

By these small changes almost a MB of volume is saved between the 32 and 64 bit builds. I tested it with a couple of games, such changes did not affect negatively the performance, but the improvement I saw might have been within the margin of error.