### PR TITLE
[GCC10] Include ostream in src/util/rc/util_rc_ptr.h

### DIFF
--- a/src/util/rc/util_rc_ptr.h
+++ b/src/util/rc/util_rc_ptr.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <functional>
+#include <ostream>
 
 namespace dxvk {
   


### PR DESCRIPTION
Apparently, GCC 10 requires this for successful compilation[0].

[0] https://kojipkgs.fedoraproject.org//work/tasks/8740/41288740/build.log (error near the end of the file)