### PR TITLE
[dxvk] Handle divide by zero when determining slice count

### DIFF
--- a/src/dxvk/dxvk_buffer.cpp
+++ b/src/dxvk/dxvk_buffer.cpp
@@ -20,7 +20,7 @@ namespace dxvk {
     // Limit size of multi-slice buffers to reduce fragmentation
     constexpr VkDeviceSize MaxBufferSize = 4 << 20;
 
-    m_physSliceMaxCount = MaxBufferSize >= m_physSliceStride
+    m_physSliceMaxCount = MaxBufferSize >= m_physSliceStride && m_physSliceStride != 0
       ? MaxBufferSize / m_physSliceStride
       : 1;
     


### PR DESCRIPTION
Fixes crash when making a zero-sized buffer.

May help #1138