### PR TITLE
Add installation support for pure 64-bit Wine (non WoW64)

### DIFF
--- a/setup_dxvk.sh
+++ b/setup_dxvk.sh
@@ -5,7 +5,7 @@ dxvk_lib32=${dxvk_lib32:-"x32"}
 dxvk_lib64=${dxvk_lib64:-"x64"}
 
 # figure out where we are
-basedir=`dirname "$(readlink -f $0)"`
+basedir=$(dirname "$(readlink -f $0)")
 
 # figure out which action to perform
 action="$1"
@@ -24,13 +24,13 @@ esac
 # process arguments
 shift
 
-with_dxgi=1
+with_dxgi=true
 file_cmd="cp -v"
 
-while [ $# -gt 0 ]; do
+while (($# > 0)); do
   case "$1" in
   "--without-dxgi")
-    with_dxgi=0
+    with_dxgi=false
     ;;
   "--symlink")
     file_cmd="ln -s -v"
@@ -65,7 +65,7 @@ if ! [ -f "$wine_path/$wine" ]; then
 fi
 
 # resolve 32-bit and 64-bit system32 path
-winever=`$wine --version | grep wine`
+winever=$($wine --version | grep wine)
 if [ -z "$winever" ]; then
     echo "$wine:"' Not a wine executable. Check your $wine.' >&2
     exit 1
@@ -170,7 +170,7 @@ install() {
     inst32_ret="$?"
   fi
 
-  if [ "$inst32_ret" -eq 0 ] || [ "$inst64_ret" -eq 0 ]; then
+  if (( ($inst32_ret == 0) || ($inst64_ret == 0) )); then
     overrideDll "$1"
   fi
 }
@@ -185,14 +185,14 @@ uninstall() {
     uninst32_ret="$?"
   fi
 
-  if [ "$uninst32_ret" -eq 0 ] || [ "$uninst64_ret" -eq 0 ]; then
+  if (( ($uninst32_ret == 0) || ($uninst64_ret == 0) )); then
     restoreDll "$1"
   fi
 }
 
 # skip dxgi during install if not explicitly
 # enabled, but always try to uninstall it
-if [ $with_dxgi -ne 0 ] || [ "$action" == "uninstall" ]; then
+if $with_dxgi || [ "$action" == "uninstall" ]; then
   $action dxgi
 fi
 

--- a/setup_dxvk.sh
+++ b/setup_dxvk.sh
@@ -25,7 +25,7 @@ esac
 shift
 
 with_dxgi=1
-file_cmd="cp"
+file_cmd="cp -v"
 
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -33,7 +33,7 @@ while [ $# -gt 0 ]; do
     with_dxgi=0
     ;;
   "--symlink")
-    file_cmd="ln -s"
+    file_cmd="ln -s -v"
     ;;
   esac
   shift
@@ -119,9 +119,9 @@ installFile() {
   if [ -n "$1" ]; then
     if [ -f "${dstfile}" ] || [ -h "${dstfile}" ]; then
       if ! [ -f "${dstfile}.old" ]; then
-        mv "${dstfile}" "${dstfile}.old"
+        mv -v "${dstfile}" "${dstfile}.old"
       else
-        rm "${dstfile}"
+        rm -v "${dstfile}"
       fi
       $file_cmd "${srcfile}" "${dstfile}"
     else
@@ -152,8 +152,8 @@ uninstallFile() {
   fi
 
   if [ -f "${dstfile}.old" ]; then
-    rm "${dstfile}"
-    mv "${dstfile}.old" "${dstfile}"
+    rm -v "${dstfile}"
+    mv -v "${dstfile}.old" "${dstfile}"
     return 0
   else
     return 1


### PR DESCRIPTION
This makes setup script work correctly with pure 64-bit Wine (non WoW64) since currently the script makes an implicit assumption that every 64-bit Wine is WoW64 one. Custom built Wine is a lot easier to build when it's pure 64-bit, so the change makes it skip 32-bit related steps in such case.

It also adds some minor clean-ups.

The general logic of using `$wine` to determine location is also replaced with Wine's recommended implicit logic of `$PATH`. I.e. if the user wants to use custom Wine location, it's enough to override `$PATH` and `$LD_LIBRARY_PATH` and usage of `wine`, `wine64`, `wineboot` and so on will implicitly pick up that change.