### PR TITLE
[util] Implement parent dir. based app configs

### DIFF
--- a/src/dxvk/dxvk_instance.cpp
+++ b/src/dxvk/dxvk_instance.cpp
@@ -12,7 +12,7 @@ namespace dxvk {
     Logger::info(str::format("DXVK: ", DXVK_VERSION));
 
     m_config = Config::getUserConfig();
-    m_config.merge(Config::getAppConfig(env::getExeName()));
+    m_config.merge(Config::getAppConfig(env::getExeName(), env::getParentDirectoryPath()));
     m_config.logOptions();
 
     g_vrInstance.initInstanceExtensions();

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -324,11 +324,22 @@ namespace dxvk {
   }
 
 
-  Config Config::getAppConfig(const std::string& appName) {
+  Config Config::getAppConfig(const std::string& appName, const std::string& parentDir) {
+    // Find configs by executable name
     auto appConfig = g_appDefaults.find(appName);
+
+    // Didn't find anything?
+    // Find configs by parent directory
+    if (appConfig == g_appDefaults.end()) {
+      appConfig = std::find_if(g_appDefaults.begin(), g_appDefaults.end(),
+        [&](const auto& appDir) -> bool {
+          return parentDir.ends_with(appDir.first);
+      });
+    }
+
     if (appConfig != g_appDefaults.end()) {
       // Inform the user that we loaded a default config
-      Logger::info(str::format("Found built-in config: ", appName));
+      Logger::info(str::format("Found built-in config: ", appConfig->first));
 
       return appConfig->second;
     }

--- a/src/util/config/config.h
+++ b/src/util/config/config.h
@@ -89,9 +89,10 @@ namespace dxvk {
      * \brief Retrieves default options for an app
      * 
      * \param [in] appName Name of the application
+     * \param [in] parentDir Parent directory path
      * \returns Default options for the application
      */
-    static Config getAppConfig(const std::string& appName);
+    static Config getAppConfig(const std::string& appName, const std::string& parentDir);
 
     /**
      * \brief Retrieves user configuration

--- a/src/util/util_env.cpp
+++ b/src/util/util_env.cpp
@@ -12,18 +12,35 @@ namespace dxvk::env {
   }
   
   
-  std::string getExeName() {
+  std::string getExePath() {
     std::vector<WCHAR> exePath;
     exePath.resize(MAX_PATH + 1);
     
     DWORD len = ::GetModuleFileNameW(NULL, exePath.data(), MAX_PATH);
     exePath.resize(len);
     
-    std::string fullPath = str::fromws(exePath.data());
+    return str::fromws(exePath.data());
+  }
+  
+  
+  std::string getExeName() {
+    std::string fullPath = getExePath();
+
     auto n = fullPath.find_last_of('\\');
     
     return (n != std::string::npos)
       ? fullPath.substr(n + 1)
+      : fullPath;
+  }
+
+
+  std::string getParentDirectoryPath() {
+    std::string fullPath = getExePath();
+
+    auto n = fullPath.find_last_of('\\');
+
+    return (n != std::string::npos)
+      ? fullPath.substr(0, n)
       : fullPath;
   }
   

--- a/src/util/util_env.h
+++ b/src/util/util_env.h
@@ -16,6 +16,16 @@ namespace dxvk::env {
   std::string getEnvVar(const char* name);
   
   /**
+   * \brief Gets the executable path
+   * 
+   * Returns the the full path of the
+   * program executable, including the file extension.
+   * This function should be used to identify programs.
+   * \returns Executable path
+   */
+  std::string getExePath();
+
+  /**
    * \brief Gets the executable name
    * 
    * Returns the base name (not the full path) of the
@@ -24,6 +34,16 @@ namespace dxvk::env {
    * \returns Executable name
    */
   std::string getExeName();
+
+  /**
+   * \brief Gets the directory path
+   *
+   * Returns the parent directory path
+   * of the program executable.
+   * This function should be used to identify programs.
+   * \returns Parent directory path
+   */
+  std::string getParentDirectoryPath();
   
   /**
    * \brief Sets name of the calling thread


### PR DESCRIPTION
## What?

This helps with identifying games where the executable name is variable or non-unique/generic.

To use a directory check in an app config, prepend it with a \\\\ [escaped backslash \\] in the name.

This is not an issue as \ is an illegal character for filenames on Windows.

## Why?

Sonic Adventure 2 uses the name "launcher.exe" for it's filename, but the parent directory is `Sonic Adventure 2`

## Example

```cpp
    /* Sonic Adventure 2                          */
    { "\\Sonic Adventure 2", {{
      { "d3d9.floatEmulation",              "False" },
    }} }
```