### PR TITLE
GetAvailableTextureMem should return amount of both local and shared memory available

### DIFF
--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -4373,9 +4373,7 @@ namespace dxvk {
 
     for (uint32_t i = 0; i < memoryProp.memoryHeapCount; i++) {
       VkMemoryHeap& heap = memoryProp.memoryHeaps[i];
-
-      if (heap.flags & VK_MEMORY_HEAP_DEVICE_LOCAL_BIT)
-        availableTextureMemory += memoryProp.memoryHeaps[i].size;
+      availableTextureMemory += heap.size;
     }
 
     constexpr VkDeviceSize Megabytes = 1024 * 1024;


### PR DESCRIPTION
In continue our discussion https://github.com/Joshua-Ashton/d9vk/issues/256...

I think this is right way to allow GetAvailableTextureMem return shared memory to. Docs not declaring about what exactly memory should include in this amount. Because this value is huge approximate, some games still rely(like CoD MW2) on this value, and turn on some different rendering algorithm to save memory if this amount is not enough, and I had lower performance than on native. My windows setup return same values as with dxvk with this patch(see discussion by link). 

So, this fixes performance problem on my machine with CoD MW2. Other games that a have seems not affected