### PR TITLE
[meta] Recommend using new validation layers

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ The following environment variables can be used to control the cache:
 
 ### Debugging
 The following environment variables can be used for **debugging** purposes.
-- `VK_INSTANCE_LAYERS=VK_LAYER_LUNARG_standard_validation` Enables Vulkan debug layers. Highly recommended for troubleshooting rendering issues and driver crashes. Requires the Vulkan SDK to be installed on the host system.
+- `VK_INSTANCE_LAYERS=VK_LAYER_KHRONOS_validation` Enables Vulkan debug layers. Highly recommended for troubleshooting rendering issues and driver crashes. Requires the Vulkan SDK to be installed on the host system.
 - `DXVK_LOG_LEVEL=none|error|warn|info|debug` Controls message logging.
 - `DXVK_LOG_PATH=/some/directory` Changes path where log files are stored.
 - `DXVK_CONFIG_FILE=/xxx/dxvk.conf` Sets path to the configuration file.


### PR DESCRIPTION
VK_LAYER_LUNARG_standard_validation is deprecated and not available in the latest Vulkan SDK, recommend the new VK_LAYER_KHRONOS_validation instead.