### PR TITLE
[util] Wide character conversion changes

### DIFF
--- a/src/dxgi/dxgi_adapter.cpp
+++ b/src/dxgi/dxgi_adapter.cpp
@@ -223,8 +223,7 @@ namespace dxvk {
     
     // Convert device name
     std::memset(pDesc->Description, 0, sizeof(pDesc->Description));
-    ::MultiByteToWideChar(CP_UTF8, 0, deviceProp.deviceName, -1,
-        pDesc->Description, sizeof(pDesc->Description) / sizeof(*pDesc->Description));
+    str::tows(deviceProp.deviceName, pDesc->Description);
     
     // Get amount of video memory
     // based on the Vulkan heaps

--- a/src/util/util_env.cpp
+++ b/src/util/util_env.cpp
@@ -40,15 +40,17 @@ namespace dxvk::env {
       ::GetProcAddress(::GetModuleHandleW(L"kernel32.dll"), "SetThreadDescription"));
 
     if (proc != nullptr) {
-      auto wideName = str::tows(name);
+      auto wideName = std::vector<WCHAR>(name.length() + 1);
+      str::tows(name.c_str(), wideName.data(), wideName.size());
       (*proc)(::GetCurrentThread(), wideName.data());
     }
   }
 
 
   bool createDirectory(const std::string& path) {
-    auto widePath = str::tows(path);
-    return !!CreateDirectoryW(widePath.data(), nullptr);
+    WCHAR widePath[MAX_PATH];
+    str::tows(path.c_str(), widePath);
+    return !!CreateDirectoryW(widePath, nullptr);
   }
   
 }

--- a/src/util/util_string.cpp
+++ b/src/util/util_string.cpp
@@ -1,14 +1,8 @@
 #include "util_string.h"
 
-#ifdef CP_UNIXCP
-static constexpr int cp = CP_UNIXCP;
-#else
-static constexpr int cp = CP_ACP;
-#endif
-
 namespace dxvk::str {
   std::string fromws(const WCHAR *ws) {
-    size_t len = ::WideCharToMultiByte(cp,
+    size_t len = ::WideCharToMultiByte(CP_UTF8,
       0, ws, -1, nullptr, 0, nullptr, nullptr);
 
     if (len <= 1)
@@ -18,24 +12,16 @@ namespace dxvk::str {
 
     std::string result;
     result.resize(len);
-    ::WideCharToMultiByte(cp, 0, ws, -1,
+    ::WideCharToMultiByte(CP_UTF8, 0, ws, -1,
       &result.at(0), len, nullptr, nullptr);
     return result;
   }
 
 
-  std::vector<WCHAR> tows(const std::string& str) {
-    int strLen = ::MultiByteToWideChar(
-      CP_ACP, 0, str.c_str(), str.length() + 1,
-      nullptr, 0);
-
-    std::vector<WCHAR> wideStr(strLen);
-
+  void tows(const char* mbs, WCHAR* wcs, size_t wcsLen) {
     ::MultiByteToWideChar(
-      CP_ACP, 0, str.c_str(), str.length() + 1,
-      wideStr.data(), strLen);
-    
-    return wideStr;
+      CP_UTF8, 0, mbs, -1,
+      wcs, wcsLen);
   }
 
 }

--- a/src/util/util_string.h
+++ b/src/util/util_string.h
@@ -10,7 +10,12 @@ namespace dxvk::str {
   
   std::string fromws(const WCHAR *ws);
 
-  std::vector<WCHAR> tows(const std::string& str);
+  void tows(const char* mbs, WCHAR* wcs, size_t wcsLen);
+
+  template <size_t N>
+  void tows(const char* mbs, WCHAR (&wcs)[N]) {
+    return tows(mbs, wcs, N);
+  }
   
   inline void format1(std::stringstream&) { }
 


### PR DESCRIPTION
Replaces tows with an easier helper that fits in nicer with fixed-size arrays in DXGI, etc.

Make setThreadName take a wide char name by default given we know this entirely deterministically. Avoids needing to convert this and alloc a std::vector every time we call this.

Prefer UTF8 in tows/fromws.