### PR TITLE
[d3d9] Fix some off-by-one TSS types enum values

### DIFF
--- a/src/d3d9/d3d9_util.h
+++ b/src/d3d9/d3d9_util.h
@@ -263,9 +263,9 @@ namespace dxvk {
       DXVK_TSS_BUMPENVLSCALE  = 21,
       DXVK_TSS_BUMPENVLOFFSET = 22,
       DXVK_TSS_TEXTURETRANSFORMFLAGS = 23,
-      DXVK_TSS_COLORARG0      = 24,
-      DXVK_TSS_ALPHAARG0      = 25,
-      DXVK_TSS_RESULTARG      = 26,
+      DXVK_TSS_COLORARG0      = 25,
+      DXVK_TSS_ALPHAARG0      = 26,
+      DXVK_TSS_RESULTARG      = 27,
       DXVK_TSS_CONSTANT       = 31,
       DXVK_TSS_COUNT          = 32
   };


### PR DESCRIPTION
Note: I have no idea what the code actually does or what TSS is, but I've noticed that rails started looking odd in ZUSI 3 today, and then I noticed that three numbers in the new enum look off compared to D3DTEXTURESTAGESTATETYPE. This patch fixes that, and now rails look good again (even though the game still looks odd in general for other reasons, but I will file a bug for that once I give up on finding a fix for it).

-------------------------------
[d3d9] Fix some off-by-one TSS types enum values

They are 0-based instead of 1-based, and therefore supposed to be
off-by-one compared to D3DTEXTURESTAGESTATETYPE, but three values in the
enum are actually off-by-two.

For me, this fixes some odd rail rendering in ZUSI 3.

Fixes: 7d0ddc4b