### PR TITLE
[d3d10] Implement D3D10[Core]GetVersion and D3D10[Core]RegisterLayers

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -65,6 +65,7 @@ else
 
   lib_vulkan  = dxvk_compiler.find_library('vulkan-1', dirs : dxvk_library_path)
   lib_d3d9    = dxvk_compiler.find_library('d3d9')
+  lib_d3d10   = dxvk_compiler.find_library('d3d10')
   lib_d3d11   = dxvk_compiler.find_library('d3d11')
   lib_dxgi    = dxvk_compiler.find_library('dxgi')
   lib_d3dcompiler_43 = dxvk_compiler.find_library('d3dcompiler_43', dirs : dxvk_library_path)

--- a/src/d3d10/d3d10.def
+++ b/src/d3d10/d3d10.def
@@ -25,3 +25,4 @@ EXPORTS
     D3D10StateBlockMaskGetSetting
     D3D10StateBlockMaskIntersect
     D3D10StateBlockMaskUnion
+    D3D10GetVersion

--- a/src/d3d10/d3d10.def
+++ b/src/d3d10/d3d10.def
@@ -26,3 +26,4 @@ EXPORTS
     D3D10StateBlockMaskIntersect
     D3D10StateBlockMaskUnion
     D3D10GetVersion
+    D3D10RegisterLayers

--- a/src/d3d10/d3d10.spec
+++ b/src/d3d10/d3d10.spec
@@ -29,3 +29,5 @@
 @ stdcall D3D10StateBlockMaskGetSetting(ptr long long)
 @ stdcall D3D10StateBlockMaskIntersect(ptr ptr ptr)
 @ stdcall D3D10StateBlockMaskUnion(ptr ptr ptr)
+
+@ stdcall D3D10GetVersion()

--- a/src/d3d10/d3d10.spec
+++ b/src/d3d10/d3d10.spec
@@ -31,3 +31,4 @@
 @ stdcall D3D10StateBlockMaskUnion(ptr ptr ptr)
 
 @ stdcall D3D10GetVersion()
+@ stdcall D3D10RegisterLayers()

--- a/src/d3d10/d3d10_1.def
+++ b/src/d3d10/d3d10_1.def
@@ -25,3 +25,4 @@ EXPORTS
     D3D10StateBlockMaskGetSetting
     D3D10StateBlockMaskIntersect
     D3D10StateBlockMaskUnion
+    D3D10GetVersion

--- a/src/d3d10/d3d10_1.def
+++ b/src/d3d10/d3d10_1.def
@@ -26,3 +26,4 @@ EXPORTS
     D3D10StateBlockMaskIntersect
     D3D10StateBlockMaskUnion
     D3D10GetVersion
+    D3D10RegisterLayers

--- a/src/d3d10/d3d10_1.spec
+++ b/src/d3d10/d3d10_1.spec
@@ -29,3 +29,5 @@
 @ stdcall D3D10StateBlockMaskGetSetting(ptr long long)
 @ stdcall D3D10StateBlockMaskIntersect(ptr ptr ptr)
 @ stdcall D3D10StateBlockMaskUnion(ptr ptr ptr)
+
+@ stdcall D3D10GetVersion()

--- a/src/d3d10/d3d10_1.spec
+++ b/src/d3d10/d3d10_1.spec
@@ -31,3 +31,4 @@
 @ stdcall D3D10StateBlockMaskUnion(ptr ptr ptr)
 
 @ stdcall D3D10GetVersion()
+@ stdcall D3D10RegisterLayers()

--- a/src/d3d10/d3d10_main.cpp
+++ b/src/d3d10/d3d10_main.cpp
@@ -374,6 +374,22 @@ extern "C" {
     return 0xa000100041770ull;
   }
 
+
+  HRESULT STDMETHODCALLTYPE D3D10RegisterLayers() {
+    // See test_d3d10_core.cpp
+    Logger::warn("D3D10RegisterLayers: Not implemented");
+
+    return E_NOTIMPL;
+  }
+
+
+  HRESULT STDMETHODCALLTYPE D3D10CoreRegisterLayers() {
+    // See test_d3d10_core.cpp
+    Logger::warn("D3D10CoreRegisterLayers: Not implemented");
+
+    return E_NOTIMPL;
+  }
+
 }
 
 

--- a/src/d3d10/d3d10_main.cpp
+++ b/src/d3d10/d3d10_main.cpp
@@ -360,6 +360,20 @@ extern "C" {
       ppErrorMsgs);
   }
 
+
+  UINT64 STDMETHODCALLTYPE D3D10CoreGetVersion() {
+    // See test_d3d10_core.cpp
+    // D3D10CoreVersion: a000100041770
+    return 0xa000100041770ull;
+  }
+
+
+  UINT64 STDMETHODCALLTYPE D3D10GetVersion() {
+    // See test_d3d10_core.cpp
+    // D3D10GetVersion: a000100041770
+    return 0xa000100041770ull;
+  }
+
 }
 
 

--- a/src/d3d10/d3d10core.def
+++ b/src/d3d10/d3d10core.def
@@ -2,3 +2,4 @@ LIBRARY D3D10CORE.DLL
 EXPORTS  
     D3D10CoreCreateDevice
     D3D10CoreGetVersion
+    D3D10CoreRegisterLayers

--- a/src/d3d10/d3d10core.def
+++ b/src/d3d10/d3d10core.def
@@ -1,3 +1,4 @@
 LIBRARY D3D10CORE.DLL
 EXPORTS  
     D3D10CoreCreateDevice
+    D3D10CoreGetVersion

--- a/src/d3d10/d3d10core.spec
+++ b/src/d3d10/d3d10core.spec
@@ -1,2 +1,3 @@
 @ stdcall D3D10CoreCreateDevice(ptr ptr long long ptr)
 @ stdcall D3D10CoreGetVersion()
+@ stdcall D3D10CoreRegisterLayers()

--- a/src/d3d10/d3d10core.spec
+++ b/src/d3d10/d3d10core.spec
@@ -1,1 +1,2 @@
 @ stdcall D3D10CoreCreateDevice(ptr ptr long long ptr)
+@ stdcall D3D10CoreGetVersion()

--- a/tests/d3d10/meson.build
+++ b/tests/d3d10/meson.build
@@ -1,0 +1,3 @@
+test_d3d10_deps = [ util_dep, lib_dxgi, lib_d3dcompiler_47 ]
+
+executable('d3d10-core'+exe_ext,   files('test_d3d10_core.cpp'),   dependencies : test_d3d10_deps, install : true, override_options: ['cpp_std='+dxvk_cpp_std])

--- a/tests/d3d10/test_d3d10_core.cpp
+++ b/tests/d3d10/test_d3d10_core.cpp
@@ -17,6 +17,11 @@ using namespace dxvk;
 // which matches the values of eax and edx which is consistent to some
 // function returing a UINT64 value across these arches.
 using pfnD3D10CoreGetVersion = UINT64(_stdcall *)();
+
+// Calling this function as a HRESULT type, gives us a E_NOTIMPL value
+// 99% confident this is at least the correct return type given that.
+// No idea what it takes in though.
+using pfnD3D10CoreRegisterLayers = HRESULT(_stdcall*)();
   
 int main(int argc, char** argv) {
   HMODULE hD3D10     = LoadLibraryA("d3d10.dll");
@@ -44,6 +49,25 @@ int main(int argc, char** argv) {
   std::cout << "(d3d10core.dll) D3D10CoreGetVersion: " << std::hex << D3D10CoreGetVersion() << std::endl;
 
   std::cout << "(d3d10_1.dll) D3D10GetVersion: " << std::hex << D3D10GetVersion1() << std::endl;
+
+
+  std::cout << std::endl;
+
+
+  auto* D3D10RegisterLayers = reinterpret_cast<pfnD3D10CoreRegisterLayers>(
+    GetProcAddress(hD3D10, "D3D10RegisterLayers"));
+
+  auto* D3D10CoreRegisterLayers = reinterpret_cast<pfnD3D10CoreRegisterLayers>(
+    GetProcAddress(hD3D10Core, "D3D10CoreRegisterLayers"));
+
+  auto* D3D10RegisterLayers1 = reinterpret_cast<pfnD3D10CoreRegisterLayers>(
+    GetProcAddress(hD3D10_1, "D3D10RegisterLayers"));
+
+  std::cout << "(d3d10.dll) D3D10RegisterLayers: " << std::hex << D3D10RegisterLayers() << std::endl;
+
+  std::cout << "(d3d10core.dll) D3D10CoreRegisterLayers: " << std::hex << D3D10CoreRegisterLayers() << std::endl;
+
+  std::cout << "(d3d10_1.dll) D3D10RegisterLayers: " << std::hex << D3D10RegisterLayers1() << std::endl;
 
   return 0;
 }

--- a/tests/d3d10/test_d3d10_core.cpp
+++ b/tests/d3d10/test_d3d10_core.cpp
@@ -1,0 +1,49 @@
+#include <cstring>
+#include <iostream>
+#include <sstream>
+#include <windows.h>
+
+#include "../test_utils.h"
+
+using namespace dxvk;
+
+// Basically just guesswork, but it appears they return a UINT64 (or *something* of that size)
+// and the return value is consistent when calling it this way.
+// This was consistent across tests on x86 and x64, so it isn't a SIZE_T.
+//
+// Using a debugger:
+// Calling this function on it's own on x86 modifies both eax and edx
+// whereas on x64 it only modifies all of rax to 0xa000100041770
+// which matches the values of eax and edx which is consistent to some
+// function returing a UINT64 value across these arches.
+using pfnD3D10CoreGetVersion = UINT64(_stdcall *)();
+  
+int main(int argc, char** argv) {
+  HMODULE hD3D10     = LoadLibraryA("d3d10.dll");
+  HMODULE hD3D10Core = LoadLibraryA("d3d10core.dll");
+  HMODULE hD3D10_1   = LoadLibraryA("d3d10_1.dll");
+
+  auto* D3D10GetVersion = reinterpret_cast<pfnD3D10CoreGetVersion>(
+    GetProcAddress(hD3D10, "D3D10GetVersion"));
+
+  auto* D3D10CoreGetVersion = reinterpret_cast<pfnD3D10CoreGetVersion>(
+    GetProcAddress(hD3D10Core, "D3D10CoreGetVersion"));
+
+  auto* D3D10GetVersion1 = reinterpret_cast<pfnD3D10CoreGetVersion>(
+    GetProcAddress(hD3D10_1, "D3D10GetVersion"));
+
+  // x86:
+  // edx -> 0x000a0001
+  // eax -> 0x00041770
+  // x64:
+  // rax -> 0xa000100041770
+  UINT64 version = D3D10GetVersion();
+
+  std::cout << "(d3d10.dll) D3D10GetVersion: " << std::hex << D3D10GetVersion() << std::endl;
+
+  std::cout << "(d3d10core.dll) D3D10CoreGetVersion: " << std::hex << D3D10CoreGetVersion() << std::endl;
+
+  std::cout << "(d3d10_1.dll) D3D10GetVersion: " << std::hex << D3D10GetVersion1() << std::endl;
+
+  return 0;
+}

--- a/tests/d3d10/test_d3d10_core.cpp
+++ b/tests/d3d10/test_d3d10_core.cpp
@@ -63,6 +63,10 @@ int main(int argc, char** argv) {
   auto* D3D10RegisterLayers1 = reinterpret_cast<pfnD3D10CoreRegisterLayers>(
     GetProcAddress(hD3D10_1, "D3D10RegisterLayers"));
 
+  HRESULT layers = D3D10RegisterLayers();
+  if (layers == E_NOTIMPL)
+    std::cout << "D3D10RegisterLayers: E_NOTIMPL" << std::endl;
+
   std::cout << "(d3d10.dll) D3D10RegisterLayers: " << std::hex << D3D10RegisterLayers() << std::endl;
 
   std::cout << "(d3d10core.dll) D3D10CoreRegisterLayers: " << std::hex << D3D10CoreRegisterLayers() << std::endl;

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,4 +1,5 @@
 subdir('d3d9')
+subdir('d3d10')
 subdir('d3d11')
 subdir('dxbc')
 subdir('dxgi')


### PR DESCRIPTION
I spent some time testing these functions' behaviour to make some decent stub implementations that satisfy enough for Crysis x64 to run with our D3D10 implementation.

See the test commits/files for how the signatures and return values were derived.

It was a fun little side-project anyway 🐸!