### PR TITLE
Enable deferSurfaceCreation for ELEX

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -153,6 +153,10 @@ namespace dxvk {
     /* The Surge                                  */
     { "TheSurge.exe", {{
       { "d3d11.allowMapFlagNoWait",         "True" },
+    }} },
+    /* ELEX: Fix crashes on nvidia                */
+    { "ELEX.exe", {{
+      { "dxgi.deferSurfaceCreation",        "True" },
     }} }
   }};
 


### PR DESCRIPTION
Elex crashes when creating some particles e.g. when using the Jetpack.
This problem only seems to affect nvidia.
deferSurfaceCreation fixes this behavior.