### PR TITLE
Small RSGetViewports fix

### DIFF
--- a/src/d3d11/d3d11_context.cpp
+++ b/src/d3d11/d3d11_context.cpp
@@ -2879,9 +2879,8 @@ namespace dxvk {
           pRects[i].bottom = 0;
         }
       }
-    }
-    
-    *pNumRects = m_state.rs.numScissors;
+    } else
+      *pNumRects = m_state.rs.numScissors;
   }
 
 

--- a/src/d3d11/d3d11_context.cpp
+++ b/src/d3d11/d3d11_context.cpp
@@ -2858,9 +2858,8 @@ namespace dxvk {
           pViewports[i].MaxDepth = 0.0f;
         }
       }
-    }
-    
-    *pNumViewports = m_state.rs.numViewports;
+    } else
+      *pNumViewports = m_state.rs.numViewports;
   }
   
   


### PR DESCRIPTION
Closes #1116 

In D3D11DeviceContext::RSGetViewports, D3D11 only sets pNumViewports if pViewports is null.
I've verified this with Windows D3D11. Wine also does it that way.

The behavior for RSGetScissorRects is the same.
______
MyGUI (a gui library that Scrap Mechanic uses) has a useless assert that only checks D3D11 runtime behavior.
```
UINT numViewports = 0;
D3D11_VIEWPORT viewports[8];
mpD3DContext->RSGetViewports(&numViewports, viewports);
MYGUI_PLATFORM_ASSERT(numViewports == 0, getClassTypeName() << " 0 viewport sets");
```
It does have a viewport at the point this gets executed but because it passes a valid pointer as pViewports, the count doesnt get changed.

https://github.com/MyGUI/mygui/blob/master/Platforms/DirectX11/DirectX11Platform/src/MyGUI_DirectX11RenderManager.cpp#L122

The MyGUI demos run fine with this PR.