### PR TITLE
Change setthreadname to retrieve the function pointer only once

### DIFF
--- a/src/util/util_env.cpp
+++ b/src/util/util_env.cpp
@@ -36,13 +36,8 @@ namespace dxvk::env {
   void setThreadName(const std::string& name) {
     using SetThreadDescriptionProc = HRESULT (WINAPI *) (HANDLE, PCWSTR);
 
-    HMODULE module = ::GetModuleHandleW(L"kernel32.dll");
-
-    if (module == nullptr)
-      return;
-
-    auto proc = reinterpret_cast<SetThreadDescriptionProc>(
-      ::GetProcAddress(module, "SetThreadDescription"));
+    static auto proc = reinterpret_cast<SetThreadDescriptionProc>(
+      ::GetProcAddress(::GetModuleHandleW(L"kernel32.dll"), "SetThreadDescription"));
 
     if (proc != nullptr) {
       auto wideName = str::tows(name);


### PR DESCRIPTION
by using a static variable the callback should be retrieved only once, instead of having to get the module handle and the function pointer every time the function is called