### PR TITLE
[dxvk] Use Vulkan 1.1

### DIFF
--- a/src/d3d11/d3d11_device.cpp
+++ b/src/d3d11/d3d11_device.cpp
@@ -1903,6 +1903,8 @@ namespace dxvk {
     enabled.core.features.shaderStorageImageWriteWithoutFormat    = VK_TRUE;
     enabled.core.features.depthBounds                             = supported.core.features.depthBounds;
 
+    enabled.shaderDrawParameters.shaderDrawParameters             = VK_TRUE;
+
     enabled.extMemoryPriority.memoryPriority                      = supported.extMemoryPriority.memoryPriority;
 
     enabled.extShaderDemoteToHelperInvocation.shaderDemoteToHelperInvocation  = supported.extShaderDemoteToHelperInvocation.shaderDemoteToHelperInvocation;

--- a/src/d3d11/d3d11_texture.cpp
+++ b/src/d3d11/d3d11_texture.cpp
@@ -114,7 +114,7 @@ namespace dxvk {
     
     if (Dimension == D3D11_RESOURCE_DIMENSION_TEXTURE3D &&
         (m_desc.BindFlags & D3D11_BIND_RENDER_TARGET))
-      imageInfo.flags |= VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT_KHR;
+      imageInfo.flags |= VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT;
     
     // Some image formats (i.e. the R32G32B32 ones) are
     // only supported with linear tiling on most GPUs

--- a/src/d3d9/d3d9_fixed_function.cpp
+++ b/src/d3d9/d3d9_fixed_function.cpp
@@ -1408,9 +1408,6 @@ namespace dxvk {
 
     // VS Caps
     m_module.enableCapability(spv::CapabilityClipDistance);
-    m_module.enableCapability(spv::CapabilityDrawParameters);
-
-    m_module.enableExtension("SPV_KHR_shader_draw_parameters");
 
     emitLightTypeDecl();
     emitBaseBufferDecl();

--- a/src/dxbc/dxbc_compiler.cpp
+++ b/src/dxbc/dxbc_compiler.cpp
@@ -6569,8 +6569,6 @@ namespace dxvk {
     m_module.enableCapability(spv::CapabilityCullDistance);
     m_module.enableCapability(spv::CapabilityDrawParameters);
     
-    m_module.enableExtension("SPV_KHR_shader_draw_parameters");
-    
     // Declare the per-vertex output block. This is where
     // the vertex shader will write the vertex position.
     const uint32_t perVertexStruct = this->getPerVertexBlockId();

--- a/src/dxso/dxso_compiler.cpp
+++ b/src/dxso/dxso_compiler.cpp
@@ -385,9 +385,6 @@ namespace dxvk {
 
   void DxsoCompiler::emitVsInit() {
     m_module.enableCapability(spv::CapabilityClipDistance);
-    m_module.enableCapability(spv::CapabilityDrawParameters);
-
-    m_module.enableExtension("SPV_KHR_shader_draw_parameters");
 
     // Only VS needs this, because PS has
     // non-indexable specialized output regs

--- a/src/dxvk/dxvk_adapter.cpp
+++ b/src/dxvk/dxvk_adapter.cpp
@@ -243,7 +243,7 @@ namespace dxvk {
           DxvkDeviceFeatures  enabledFeatures) {
     DxvkDeviceExtensions devExtensions;
 
-    std::array<DxvkExt*, 21> devExtensionList = {{
+    std::array<DxvkExt*, 20> devExtensionList = {{
       &devExtensions.amdMemoryOverallocationBehaviour,
       &devExtensions.amdShaderFragmentMask,
       &devExtensions.extConditionalRendering,
@@ -259,7 +259,6 @@ namespace dxvk {
       &devExtensions.extVertexAttributeDivisor,
       &devExtensions.khrCreateRenderPass2,
       &devExtensions.khrDepthStencilResolve,
-      &devExtensions.khrDescriptorUpdateTemplate,
       &devExtensions.khrDrawIndirectCount,
       &devExtensions.khrDriverProperties,
       &devExtensions.khrImageFormatList,

--- a/src/dxvk/dxvk_adapter.cpp
+++ b/src/dxvk/dxvk_adapter.cpp
@@ -241,7 +241,7 @@ namespace dxvk {
           DxvkDeviceFeatures  enabledFeatures) {
     DxvkDeviceExtensions devExtensions;
 
-    std::array<DxvkExt*, 26> devExtensionList = {{
+    std::array<DxvkExt*, 24> devExtensionList = {{
       &devExtensions.amdMemoryOverallocationBehaviour,
       &devExtensions.amdShaderFragmentMask,
       &devExtensions.extConditionalRendering,
@@ -256,12 +256,10 @@ namespace dxvk {
       &devExtensions.extTransformFeedback,
       &devExtensions.extVertexAttributeDivisor,
       &devExtensions.khrCreateRenderPass2,
-      &devExtensions.khrDedicatedAllocation,
       &devExtensions.khrDepthStencilResolve,
       &devExtensions.khrDescriptorUpdateTemplate,
       &devExtensions.khrDrawIndirectCount,
       &devExtensions.khrDriverProperties,
-      &devExtensions.khrGetMemoryRequirements2,
       &devExtensions.khrImageFormatList,
       &devExtensions.khrMaintenance1,
       &devExtensions.khrMaintenance2,

--- a/src/dxvk/dxvk_adapter.cpp
+++ b/src/dxvk/dxvk_adapter.cpp
@@ -241,7 +241,7 @@ namespace dxvk {
           DxvkDeviceFeatures  enabledFeatures) {
     DxvkDeviceExtensions devExtensions;
 
-    std::array<DxvkExt*, 24> devExtensionList = {{
+    std::array<DxvkExt*, 22> devExtensionList = {{
       &devExtensions.amdMemoryOverallocationBehaviour,
       &devExtensions.amdShaderFragmentMask,
       &devExtensions.extConditionalRendering,
@@ -261,8 +261,6 @@ namespace dxvk {
       &devExtensions.khrDrawIndirectCount,
       &devExtensions.khrDriverProperties,
       &devExtensions.khrImageFormatList,
-      &devExtensions.khrMaintenance1,
-      &devExtensions.khrMaintenance2,
       &devExtensions.khrSamplerMirrorClampToEdge,
       &devExtensions.khrShaderDrawParameters,
       &devExtensions.khrSwapchain,

--- a/src/dxvk/dxvk_adapter.cpp
+++ b/src/dxvk/dxvk_adapter.cpp
@@ -32,11 +32,11 @@ namespace dxvk {
     memBudget.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_BUDGET_PROPERTIES_EXT;
     memBudget.pNext = nullptr;
 
-    VkPhysicalDeviceMemoryProperties2KHR memProps = { };
-    memProps.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_PROPERTIES_2_KHR;
+    VkPhysicalDeviceMemoryProperties2 memProps = { };
+    memProps.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_PROPERTIES_2;
     memProps.pNext = m_hasMemoryBudget ? &memBudget : nullptr;
 
-    m_vki->vkGetPhysicalDeviceMemoryProperties2KHR(m_handle, &memProps);
+    m_vki->vkGetPhysicalDeviceMemoryProperties2(m_handle, &memProps);
     
     DxvkAdapterMemoryInfo info = { };
     info.heapCount = memProps.memoryProperties.memoryHeapCount;
@@ -472,19 +472,17 @@ namespace dxvk {
 
   void DxvkAdapter::queryDeviceInfo() {
     m_deviceInfo = DxvkDeviceInfo();
-    m_deviceInfo.core.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2_KHR;
+    m_deviceInfo.core.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2;
     m_deviceInfo.core.pNext = nullptr;
 
     // Query info now so that we have basic device properties available
-    m_vki->vkGetPhysicalDeviceProperties2KHR(m_handle, &m_deviceInfo.core);
+    m_vki->vkGetPhysicalDeviceProperties2(m_handle, &m_deviceInfo.core);
 
-    if (m_deviceInfo.core.properties.apiVersion >= VK_MAKE_VERSION(1, 1, 0)) {
-      m_deviceInfo.coreDeviceId.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ID_PROPERTIES;
-      m_deviceInfo.coreDeviceId.pNext = std::exchange(m_deviceInfo.core.pNext, &m_deviceInfo.coreDeviceId);
+    m_deviceInfo.coreDeviceId.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ID_PROPERTIES;
+    m_deviceInfo.coreDeviceId.pNext = std::exchange(m_deviceInfo.core.pNext, &m_deviceInfo.coreDeviceId);
 
-      m_deviceInfo.coreSubgroup.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SUBGROUP_PROPERTIES;
-      m_deviceInfo.coreSubgroup.pNext = std::exchange(m_deviceInfo.core.pNext, &m_deviceInfo.coreSubgroup);
-    }
+    m_deviceInfo.coreSubgroup.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SUBGROUP_PROPERTIES;
+    m_deviceInfo.coreSubgroup.pNext = std::exchange(m_deviceInfo.core.pNext, &m_deviceInfo.coreSubgroup);
 
     if (m_deviceExtensions.supports(VK_EXT_TRANSFORM_FEEDBACK_EXTENSION_NAME)) {
       m_deviceInfo.extTransformFeedback.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TRANSFORM_FEEDBACK_PROPERTIES_EXT;
@@ -507,7 +505,7 @@ namespace dxvk {
     }
 
     // Query full device properties for all enabled extensions
-    m_vki->vkGetPhysicalDeviceProperties2KHR(m_handle, &m_deviceInfo.core);
+    m_vki->vkGetPhysicalDeviceProperties2(m_handle, &m_deviceInfo.core);
     
     // Nvidia reports the driver version in a slightly different format
     if (DxvkGpuVendor(m_deviceInfo.core.properties.vendorID) == DxvkGpuVendor::Nvidia) {
@@ -521,7 +519,7 @@ namespace dxvk {
 
   void DxvkAdapter::queryDeviceFeatures() {
     m_deviceFeatures = DxvkDeviceFeatures();
-    m_deviceFeatures.core.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2_KHR;
+    m_deviceFeatures.core.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
     m_deviceFeatures.core.pNext = nullptr;
 
     if (m_deviceExtensions.supports(VK_EXT_CONDITIONAL_RENDERING_EXTENSION_NAME)) {
@@ -559,7 +557,7 @@ namespace dxvk {
       m_deviceFeatures.extVertexAttributeDivisor.pNext = std::exchange(m_deviceFeatures.core.pNext, &m_deviceFeatures.extVertexAttributeDivisor);
     }
 
-    m_vki->vkGetPhysicalDeviceFeatures2KHR(m_handle, &m_deviceFeatures.core);
+    m_vki->vkGetPhysicalDeviceFeatures2(m_handle, &m_deviceFeatures.core);
   }
 
 

--- a/src/dxvk/dxvk_adapter.cpp
+++ b/src/dxvk/dxvk_adapter.cpp
@@ -213,6 +213,8 @@ namespace dxvk {
                 || !required.core.features.variableMultisampleRate)
         && (m_deviceFeatures.core.features.inheritedQueries
                 || !required.core.features.inheritedQueries)
+        && (m_deviceFeatures.shaderDrawParameters.shaderDrawParameters
+                || !required.shaderDrawParameters.shaderDrawParameters)
         && (m_deviceFeatures.extConditionalRendering.conditionalRendering
                 || !required.extConditionalRendering.conditionalRendering)
         && (m_deviceFeatures.extDepthClipEnable.depthClipEnable
@@ -241,7 +243,7 @@ namespace dxvk {
           DxvkDeviceFeatures  enabledFeatures) {
     DxvkDeviceExtensions devExtensions;
 
-    std::array<DxvkExt*, 22> devExtensionList = {{
+    std::array<DxvkExt*, 21> devExtensionList = {{
       &devExtensions.amdMemoryOverallocationBehaviour,
       &devExtensions.amdShaderFragmentMask,
       &devExtensions.extConditionalRendering,
@@ -262,7 +264,6 @@ namespace dxvk {
       &devExtensions.khrDriverProperties,
       &devExtensions.khrImageFormatList,
       &devExtensions.khrSamplerMirrorClampToEdge,
-      &devExtensions.khrShaderDrawParameters,
       &devExtensions.khrSwapchain,
     }};
 
@@ -293,46 +294,42 @@ namespace dxvk {
     enabledFeatures.core.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2_KHR;
     enabledFeatures.core.pNext = nullptr;
 
+    enabledFeatures.shaderDrawParameters.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_DRAW_PARAMETERS_FEATURES;
+    enabledFeatures.shaderDrawParameters.pNext = std::exchange(enabledFeatures.core.pNext, &enabledFeatures.shaderDrawParameters);
+
     if (devExtensions.extConditionalRendering) {
       enabledFeatures.extConditionalRendering.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CONDITIONAL_RENDERING_FEATURES_EXT;
-      enabledFeatures.extConditionalRendering.pNext = enabledFeatures.core.pNext;
-      enabledFeatures.core.pNext = &enabledFeatures.extConditionalRendering;
+      enabledFeatures.extConditionalRendering.pNext = std::exchange(enabledFeatures.core.pNext, &enabledFeatures.extConditionalRendering);
     }
 
     if (devExtensions.extDepthClipEnable) {
       enabledFeatures.extDepthClipEnable.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEPTH_CLIP_ENABLE_FEATURES_EXT;
-      enabledFeatures.extDepthClipEnable.pNext = enabledFeatures.core.pNext;
-      enabledFeatures.core.pNext = &enabledFeatures.extDepthClipEnable;
+      enabledFeatures.extDepthClipEnable.pNext = std::exchange(enabledFeatures.core.pNext, &enabledFeatures.extDepthClipEnable);
     }
 
     if (devExtensions.extHostQueryReset) {
       enabledFeatures.extHostQueryReset.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_HOST_QUERY_RESET_FEATURES_EXT;
-      enabledFeatures.extHostQueryReset.pNext = enabledFeatures.core.pNext;
-      enabledFeatures.core.pNext = &enabledFeatures.extHostQueryReset;
+      enabledFeatures.extHostQueryReset.pNext = std::exchange(enabledFeatures.core.pNext, &enabledFeatures.extHostQueryReset);
     }
 
     if (devExtensions.extMemoryPriority) {
       enabledFeatures.extMemoryPriority.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_PRIORITY_FEATURES_EXT;
-      enabledFeatures.extMemoryPriority.pNext = enabledFeatures.core.pNext;
-      enabledFeatures.core.pNext = &enabledFeatures.extMemoryPriority;
+      enabledFeatures.extMemoryPriority.pNext = std::exchange(enabledFeatures.core.pNext, &enabledFeatures.extMemoryPriority);
     }
 
     if (devExtensions.extShaderDemoteToHelperInvocation) {
       enabledFeatures.extShaderDemoteToHelperInvocation.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_DEMOTE_TO_HELPER_INVOCATION_FEATURES_EXT;
-      enabledFeatures.extShaderDemoteToHelperInvocation.pNext = enabledFeatures.core.pNext;
-      enabledFeatures.core.pNext = &enabledFeatures.extShaderDemoteToHelperInvocation;
+      enabledFeatures.extShaderDemoteToHelperInvocation.pNext = std::exchange(enabledFeatures.core.pNext, &enabledFeatures.extShaderDemoteToHelperInvocation);
     }
 
     if (devExtensions.extTransformFeedback) {
       enabledFeatures.extTransformFeedback.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TRANSFORM_FEEDBACK_FEATURES_EXT;
-      enabledFeatures.extTransformFeedback.pNext = enabledFeatures.core.pNext;
-      enabledFeatures.core.pNext = &enabledFeatures.extTransformFeedback;
+      enabledFeatures.extTransformFeedback.pNext = std::exchange(enabledFeatures.core.pNext, &enabledFeatures.extTransformFeedback);
     }
 
     if (devExtensions.extVertexAttributeDivisor.revision() >= 3) {
       enabledFeatures.extVertexAttributeDivisor.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_ATTRIBUTE_DIVISOR_FEATURES_EXT;
-      enabledFeatures.extVertexAttributeDivisor.pNext = enabledFeatures.core.pNext;
-      enabledFeatures.core.pNext = &enabledFeatures.extVertexAttributeDivisor;
+      enabledFeatures.extVertexAttributeDivisor.pNext = std::exchange(enabledFeatures.core.pNext, &enabledFeatures.extVertexAttributeDivisor);
     }
 
     // Report the desired overallocation behaviour to the driver
@@ -517,6 +514,9 @@ namespace dxvk {
     m_deviceFeatures = DxvkDeviceFeatures();
     m_deviceFeatures.core.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
     m_deviceFeatures.core.pNext = nullptr;
+
+    m_deviceFeatures.shaderDrawParameters.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_DRAW_PARAMETERS_FEATURES;
+    m_deviceFeatures.shaderDrawParameters.pNext = std::exchange(m_deviceFeatures.core.pNext, &m_deviceFeatures.shaderDrawParameters);
 
     if (m_deviceExtensions.supports(VK_EXT_CONDITIONAL_RENDERING_EXTENSION_NAME)) {
       m_deviceFeatures.extConditionalRendering.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CONDITIONAL_RENDERING_FEATURES_EXT;

--- a/src/dxvk/dxvk_buffer.cpp
+++ b/src/dxvk/dxvk_buffer.cpp
@@ -74,28 +74,28 @@ namespace dxvk {
         "\n  usage: ", info.usage));
     }
     
-    VkMemoryDedicatedRequirementsKHR dedicatedRequirements;
-    dedicatedRequirements.sType                       = VK_STRUCTURE_TYPE_MEMORY_DEDICATED_REQUIREMENTS_KHR;
+    VkMemoryDedicatedRequirements dedicatedRequirements;
+    dedicatedRequirements.sType                       = VK_STRUCTURE_TYPE_MEMORY_DEDICATED_REQUIREMENTS;
     dedicatedRequirements.pNext                       = VK_NULL_HANDLE;
     dedicatedRequirements.prefersDedicatedAllocation  = VK_FALSE;
     dedicatedRequirements.requiresDedicatedAllocation = VK_FALSE;
     
-    VkMemoryRequirements2KHR memReq;
-    memReq.sType = VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2_KHR;
+    VkMemoryRequirements2 memReq;
+    memReq.sType = VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2;
     memReq.pNext = &dedicatedRequirements;
     
-    VkBufferMemoryRequirementsInfo2KHR memReqInfo;
-    memReqInfo.sType  = VK_STRUCTURE_TYPE_BUFFER_MEMORY_REQUIREMENTS_INFO_2_KHR;
+    VkBufferMemoryRequirementsInfo2 memReqInfo;
+    memReqInfo.sType  = VK_STRUCTURE_TYPE_BUFFER_MEMORY_REQUIREMENTS_INFO_2;
     memReqInfo.buffer = handle.buffer;
     memReqInfo.pNext  = VK_NULL_HANDLE;
     
-    VkMemoryDedicatedAllocateInfoKHR dedMemoryAllocInfo;
-    dedMemoryAllocInfo.sType  = VK_STRUCTURE_TYPE_MEMORY_DEDICATED_ALLOCATE_INFO_KHR;
+    VkMemoryDedicatedAllocateInfo dedMemoryAllocInfo;
+    dedMemoryAllocInfo.sType  = VK_STRUCTURE_TYPE_MEMORY_DEDICATED_ALLOCATE_INFO;
     dedMemoryAllocInfo.pNext  = VK_NULL_HANDLE;
     dedMemoryAllocInfo.buffer = handle.buffer;
     dedMemoryAllocInfo.image  = VK_NULL_HANDLE;
 
-    vkd->vkGetBufferMemoryRequirements2KHR(
+    vkd->vkGetBufferMemoryRequirements2(
        vkd->device(), &memReqInfo, &memReq);
 
     // Use high memory priority for GPU-writable resources

--- a/src/dxvk/dxvk_cmdlist.h
+++ b/src/dxvk/dxvk_cmdlist.h
@@ -221,9 +221,9 @@ namespace dxvk {
     
     void updateDescriptorSetWithTemplate(
             VkDescriptorSet               descriptorSet,
-            VkDescriptorUpdateTemplateKHR descriptorTemplate,
+            VkDescriptorUpdateTemplate    descriptorTemplate,
       const void*                         data) {
-      m_vkd->vkUpdateDescriptorSetWithTemplateKHR(m_vkd->device(),
+      m_vkd->vkUpdateDescriptorSetWithTemplate(m_vkd->device(),
         descriptorSet, descriptorTemplate, data);
     }
 

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -274,7 +274,7 @@ namespace dxvk {
 
     bool canUseFb = (srcImage->info().usage & VK_IMAGE_USAGE_SAMPLED_BIT)
                  && (dstImage->info().usage & VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT)
-                 && ((dstImage->info().flags & VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT_KHR)
+                 && ((dstImage->info().flags & VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT)
                   || (dstImage->info().type != VK_IMAGE_TYPE_3D));
 
     bool useFb = dstImage->info().sampleCount != VK_SAMPLE_COUNT_1_BIT

--- a/src/dxvk/dxvk_device_info.h
+++ b/src/dxvk/dxvk_device_info.h
@@ -13,7 +13,7 @@ namespace dxvk {
    * so before using them, check whether they are supported.
    */
   struct DxvkDeviceInfo {
-    VkPhysicalDeviceProperties2KHR                      core;
+    VkPhysicalDeviceProperties2                         core;
     VkPhysicalDeviceIDProperties                        coreDeviceId;
     VkPhysicalDeviceSubgroupProperties                  coreSubgroup;
     VkPhysicalDeviceTransformFeedbackPropertiesEXT      extTransformFeedback;
@@ -31,7 +31,7 @@ namespace dxvk {
    * extended features will be marked as unsupported.
    */
   struct DxvkDeviceFeatures {
-    VkPhysicalDeviceFeatures2KHR                              core;
+    VkPhysicalDeviceFeatures2                                 core;
     VkPhysicalDeviceConditionalRenderingFeaturesEXT           extConditionalRendering;
     VkPhysicalDeviceDepthClipEnableFeaturesEXT                extDepthClipEnable;
     VkPhysicalDeviceHostQueryResetFeaturesEXT                 extHostQueryReset;

--- a/src/dxvk/dxvk_device_info.h
+++ b/src/dxvk/dxvk_device_info.h
@@ -32,6 +32,7 @@ namespace dxvk {
    */
   struct DxvkDeviceFeatures {
     VkPhysicalDeviceFeatures2                                 core;
+    VkPhysicalDeviceShaderDrawParametersFeatures              shaderDrawParameters;
     VkPhysicalDeviceConditionalRenderingFeaturesEXT           extConditionalRendering;
     VkPhysicalDeviceDepthClipEnableFeaturesEXT                extDepthClipEnable;
     VkPhysicalDeviceHostQueryResetFeaturesEXT                 extHostQueryReset;

--- a/src/dxvk/dxvk_extensions.h
+++ b/src/dxvk/dxvk_extensions.h
@@ -277,8 +277,6 @@ namespace dxvk {
     DxvkExt khrDrawIndirectCount              = { VK_KHR_DRAW_INDIRECT_COUNT_EXTENSION_NAME,                DxvkExtMode::Optional };
     DxvkExt khrDriverProperties               = { VK_KHR_DRIVER_PROPERTIES_EXTENSION_NAME,                  DxvkExtMode::Optional };
     DxvkExt khrImageFormatList                = { VK_KHR_IMAGE_FORMAT_LIST_EXTENSION_NAME,                  DxvkExtMode::Required };
-    DxvkExt khrMaintenance1                   = { VK_KHR_MAINTENANCE1_EXTENSION_NAME,                       DxvkExtMode::Required };
-    DxvkExt khrMaintenance2                   = { VK_KHR_MAINTENANCE2_EXTENSION_NAME,                       DxvkExtMode::Required };
     DxvkExt khrSamplerMirrorClampToEdge       = { VK_KHR_SAMPLER_MIRROR_CLAMP_TO_EDGE_EXTENSION_NAME,       DxvkExtMode::Optional };
     DxvkExt khrShaderDrawParameters           = { VK_KHR_SHADER_DRAW_PARAMETERS_EXTENSION_NAME,             DxvkExtMode::Required };
     DxvkExt khrSwapchain                      = { VK_KHR_SWAPCHAIN_EXTENSION_NAME,                          DxvkExtMode::Required };

--- a/src/dxvk/dxvk_extensions.h
+++ b/src/dxvk/dxvk_extensions.h
@@ -272,12 +272,10 @@ namespace dxvk {
     DxvkExt extTransformFeedback              = { VK_EXT_TRANSFORM_FEEDBACK_EXTENSION_NAME,                 DxvkExtMode::Optional };
     DxvkExt extVertexAttributeDivisor         = { VK_EXT_VERTEX_ATTRIBUTE_DIVISOR_EXTENSION_NAME,           DxvkExtMode::Optional };
     DxvkExt khrCreateRenderPass2              = { VK_KHR_CREATE_RENDERPASS_2_EXTENSION_NAME,                DxvkExtMode::Optional };
-    DxvkExt khrDedicatedAllocation            = { VK_KHR_DEDICATED_ALLOCATION_EXTENSION_NAME,               DxvkExtMode::Required };
     DxvkExt khrDepthStencilResolve            = { VK_KHR_DEPTH_STENCIL_RESOLVE_EXTENSION_NAME,              DxvkExtMode::Optional };
     DxvkExt khrDescriptorUpdateTemplate       = { VK_KHR_DESCRIPTOR_UPDATE_TEMPLATE_EXTENSION_NAME,         DxvkExtMode::Required };
     DxvkExt khrDrawIndirectCount              = { VK_KHR_DRAW_INDIRECT_COUNT_EXTENSION_NAME,                DxvkExtMode::Optional };
     DxvkExt khrDriverProperties               = { VK_KHR_DRIVER_PROPERTIES_EXTENSION_NAME,                  DxvkExtMode::Optional };
-    DxvkExt khrGetMemoryRequirements2         = { VK_KHR_GET_MEMORY_REQUIREMENTS_2_EXTENSION_NAME,          DxvkExtMode::Required };
     DxvkExt khrImageFormatList                = { VK_KHR_IMAGE_FORMAT_LIST_EXTENSION_NAME,                  DxvkExtMode::Required };
     DxvkExt khrMaintenance1                   = { VK_KHR_MAINTENANCE1_EXTENSION_NAME,                       DxvkExtMode::Required };
     DxvkExt khrMaintenance2                   = { VK_KHR_MAINTENANCE2_EXTENSION_NAME,                       DxvkExtMode::Required };

--- a/src/dxvk/dxvk_extensions.h
+++ b/src/dxvk/dxvk_extensions.h
@@ -278,7 +278,6 @@ namespace dxvk {
     DxvkExt khrDriverProperties               = { VK_KHR_DRIVER_PROPERTIES_EXTENSION_NAME,                  DxvkExtMode::Optional };
     DxvkExt khrImageFormatList                = { VK_KHR_IMAGE_FORMAT_LIST_EXTENSION_NAME,                  DxvkExtMode::Required };
     DxvkExt khrSamplerMirrorClampToEdge       = { VK_KHR_SAMPLER_MIRROR_CLAMP_TO_EDGE_EXTENSION_NAME,       DxvkExtMode::Optional };
-    DxvkExt khrShaderDrawParameters           = { VK_KHR_SHADER_DRAW_PARAMETERS_EXTENSION_NAME,             DxvkExtMode::Required };
     DxvkExt khrSwapchain                      = { VK_KHR_SWAPCHAIN_EXTENSION_NAME,                          DxvkExtMode::Required };
   };
   

--- a/src/dxvk/dxvk_extensions.h
+++ b/src/dxvk/dxvk_extensions.h
@@ -293,7 +293,6 @@ namespace dxvk {
    * used by DXVK if supported by the implementation.
    */
   struct DxvkInstanceExtensions {
-    DxvkExt khrGetPhysicalDeviceProperties2 = { VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME, DxvkExtMode::Required };
     DxvkExt khrGetSurfaceCapabilities2      = { VK_KHR_GET_SURFACE_CAPABILITIES_2_EXTENSION_NAME,       DxvkExtMode::Optional };
     DxvkExt khrSurface                      = { VK_KHR_SURFACE_EXTENSION_NAME,                          DxvkExtMode::Required };
   };

--- a/src/dxvk/dxvk_extensions.h
+++ b/src/dxvk/dxvk_extensions.h
@@ -273,7 +273,6 @@ namespace dxvk {
     DxvkExt extVertexAttributeDivisor         = { VK_EXT_VERTEX_ATTRIBUTE_DIVISOR_EXTENSION_NAME,           DxvkExtMode::Optional };
     DxvkExt khrCreateRenderPass2              = { VK_KHR_CREATE_RENDERPASS_2_EXTENSION_NAME,                DxvkExtMode::Optional };
     DxvkExt khrDepthStencilResolve            = { VK_KHR_DEPTH_STENCIL_RESOLVE_EXTENSION_NAME,              DxvkExtMode::Optional };
-    DxvkExt khrDescriptorUpdateTemplate       = { VK_KHR_DESCRIPTOR_UPDATE_TEMPLATE_EXTENSION_NAME,         DxvkExtMode::Required };
     DxvkExt khrDrawIndirectCount              = { VK_KHR_DRAW_INDIRECT_COUNT_EXTENSION_NAME,                DxvkExtMode::Optional };
     DxvkExt khrDriverProperties               = { VK_KHR_DRIVER_PROPERTIES_EXTENSION_NAME,                  DxvkExtMode::Optional };
     DxvkExt khrImageFormatList                = { VK_KHR_IMAGE_FORMAT_LIST_EXTENSION_NAME,                  DxvkExtMode::Required };

--- a/src/dxvk/dxvk_image.cpp
+++ b/src/dxvk/dxvk_image.cpp
@@ -217,7 +217,7 @@ namespace dxvk {
       case VK_IMAGE_VIEW_TYPE_3D: {
         this->createView(VK_IMAGE_VIEW_TYPE_3D, 1);
         
-        if (m_image->info().flags & VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT_KHR && m_info.numLevels == 1) {
+        if (m_image->info().flags & VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT && m_info.numLevels == 1) {
           this->createView(VK_IMAGE_VIEW_TYPE_2D,       1);
           this->createView(VK_IMAGE_VIEW_TYPE_2D_ARRAY, m_image->mipLevelExtent(m_info.minLevel).depth);
         }
@@ -247,8 +247,8 @@ namespace dxvk {
     subresourceRange.baseArrayLayer = m_info.minLayer;
     subresourceRange.layerCount     = numLayers;
 
-    VkImageViewUsageCreateInfoKHR viewUsage;
-    viewUsage.sType           = VK_STRUCTURE_TYPE_IMAGE_VIEW_USAGE_CREATE_INFO_KHR;
+    VkImageViewUsageCreateInfo viewUsage;
+    viewUsage.sType           = VK_STRUCTURE_TYPE_IMAGE_VIEW_USAGE_CREATE_INFO;
     viewUsage.pNext           = nullptr;
     viewUsage.usage           = m_info.usage;
     

--- a/src/dxvk/dxvk_image.cpp
+++ b/src/dxvk/dxvk_image.cpp
@@ -60,28 +60,28 @@ namespace dxvk {
     // alignment on non-linear images in order not to violate the
     // bufferImageGranularity limit, which may be greater than the
     // required resource memory alignment on some GPUs.
-    VkMemoryDedicatedRequirementsKHR dedicatedRequirements;
-    dedicatedRequirements.sType                       = VK_STRUCTURE_TYPE_MEMORY_DEDICATED_REQUIREMENTS_KHR;
+    VkMemoryDedicatedRequirements dedicatedRequirements;
+    dedicatedRequirements.sType                       = VK_STRUCTURE_TYPE_MEMORY_DEDICATED_REQUIREMENTS;
     dedicatedRequirements.pNext                       = VK_NULL_HANDLE;
     dedicatedRequirements.prefersDedicatedAllocation  = VK_FALSE;
     dedicatedRequirements.requiresDedicatedAllocation = VK_FALSE;
     
-    VkMemoryRequirements2KHR memReq;
-    memReq.sType = VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2_KHR;
+    VkMemoryRequirements2 memReq;
+    memReq.sType = VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2;
     memReq.pNext = &dedicatedRequirements;
     
-    VkImageMemoryRequirementsInfo2KHR memReqInfo;
-    memReqInfo.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_REQUIREMENTS_INFO_2_KHR;
+    VkImageMemoryRequirementsInfo2 memReqInfo;
+    memReqInfo.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_REQUIREMENTS_INFO_2;
     memReqInfo.image = m_image.image;
     memReqInfo.pNext = VK_NULL_HANDLE;
 
-    VkMemoryDedicatedAllocateInfoKHR dedMemoryAllocInfo;
-    dedMemoryAllocInfo.sType  = VK_STRUCTURE_TYPE_MEMORY_DEDICATED_ALLOCATE_INFO_KHR;
+    VkMemoryDedicatedAllocateInfo dedMemoryAllocInfo;
+    dedMemoryAllocInfo.sType  = VK_STRUCTURE_TYPE_MEMORY_DEDICATED_ALLOCATE_INFO;
     dedMemoryAllocInfo.pNext  = VK_NULL_HANDLE;
     dedMemoryAllocInfo.buffer = VK_NULL_HANDLE;
     dedMemoryAllocInfo.image  = m_image.image;
     
-    m_vkd->vkGetImageMemoryRequirements2KHR(
+    m_vkd->vkGetImageMemoryRequirements2(
       m_vkd->device(), &memReqInfo, &memReq);
  
     if (info.tiling != VK_IMAGE_TILING_LINEAR) {

--- a/src/dxvk/dxvk_instance.cpp
+++ b/src/dxvk/dxvk_instance.cpp
@@ -87,8 +87,7 @@ namespace dxvk {
   VkInstance DxvkInstance::createInstance() {
     DxvkInstanceExtensions insExtensions;
 
-    std::array<DxvkExt*, 3> insExtensionList = {{
-      &insExtensions.khrGetPhysicalDeviceProperties2,
+    std::array<DxvkExt*, 2> insExtensionList = {{
       &insExtensions.khrGetSurfaceCapabilities2,
       &insExtensions.khrSurface,
     }};

--- a/src/dxvk/dxvk_memory.cpp
+++ b/src/dxvk/dxvk_memory.cpp
@@ -180,7 +180,7 @@ namespace dxvk {
   DxvkMemory DxvkMemoryAllocator::alloc(
     const VkMemoryRequirements*             req,
     const VkMemoryDedicatedRequirements&    dedAllocReq,
-    const VkMemoryDedicatedAllocateInfoKHR& dedAllocInfo,
+    const VkMemoryDedicatedAllocateInfo&    dedAllocInfo,
           VkMemoryPropertyFlags             flags,
           float                             priority) {
     std::lock_guard<std::mutex> lock(m_mutex);
@@ -234,7 +234,7 @@ namespace dxvk {
   
   DxvkMemory DxvkMemoryAllocator::tryAlloc(
     const VkMemoryRequirements*             req,
-    const VkMemoryDedicatedAllocateInfoKHR* dedAllocInfo,
+    const VkMemoryDedicatedAllocateInfo*    dedAllocInfo,
           VkMemoryPropertyFlags             flags,
           float                             priority) {
     DxvkMemory result;
@@ -259,7 +259,7 @@ namespace dxvk {
           VkDeviceSize                      size,
           VkDeviceSize                      align,
           float                             priority,
-    const VkMemoryDedicatedAllocateInfoKHR* dedAllocInfo) {
+    const VkMemoryDedicatedAllocateInfo*    dedAllocInfo) {
     // Prevent unnecessary external host memory fragmentation
     bool isDeviceLocal = (flags & VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT) != 0;
 
@@ -305,7 +305,7 @@ namespace dxvk {
           VkMemoryPropertyFlags             flags,
           VkDeviceSize                      size,
           float                             priority,
-    const VkMemoryDedicatedAllocateInfoKHR* dedAllocInfo) {
+    const VkMemoryDedicatedAllocateInfo*    dedAllocInfo) {
     bool useMemoryPriority = (flags & VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT)
                           && (m_device->features().extMemoryPriority.memoryPriority);
     

--- a/src/dxvk/dxvk_memory.h
+++ b/src/dxvk/dxvk_memory.h
@@ -258,7 +258,7 @@ namespace dxvk {
     DxvkMemory alloc(
       const VkMemoryRequirements*             req,
       const VkMemoryDedicatedRequirements&    dedAllocReq,
-      const VkMemoryDedicatedAllocateInfoKHR& dedAllocInfo,
+      const VkMemoryDedicatedAllocateInfo&    dedAllocInfo,
             VkMemoryPropertyFlags             flags,
             float                             priority);
     
@@ -287,7 +287,7 @@ namespace dxvk {
     
     DxvkMemory tryAlloc(
       const VkMemoryRequirements*             req,
-      const VkMemoryDedicatedAllocateInfoKHR* dedAllocInfo,
+      const VkMemoryDedicatedAllocateInfo*    dedAllocInfo,
             VkMemoryPropertyFlags             flags,
             float                             priority);
     
@@ -297,14 +297,14 @@ namespace dxvk {
             VkDeviceSize                      size,
             VkDeviceSize                      align,
             float                             priority,
-      const VkMemoryDedicatedAllocateInfoKHR* dedAllocInfo);
+      const VkMemoryDedicatedAllocateInfo*    dedAllocInfo);
     
     DxvkDeviceMemory tryAllocDeviceMemory(
             DxvkMemoryType*                   type,
             VkMemoryPropertyFlags             flags,
             VkDeviceSize                      size,
             float                             priority,
-      const VkMemoryDedicatedAllocateInfoKHR* dedAllocInfo);
+      const VkMemoryDedicatedAllocateInfo*    dedAllocInfo);
     
     void free(
       const DxvkMemory&           memory);

--- a/src/dxvk/dxvk_meta_pack.cpp
+++ b/src/dxvk/dxvk_meta_pack.cpp
@@ -36,8 +36,8 @@ namespace dxvk {
     m_vkd->vkDestroyPipeline(m_vkd->device(), m_pipePackD32S8, nullptr);
     m_vkd->vkDestroyPipeline(m_vkd->device(), m_pipePackD24S8, nullptr);
     
-    m_vkd->vkDestroyDescriptorUpdateTemplateKHR(m_vkd->device(), m_templatePack, nullptr);
-    m_vkd->vkDestroyDescriptorUpdateTemplateKHR(m_vkd->device(), m_templateUnpack, nullptr);
+    m_vkd->vkDestroyDescriptorUpdateTemplate(m_vkd->device(), m_templatePack, nullptr);
+    m_vkd->vkDestroyDescriptorUpdateTemplate(m_vkd->device(), m_templateUnpack, nullptr);
     
     m_vkd->vkDestroyPipelineLayout(m_vkd->device(), m_pipeLayoutPack, nullptr);
     m_vkd->vkDestroyPipelineLayout(m_vkd->device(), m_pipeLayoutUnpack, nullptr);
@@ -185,54 +185,54 @@ namespace dxvk {
   }
 
 
-  VkDescriptorUpdateTemplateKHR DxvkMetaPackObjects::createPackDescriptorUpdateTemplate() {
-    std::array<VkDescriptorUpdateTemplateEntryKHR, 3> bindings = {{
+  VkDescriptorUpdateTemplate DxvkMetaPackObjects::createPackDescriptorUpdateTemplate() {
+    std::array<VkDescriptorUpdateTemplateEntry, 3> bindings = {{
       { 0, 0, 1, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,         offsetof(DxvkMetaPackDescriptors, dstBuffer),  0 },
       { 1, 0, 1, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, offsetof(DxvkMetaPackDescriptors, srcDepth),   0 },
       { 2, 0, 1, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, offsetof(DxvkMetaPackDescriptors, srcStencil), 0 },
     }};
 
-    VkDescriptorUpdateTemplateCreateInfoKHR templateInfo;
-    templateInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_UPDATE_TEMPLATE_CREATE_INFO_KHR;
+    VkDescriptorUpdateTemplateCreateInfo templateInfo;
+    templateInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_UPDATE_TEMPLATE_CREATE_INFO;
     templateInfo.pNext = nullptr;
     templateInfo.flags = 0;
     templateInfo.descriptorUpdateEntryCount = bindings.size();
     templateInfo.pDescriptorUpdateEntries   = bindings.data();
-    templateInfo.templateType               = VK_DESCRIPTOR_UPDATE_TEMPLATE_TYPE_DESCRIPTOR_SET_KHR;
+    templateInfo.templateType               = VK_DESCRIPTOR_UPDATE_TEMPLATE_TYPE_DESCRIPTOR_SET;
     templateInfo.descriptorSetLayout        = m_dsetLayoutPack;
     templateInfo.pipelineBindPoint          = VK_PIPELINE_BIND_POINT_COMPUTE;
     templateInfo.pipelineLayout             = m_pipeLayoutPack;
     templateInfo.set                        = 0;
 
-    VkDescriptorUpdateTemplateKHR result = VK_NULL_HANDLE;
-    if (m_vkd->vkCreateDescriptorUpdateTemplateKHR(m_vkd->device(),
+    VkDescriptorUpdateTemplate result = VK_NULL_HANDLE;
+    if (m_vkd->vkCreateDescriptorUpdateTemplate(m_vkd->device(),
           &templateInfo, nullptr, &result) != VK_SUCCESS)
       throw DxvkError("DxvkMetaPackObjects: Failed to create descriptor update template");
     return result;
   }
 
 
-  VkDescriptorUpdateTemplateKHR DxvkMetaPackObjects::createUnpackDescriptorUpdateTemplate() {
-    std::array<VkDescriptorUpdateTemplateEntryKHR, 3> bindings = {{
+  VkDescriptorUpdateTemplate DxvkMetaPackObjects::createUnpackDescriptorUpdateTemplate() {
+    std::array<VkDescriptorUpdateTemplateEntry, 3> bindings = {{
       { 0, 0, 1, VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER, offsetof(DxvkMetaUnpackDescriptors, dstDepth),   0 },
       { 1, 0, 1, VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER, offsetof(DxvkMetaUnpackDescriptors, dstStencil), 0 },
       { 2, 0, 1, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,       offsetof(DxvkMetaUnpackDescriptors, srcBuffer),  0 },
     }};
 
-    VkDescriptorUpdateTemplateCreateInfoKHR templateInfo;
-    templateInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_UPDATE_TEMPLATE_CREATE_INFO_KHR;
+    VkDescriptorUpdateTemplateCreateInfo templateInfo;
+    templateInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_UPDATE_TEMPLATE_CREATE_INFO;
     templateInfo.pNext = nullptr;
     templateInfo.flags = 0;
     templateInfo.descriptorUpdateEntryCount = bindings.size();
     templateInfo.pDescriptorUpdateEntries   = bindings.data();
-    templateInfo.templateType               = VK_DESCRIPTOR_UPDATE_TEMPLATE_TYPE_DESCRIPTOR_SET_KHR;
+    templateInfo.templateType               = VK_DESCRIPTOR_UPDATE_TEMPLATE_TYPE_DESCRIPTOR_SET;
     templateInfo.descriptorSetLayout        = m_dsetLayoutUnpack;
     templateInfo.pipelineBindPoint          = VK_PIPELINE_BIND_POINT_COMPUTE;
     templateInfo.pipelineLayout             = m_pipeLayoutUnpack;
     templateInfo.set                        = 0;
 
-    VkDescriptorUpdateTemplateKHR result = VK_NULL_HANDLE;
-    if (m_vkd->vkCreateDescriptorUpdateTemplateKHR(m_vkd->device(),
+    VkDescriptorUpdateTemplate result = VK_NULL_HANDLE;
+    if (m_vkd->vkCreateDescriptorUpdateTemplate(m_vkd->device(),
           &templateInfo, nullptr, &result) != VK_SUCCESS)
       throw DxvkError("DxvkMetaPackObjects: Failed to create descriptor update template");
     return result;

--- a/src/dxvk/dxvk_pipelayout.cpp
+++ b/src/dxvk/dxvk_pipelayout.cpp
@@ -95,8 +95,8 @@ namespace dxvk {
     for (uint32_t i = 0; i < bindingCount; i++)
       m_bindingSlots[i] = bindingInfos[i];
     
-    std::vector<VkDescriptorSetLayoutBinding>       bindings(bindingCount);
-    std::vector<VkDescriptorUpdateTemplateEntryKHR> tEntries(bindingCount);
+    std::vector<VkDescriptorSetLayoutBinding>    bindings(bindingCount);
+    std::vector<VkDescriptorUpdateTemplateEntry> tEntries(bindingCount);
     
     for (uint32_t i = 0; i < bindingCount; i++) {
       bindings[i].binding            = i;
@@ -157,19 +157,19 @@ namespace dxvk {
     // Create descriptor update template. If there are no active
     // resource bindings, there won't be any descriptors to update.
     if (bindingCount > 0) {
-      VkDescriptorUpdateTemplateCreateInfoKHR templateInfo;
-      templateInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_UPDATE_TEMPLATE_CREATE_INFO_KHR;
+      VkDescriptorUpdateTemplateCreateInfo templateInfo;
+      templateInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_UPDATE_TEMPLATE_CREATE_INFO;
       templateInfo.pNext = nullptr;
       templateInfo.flags = 0;
       templateInfo.descriptorUpdateEntryCount = tEntries.size();
       templateInfo.pDescriptorUpdateEntries   = tEntries.data();
-      templateInfo.templateType               = VK_DESCRIPTOR_UPDATE_TEMPLATE_TYPE_DESCRIPTOR_SET_KHR;
+      templateInfo.templateType               = VK_DESCRIPTOR_UPDATE_TEMPLATE_TYPE_DESCRIPTOR_SET;
       templateInfo.descriptorSetLayout        = m_descriptorSetLayout;
       templateInfo.pipelineBindPoint          = pipelineBindPoint;
       templateInfo.pipelineLayout             = m_pipelineLayout;
       templateInfo.set                        = 0;
       
-      if (m_vkd->vkCreateDescriptorUpdateTemplateKHR(
+      if (m_vkd->vkCreateDescriptorUpdateTemplate(
           m_vkd->device(), &templateInfo, nullptr, &m_descriptorTemplate) != VK_SUCCESS) {
         m_vkd->vkDestroyDescriptorSetLayout(m_vkd->device(), m_descriptorSetLayout, nullptr);
         m_vkd->vkDestroyPipelineLayout(m_vkd->device(), m_pipelineLayout, nullptr);
@@ -180,7 +180,7 @@ namespace dxvk {
   
   
   DxvkPipelineLayout::~DxvkPipelineLayout() {
-    m_vkd->vkDestroyDescriptorUpdateTemplateKHR(
+    m_vkd->vkDestroyDescriptorUpdateTemplate(
       m_vkd->device(), m_descriptorTemplate, nullptr);
     
     m_vkd->vkDestroyPipelineLayout(

--- a/src/vulkan/vulkan_loader.h
+++ b/src/vulkan/vulkan_loader.h
@@ -82,22 +82,19 @@ namespace dxvk::vk {
     VULKAN_FN(vkEnumerateDeviceExtensionProperties);
     VULKAN_FN(vkEnumeratePhysicalDevices);
     VULKAN_FN(vkGetPhysicalDeviceFeatures);
+    VULKAN_FN(vkGetPhysicalDeviceFeatures2);
     VULKAN_FN(vkGetPhysicalDeviceFormatProperties);
+    VULKAN_FN(vkGetPhysicalDeviceFormatProperties2);
+    VULKAN_FN(vkGetPhysicalDeviceProperties2);
     VULKAN_FN(vkGetPhysicalDeviceImageFormatProperties);
+    VULKAN_FN(vkGetPhysicalDeviceImageFormatProperties2);
     VULKAN_FN(vkGetPhysicalDeviceMemoryProperties);
+    VULKAN_FN(vkGetPhysicalDeviceMemoryProperties2);
     VULKAN_FN(vkGetPhysicalDeviceProperties);
     VULKAN_FN(vkGetPhysicalDeviceQueueFamilyProperties);
+    VULKAN_FN(vkGetPhysicalDeviceQueueFamilyProperties2);
     VULKAN_FN(vkGetPhysicalDeviceSparseImageFormatProperties);
-
-    #ifdef VK_KHR_get_physical_device_properties2
-    VULKAN_FN(vkGetPhysicalDeviceFeatures2KHR);
-    VULKAN_FN(vkGetPhysicalDeviceProperties2KHR);
-    VULKAN_FN(vkGetPhysicalDeviceFormatProperties2KHR);
-    VULKAN_FN(vkGetPhysicalDeviceImageFormatProperties2KHR);
-    VULKAN_FN(vkGetPhysicalDeviceQueueFamilyProperties2KHR);
-    VULKAN_FN(vkGetPhysicalDeviceMemoryProperties2KHR);
-    VULKAN_FN(vkGetPhysicalDeviceSparseImageFormatProperties2KHR);
-    #endif
+    VULKAN_FN(vkGetPhysicalDeviceSparseImageFormatProperties2);
 
     #ifdef VK_KHR_get_surface_capabilities2
     VULKAN_FN(vkGetPhysicalDeviceSurfaceCapabilities2KHR);

--- a/src/vulkan/vulkan_loader.h
+++ b/src/vulkan/vulkan_loader.h
@@ -167,8 +167,11 @@ namespace dxvk::vk {
     VULKAN_FN(vkBindBufferMemory);
     VULKAN_FN(vkBindImageMemory);
     VULKAN_FN(vkGetBufferMemoryRequirements);
+    VULKAN_FN(vkGetBufferMemoryRequirements2);
     VULKAN_FN(vkGetImageMemoryRequirements);
+    VULKAN_FN(vkGetImageMemoryRequirements2);
     VULKAN_FN(vkGetImageSparseMemoryRequirements);
+    VULKAN_FN(vkGetImageSparseMemoryRequirements2);
     VULKAN_FN(vkQueueBindSparse);
     VULKAN_FN(vkCreateFence);
     VULKAN_FN(vkDestroyFence);
@@ -298,11 +301,6 @@ namespace dxvk::vk {
     VULKAN_FN(vkGetSwapchainImagesKHR);
     VULKAN_FN(vkAcquireNextImageKHR);
     VULKAN_FN(vkQueuePresentKHR);
-    #endif
-
-    #ifdef VK_KHR_get_memory_requirements2
-    VULKAN_FN(vkGetBufferMemoryRequirements2KHR);
-    VULKAN_FN(vkGetImageMemoryRequirements2KHR);
     #endif
 
     #ifdef VK_EXT_conditional_rendering

--- a/src/vulkan/vulkan_loader.h
+++ b/src/vulkan/vulkan_loader.h
@@ -231,6 +231,9 @@ namespace dxvk::vk {
     VULKAN_FN(vkBeginCommandBuffer);
     VULKAN_FN(vkEndCommandBuffer);
     VULKAN_FN(vkResetCommandBuffer);
+    VULKAN_FN(vkCreateDescriptorUpdateTemplate);
+    VULKAN_FN(vkDestroyDescriptorUpdateTemplate);
+    VULKAN_FN(vkUpdateDescriptorSetWithTemplate);
     VULKAN_FN(vkCmdBindPipeline);
     VULKAN_FN(vkCmdSetViewport);
     VULKAN_FN(vkCmdSetScissor);
@@ -283,13 +286,6 @@ namespace dxvk::vk {
     VULKAN_FN(vkCmdEndRenderPass2KHR);
     #endif
     
-    #ifdef VK_KHR_descriptor_update_template
-    VULKAN_FN(vkCreateDescriptorUpdateTemplateKHR);
-    VULKAN_FN(vkDestroyDescriptorUpdateTemplateKHR);
-    VULKAN_FN(vkUpdateDescriptorSetWithTemplateKHR);
-    VULKAN_FN(vkCmdPushDescriptorSetWithTemplateKHR);
-    #endif
-
     #ifdef VK_KHR_draw_indirect_count
     VULKAN_FN(vkCmdDrawIndirectCountKHR);
     VULKAN_FN(vkCmdDrawIndexedIndirectCountKHR);


### PR DESCRIPTION
Title. This is a minor cleanup, replacing some old 1.0 extensions with the corresponding core 1.1 functinoality.

On the D3D9 side, don't enable the draw parameters feature because it is not used.  It's only needed to use BaseInstance/BaseVertex in vertex shaders. For D3D11, enable the newly introduced device feature.