### PR TITLE
[d3d9] Don't arbitrarily set fog scale to 0

### DIFF
--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -4589,9 +4589,6 @@ namespace dxvk {
       float start = bit::cast<float>(rs[D3DRS_FOGSTART]);
 
       float scale = 1.0f / (end - start);
-      if (!std::isfinite(scale))
-        scale = 0.0f;
-
       UpdatePushConstant<offsetof(D3D9RenderStateInfo, fogScale), sizeof(float)>(&scale);
     }
     else if constexpr (Item == D3D9RenderStateItem::PointSize) {

--- a/src/d3d9/d3d9_fixed_function.cpp
+++ b/src/d3d9/d3d9_fixed_function.cpp
@@ -129,7 +129,7 @@ namespace dxvk {
           case D3DFOG_LINEAR: {
             uint32_t fogFactor = spvModule.opFSub(floatType, fogEnd, depth);
             fogFactor = spvModule.opFMul(floatType, fogFactor, fogScale);
-            fogFactor = spvModule.opFClamp(floatType, fogFactor, spvModule.constf32(0.0f), spvModule.constf32(1.0f));
+            fogFactor = spvModule.opNClamp(floatType, fogFactor, spvModule.constf32(0.0f), spvModule.constf32(1.0f));
             return fogFactor;
           }
 


### PR DESCRIPTION
The Witcher 1 sets `FOGSTART == FOGEND` together with `LINEAR` fog mode, in
which case we previously set fog_scale to 0 and therefore incorrectly
override the pixel color with the fog color.

Uses `NClamp` so that we're not accidentally generating NaNs when multiplying 0 by infinity.

Fixes #1401.