### PR TITLE
[RFC][D3D9]Avoid infinite loops in SetCursorPosition 

### DIFF
--- a/src/d3d9/d3d9_cursor.h
+++ b/src/d3d9/d3d9_cursor.h
@@ -18,6 +18,9 @@ namespace dxvk {
 
     void UpdateCursor(int X, int Y);
 
+    int PrevPosX;
+    int PrevPosY;
+
     BOOL ShowCursor(BOOL bShow);
 
     HRESULT SetHardwareCursor(UINT XHotSpot, UINT YHotSpot, const CursorBitmap& bitmap);

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -237,7 +237,7 @@ namespace dxvk {
 
   void    STDMETHODCALLTYPE D3D9DeviceEx::SetCursorPosition(int X, int Y, DWORD Flags) {
     D3D9DeviceLock lock = LockDevice();
-
+  
     // I was not able to find an instance
     // where the cursor update was not immediate.
 
@@ -245,8 +245,14 @@ namespace dxvk {
     // behaviour here.
 
     // Hence we ignore the flag D3DCURSOR_IMMEDIATE_UPDATE.
-
-    m_cursor.UpdateCursor(X, Y);
+    if(m_cursor.PrevPosX == X && m_cursor.PrevPosY == Y) {
+    	return;
+    }
+    else{
+      m_cursor.PrevPosX = X;
+     m_cursor.PrevPosY = Y;
+     m_cursor.UpdateCursor(X, Y);
+    }
   }
 
 


### PR DESCRIPTION
based on G9 solution 
Fixes #1400 