### PR TITLE
Platform-specific clock implementation

### DIFF
--- a/src/d3d11/d3d11_context_imm.cpp
+++ b/src/d3d11/d3d11_context_imm.cpp
@@ -166,7 +166,7 @@ namespace dxvk {
       FlushCsChunk();
       
       // Reset flush timer used for implicit flushes
-      m_lastFlush = std::chrono::high_resolution_clock::now();
+      m_lastFlush = dxvk::high_resolution_clock::now();
       m_csIsBusy  = false;
     }
   }
@@ -633,7 +633,7 @@ namespace dxvk {
     uint32_t pending = m_device->pendingSubmissions();
 
     if (StrongHint || pending <= MaxPendingSubmits) {
-      auto now = std::chrono::high_resolution_clock::now();
+      auto now = dxvk::high_resolution_clock::now();
 
       uint32_t delay = MinFlushIntervalUs
                      + IncFlushIntervalUs * pending;

--- a/src/d3d11/d3d11_context_imm.h
+++ b/src/d3d11/d3d11_context_imm.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <chrono>
+#include "../util/util_time.h"
 
 #include "d3d11_context.h"
 #include "d3d11_state_object.h"
@@ -116,8 +116,8 @@ namespace dxvk {
 
     std::atomic<uint32_t> m_refCount = { 0 };
 
-    std::chrono::high_resolution_clock::time_point m_lastFlush
-      = std::chrono::high_resolution_clock::now();
+    dxvk::high_resolution_clock::time_point m_lastFlush
+      = dxvk::high_resolution_clock::now();
     
     Com<D3D11DeviceContextState> m_stateObject;
     

--- a/src/dxvk/dxvk_compute.cpp
+++ b/src/dxvk/dxvk_compute.cpp
@@ -1,4 +1,4 @@
-#include <chrono>
+#include "../util/util_time.h"
 #include <cstring>
 
 #include "dxvk_compute.h"
@@ -117,10 +117,10 @@ namespace dxvk {
     info.basePipelineIndex    = -1;
     
     // Time pipeline compilation for debugging purposes
-    std::chrono::high_resolution_clock::time_point t0, t1;
+    dxvk::high_resolution_clock::time_point t0, t1;
 
     if (Logger::logLevel() <= LogLevel::Debug)
-      t0 = std::chrono::high_resolution_clock::now();
+      t0 = dxvk::high_resolution_clock::now();
     
     VkPipeline pipeline = VK_NULL_HANDLE;
     if (m_vkd->vkCreateComputePipelines(m_vkd->device(),
@@ -131,7 +131,7 @@ namespace dxvk {
     }
     
     if (Logger::logLevel() <= LogLevel::Debug) {
-      t1 = std::chrono::high_resolution_clock::now();
+      t1 = dxvk::high_resolution_clock::now();
       auto td = std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0);
       Logger::debug(str::format("DxvkComputePipeline: Finished in ", td.count(), " ms"));
     }

--- a/src/dxvk/dxvk_graphics.cpp
+++ b/src/dxvk/dxvk_graphics.cpp
@@ -1,4 +1,4 @@
-#include <chrono>
+#include "../util/util_time.h"
 
 #include "dxvk_device.h"
 #include "dxvk_graphics.h"
@@ -396,10 +396,10 @@ namespace dxvk {
       info.pTessellationState = nullptr;
     
     // Time pipeline compilation for debugging purposes
-    std::chrono::high_resolution_clock::time_point t0, t1;
+    dxvk::high_resolution_clock::time_point t0, t1;
 
     if (Logger::logLevel() <= LogLevel::Debug)
-      t0 = std::chrono::high_resolution_clock::now();
+      t0 = dxvk::high_resolution_clock::now();
     
     VkPipeline pipeline = VK_NULL_HANDLE;
     if (m_vkd->vkCreateGraphicsPipelines(m_vkd->device(),
@@ -410,7 +410,7 @@ namespace dxvk {
     }
     
     if (Logger::logLevel() <= LogLevel::Debug) {
-      t1 = std::chrono::high_resolution_clock::now();
+      t1 = dxvk::high_resolution_clock::now();
       auto td = std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0);
       Logger::debug(str::format("DxvkGraphicsPipeline: Finished in ", td.count(), " ms"));
     }

--- a/src/dxvk/dxvk_pipecache.h
+++ b/src/dxvk/dxvk_pipecache.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <atomic>
-#include <chrono>
+#include "../util/util_time.h"
 #include <condition_variable>
 #include <fstream>
 

--- a/src/dxvk/dxvk_queue.cpp
+++ b/src/dxvk/dxvk_queue.cpp
@@ -145,13 +145,13 @@ namespace dxvk {
 
     while (!m_stopped.load()) {
       if (m_finishQueue.empty()) {
-        auto t0 = std::chrono::high_resolution_clock::now();
+        auto t0 = dxvk::high_resolution_clock::now();
 
         m_submitCond.wait(lock, [this] {
           return m_stopped.load() || !m_finishQueue.empty();
         });
 
-        auto t1 = std::chrono::high_resolution_clock::now();
+        auto t1 = dxvk::high_resolution_clock::now();
         m_gpuIdle += std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0).count();
       }
 

--- a/src/dxvk/hud/dxvk_hud_fps.h
+++ b/src/dxvk/hud/dxvk_hud_fps.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <chrono>
+#include "../util/util_time.h"
 
 #include "dxvk_hud_config.h"
 #include "dxvk_hud_renderer.h"
@@ -13,7 +13,7 @@ namespace dxvk::hud {
    * Displays the current frames per second.
    */
   class HudFps {
-    using Clock     = std::chrono::high_resolution_clock;
+    using Clock     = dxvk::high_resolution_clock;
     using TimeDiff  = std::chrono::microseconds;
     using TimePoint = typename Clock::time_point;
     

--- a/src/dxvk/hud/dxvk_hud_stats.cpp
+++ b/src/dxvk/hud/dxvk_hud_stats.cpp
@@ -4,7 +4,7 @@ namespace dxvk::hud {
   
   HudStats::HudStats(HudElements elements)
   : m_elements(filterElements(elements)),
-    m_compilerShowTime(std::chrono::high_resolution_clock::now()) { }
+    m_compilerShowTime(dxvk::high_resolution_clock::now()) { }
   
   
   HudStats::~HudStats() {
@@ -58,7 +58,7 @@ namespace dxvk::hud {
   
   
   void HudStats::updateGpuLoad() {
-    auto now = std::chrono::high_resolution_clock::now();
+    auto now = dxvk::high_resolution_clock::now();
     uint64_t ticks = std::chrono::duration_cast<std::chrono::microseconds>(now - m_gpuLoadUpdateTime).count();
 
     if (ticks >= 500'000) {
@@ -194,7 +194,7 @@ namespace dxvk::hud {
     const Rc<DxvkContext>&  context,
           HudRenderer&      renderer,
           HudPos            position) {
-    auto now    = std::chrono::high_resolution_clock::now();
+    auto now    = dxvk::high_resolution_clock::now();
     bool doShow = m_prevCounters.getCtr(DxvkStatCounter::PipeCompilerBusy);
 
     if (m_prevCounters.getCtr(DxvkStatCounter::PipeCompilerBusy)

--- a/src/dxvk/hud/dxvk_hud_stats.h
+++ b/src/dxvk/hud/dxvk_hud_stats.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <chrono>
+#include "../util/util_time.h"
 
 #include "../dxvk_stats.h"
 
@@ -38,8 +38,8 @@ namespace dxvk::hud {
     DxvkStatCounters  m_prevCounters;
     DxvkStatCounters  m_diffCounters;
 
-    std::chrono::high_resolution_clock::time_point m_gpuLoadUpdateTime;
-    std::chrono::high_resolution_clock::time_point m_compilerShowTime;
+    dxvk::high_resolution_clock::time_point m_gpuLoadUpdateTime;
+    dxvk::high_resolution_clock::time_point m_compilerShowTime;
 
     uint64_t m_prevGpuIdleTicks = 0;
     uint64_t m_diffGpuIdleTicks = 0;

--- a/src/util/util_time.h
+++ b/src/util/util_time.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <chrono>
+#include <cstdint>
+
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
+namespace dxvk {
+
+#ifdef _WIN32
+  struct high_resolution_clock {
+    static constexpr bool is_steady = true;
+
+    using rep        = int64_t;
+    using period     = std::nano;
+    using duration   = std::chrono::nanoseconds;
+    using time_point = std::chrono::time_point<high_resolution_clock>;
+
+    static inline time_point now() noexcept {
+      // Keep the frequency static, this doesn't change at all.
+      static const int64_t freq = getFrequency();
+      const int64_t counter     = getCounter();
+
+      const int64_t whole = (counter / freq) * period::den;
+      const int64_t part  = (counter % freq) * period::den / freq;
+
+      return time_point(duration(whole + part));
+    }
+
+    static inline int64_t getFrequency() {
+      LARGE_INTEGER freq;
+      QueryPerformanceFrequency(&freq);
+
+      return freq.QuadPart;
+    }
+
+    static inline int64_t getCounter() {
+      LARGE_INTEGER count;
+      QueryPerformanceCounter(&count);
+
+      return count.QuadPart;
+    }
+  };
+#else
+  using clock = std::chrono::high_resolution_clock;
+#endif
+
+}


### PR DESCRIPTION
MinGW calls to GetSystemTimeAsFileTime via gettimeofday for std::chrono::high_resolution_clock::now,
This is horribly slow and inaccurate.

There are also issues if MinGW is not built with libstdc++ at the same time that can cause the precision to be bad enough to cause massive hangs.
This effectively works around that as well.

Relevant: https://github.com/ValveSoftware/Proton/issues/3198