### PR TITLE
Fixes refcounting to match native d3d11 behavior

### DIFF
--- a/src/d3d11/d3d11_context_imm.cpp
+++ b/src/d3d11/d3d11_context_imm.cpp
@@ -35,22 +35,6 @@ namespace dxvk {
   }
   
   
-  ULONG STDMETHODCALLTYPE D3D11ImmediateContext::AddRef() {
-    ULONG refCount = m_refCount++;
-    if (!refCount)
-      m_parent->AddRef();
-    return refCount + 1;
-  }
-  
-  
-  ULONG STDMETHODCALLTYPE D3D11ImmediateContext::Release() {
-    ULONG refCount = --m_refCount;
-    if (!refCount)
-      m_parent->Release();
-    return refCount;
-  }
-  
-  
   D3D11_DEVICE_CONTEXT_TYPE STDMETHODCALLTYPE D3D11ImmediateContext::GetType() {
     return D3D11_DEVICE_CONTEXT_IMMEDIATE;
   }

--- a/src/d3d11/d3d11_context_imm.h
+++ b/src/d3d11/d3d11_context_imm.h
@@ -19,10 +19,6 @@ namespace dxvk {
       const Rc<DxvkDevice>& Device);
     ~D3D11ImmediateContext();
     
-    ULONG STDMETHODCALLTYPE AddRef();
-    
-    ULONG STDMETHODCALLTYPE Release();
-    
     D3D11_DEVICE_CONTEXT_TYPE STDMETHODCALLTYPE GetType();
     
     UINT STDMETHODCALLTYPE GetContextFlags();

--- a/src/d3d11/d3d11_context_state.h
+++ b/src/d3d11/d3d11_context_state.h
@@ -16,7 +16,7 @@
 namespace dxvk {
   
   struct D3D11ConstantBufferBinding {
-    Com<D3D11Buffer> buffer         = nullptr;
+    Com<D3D11Buffer, false> buffer         = nullptr;
     UINT             constantOffset = 0;
     UINT             constantCount  = 0;
     UINT             constantBound  = 0;
@@ -31,7 +31,7 @@ namespace dxvk {
     
   
   struct D3D11ShaderResourceBindings {
-    std::array<Com<D3D11ShaderResourceView>, D3D11_COMMONSHADER_INPUT_RESOURCE_SLOT_COUNT> views;
+    std::array<Com<D3D11ShaderResourceView, false>, D3D11_COMMONSHADER_INPUT_RESOURCE_SLOT_COUNT> views;
     DxvkBindingSet<D3D11_COMMONSHADER_INPUT_RESOURCE_SLOT_COUNT>                           hazardous;
   };
     
@@ -41,7 +41,7 @@ namespace dxvk {
   
   
   struct D3D11ContextStateVS {
-    Com<D3D11VertexShader>        shader;
+    Com<D3D11VertexShader, false>        shader;
     D3D11ConstantBufferBindings   constantBuffers;
     D3D11SamplerBindings          samplers;
     D3D11ShaderResourceBindings   shaderResources;
@@ -73,7 +73,7 @@ namespace dxvk {
   
   
   struct D3D11ContextStatePS {
-    Com<D3D11PixelShader>         shader;
+    Com<D3D11PixelShader, false>         shader;
     D3D11ConstantBufferBindings   constantBuffers;
     D3D11SamplerBindings          samplers;
     D3D11ShaderResourceBindings   shaderResources;
@@ -93,14 +93,14 @@ namespace dxvk {
   
   
   struct D3D11VertexBufferBinding {
-    Com<D3D11Buffer> buffer = nullptr;
+    Com<D3D11Buffer, false> buffer = nullptr;
     UINT             offset = 0;
     UINT             stride = 0;
   };
   
   
   struct D3D11IndexBufferBinding {
-    Com<D3D11Buffer> buffer = nullptr;
+    Com<D3D11Buffer, false> buffer = nullptr;
     UINT             offset = 0;
     DXGI_FORMAT      format = DXGI_FORMAT_UNKNOWN;
   };

--- a/src/d3d11/d3d11_device.cpp
+++ b/src/d3d11/d3d11_device.cpp
@@ -42,13 +42,14 @@ namespace dxvk {
     m_dxbcOptions   (m_dxvkDevice, m_d3d11Options) {
     m_initializer = new D3D11Initializer(this);
     m_context     = new D3D11ImmediateContext(this, m_dxvkDevice);
+    m_context->AddRefPrivate();
     m_d3d10Device = new D3D10Device(this, m_context);
   }
   
   
   D3D11Device::~D3D11Device() {
     delete m_d3d10Device;
-    delete m_context;
+    m_context->ReleasePrivate();
     delete m_initializer;
   }
   

--- a/src/d3d11/d3d11_device.h
+++ b/src/d3d11/d3d11_device.h
@@ -61,6 +61,10 @@ namespace dxvk {
     
     ULONG STDMETHODCALLTYPE Release();
     
+    void AddRefPrivate();
+    
+    void ReleasePrivate();
+    
     HRESULT STDMETHODCALLTYPE QueryInterface(
             REFIID                  riid,
             void**                  ppvObject);


### PR DESCRIPTION
These bugs were found when trying to run bgfx on top of dxvk.
The dxvk refcount on COM objects doesn't match the refcount of native d3d11.
Bgfx expects the refcount values to be as on windows.