### PR TITLE
[d3d11] Move shader stage and buffer slot calc to inside lambda

### DIFF
--- a/src/d3d11/d3d11_context.cpp
+++ b/src/d3d11/d3d11_context.cpp
@@ -3366,12 +3366,7 @@ namespace dxvk {
   void D3D11DeviceContext::BindShader(
     const D3D11CommonShader*    pShaderModule) {
     // Bind the shader and the ICB at once
-    uint32_t slotId = computeConstantBufferBinding(ShaderStage,
-      D3D11_COMMONSHADER_CONSTANT_BUFFER_API_SLOT_COUNT);
-    
     EmitCs([
-      cSlotId = slotId,
-      cStage  = GetShaderStage(ShaderStage),
       cSlice  = pShaderModule           != nullptr
              && pShaderModule->GetIcb() != nullptr
         ? DxvkBufferSlice(pShaderModule->GetIcb())
@@ -3380,8 +3375,13 @@ namespace dxvk {
         ? pShaderModule->GetShader()
         : nullptr
     ] (DxvkContext* ctx) {
-      ctx->bindShader        (cStage, cShader);
-      ctx->bindResourceBuffer(cSlotId, cSlice);
+      VkShaderStageFlagBits stage = GetShaderStage(ShaderStage);
+
+      uint32_t slotId = computeConstantBufferBinding(ShaderStage,
+        D3D11_COMMONSHADER_CONSTANT_BUFFER_API_SLOT_COUNT);
+
+      ctx->bindShader        (stage,  cShader);
+      ctx->bindResourceBuffer(slotId, cSlice);
     });
   }
 


### PR DESCRIPTION
Take advantage of the fact that template permutations transfer into lambdas inside of them.
Removes some unnecessary captures.

(These two values can also be calculated constexprly... we could mark the funcs as such but it's not really necessary as the compiler will figure that out anyway)