### PR TITLE
[spirv] Allow specifying the SPIR-V version explicitly

### DIFF
--- a/src/d3d9/d3d9_fixed_function.cpp
+++ b/src/d3d9/d3d9_fixed_function.cpp
@@ -622,7 +622,7 @@ namespace dxvk {
     const D3D9FFShaderKeyVS&       Key,
     const std::string&             Name,
           D3D9FixedFunctionOptions Options)
-      : m_options (Options) {
+  : m_module(spvVersion(1, 3)), m_options(Options) {
     m_programType = DxsoProgramTypes::VertexShader;
     m_vsKey    = Key;
     m_filename = Name;
@@ -634,7 +634,7 @@ namespace dxvk {
     const D3D9FFShaderKeyFS&       Key,
     const std::string&             Name,
           D3D9FixedFunctionOptions Options)
-      : m_options(Options) {
+  : m_module(spvVersion(1, 3)), m_options(Options) {
     m_programType = DxsoProgramTypes::PixelShader;
     m_fsKey    = Key;
     m_filename = Name;

--- a/src/d3d9/d3d9_swvp_emu.cpp
+++ b/src/d3d9/d3d9_swvp_emu.cpp
@@ -82,7 +82,8 @@ namespace dxvk {
 
   public:
 
-    D3D9SWVPEmulatorGenerator(const std::string& name) {
+    D3D9SWVPEmulatorGenerator(const std::string& name)
+    : m_module(spvVersion(1, 3)) {
       m_entryPointId = m_module.allocateId();
 
       m_module.setDebugSource(

--- a/src/dxbc/dxbc_compiler.cpp
+++ b/src/dxbc/dxbc_compiler.cpp
@@ -19,6 +19,7 @@ namespace dxvk {
     const DxbcAnalysisInfo&   analysis)
   : m_moduleInfo (moduleInfo),
     m_programInfo(programInfo),
+    m_module     (spvVersion(1, 3)),
     m_isgn       (isgn),
     m_osgn       (osgn),
     m_psgn       (psgn),

--- a/src/dxso/dxso_compiler.cpp
+++ b/src/dxso/dxso_compiler.cpp
@@ -24,7 +24,8 @@ namespace dxvk {
     : m_moduleInfo ( moduleInfo )
     , m_programInfo( programInfo )
     , m_analysis   ( &analysis )
-    , m_layout     ( &layout ) {
+    , m_layout     ( &layout )
+    , m_module     ( spvVersion(1, 3) ) {
     // Declare an entry point ID. We'll need it during the
     // initialization phase where the execution mode is set.
     m_entryPointId = m_module.allocateId();

--- a/src/spirv/spirv_code_buffer.cpp
+++ b/src/spirv/spirv_code_buffer.cpp
@@ -123,9 +123,9 @@ namespace dxvk {
   }
   
   
-  void SpirvCodeBuffer::putHeader(uint32_t boundIds) {
+  void SpirvCodeBuffer::putHeader(uint32_t version, uint32_t boundIds) {
     this->putWord(spv::MagicNumber);
-    this->putWord(0x00010300); // v1.3
+    this->putWord(version);
     this->putWord(0); // Generator
     this->putWord(boundIds);
     this->putWord(0); // Schema

--- a/src/spirv/spirv_code_buffer.h
+++ b/src/spirv/spirv_code_buffer.h
@@ -145,9 +145,11 @@ namespace dxvk {
     
     /**
      * \brief Adds the header to the buffer
+     *
+     * \param [in] version SPIR-V version
      * \param [in] boundIds Number of bound IDs
      */
-    void putHeader(uint32_t boundIds);
+    void putHeader(uint32_t version, uint32_t boundIds);
 
     /**
      * \brief Erases given number of dwords

--- a/src/spirv/spirv_module.cpp
+++ b/src/spirv/spirv_module.cpp
@@ -4,7 +4,8 @@
 
 namespace dxvk {
   
-  SpirvModule:: SpirvModule() {
+  SpirvModule::SpirvModule(uint32_t version)
+  : m_version(version) {
     this->instImportGlsl450();
   }
   
@@ -16,7 +17,7 @@ namespace dxvk {
   
   SpirvCodeBuffer SpirvModule::compile() const {
     SpirvCodeBuffer result;
-    result.putHeader(m_id);
+    result.putHeader(m_version, m_id);
     result.append(m_capabilities);
     result.append(m_extensions);
     result.append(m_instExt);

--- a/src/spirv/spirv_module.h
+++ b/src/spirv/spirv_module.h
@@ -28,6 +28,10 @@ namespace dxvk {
     uint32_t sSampleId     = 0;
     uint32_t sMinLod       = 0;
   };
+
+  constexpr uint32_t spvVersion(uint32_t major, uint32_t minor) {
+    return (major << 16) | (minor << 8);
+  }
   
   /**
    * \brief SPIR-V module
@@ -41,7 +45,8 @@ namespace dxvk {
     
   public:
     
-    SpirvModule();
+    explicit SpirvModule(uint32_t version);
+
     ~SpirvModule();
     
     SpirvCodeBuffer compile() const;
@@ -1204,6 +1209,7 @@ namespace dxvk {
     
   private:
     
+    uint32_t m_version;
     uint32_t m_id             = 1;
     uint32_t m_instExtGlsl450 = 0;
     


### PR DESCRIPTION
We're going to use some SPIR-V 1.4 features for D3D11 if supported, but 1.4 is not supported by all implementations.

Touches some D3D9 code (I don't think you need to bother with 1.4 support though).