### PR TITLE
[d3d9] Handle invalid alpha ref correctly

### DIFF
--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -4567,7 +4567,7 @@ namespace dxvk {
     auto& rs = m_state.renderStates;
 
     if constexpr (Item == D3D9RenderStateItem::AlphaRef) {
-      float alpha = float(rs[D3DRS_ALPHAREF]) / 255.0f;
+      float alpha = float(rs[D3DRS_ALPHAREF] & 0xFF) / 255.0f;
       UpdatePushConstant<offsetof(D3D9RenderStateInfo, alphaRef), sizeof(float)>(&alpha);
     }
     else if constexpr (Item == D3D9RenderStateItem::FogColor) {


### PR DESCRIPTION
Some games pass a floating point value to the alpha ref, in which case the integer value is >255, which leads to unconditional alpha test failures. Matches Nine's behaviour.

Fixes #1428.