### PR TITLE
[dxgi] Don't check window validity in IDXGISwapchain::GetFullscreenState

### DIFF
--- a/src/dxgi/dxgi_swapchain.cpp
+++ b/src/dxgi/dxgi_swapchain.cpp
@@ -182,9 +182,6 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE DxgiSwapChain::GetFullscreenState(
           BOOL*         pFullscreen,
           IDXGIOutput** ppTarget) {
-    if (!IsWindow(m_window))
-      return DXGI_ERROR_INVALID_CALL;
-    
     HRESULT hr = S_OK;
     
     if (pFullscreen != nullptr)


### PR DESCRIPTION
Returning this error here triggers a dialog box on exit in Jump King (steam game id 1061090), which uses SharpDX and SlimDX.

Wine test diff against `wine-5.0-rc5-27-g9f8935d823c` (will send upstream after code freeze): [dxgi_getfs_test.txt](https://github.com/doitsujin/dxvk/files/4072373/dxgi_getfs_test.txt)

Tests pass on Windows: https://testbot.winehq.org/JobDetails.pl?Key=63291

Tests fail with DXVK before this change: [fail.txt](https://github.com/doitsujin/dxvk/files/4072378/fail.txt)

Tests succeed with DXVK after this change: [pass.txt](https://github.com/doitsujin/dxvk/files/4072381/pass.txt)
