### PR TITLE
[d3d9] Fix broken image view creation

### DIFF
--- a/src/d3d9/d3d9_common_texture.cpp
+++ b/src/d3d9/d3d9_common_texture.cpp
@@ -455,7 +455,9 @@ namespace dxvk {
       return;
 
     m_sampleView.Color = CreateView(AllLayers, Lod, VK_IMAGE_USAGE_SAMPLED_BIT, false);
-    m_sampleView.Srgb  = CreateView(AllLayers, Lod, VK_IMAGE_USAGE_SAMPLED_BIT, true);
+
+    if (IsSrgbCompatible())
+      m_sampleView.Srgb = CreateView(AllLayers, Lod, VK_IMAGE_USAGE_SAMPLED_BIT, true);
   }
 
 

--- a/src/d3d9/d3d9_common_texture.h
+++ b/src/d3d9/d3d9_common_texture.h
@@ -331,8 +331,8 @@ namespace dxvk {
     bool SetDirty(UINT Subresource, bool value) { return std::exchange(m_dirty[Subresource], value); }
     void MarkAllDirty() { for (uint32_t i = 0; i < m_dirty.size(); i++) m_dirty[i] = true; }
 
-    const D3D9ColorView& GetSampleView() const {
-      return m_sampleView;
+    const Rc<DxvkImageView>& GetSampleView(bool srgb) const {
+      return m_sampleView.Pick(srgb);
     }
 
     VkImageLayout DetermineRenderTargetLayout() const {

--- a/src/d3d9/d3d9_common_texture.h
+++ b/src/d3d9/d3d9_common_texture.h
@@ -293,6 +293,14 @@ namespace dxvk {
     }
 
     /**
+     * \brief Checks whether sRGB views can be created
+     * \returns Whether the format is sRGB compatible.
+     */
+    bool IsSrgbCompatible() const {
+      return m_mapping.FormatSrgb;
+    }
+
+    /**
      * \brief Recreate main image view
      * Recreates the main view of the sampler w/ a specific LOD.
      * SetLOD only works on MANAGED textures so this is A-okay.
@@ -332,7 +340,7 @@ namespace dxvk {
     void MarkAllDirty() { for (uint32_t i = 0; i < m_dirty.size(); i++) m_dirty[i] = true; }
 
     const Rc<DxvkImageView>& GetSampleView(bool srgb) const {
-      return m_sampleView.Pick(srgb);
+      return m_sampleView.Pick(srgb && IsSrgbCompatible());
     }
 
     VkImageLayout DetermineRenderTargetLayout() const {

--- a/src/d3d9/d3d9_common_texture.h
+++ b/src/d3d9/d3d9_common_texture.h
@@ -93,8 +93,7 @@ namespace dxvk {
     D3D9CommonTexture(
             D3D9DeviceEx*             pDevice,
       const D3D9_COMMON_TEXTURE_DESC* pDesc,
-            D3DRESOURCETYPE           ResourceType,
-            D3D9_VK_FORMAT_MAPPING    Mapping);
+            D3DRESOURCETYPE           ResourceType);
 
     ~D3D9CommonTexture();
 
@@ -203,8 +202,7 @@ namespace dxvk {
      */
     static HRESULT NormalizeTextureProperties(
             D3D9DeviceEx*              pDevice,
-            D3D9_COMMON_TEXTURE_DESC*  pDesc,
-            D3D9_VK_FORMAT_MAPPING*    pMapping);
+            D3D9_COMMON_TEXTURE_DESC*  pDesc);
 
     /**
      * \brief Lock Flags

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -4058,7 +4058,7 @@ namespace dxvk {
   void D3D9DeviceEx::GenerateMips(
     D3D9CommonTexture* pResource) {
     EmitCs([
-      cImageView = pResource->GetSampleView().Color
+      cImageView = pResource->GetSampleView(false)
     ] (DxvkContext* ctx) {
       ctx->generateMipmaps(cImageView);
     });
@@ -5289,7 +5289,7 @@ namespace dxvk {
       cColorSlot = colorSlot,
       cDepthSlot = depthSlot,
       cDepth     = commonTex->IsShadow(),
-      cImageView = commonTex->GetSampleView().Pick(srgb)
+      cImageView = commonTex->GetSampleView(srgb)
     ](DxvkContext* ctx) {
       ctx->bindResourceView(cColorSlot, !cDepth ? cImageView : nullptr, nullptr);
       ctx->bindResourceView(cDepthSlot,  cDepth ? cImageView : nullptr, nullptr);

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -398,12 +398,11 @@ namespace dxvk {
     desc.MultiSample        = D3DMULTISAMPLE_NONE;
     desc.MultisampleQuality = 0;
 
-    D3D9_VK_FORMAT_MAPPING mapping;
-    if (FAILED(D3D9CommonTexture::NormalizeTextureProperties(this, &desc, &mapping)))
+    if (FAILED(D3D9CommonTexture::NormalizeTextureProperties(this, &desc)))
       return D3DERR_INVALIDCALL;
 
     try {
-      const Com<D3D9Texture2D> texture = new D3D9Texture2D(this, &desc, mapping);
+      const Com<D3D9Texture2D> texture = new D3D9Texture2D(this, &desc);
 
       void* initialData = nullptr;
 
@@ -454,12 +453,11 @@ namespace dxvk {
     desc.MultiSample        = D3DMULTISAMPLE_NONE;
     desc.MultisampleQuality = 0;
 
-    D3D9_VK_FORMAT_MAPPING mapping;
-    if (FAILED(D3D9CommonTexture::NormalizeTextureProperties(this, &desc, &mapping)))
+    if (FAILED(D3D9CommonTexture::NormalizeTextureProperties(this, &desc)))
       return D3DERR_INVALIDCALL;
 
     try {
-      const Com<D3D9Texture3D> texture = new D3D9Texture3D(this, &desc, mapping);
+      const Com<D3D9Texture3D> texture = new D3D9Texture3D(this, &desc);
       m_initializer->InitTexture(texture->GetCommonTexture());
       *ppVolumeTexture = texture.ref();
 
@@ -500,12 +498,11 @@ namespace dxvk {
     desc.MultiSample        = D3DMULTISAMPLE_NONE;
     desc.MultisampleQuality = 0;
 
-    D3D9_VK_FORMAT_MAPPING mapping;
-    if (FAILED(D3D9CommonTexture::NormalizeTextureProperties(this, &desc, &mapping)))
+    if (FAILED(D3D9CommonTexture::NormalizeTextureProperties(this, &desc)))
       return D3DERR_INVALIDCALL;
 
     try {
-      const Com<D3D9TextureCube> texture = new D3D9TextureCube(this, &desc, mapping);
+      const Com<D3D9TextureCube> texture = new D3D9TextureCube(this, &desc);
       m_initializer->InitTexture(texture->GetCommonTexture());
       *ppCubeTexture = texture.ref();
 
@@ -3293,12 +3290,11 @@ namespace dxvk {
     desc.MultiSample        = MultiSample;
     desc.MultisampleQuality = MultisampleQuality;
 
-    D3D9_VK_FORMAT_MAPPING mapping;
-    if (FAILED(D3D9CommonTexture::NormalizeTextureProperties(this, &desc, &mapping)))
+    if (FAILED(D3D9CommonTexture::NormalizeTextureProperties(this, &desc)))
       return D3DERR_INVALIDCALL;
 
     try {
-      const Com<D3D9Surface> surface = new D3D9Surface(this, &desc, mapping);
+      const Com<D3D9Surface> surface = new D3D9Surface(this, &desc);
       m_initializer->InitTexture(surface->GetCommonTexture());
       *ppSurface = surface.ref();
       return D3D_OK;
@@ -3337,12 +3333,11 @@ namespace dxvk {
     desc.MultiSample        = D3DMULTISAMPLE_NONE;
     desc.MultisampleQuality = 0;
 
-    D3D9_VK_FORMAT_MAPPING mapping;
-    if (FAILED(D3D9CommonTexture::NormalizeTextureProperties(this, &desc, &mapping)))
+    if (FAILED(D3D9CommonTexture::NormalizeTextureProperties(this, &desc)))
       return D3DERR_INVALIDCALL;
 
     try {
-      const Com<D3D9Surface> surface = new D3D9Surface(this, &desc, mapping);
+      const Com<D3D9Surface> surface = new D3D9Surface(this, &desc);
       m_initializer->InitTexture(surface->GetCommonTexture());
       *ppSurface = surface.ref();
       return D3D_OK;
@@ -3383,12 +3378,11 @@ namespace dxvk {
     desc.MultiSample        = MultiSample;
     desc.MultisampleQuality = MultisampleQuality;
 
-    D3D9_VK_FORMAT_MAPPING mapping;
-    if (FAILED(D3D9CommonTexture::NormalizeTextureProperties(this, &desc, &mapping)))
+    if (FAILED(D3D9CommonTexture::NormalizeTextureProperties(this, &desc)))
       return D3DERR_INVALIDCALL;
 
     try {
-      const Com<D3D9Surface> surface = new D3D9Surface(this, &desc, mapping);
+      const Com<D3D9Surface> surface = new D3D9Surface(this, &desc);
       m_initializer->InitTexture(surface->GetCommonTexture());
       *ppSurface = surface.ref();
       return D3D_OK;
@@ -6523,11 +6517,10 @@ namespace dxvk {
       desc.MultiSample        = pPresentationParameters->MultiSampleType;
       desc.MultisampleQuality = pPresentationParameters->MultiSampleQuality;
 
-      D3D9_VK_FORMAT_MAPPING mapping;
-      if (FAILED(D3D9CommonTexture::NormalizeTextureProperties(this, &desc, &mapping)))
+      if (FAILED(D3D9CommonTexture::NormalizeTextureProperties(this, &desc)))
         return D3DERR_NOTAVAILABLE;
 
-      m_autoDepthStencil = new D3D9Surface(this, &desc, mapping);
+      m_autoDepthStencil = new D3D9Surface(this, &desc);
       m_initializer->InitTexture(m_autoDepthStencil->GetCommonTexture());
       SetDepthStencilSurface(m_autoDepthStencil.ptr());
     }

--- a/src/d3d9/d3d9_subresource.h
+++ b/src/d3d9/d3d9_subresource.h
@@ -20,7 +20,8 @@ namespace dxvk {
       , m_container                ( pContainer )
       , m_texture                  ( pTexture )
       , m_face                     ( Face )
-      , m_mipLevel                 ( MipLevel ) { }
+      , m_mipLevel                 ( MipLevel )
+      , m_isSrgbCompatible         ( pTexture->IsSrgbCompatible() ) { }
 
     ~D3D9Subresource() {
       // We own the texture!
@@ -66,6 +67,7 @@ namespace dxvk {
     }
 
     Rc<DxvkImageView> GetImageView(bool Srgb) {
+      Srgb &= m_isSrgbCompatible;
       Rc<DxvkImageView>& view = m_sampleView.Pick(Srgb);
 
       if (unlikely(view == nullptr && !IsNull()))
@@ -75,6 +77,7 @@ namespace dxvk {
     }
 
     Rc<DxvkImageView> GetRenderTargetView(bool Srgb) {
+      Srgb &= m_isSrgbCompatible;
       Rc<DxvkImageView>& view = m_renderTargetView.Pick(Srgb);
 
       if (unlikely(view == nullptr && !IsNull()))
@@ -116,6 +119,7 @@ namespace dxvk {
     UINT                    m_face;
     UINT                    m_mipLevel;
 
+    bool                    m_isSrgbCompatible;
     D3D9ColorView           m_sampleView;
     D3D9ColorView           m_renderTargetView;
     Rc<DxvkImageView>       m_depthStencilView;

--- a/src/d3d9/d3d9_surface.cpp
+++ b/src/d3d9/d3d9_surface.cpp
@@ -7,11 +7,10 @@ namespace dxvk {
 
   D3D9Surface::D3D9Surface(
           D3D9DeviceEx*             pDevice,
-    const D3D9_COMMON_TEXTURE_DESC* pDesc,
-          D3D9_VK_FORMAT_MAPPING    Mapping)
+    const D3D9_COMMON_TEXTURE_DESC* pDesc)
     : D3D9SurfaceBase(
         pDevice,
-        new D3D9CommonTexture( pDevice, pDesc, D3DRTYPE_TEXTURE, Mapping ),
+        new D3D9CommonTexture( pDevice, pDesc, D3DRTYPE_TEXTURE),
         0, 0,
         nullptr) { }
 

--- a/src/d3d9/d3d9_surface.h
+++ b/src/d3d9/d3d9_surface.h
@@ -19,8 +19,7 @@ namespace dxvk {
 
     D3D9Surface(
             D3D9DeviceEx*             pDevice,
-      const D3D9_COMMON_TEXTURE_DESC* pDesc,
-            D3D9_VK_FORMAT_MAPPING    Mapping);
+      const D3D9_COMMON_TEXTURE_DESC* pDesc);
 
     D3D9Surface(
             D3D9DeviceEx*             pDevice,

--- a/src/d3d9/d3d9_swapchain.cpp
+++ b/src/d3d9/d3d9_swapchain.cpp
@@ -890,10 +890,8 @@ namespace dxvk {
     desc.Usage              = D3DUSAGE_RENDERTARGET;
     desc.Discard            = FALSE;
 
-    auto mapping = m_parent->LookupFormat(desc.Format);
-
     for (uint32_t i = 0; i < NumBackBuffers; i++)
-      m_backBuffers[i] = new D3D9Surface(m_parent, &desc, mapping);
+      m_backBuffers[i] = new D3D9Surface(m_parent, &desc);
 
     m_swapImage = m_backBuffers[0]->GetCommonTexture()->GetImage();
 

--- a/src/d3d9/d3d9_texture.cpp
+++ b/src/d3d9/d3d9_texture.cpp
@@ -8,9 +8,8 @@ namespace dxvk {
 
   D3D9Texture2D::D3D9Texture2D(
           D3D9DeviceEx*             pDevice,
-    const D3D9_COMMON_TEXTURE_DESC* pDesc,
-          D3D9_VK_FORMAT_MAPPING    Mapping)
-    : D3D9Texture2DBase( pDevice, pDesc, D3DRTYPE_TEXTURE, Mapping ) { }
+    const D3D9_COMMON_TEXTURE_DESC* pDesc)
+    : D3D9Texture2DBase( pDevice, pDesc, D3DRTYPE_TEXTURE ) { }
 
 
   HRESULT STDMETHODCALLTYPE D3D9Texture2D::QueryInterface(REFIID riid, void** ppvObject) {
@@ -87,9 +86,8 @@ namespace dxvk {
 
   D3D9Texture3D::D3D9Texture3D(
           D3D9DeviceEx*             pDevice,
-    const D3D9_COMMON_TEXTURE_DESC* pDesc,
-          D3D9_VK_FORMAT_MAPPING    Mapping)
-    : D3D9Texture3DBase( pDevice, pDesc, D3DRTYPE_VOLUMETEXTURE, Mapping ) { }
+    const D3D9_COMMON_TEXTURE_DESC* pDesc)
+    : D3D9Texture3DBase( pDevice, pDesc, D3DRTYPE_VOLUMETEXTURE ) { }
 
 
   HRESULT STDMETHODCALLTYPE D3D9Texture3D::QueryInterface(REFIID riid, void** ppvObject) {
@@ -166,9 +164,8 @@ namespace dxvk {
 
   D3D9TextureCube::D3D9TextureCube(
           D3D9DeviceEx*             pDevice,
-    const D3D9_COMMON_TEXTURE_DESC* pDesc,
-          D3D9_VK_FORMAT_MAPPING    Mapping)
-    : D3D9TextureCubeBase( pDevice, pDesc, D3DRTYPE_CUBETEXTURE, Mapping ) { }
+    const D3D9_COMMON_TEXTURE_DESC* pDesc)
+    : D3D9TextureCubeBase( pDevice, pDesc, D3DRTYPE_CUBETEXTURE ) { }
 
 
   HRESULT STDMETHODCALLTYPE D3D9TextureCube::QueryInterface(REFIID riid, void** ppvObject) {

--- a/src/d3d9/d3d9_texture.h
+++ b/src/d3d9/d3d9_texture.h
@@ -22,10 +22,9 @@ namespace dxvk {
     D3D9BaseTexture(
             D3D9DeviceEx*             pDevice,
       const D3D9_COMMON_TEXTURE_DESC* pDesc,
-            D3DRESOURCETYPE           ResourceType,
-            D3D9_VK_FORMAT_MAPPING    Mapping)
+            D3DRESOURCETYPE           ResourceType)
       : D3D9Resource<Base...> ( pDevice )
-      , m_texture             ( pDevice, pDesc, ResourceType, Mapping )
+      , m_texture             ( pDevice, pDesc, ResourceType )
       , m_lod                 ( 0 )
       , m_autogenFilter       ( D3DTEXF_LINEAR ) {
       const uint32_t arraySlices = m_texture.Desc()->ArraySize;
@@ -117,8 +116,7 @@ namespace dxvk {
 
     D3D9Texture2D(
             D3D9DeviceEx*             pDevice,
-      const D3D9_COMMON_TEXTURE_DESC* pDesc,
-            D3D9_VK_FORMAT_MAPPING    Mapping);
+      const D3D9_COMMON_TEXTURE_DESC* pDesc);
 
     HRESULT STDMETHODCALLTYPE QueryInterface(REFIID riid, void** ppvObject);
 
@@ -143,8 +141,7 @@ namespace dxvk {
 
     D3D9Texture3D(
             D3D9DeviceEx*             pDevice,
-      const D3D9_COMMON_TEXTURE_DESC* pDesc,
-            D3D9_VK_FORMAT_MAPPING    Mapping);
+      const D3D9_COMMON_TEXTURE_DESC* pDesc);
 
     HRESULT STDMETHODCALLTYPE QueryInterface(REFIID riid, void** ppvObject);
 
@@ -169,8 +166,7 @@ namespace dxvk {
 
     D3D9TextureCube(
             D3D9DeviceEx*             pDevice,
-      const D3D9_COMMON_TEXTURE_DESC* pDesc,
-            D3D9_VK_FORMAT_MAPPING    Mapping);
+      const D3D9_COMMON_TEXTURE_DESC* pDesc);
 
     HRESULT STDMETHODCALLTYPE QueryInterface(REFIID riid, void** ppvObject);
 

--- a/src/d3d9/d3d9_volume.cpp
+++ b/src/d3d9/d3d9_volume.cpp
@@ -7,11 +7,10 @@ namespace dxvk {
 
   D3D9Volume::D3D9Volume(
           D3D9DeviceEx*             pDevice,
-    const D3D9_COMMON_TEXTURE_DESC* pDesc,
-          D3D9_VK_FORMAT_MAPPING    Mapping)
+    const D3D9_COMMON_TEXTURE_DESC* pDesc)
     : D3D9VolumeBase(
         pDevice,
-        new D3D9CommonTexture( pDevice, pDesc, D3DRTYPE_VOLUMETEXTURE, Mapping ),
+        new D3D9CommonTexture( pDevice, pDesc, D3DRTYPE_VOLUMETEXTURE ),
         0, 0,
         nullptr) { }
 

--- a/src/d3d9/d3d9_volume.h
+++ b/src/d3d9/d3d9_volume.h
@@ -13,8 +13,7 @@ namespace dxvk {
 
     D3D9Volume(
             D3D9DeviceEx*             pDevice,
-      const D3D9_COMMON_TEXTURE_DESC* pDesc,
-            D3D9_VK_FORMAT_MAPPING    Mapping);
+      const D3D9_COMMON_TEXTURE_DESC* pDesc);
 
     D3D9Volume(
             D3D9DeviceEx*             pDevice,


### PR DESCRIPTION
This addresses a regression introduced with 7c53a997effc64adbe52a8f67ee6bb6b5f2fe580 that would lead to us creating views with `VK_IMAGE_FORMAT_UNDEFINED`.

The first page refactors the `D3D9CommonTexture` constructor to not take a `D3D9_VK_FORMAT_MAPPING`. This seemed like bad design to begin with since it expects the mapping to match the image format anyway, and might have been causing issues for images with `Unknown` format.

The second patch fixes sRGB lookup for formats that have no corresponding sRGB format, which seems ot be responsible for most of the current issues.

Fixes #1349.