### PR TITLE
Workaround build failure with winegcc/clang.

### DIFF
--- a/build-wine32.txt
+++ b/build-wine32.txt
@@ -8,7 +8,7 @@ strip = 'strip'
 needs_exe_wrapper = true
 
 c_args=['-m32', '-msse', '-msse2', '-fvisibility=hidden']
-cpp_args=['-m32', '--no-gnu-unique', '-msse', '-msse2', '-fvisibility=hidden', '-fvisibility-inlines-hidden', '-D__WIDL_objidl_generated_name_0000000C=']
+cpp_args=['-m32', '-msse', '-msse2', '-fvisibility=hidden', '-fvisibility-inlines-hidden', '-D__WIDL_objidl_generated_name_0000000C=']
 cpp_link_args=['-m32', '-mwindows']
 
 [host_machine]

--- a/build-wine64.txt
+++ b/build-wine64.txt
@@ -8,7 +8,7 @@ strip = 'strip'
 needs_exe_wrapper = true
 
 c_args=['-m64', '-fvisibility=hidden']
-cpp_args=['-m64', '--no-gnu-unique', '-fvisibility=hidden', '-fvisibility-inlines-hidden', '-D__WIDL_objidl_generated_name_0000000C=']
+cpp_args=['-m64', '-fvisibility=hidden', '-fvisibility-inlines-hidden', '-D__WIDL_objidl_generated_name_0000000C=']
 cpp_link_args=['-m64', '-mwindows']
 
 [host_machine]

--- a/meson.build
+++ b/meson.build
@@ -33,6 +33,9 @@ dxvk_winelib = dxvk_compiler.compiles(code, name: 'winelib check')
 dxvk_extradep = [ ]
 
 if dxvk_winelib
+  if dxvk_compiler.has_argument('--no-gnu-unique')
+    add_project_arguments('--no-gnu-unique', language : ['cpp'])
+  endif
   wrc = find_program('wrc')
   lib_vulkan  = declare_dependency(link_args: [ '-lwinevulkan' ])
   lib_d3d11   = declare_dependency(link_args: [ '-ld3d11' ])

--- a/src/util/util_bit.h
+++ b/src/util/util_bit.h
@@ -1,7 +1,14 @@
 #pragma once
 
 #ifndef _MSC_VER
+#if defined(__WINE__) && defined(__clang__)
+#pragma push_macro("_WIN32")
+#undef _WIN32
+#endif
 #include <x86intrin.h>
+#if defined(__WINE__) && defined(__clang__)
+#pragma pop_macro("_WIN32")
+#endif
 #else
 #include <intrin.h>
 #endif


### PR DESCRIPTION
Fixes https://github.com/doitsujin/dxvk/issues/1182

I briefly tested this with one game (`Grim Dawn`) without issues. I also tested that `--no-gnu-unique` is still used with `winegcc` as built by `gcc`.