### PR TITLE
D3D9: Support multiple back buffers

### DIFF
--- a/src/d3d9/d3d9_swapchain.cpp
+++ b/src/d3d9/d3d9_swapchain.cpp
@@ -289,6 +289,7 @@ namespace dxvk {
           D3DDISPLAYMODEEX*      pFullscreenDisplayMode) {
     auto lock = m_parent->LockDevice();
 
+    this->SynchronizePresent();
     this->NormalizePresentParameters(pPresentParams);
 
     m_dirty    |= m_presentParams.BackBufferFormat   != pPresentParams->BackBufferFormat

--- a/src/d3d9/d3d9_swapchain.cpp
+++ b/src/d3d9/d3d9_swapchain.cpp
@@ -42,7 +42,7 @@ namespace dxvk {
     if (!pDevice->GetOptions()->deferSurfaceCreation)
       CreatePresenter();
 
-    CreateBackBuffer();
+    CreateBackBuffers(m_presentParams.BackBufferCount);
     CreateHud();
 
     InitRenderState();
@@ -166,13 +166,12 @@ namespace dxvk {
     if (ppBackBuffer == nullptr)
       return D3DERR_INVALIDCALL;
 
-    if (iBackBuffer > 0) {
-      Logger::err("D3D9: GetBackBuffer: iBackBuffer > 0 not supported");
+    if (iBackBuffer >= m_backBuffers.size()) {
+      Logger::err(str::format("D3D9: GetBackBuffer: Invalid back buffer index: ", iBackBuffer));
       return D3DERR_INVALIDCALL;
     }
 
-    *ppBackBuffer = m_backBuffer.ref();
-
+    *ppBackBuffer = m_backBuffers[iBackBuffer].ref();
     return D3D_OK;
   }
 
@@ -338,7 +337,7 @@ namespace dxvk {
       SetGammaRamp(0, &m_ramp);
 
     UpdatePresentRegion(nullptr, nullptr);
-    CreateBackBuffer();
+    CreateBackBuffers(m_presentParams.BackBufferCount);
   }
 
 
@@ -409,7 +408,10 @@ namespace dxvk {
 
 
   D3D9Surface* D3D9SwapChainEx::GetBackBuffer(UINT iBackBuffer) {
-    return m_backBuffer.ptr();
+    if (iBackBuffer >= m_backBuffers.size())
+      return nullptr;
+
+    return m_backBuffers[iBackBuffer].ptr();
   }
 
 
@@ -573,6 +575,14 @@ namespace dxvk {
 
       m_device->presentImage(m_presenter,
         cSync.present, &m_presentStatus);
+
+      // Shift back buffers so that m_backBuffers[1] will
+      // contain the image that we just presented
+      for (uint32_t i = m_backBuffers.size(); i > 1; i--) {
+        ctx->swapImages(
+          m_backBuffers[i - 1]->GetCommonTexture()->GetImage(),
+          m_backBuffers[i - 2]->GetCommonTexture()->GetImage());
+      }
     });
 
     m_parent->FlushCsChunk();
@@ -676,13 +686,15 @@ namespace dxvk {
   }
 
 
-  void D3D9SwapChainEx::CreateBackBuffer() {
+  void D3D9SwapChainEx::CreateBackBuffers(uint32_t NumBackBuffers) {
     // Explicitly destroy current swap image before
     // creating a new one to free up resources
     m_swapImage         = nullptr;
     m_swapImageResolve  = nullptr;
     m_swapImageView     = nullptr;
-    m_backBuffer        = nullptr;
+
+    m_backBuffers.clear();
+    m_backBuffers.resize(NumBackBuffers);
 
     // Create new back buffer
     D3D9_COMMON_TEXTURE_DESC desc;
@@ -700,9 +712,10 @@ namespace dxvk {
 
     auto mapping = m_parent->LookupFormat(desc.Format);
 
-    m_backBuffer = new D3D9Surface(m_parent, &desc, mapping);
+    for (uint32_t i = 0; i < NumBackBuffers; i++)
+      m_backBuffers[i] = new D3D9Surface(m_parent, &desc, mapping);
 
-    m_swapImage = m_backBuffer->GetCommonTexture()->GetImage();
+    m_swapImage = m_backBuffers[0]->GetCommonTexture()->GetImage();
 
     // If the image is multisampled, we need to create
     // another image which we'll use as a resolve target

--- a/src/d3d9/d3d9_swapchain.h
+++ b/src/d3d9/d3d9_swapchain.h
@@ -128,7 +128,7 @@ namespace dxvk {
     DxvkLogicOpState        m_loState;
     DxvkBlendMode           m_blendMode;
 
-    Com<D3D9Surface, false> m_backBuffer = nullptr;
+    std::vector<Com<D3D9Surface, false>> m_backBuffers;
     
     RECT                    m_srcRect;
     RECT                    m_dstRect;
@@ -168,7 +168,8 @@ namespace dxvk {
 
     void CreateRenderTargetViews();
 
-    void CreateBackBuffer();
+    void CreateBackBuffers(
+            uint32_t            NumBackBuffers);
 
     void CreateGammaTexture(
             UINT                NumControlPoints,

--- a/src/dxvk/dxvk_context.h
+++ b/src/dxvk/dxvk_context.h
@@ -709,6 +709,21 @@ namespace dxvk {
             VkResolveModeFlagBitsKHR  stencilMode);
 
     /**
+     * \brief Swaps two images
+     *
+     * Exchanges the image handles and backing storage
+     * of the two images, and recreates all the views.
+     * Note that the two images must have been created
+     * with identical properties, including the memory
+     * properties.
+     * \param [in] image1 The first image
+     * \param [in] image2 The second image
+     */
+    void swapImages(
+      const Rc<DxvkImage>&            image1,
+      const Rc<DxvkImage>&            image2);
+
+    /**
      * \brief Transforms image subresource layouts
      * 
      * \param [in] dstImage Image to transform

--- a/src/dxvk/dxvk_image.h
+++ b/src/dxvk/dxvk_image.h
@@ -7,6 +7,8 @@
 #include "dxvk_util.h"
 
 namespace dxvk {
+
+  class DxvkImageView;
   
   /**
    * \brief Image create info
@@ -104,7 +106,7 @@ namespace dxvk {
    * memory type and if created with the linear tiling option.
    */
   class DxvkImage : public DxvkResource {
-    
+    friend class DxvkImageView;
   public:
     
     DxvkImage(
@@ -283,6 +285,12 @@ namespace dxvk {
 
     small_vector<VkFormat, 4> m_viewFormats;
     
+    sync::Spinlock                  m_viewLock;
+    small_vector<DxvkImageView*, 4> m_viewList;
+
+    void addView(DxvkImageView* view);
+    void removeView(DxvkImageView* view);
+    
   };
   
   
@@ -290,6 +298,7 @@ namespace dxvk {
    * \brief DXVK image view
    */
   class DxvkImageView : public DxvkResource {
+    friend class DxvkImage;
     constexpr static uint32_t ViewCount = VK_IMAGE_VIEW_TYPE_CUBE_ARRAY + 1;
   public:
     

--- a/src/dxvk/dxvk_image.h
+++ b/src/dxvk/dxvk_image.h
@@ -9,6 +9,7 @@
 namespace dxvk {
 
   class DxvkImageView;
+  class DxvkImageViewDump;
   
   /**
    * \brief Image create info
@@ -115,6 +116,7 @@ namespace dxvk {
    * memory type and if created with the linear tiling option.
    */
   class DxvkImage : public DxvkResource {
+    friend class DxvkContext;
     friend class DxvkImageView;
   public:
     
@@ -283,6 +285,16 @@ namespace dxvk {
     VkDeviceSize memSize() const {
       return m_image.memory.length();
     }
+
+    /**
+     * \brief Swaps the image with another
+     *
+     * \param [in] next The other image
+     * \param [in] dump Image view dump
+     */
+    void swap(
+      const Rc<DxvkImage>&         next,
+      const Rc<DxvkImageViewDump>& dump);
     
   private:
     
@@ -298,6 +310,8 @@ namespace dxvk {
 
     void addView(DxvkImageView* view);
     void removeView(DxvkImageView* view);
+
+    void recreateViews(const Rc<DxvkImageViewDump>& dump);
     
   };
   
@@ -481,7 +495,32 @@ namespace dxvk {
     void createViews();
     
     void createView(VkImageViewType type, uint32_t numLayers);
+
+    void discardViews(const Rc<DxvkImageViewDump>& dump);
     
+  };
+
+
+  /**
+   * \brief Image view dump
+   *
+   * Takes orphaned image view objects and destroys
+   * them when they are no longer needed.
+   */
+  class DxvkImageViewDump : public DxvkResource {
+
+  public:
+
+    DxvkImageViewDump(const Rc<vk::DeviceFn>& vkd);
+    ~DxvkImageViewDump();
+
+    void addView(VkImageView view);
+
+  private:
+
+    Rc<vk::DeviceFn>         m_vkd;
+    std::vector<VkImageView> m_views;
+
   };
   
 }

--- a/src/dxvk/dxvk_image.h
+++ b/src/dxvk/dxvk_image.h
@@ -461,6 +461,8 @@ namespace dxvk {
     DxvkImageViewCreateInfo m_info;
     VkImageView             m_views[ViewCount];
 
+    void createViews();
+    
     void createView(VkImageViewType type, uint32_t numLayers);
     
   };

--- a/src/dxvk/dxvk_image.h
+++ b/src/dxvk/dxvk_image.h
@@ -281,7 +281,7 @@ namespace dxvk {
     DxvkMemory            m_memory;
     VkImage               m_image = VK_NULL_HANDLE;
 
-    std::vector<VkFormat> m_viewFormats;
+    small_vector<VkFormat, 4> m_viewFormats;
     
   };
   

--- a/src/dxvk/dxvk_image.h
+++ b/src/dxvk/dxvk_image.h
@@ -96,6 +96,15 @@ namespace dxvk {
       VK_COMPONENT_SWIZZLE_IDENTITY,
     };
   };
+
+
+  /**
+   * \brief Stores an image and its memory slice.
+   */
+  struct DxvkPhysicalImage {
+    VkImage     image = VK_NULL_HANDLE;
+    DxvkMemory  memory;
+  };
   
   
   /**
@@ -143,7 +152,7 @@ namespace dxvk {
      * \returns Image handle
      */
     VkImage handle() const {
-      return m_image;
+      return m_image.image;
     }
     
     /**
@@ -177,7 +186,7 @@ namespace dxvk {
      * \returns Pointer to mapped memory region
      */
     void* mapPtr(VkDeviceSize offset) const {
-      return m_memory.mapPtr(offset);
+      return m_image.memory.mapPtr(offset);
     }
     
     /**
@@ -210,7 +219,7 @@ namespace dxvk {
       const VkImageSubresource& subresource) const {
       VkSubresourceLayout result;
       m_vkd->vkGetImageSubresourceLayout(
-        m_vkd->device(), m_image,
+        m_vkd->device(), m_image.image,
         &subresource, &result);
       return result;
     }
@@ -272,7 +281,7 @@ namespace dxvk {
      * \returns The memory size of the image
      */
     VkDeviceSize memSize() const {
-      return m_memory.length();
+      return m_image.memory.length();
     }
     
   private:
@@ -280,8 +289,7 @@ namespace dxvk {
     Rc<vk::DeviceFn>      m_vkd;
     DxvkImageCreateInfo   m_info;
     VkMemoryPropertyFlags m_memFlags;
-    DxvkMemory            m_memory;
-    VkImage               m_image = VK_NULL_HANDLE;
+    DxvkPhysicalImage     m_image;
 
     small_vector<VkFormat, 4> m_viewFormats;
     

--- a/src/dxvk/dxvk_include.h
+++ b/src/dxvk/dxvk_include.h
@@ -8,6 +8,7 @@
 #include "../util/util_flags.h"
 #include "../util/util_likely.h"
 #include "../util/util_math.h"
+#include "../util/util_small_vector.h"
 #include "../util/util_string.h"
 
 #include "../util/rc/util_rc.h"

--- a/src/util/util_small_vector.h
+++ b/src/util/util_small_vector.h
@@ -1,0 +1,133 @@
+#pragma once
+
+#include <type_traits>
+
+namespace dxvk {
+
+  template<typename T, size_t N>
+  class small_vector {
+    using storage = std::aligned_storage_t<sizeof(T), alignof(T)>;
+  public:
+
+    small_vector() { }
+
+    small_vector             (const small_vector&) = delete;
+    small_vector& operator = (const small_vector&) = delete;
+
+    ~small_vector() {
+      for (size_t i = 0; i < m_size; i++)
+        ptr(i)->~T();
+
+      if (m_capacity > N)
+        delete[] u.m_ptr;
+    }
+    
+    size_t size() const {
+      return m_size;
+    }
+
+    void reserve(size_t n) {
+      n = pick_capacity(n);
+
+      if (n <= m_capacity)
+        return;
+
+      storage* data = new storage[n];
+
+      for (size_t i = 0; i < m_size; i++) {
+        new (&data[i]) T(std::move(*ptr(i)));
+        ptr(i)->~T();
+      }
+
+      if (m_capacity > N)
+        delete[] u.m_ptr;
+      
+      m_capacity = n;
+      u.m_ptr = data;
+    }
+
+    const T* data() const { return ptr(0); }
+          T* data()       { return ptr(0); }
+
+    void resize(size_t n) {
+      reserve(n);
+
+      for (size_t i = n; i < m_size; i++)
+        ptr(i)->~T();
+      
+      for (size_t i = m_size; i < n; i++)
+        new (ptr(i)) T();
+    }
+
+    void push_back(const T& object) {
+      reserve(m_size + 1);
+      new (ptr(m_size++)) T(object);
+    }
+
+    void push_back(T&& object) {
+      reserve(m_size + 1);
+      new (ptr(m_size++)) T(std::move(object));
+    }
+
+    template<typename... Args>
+    void emplace_back(Args... args) {
+      reserve(m_size + 1);
+      new (ptr(m_size++)) T(std::forward<Args>(args)...);
+    }
+
+    void erase(size_t idx) {
+      ptr(idx)->~T();
+
+      for (size_t i = idx; i < m_size - 1; i++) {
+        new (ptr(i)) T(std::move(*ptr(i + 1)));
+        ptr(i + 1)->~T();
+      }
+    }
+
+    void pop_back() {
+      ptr(--m_size)->~T();
+    }
+
+          T& operator [] (size_t idx)       { return *ptr(idx); }
+    const T& operator [] (size_t idx) const { return *ptr(idx); }
+
+          T& front()       { return *ptr(0); }
+    const T& front() const { return *ptr(0); }
+
+          T& back()       { return *ptr(m_size - 1); }
+    const T& back() const { return *ptr(m_size - 1); }
+
+  private:
+
+    size_t m_capacity = N;
+    size_t m_size     = 0;
+
+    union {
+      storage* m_ptr;
+      storage  m_data[sizeof(T) * N];
+    } u;
+
+    size_t pick_capacity(size_t n) {
+      size_t capacity = m_capacity;
+
+      while (capacity < n)
+        capacity *= 2;
+
+      return capacity;
+    }
+
+    T* ptr(size_t idx) {
+      return m_capacity == N
+        ? reinterpret_cast<T*>(&u.m_data[idx])
+        : reinterpret_cast<T*>(&u.m_ptr[idx]);
+    }
+
+    const T* ptr(size_t idx) const {
+      return m_capacity == N
+        ? reinterpret_cast<const T*>(&u.m_data[idx])
+        : reinterpret_cast<const T*>(&u.m_ptr[idx]);
+    }
+
+  };
+
+}


### PR DESCRIPTION
Title, fixes #1341.

The backend patches implement image swapping, which effectively allows us to implement our own "swap chain" kind of thing. This is used in D3D9 to give the game access to already presented back buffes.