### PR TITLE
[d3d10] define IID_PPV_ARGS macro for winelib build

### DIFF
--- a/src/d3d10/d3d10_include.h
+++ b/src/d3d10/d3d10_include.h
@@ -5,3 +5,14 @@
 
 #include <d3d10_1.h>
 #include <d3d11_1.h>
+
+#ifdef __WINE__
+extern "C++" {
+  template<typename T> void **IID_PPV_ARGS_Helper (T **pp) {
+    static_cast<IUnknown *> (*pp);
+    return reinterpret_cast<void **> (pp);
+  }
+}
+
+#define IID_PPV_ARGS(ppType) __uuidof (**(ppType)), IID_PPV_ARGS_Helper (ppType)
+#endif // __WINE__


### PR DESCRIPTION
This fixes following error after commit 78ab26347d3524061cb05599e563853f14e95a1e :
`src/d3d10/d3d10_main.cpp:150:25: error: ‘IID_PPV_ARGS’ was not declared in this scope
`