### PR TITLE
[util] Define Windows API version

### DIFF
--- a/src/d3d10/d3d10_include.h
+++ b/src/d3d10/d3d10_include.h
@@ -3,5 +3,6 @@
 #include "../dxgi/dxgi_include.h"
 #include "../util/sync/sync_spinlock.h"
 
+#include "../util/util_targetver.h"
 #include <d3d10_1.h>
 #include <d3d11_1.h>

--- a/src/d3d10/d3d10_reflection.h
+++ b/src/d3d10/d3d10_reflection.h
@@ -4,6 +4,7 @@
 
 #include "d3d10_include.h"
 
+#include "../util/util_targetver.h"
 #include <d3d10shader.h>
 #include <d3d11shader.h>
 

--- a/src/d3d11/d3d11_include.h
+++ b/src/d3d11/d3d11_include.h
@@ -2,6 +2,7 @@
 
 #include "../dxgi/dxgi_include.h"
 
+#include "../util/util_targetver.h"
 #include <d3d11_1.h>
 
 // This is not defined in the mingw headers

--- a/src/dxgi/dxgi_adapter.cpp
+++ b/src/dxgi/dxgi_adapter.cpp
@@ -1,6 +1,7 @@
 #include <cstdlib>
 #include <cstring>
 
+#include "../util/util_targetver.h"
 #include <d3d10_1.h>
 
 #include "dxgi_adapter.h"

--- a/src/dxgi/dxgi_include.h
+++ b/src/dxgi/dxgi_include.h
@@ -27,6 +27,7 @@
 #include "../util/util_math.h"
 #include "../util/util_string.h"
 
+#include "../util/util_targetver.h"
 #include <dxgi1_4.h>
 
 // For some reason, these are not exposed

--- a/src/util/com/com_include.h
+++ b/src/util/com/com_include.h
@@ -6,7 +6,7 @@
 #pragma GCC diagnostic ignored "-Wnon-virtual-dtor"
 #endif // __GNUC__
 
-#define WIN32_LEAN_AND_MEAN
+#include "../util_targetver.h"
 #include <windows.h>
 #include <unknwn.h>
 

--- a/src/util/util_targetver.h
+++ b/src/util/util_targetver.h
@@ -1,0 +1,13 @@
+#pragma once
+
+// We want to target Windows 10,
+// so we need to define this before
+// including the following header...
+
+#define WINVER       0x0A00
+#define _WIN32_WINNT 0x0A00
+
+// Exclude some superflous stuff...
+#define WIN32_LEAN_AND_MEAN
+
+#include <sdkddkver.h>

--- a/src/vulkan/vulkan_loader_fn.h
+++ b/src/vulkan/vulkan_loader_fn.h
@@ -11,6 +11,7 @@
 #undef _WIN32
 #endif
 
+#include "../util/util_targetver.h"
 #define VK_USE_PLATFORM_WIN32_KHR 1
 #include <vulkan/vulkan.h>
 


### PR DESCRIPTION
Exposes some more API features that are locked away behind ifdefs...

Some D3D9 stuff is like this for some reason in the MinGW headers I build with at least -- this patch would allow me to remove my hardcoded ``ifdef undef define endif`` for the proper solution as per https://docs.microsoft.com/en-us/cpp/porting/modifying-winver-and-win32-winnt?view=vs-2019

This also fixes the fact that previously the WIN32_LEAN_AND_MEAN define was doing nothing as there were other includes that included ``windows.h`` before that definition.