### PR TITLE
Report gpu vendor as Nvidia for Star Wars Battlefront II

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -157,6 +157,10 @@ namespace dxvk {
     { R"(\\Atelier_Ryza\.exe$)", {{
       { "d3d9.deferSurfaceCreation",        "True" },
     }} },
+    /* Star Wars Battlefront II: amdags issues    */
+    { R"(\\starwarsbattlefrontii\.exe$)", {{
+      { "dxgi.customVendorId",              "10de" },
+    }} },
 
     /**********************************************/
     /* D3D9 GAMES                                 */


### PR DESCRIPTION
Star Wars Battlefront II requires requires AGS library.