### PR TITLE
[d3d9] Remove unused variable from D3D9DeviceEx::Clear

### DIFF
--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -1315,9 +1315,6 @@ namespace dxvk {
     }
 
     // Here, Count of 0 will denote whether or not to care about user rects.
-
-    auto* rt0Desc = m_state.renderTargets[0]->GetCommonTexture()->Desc();
-
     VkClearValue clearValueDepth;
     clearValueDepth.depthStencil.depth   = Z;
     clearValueDepth.depthStencil.stencil = Stencil;


### PR DESCRIPTION
Fixes a compiler warning.