### PR TITLE
Revert "[util] Disable float emulation for Hat in Time"

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -181,7 +181,7 @@ namespace dxvk {
 
     /* A Hat in Time                              */
     { R"(\\HatinTimeGame\.exe$)", {{
-      { "d3d9.floatEmulation",              "False" },
+      { "d3d9.strictPow",                   "False" },
       { "d3d9.lenientClear",                "True" },
     }} },
     /* Borderlands: The Pre Sequel!               */


### PR DESCRIPTION
Turns out this breaks some levels (e.g. Chapter 1 Act 3).
Performance impact seems minimal on RADV+ACO.

This reverts commit 6f93d3bf22fe2c46ee60b8b9f4487dd6a0b6a078.