### PR TITLE
[d3d9] Copy shader metadata to shader constant structs

### DIFF
--- a/src/d3d9/d3d9_constant_set.h
+++ b/src/d3d9/d3d9_constant_set.h
@@ -40,7 +40,7 @@ namespace dxvk {
 
   struct D3D9ConstantSets {
     Rc<DxvkBuffer>            buffer;
-    const DxsoShaderMetaInfo* meta  = nullptr;
+    DxsoShaderMetaInfo        meta  = {};
     bool                      dirty = true;
   };
 

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -5785,26 +5785,13 @@ namespace dxvk {
         pConstantData,
         Count);
 
-    auto DetermineMaxCount = [&](const auto& shader) {
-      if (unlikely(shader == nullptr))
-        return 0u;
+    if constexpr (ConstantType != D3D9ConstantType::Bool) {
+      uint32_t maxCount = ConstantType == D3D9ConstantType::Float
+        ? m_consts[ProgramType].meta.maxConstIndexF
+        : m_consts[ProgramType].meta.maxConstIndexI;
 
-      const auto& meta = GetCommonShader(shader)->GetMeta();
-
-      if constexpr      (ConstantType == D3D9ConstantType::Float)
-        return meta.maxConstIndexF;
-      else if constexpr (ConstantType == D3D9ConstantType::Int)
-        return meta.maxConstIndexI;
-      else
-        return meta.maxConstIndexB;
-    };
-
-    uint32_t maxCount = ProgramType == DxsoProgramTypes::VertexShader
-      ? DetermineMaxCount(m_state.vertexShader)
-      : DetermineMaxCount(m_state.pixelShader);
-
-    if constexpr (ConstantType != D3D9ConstantType::Bool)
       m_consts[ProgramType].dirty |= StartRegister < maxCount;
+    }
 
     UpdateStateConstants<ProgramType, ConstantType, T>(
       &m_state,

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -2644,7 +2644,7 @@ namespace dxvk {
     bool newCopies = newShader && newShader->GetMeta().needsConstantCopies;
 
     m_consts[DxsoProgramTypes::VertexShader].dirty |= oldCopies || newCopies || !oldShader;
-    m_consts[DxsoProgramTypes::VertexShader].meta  = newShader ? &newShader->GetMeta() : nullptr;
+    m_consts[DxsoProgramTypes::VertexShader].meta  = newShader ? newShader->GetMeta() : DxsoShaderMetaInfo();
 
     if (newShader && oldShader) {
       m_consts[DxsoProgramTypes::VertexShader].dirty
@@ -2970,7 +2970,7 @@ namespace dxvk {
     bool newCopies = newShader && newShader->GetMeta().needsConstantCopies;
 
     m_consts[DxsoProgramTypes::PixelShader].dirty |= oldCopies || newCopies || !oldShader;
-    m_consts[DxsoProgramTypes::PixelShader].meta  = newShader ? &newShader->GetMeta() : nullptr;
+    m_consts[DxsoProgramTypes::PixelShader].meta  = newShader ? newShader->GetMeta() : DxsoShaderMetaInfo();
 
     if (newShader && oldShader) {
       m_consts[DxsoProgramTypes::PixelShader].dirty
@@ -4461,10 +4461,10 @@ namespace dxvk {
 
     auto* dst = reinterpret_cast<HardwareLayoutType*>(pData);
 
-    if (constSet.meta->maxConstIndexF)
-      std::memcpy(dst->fConsts, Src.fConsts, constSet.meta->maxConstIndexF * sizeof(Vector4));
-    if (constSet.meta->maxConstIndexI)
-      std::memcpy(dst->iConsts, Src.iConsts, constSet.meta->maxConstIndexI * sizeof(Vector4i));
+    if (constSet.meta.maxConstIndexF)
+      std::memcpy(dst->fConsts, Src.fConsts, constSet.meta.maxConstIndexF * sizeof(Vector4));
+    if (constSet.meta.maxConstIndexI)
+      std::memcpy(dst->iConsts, Src.iConsts, constSet.meta.maxConstIndexI * sizeof(Vector4i));
   }
 
 
@@ -4474,11 +4474,11 @@ namespace dxvk {
 
     auto dst = reinterpret_cast<uint8_t*>(pData);
 
-    if (constSet.meta->maxConstIndexF)
-      std::memcpy(dst + Layout.floatOffset(),   Src.fConsts, constSet.meta->maxConstIndexF * sizeof(Vector4));
-    if (constSet.meta->maxConstIndexI)
-      std::memcpy(dst + Layout.intOffset(),     Src.iConsts, constSet.meta->maxConstIndexI * sizeof(Vector4i));
-    if (constSet.meta->maxConstIndexB)
+    if (constSet.meta.maxConstIndexF)
+      std::memcpy(dst + Layout.floatOffset(),   Src.fConsts, constSet.meta.maxConstIndexF * sizeof(Vector4));
+    if (constSet.meta.maxConstIndexI)
+      std::memcpy(dst + Layout.intOffset(),     Src.iConsts, constSet.meta.maxConstIndexI * sizeof(Vector4i));
+    if (constSet.meta.maxConstIndexB)
       std::memcpy(dst + Layout.bitmaskOffset(), Src.bConsts, Layout.bitmaskSize());
   }
 
@@ -4508,7 +4508,7 @@ namespace dxvk {
     else
       UploadSoftwareConstantSet(slice.mapPtr, Src, Layout, Shader);
 
-    if (constSet.meta->needsConstantCopies) {
+    if (constSet.meta.needsConstantCopies) {
       Vector4* data = reinterpret_cast<Vector4*>(slice.mapPtr);
 
       auto& shaderConsts = GetCommonShader(Shader)->GetConstants();
@@ -5451,7 +5451,7 @@ namespace dxvk {
       if (likely(!CanSWVP())) {
         UpdateBoolSpecConstantVertex(
           m_state.vsConsts.bConsts[0] &
-          GetCommonShader(m_state.vertexShader)->GetMeta().boolConstantMask);
+          m_consts[DxsoProgramType::VertexShader].meta.boolConstantMask);
       } else
         UpdateBoolSpecConstantVertex(0);
     }
@@ -5481,7 +5481,7 @@ namespace dxvk {
 
       UpdateBoolSpecConstantPixel(
         m_state.psConsts.bConsts[0] &
-        GetCommonShader(m_state.pixelShader)->GetMeta().boolConstantMask);
+        m_consts[DxsoProgramType::PixelShader].meta.boolConstantMask);
     }
     else {
       UpdateBoolSpecConstantPixel(0);


### PR DESCRIPTION
This makes primarly `SetShaderConstants` a bit cheaper by avoiding pointer chasing, and also cleans up the code a bit. The metadata struct is small so the tradeoff should be well worth it.