### PR TITLE
[d3d9] Don't try to blit to compressed images

### DIFF
--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -941,6 +941,10 @@ namespace dxvk {
     bool stretch = srcCopyExtent != dstCopyExtent;
     fastPath &= !stretch;
 
+    // We don't support compressed destination formats at the moment
+    if (dstFormatInfo->flags.test(DxvkFormatFlag::BlockCompressed))
+      return D3DERR_INVALIDCALL;
+
     if (fastPath) {
       if (needsResolve) {
         VkImageResolve region;


### PR DESCRIPTION
Fixes Vulkan validation errors and potential driver crashes in Dragon Age Origins, and apparently matches native D3D9 behaviour.