### PR TITLE
Skip display mode setting if already set

### DIFF
--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -4373,9 +4373,7 @@ namespace dxvk {
 
     for (uint32_t i = 0; i < memoryProp.memoryHeapCount; i++) {
       VkMemoryHeap& heap = memoryProp.memoryHeaps[i];
-
-      if (heap.flags & VK_MEMORY_HEAP_DEVICE_LOCAL_BIT)
-        availableTextureMemory += memoryProp.memoryHeaps[i].size;
+      availableTextureMemory += heap.size;
     }
 
     constexpr VkDeviceSize Megabytes = 1024 * 1024;


### PR DESCRIPTION
That mostly taken from wine's code. Before setting new display mode, we are checking if our current display mode isn't equal new required mode, if new mode is same as current, do not call ChangeDisplaySettingsExW. Excludes display flickering if the application several times setup same display mode