### PR TITLE
[dxvk] Hold a reference to the DxvkAdapter's DxvkInstance

### DIFF
--- a/src/dxvk/dxvk_adapter.h
+++ b/src/dxvk/dxvk_adapter.h
@@ -255,7 +255,7 @@ namespace dxvk {
     
   private:
     
-    DxvkInstance*       m_instance;
+    Rc<DxvkInstance>    m_instance;
     Rc<vk::InstanceFn>  m_vki;
     VkPhysicalDevice    m_handle;
 


### PR DESCRIPTION
This fixes a crash when playing Beat Saber with Wine's DXGI.