### PR TITLE
[d3d9] Rotate swap chain back buffers

### DIFF
--- a/src/d3d9/d3d9_subresource.h
+++ b/src/d3d9/d3d9_subresource.h
@@ -111,6 +111,14 @@ namespace dxvk {
       return m_container;
     }
 
+    void Swap(D3D9Subresource* Other) {
+      // Only used for swap chain back buffers that don't
+      // have a container and all have identical properties
+      std::swap(m_texture,          Other->m_texture);
+      std::swap(m_sampleView,       Other->m_sampleView);
+      std::swap(m_renderTargetView, Other->m_renderTargetView);
+    }
+
   protected:
 
     IDirect3DBaseTexture9*  m_container;

--- a/src/d3d9/d3d9_swapchain.cpp
+++ b/src/d3d9/d3d9_swapchain.cpp
@@ -739,6 +739,13 @@ namespace dxvk {
 
       SubmitPresent(sync, i);
     }
+
+    // Rotate swap chain buffers so that the back
+    // buffer at index 0 becomes the front buffer.
+    for (uint32_t i = 1; i < m_backBuffers.size(); i++)
+      m_backBuffers[i]->Swap(m_backBuffers[i - 1].ptr());
+
+    m_parent->m_flags.set(D3D9DeviceFlag::DirtyFramebuffer);
   }
 
 

--- a/src/d3d9/d3d9_swapchain.h
+++ b/src/d3d9/d3d9_swapchain.h
@@ -115,9 +115,8 @@ namespace dxvk {
     Rc<DxvkImage>           m_gammaTexture;
     Rc<DxvkImageView>       m_gammaTextureView;
 
-    Rc<DxvkImage>           m_swapImage;
-    Rc<DxvkImage>           m_swapImageResolve;
-    Rc<DxvkImageView>       m_swapImageView;
+    Rc<DxvkImage>           m_resolveImage;
+    Rc<DxvkImageView>       m_resolveImageView;
 
     Rc<hud::Hud>            m_hud;
 


### PR DESCRIPTION
Restores functionality removed in 81c3daa3d068f6a1fd2e8960efa0a109a61ebe78.

The implementation assumes that it is **not** possible for the game or DXVK itself to create additional views for swap chain back buffers (looking at the API, there doesn't seem to be a way to do this), and that the DXVK views are not queried from the D3D9 surface by the CS thread.

The framebuffer on the D3D9 device gets invalidated so that we render to the correct back buffer in the next frame. Textures are not invalidated since we can't seem to bind a `Direct3DSurface9` as a texture.

This time we also shift correctly, turns out the old implementation was wrong after all.