### PR TITLE
[util] Force 16:9 aspect ratio for Hyperdimension Neptunia U: Action Unleashed

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -314,6 +314,11 @@ namespace dxvk {
     { R"(\\rthdribl\.exe$)", {{
       { "d3d9.allowDoNotWait",              "False" },
     }} },
+    /* Hyperdimension Neptunia U: Action Unleashed */
+    { R"(\\Neptunia\.exe$)", {{
+      { "d3d9.forceAspectRatio",            "16:9" },
+    }} },
+
   }};
 
 


### PR DESCRIPTION
Fixes letterboxed fullscreen when in-game.

Ran into this exact same issue in Joshua-Ashton/d9vk#460. Setting the d3d9.forceAspectRatio option also fixes this instance.

Before
![Screenshot_20200213_192600](https://user-images.githubusercontent.com/17807258/74492631-88ca1b00-4e9d-11ea-81c4-6220a0ebec79.png)

After
![Screenshot_20200213_192746](https://user-images.githubusercontent.com/17807258/74492638-9089bf80-4e9d-11ea-8519-cc84fa9e292c.png)