### PR TITLE
[hud] Fix font rendering

### DIFF
--- a/src/dxvk/hud/dxvk_hud_renderer.cpp
+++ b/src/dxvk/hud/dxvk_hud_renderer.cpp
@@ -70,7 +70,7 @@ namespace dxvk::hud {
         sizeFactor * static_cast<float>(glyph.h) };
       
       const HudPos origin = {
-        pos.x + sizeFactor * static_cast<float>(glyph.originX),
+        pos.x - sizeFactor * static_cast<float>(glyph.originX),
         pos.y - sizeFactor * static_cast<float>(glyph.originY) };
       
       const HudPos posTl = { origin.x,          origin.y          };


### PR DESCRIPTION
Some characters (like `i`,`l`, `|`) should be close to the "middle", not to prev. character.

![dxvk-hud-default-ttf](https://user-images.githubusercontent.com/10661854/62416406-e81fb680-b642-11e9-9db2-79ee70891ea1.png)

Bonus: Terminus (TTF)
![dxvk-hud-terminus-ttf](https://user-images.githubusercontent.com/10661854/62416405-e7872000-b642-11e9-8b4a-a2967ac9c388.png)
The "Advance" value should be less than '20', but was set to `20` because of "font shadows".
[0001-hud-Use-Terminus-TTF-font.patch.txt](https://github.com/doitsujin/dxvk/files/3464287/0001-hud-Use-Terminus-TTF-font.patch.txt)
