### PR TITLE
[dxvk] Fix multiple inclusion of dxvk_platform_exts.h

### DIFF
--- a/src/dxvk/dxvk_platform_exts.h
+++ b/src/dxvk/dxvk_platform_exts.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include "dxvk_extension_provider.h"
 
 namespace dxvk {


### PR DESCRIPTION
This fixes build failures when using `--unity on` meson parameter