### PR TITLE
[dxvk] Replicate R component of border color for depth compare samplers

### DIFF
--- a/src/dxvk/dxvk_sampler.cpp
+++ b/src/dxvk/dxvk_sampler.cpp
@@ -29,7 +29,7 @@ namespace dxvk {
     if (samplerInfo.addressModeU == VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER
      || samplerInfo.addressModeV == VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER
      || samplerInfo.addressModeW == VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER)
-      samplerInfo.borderColor = getBorderColor(info.borderColor);
+      samplerInfo.borderColor = getBorderColor(info.compareToDepth, info.borderColor);
     
     if (m_vkd->vkCreateSampler(m_vkd->device(),
         &samplerInfo, nullptr, &m_sampler) != VK_SUCCESS)
@@ -43,12 +43,19 @@ namespace dxvk {
   }
 
 
-  VkBorderColor DxvkSampler::getBorderColor(VkClearColorValue borderColor) const {
+  VkBorderColor DxvkSampler::getBorderColor(bool depthCompare, VkClearColorValue borderColor) const {
     static const std::array<std::pair<VkClearColorValue, VkBorderColor>, 3> s_borderColors = {{
       { { 0.0f, 0.0f, 0.0f, 0.0f }, VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK },
       { { 0.0f, 0.0f, 0.0f, 1.0f }, VK_BORDER_COLOR_FLOAT_OPAQUE_BLACK },
       { { 1.0f, 1.0f, 1.0f, 1.0f }, VK_BORDER_COLOR_FLOAT_OPAQUE_WHITE },
     }};
+
+    if (depthCompare) {
+      // If we are a depth compare sampler:
+      // Replicate the first index, only R matters.
+      for (uint32_t i = 1; i < 4; i++)
+        borderColor.float32[i] = borderColor.float32[0];
+    }
 
     for (const auto& e : s_borderColors) {
       if (!std::memcmp(&e.first, &borderColor, sizeof(VkClearColorValue)))

--- a/src/dxvk/dxvk_sampler.h
+++ b/src/dxvk/dxvk_sampler.h
@@ -77,7 +77,7 @@ namespace dxvk {
     DxvkSamplerCreateInfo m_info;
     VkSampler             m_sampler = VK_NULL_HANDLE;
 
-    VkBorderColor getBorderColor(VkClearColorValue borderColor) const;
+    VkBorderColor getBorderColor(bool depthCompare, VkClearColorValue borderColor) const;
     
   };
   


### PR DESCRIPTION
Only the red component matters for these samplers -- this lets us pick the best colour based on that alone, as we could get garbage data that doesn't matter in the other components.