### PR TITLE
[d3d9] Defer managed texture uploads until PrepareDraw and when needed

### DIFF
--- a/src/d3d9/d3d9_common_texture.h
+++ b/src/d3d9/d3d9_common_texture.h
@@ -357,6 +357,15 @@ namespace dxvk {
             UINT                   Lod,
             VkImageUsageFlags      UsageFlags,
             bool                   Srgb);
+    D3D9SubresourceBitset& GetUploadBitmask() { return m_needsUpload; }
+
+    void SetUploading(UINT Subresource, bool uploading) { m_uploading.set(Subresource, uploading); }
+    void ClearUploading() { m_uploading.clearAll(); }
+    bool GetUploading(UINT Subresource) const { return m_uploading.get(Subresource); }
+
+    void SetNeedsUpload(UINT Subresource, bool upload) { m_needsUpload.set(Subresource, upload); }
+    bool NeedsAnyUpload() { return m_needsUpload.any(); }
+    void ClearNeedsUpload() { return m_needsUpload.clearAll();  }
 
   private:
 
@@ -391,6 +400,9 @@ namespace dxvk {
     D3D9SubresourceBitset         m_readOnly = { };
 
     D3D9SubresourceBitset         m_dirty = { };
+
+    D3D9SubresourceBitset         m_uploading = { };
+    D3D9SubresourceBitset         m_needsUpload = { };
 
     /**
      * \brief Mip level

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -3868,7 +3868,7 @@ namespace dxvk {
     if (desc.Usage & D3DUSAGE_WRITEONLY)
       Flags &= ~D3DLOCK_READONLY;
 
-    pResource->SetLockFlags(Subresource, Flags);
+    pResource->SetReadOnlyLocked(Subresource, Flags & D3DLOCK_READONLY);
 
     bool renderable = desc.Usage & (D3DUSAGE_RENDERTARGET | D3DUSAGE_DEPTHSTENCIL);
 
@@ -4034,7 +4034,7 @@ namespace dxvk {
       return D3DERR_INVALIDCALL;
 
     // Do we have a pending copy?
-    if (!(pResource->GetLockFlags(Subresource) & D3DLOCK_READONLY)) {
+    if (!pResource->GetReadOnlyLocked(Subresource)) {
       // Only flush buffer -> image if we actually have an image
       if (pResource->GetMapMode() == D3D9_COMMON_TEXTURE_MAP_MODE_BACKED)
         this->FlushImage(pResource, Subresource);

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -734,15 +734,15 @@ namespace dxvk {
 
     void Flush();
 
-    D3D9ShaderMasks GetShaderMasks();
-
     void UpdateActiveRTs(uint32_t index);
 
-    void UpdateActiveRTTextures(uint32_t index);
+    void UpdateActiveTextures(uint32_t index);
 
     void UpdateActiveHazards();
 
     void MarkRenderHazards();
+
+    void UploadManagedTextures(uint32_t mask);
 
     template <bool Points>
     void UpdatePointMode();
@@ -1024,6 +1024,11 @@ namespace dxvk {
     uint32_t                        m_activeRTTextures = 0;
     uint32_t                        m_activeHazards    = 0;
     uint32_t                        m_alphaSwizzleRTs  = 0;
+    uint32_t                        m_activeTextures   = 0;
+    uint32_t                        m_activeTexturesToUpload = 0;
+
+    D3D9ShaderMasks                 m_vsShaderMasks = D3D9ShaderMasks();
+    D3D9ShaderMasks                 m_psShaderMasks = FixedFunctionMask;
 
     D3D9ViewportInfo                m_viewportInfo;
 

--- a/src/d3d9/d3d9_shader.cpp
+++ b/src/d3d9/d3d9_shader.cpp
@@ -61,6 +61,13 @@ namespace dxvk {
     m_shaders      = pModule->compile(*pDxsoModuleInfo, name, AnalysisInfo, constantLayout);
     m_isgn         = pModule->isgn();
     m_usedSamplers = pModule->usedSamplers();
+
+    // Shift up these sampler bits so we can just
+    // do an or per-draw in the device.
+    // We shift by 17 because 16 ps samplers + 1 dmap (tess)
+    if (ShaderStage == VK_SHADER_STAGE_VERTEX_BIT)
+      m_usedSamplers <<= 17;
+
     m_usedRTs      = pModule->usedRTs();
 
     m_info      = pModule->info();

--- a/src/d3d9/d3d9_util.h
+++ b/src/d3d9/d3d9_util.h
@@ -18,6 +18,9 @@ namespace dxvk {
     uint32_t rtMask;
   };
 
+  static constexpr D3D9ShaderMasks FixedFunctionMask =
+    { 0b1111111, 0b1 };
+
   struct D3D9MipFilter {
     bool                MipsEnabled;
     VkSamplerMipmapMode MipFilter;

--- a/src/util/util_bit.h
+++ b/src/util/util_bit.h
@@ -237,6 +237,11 @@ namespace dxvk::bit {
       }
     }
 
+    constexpr void clearAll() {
+      for (size_t i = 0; i < Dwords; i++)
+        m_dwords[i] = 0;
+    }
+
     constexpr bool any() {
       for (size_t i = 0; i < Dwords; i++) {
         if (m_dwords[i] != 0)

--- a/src/util/util_bit.h
+++ b/src/util/util_bit.h
@@ -205,6 +205,12 @@ namespace dxvk::bit {
         m_dwords[dword] &= ~(1u << bit);
     }
 
+    constexpr bool exchange(uint32_t idx, bool value) {
+      bool oldValue = get(idx);
+      set(idx, value);
+      return oldValue;
+    }
+
     constexpr void flip(uint32_t idx) {
       uint32_t dword = 0;
       uint32_t bit   = idx;


### PR DESCRIPTION
Fixes perf problems in games that lock D3DPOOL_MANAGED textures multiple times in a frame without doing any draws with those textures inbetween... (ie. uploading characters to a font image 1 character at a time [Silent Hill 2], uploading lightmap faces 1 at a time [VTMB])