### PR TITLE
Add support for exporting ELF information alongside the DLLS for Linux tools like perf.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -53,6 +53,15 @@ else
     wrc = find_program('rc')
   else
     wrc = cpu_family == 'x86_64' ? find_program('x86_64-w64-mingw32-windres') : find_program('i686-w64-mingw32-windres')
+    if get_option('dump_debug')
+      if get_option('buildtype') == 'release'
+        error('Option dump_debug specified in a release build')
+      endif
+      add_global_link_arguments('-Wl,--file-alignment,4096', language : ['cpp'])
+      objcopy = cpu_family == 'x86_64' ? find_program('x86_64-w64-mingw32-objcopy') : find_program('i686-w64-mingw32-objcopy')
+      bfd_target = cpu_family == 'x86_64' ? 'elf64-x86-64' : 'elf32-i386'
+      dump_debug = [objcopy, '-O', bfd_target, '--only-keep-debug', '--file-alignment=4096', '@INPUT@', '@OUTPUT@']
+    endif
   endif
   if cpu_family == 'x86'
     if dxvk_compiler.has_link_argument('-Wl,--add-stdcall-alias')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,4 +1,5 @@
 option('enable_tests', type : 'boolean', value : false)
+option('dump_debug',   type : 'boolean', value : false, description: 'Copy debug symbols alongside DLLs for linux debugging tools')
 option('enable_dxgi',  type : 'boolean', value : true, description: 'Build DXGI')
 option('enable_d3d9',  type : 'boolean', value : true, description: 'Build D3D9')
 option('enable_d3d10', type : 'boolean', value : true, description: 'Build D3D10')

--- a/package-release.sh
+++ b/package-release.sh
@@ -25,6 +25,9 @@ opt_nopackage=0
 opt_devbuild=0
 opt_winelib=0
 
+buildtype="release"
+dump_debug="false"
+
 crossfile="build-win"
 
 while [ $# -gt 0 ]; do
@@ -35,6 +38,8 @@ while [ $# -gt 0 ]; do
   "--dev-build")
     opt_nopackage=1
     opt_devbuild=1
+    buildtype="debugoptimized"
+    dump_debug="true"
     ;;
   "--winelib")
     opt_winelib=1
@@ -54,12 +59,13 @@ function build_arch {
   cd "$DXVK_SRC_DIR"
 
   meson --cross-file "$DXVK_SRC_DIR/$crossfile$1.txt" \
-        --buildtype "release"                         \
+        --buildtype "$buildtype"                  \
         --prefix "$DXVK_BUILD_DIR"                    \
         --strip                                       \
         --bindir "x$1"                                \
         --libdir "x$1"                                \
         -Denable_tests=false                          \
+        -Ddump_debug="$dump_debug"                    \
         "$DXVK_BUILD_DIR/build.$1"
 
   cd "$DXVK_BUILD_DIR/build.$1"

--- a/setup_dxvk.sh
+++ b/setup_dxvk.sh
@@ -177,3 +177,12 @@ $action d3d10
 $action d3d10_1
 $action d3d10core
 $action d3d11
+
+if [ -f ".debug" ]
+    mkdir $win32_sys_path/.debug
+    mkdir $win64_sys_path/.debug
+    $action .debug/d3d9
+    $action .debug/d3d10
+    $action .debug/d3d10_1
+    $action .debug/d3d10core
+    $action .debug/d3d11

--- a/src/d3d10/debug/meson.build
+++ b/src/d3d10/debug/meson.build
@@ -1,0 +1,21 @@
+d3d10core_debug = custom_target('d3d10core-debug',
+  input : d3d10_core_dll,
+  output : 'd3d10core.dll',
+  command: dump_debug,
+  install: true,
+  install_dir: get_option('bindir')+'/.debug')
+
+d3d10_debug = custom_target('d3d10-debug',
+  input : d3d10_dll,
+  output : 'd3d10.dll',
+  command: dump_debug,
+  install: true,
+  install_dir: get_option('bindir')+'/.debug')
+
+d3d10_1_debug = custom_target('d3d10_1-debug',
+  input : d3d10_1_dll,
+  output : 'd3d10_1.dll',
+  command: dump_debug,
+  install: true,
+  install_dir: get_option('bindir')+'/.debug')
+

--- a/src/d3d10/meson.build
+++ b/src/d3d10/meson.build
@@ -41,3 +41,7 @@ d3d10_1_dll = shared_library('d3d10_1'+dll_ext, d3d10_main_src, d3d10_1_res,
 d3d10_dep = declare_dependency(
   link_with           : [ d3d10_dll, d3d10_1_dll, d3d10_core_dll ],
   include_directories : [ dxvk_include_path ])
+
+if get_option('dump_debug')
+  subdir('debug')
+endif

--- a/src/d3d11/debug/meson.build
+++ b/src/d3d11/debug/meson.build
@@ -1,0 +1,6 @@
+d3d11_debug = custom_target('d3d11-debug',
+  input : d3d11_dll,
+  output : 'd3d11.dll',
+  command: dump_debug,
+  install: true,
+  install_dir: get_option('bindir')+'/.debug')

--- a/src/d3d11/meson.build
+++ b/src/d3d11/meson.build
@@ -75,3 +75,7 @@ d3d11_dll = shared_library('d3d11'+dll_ext, dxgi_common_src + d3d11_src + d3d10_
 d3d11_dep = declare_dependency(
   link_with           : [ d3d11_dll ],
   include_directories : [ dxvk_include_path ])
+
+if get_option('dump_debug')
+  subdir('debug')
+endif

--- a/src/d3d9/debug/meson.build
+++ b/src/d3d9/debug/meson.build
@@ -1,0 +1,6 @@
+d3d9_debug = custom_target('d3d9-debug',
+  input : d3d9_dll,
+  output : 'd3d9.dll',
+  command: dump_debug,
+  install: true,
+  install_dir: get_option('bindir')+'/.debug')

--- a/src/d3d9/meson.build
+++ b/src/d3d9/meson.build
@@ -50,3 +50,7 @@ d3d9_dll = shared_library('d3d9'+dll_ext, d3d9_src, glsl_generator.process(d3d9_
 d3d9_dep = declare_dependency(
   link_with           : [ d3d9_dll ],
   include_directories : [ dxvk_include_path ])
+
+if get_option('dump_debug')
+  subdir('debug')
+endif

--- a/src/dxgi/debug/meson.build
+++ b/src/dxgi/debug/meson.build
@@ -1,0 +1,6 @@
+dxgi_debug = custom_target('dxgi-debug',
+  input : dxgi_dll,
+  output : 'dxgi.dll',
+  command: dump_debug,
+  install: true,
+  install_dir: get_option('bindir')+'/.debug')

--- a/src/dxgi/meson.build
+++ b/src/dxgi/meson.build
@@ -24,3 +24,7 @@ dxgi_dll = shared_library('dxgi'+dll_ext, dxgi_src, dxgi_res,
 dxgi_dep = declare_dependency(
   link_with           : [ dxgi_dll ],
   include_directories : [ dxvk_include_path ])
+
+if get_option('dump_debug')
+  subdir('debug')
+endif


### PR DESCRIPTION
Based off Remi's wine patch.  I tested this with d3d11-triangle, and it seems to work, however, lot's of functions in the various dxvk dlls are actually part of mingw's libc++, so they don't show up in perf top.