### PR TITLE
[dxgi] Don't fail leaving fullscreen if window is already destroyed

### DIFF
--- a/src/dxgi/dxgi_swapchain.cpp
+++ b/src/dxgi/dxgi_swapchain.cpp
@@ -567,7 +567,7 @@ namespace dxvk {
   
   HRESULT DxgiSwapChain::LeaveFullscreenMode() {
     if (!IsWindow(m_window))
-      return DXGI_ERROR_NOT_CURRENTLY_AVAILABLE;
+      return S_OK;
     
     if (FAILED(RestoreDisplayMode(m_monitor)))
       Logger::warn("DXGI: LeaveFullscreenMode: Failed to restore display mode");


### PR DESCRIPTION
Unreal Engine 4 games (e.g. Octopath Traveler, Bloodstained) destroy the window, then call SetFullscreenMode(FALSE). If this call fails, they pop up an error dialog. Wine tests show that this call should succeed.

This commit isn't really a proper fix. It still fails some of the other return code tests. But it's sufficient to fix the UE4 error dialog on exit.

See Wine tests here:
https://source.winehq.org/git/wine.git/blob/cce8074aa9fb2191faba25ce7fd24e2678d3bd17:/dlls/dxgi/tests/dxgi.c#l2284