### PR TITLE
[build] Configure setup script to install only the enabled dlls

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -107,7 +107,7 @@ setup_dxvk_sh_conf = configuration_data()
 if get_option('enable_dxgi')
   setup_dxvk_sh_conf.set('action_dxgi', '$action dxgi')
 else
-  setup_dxvk_sh_conf.set('action_dxgi', '')
+  setup_dxvk_sh_conf.set('action_dxgi', 'true')
 endif
 
 if get_option('enable_d3d10')

--- a/meson.build
+++ b/meson.build
@@ -101,3 +101,31 @@ enable_tests = get_option('enable_tests')
 if enable_tests
   subdir('tests')
 endif
+
+setup_dxvk_sh_conf = configuration_data()
+
+if get_option('enable_dxgi')
+  setup_dxvk_sh_conf.set('action_dxgi', '$action dxgi')
+else
+  setup_dxvk_sh_conf.set('action_dxgi', '')
+endif
+
+if get_option('enable_d3d10')
+  setup_dxvk_sh_conf.set('action_d3d10', '$action d3d10')
+  setup_dxvk_sh_conf.set('action_d3d10_1', '$action d3d10_1')
+  setup_dxvk_sh_conf.set('action_d3d10core', '$action d3d10core')
+else
+  setup_dxvk_sh_conf.set('action_d3d10', '')
+  setup_dxvk_sh_conf.set('action_d3d10_1', '')
+  setup_dxvk_sh_conf.set('action_d3d10core', '')
+endif
+
+if get_option('enable_d3d11')
+  setup_dxvk_sh_conf.set('action_d3d11', '$action d3d11')
+else
+  setup_dxvk_sh_conf.set('action_d3d11', '')
+endif
+
+configure_file(input : 'setup_dxvk.sh.in',
+               output : 'setup_dxvk.sh',
+               configuration : setup_dxvk_sh_conf)

--- a/setup_dxvk.sh.in
+++ b/setup_dxvk.sh.in
@@ -137,10 +137,10 @@ uninstall() {
 # skip dxgi during install if not explicitly
 # enabled, but always try to uninstall it
 if [ $with_dxgi -ne 0 ] || [ "$action" == "uninstall" ]; then
-  $action dxgi
+  @action_dxgi@
 fi
 
-$action d3d10
-$action d3d10_1
-$action d3d10core
-$action d3d11
+@action_d3d10@
+@action_d3d10_1@
+@action_d3d10core@
+@action_d3d11@


### PR DESCRIPTION
Configures setup_dxvk.sh based on what is enabled in meson. This way it won't try to install non-existent files and fail because of it. Mostly needed for d9vk since it makes the two projects install under the same prefix cleanly with the provided script if the user selects which dlls to build. There should be a similar PR for d9vk but since that project pulls from dxvk regularly, I think this PR should start from here.