### PR TITLE
[d3d9] Don't use m_monitor in GetDisplayModeEx

### DIFF
--- a/src/d3d9/d3d9_swapchain.cpp
+++ b/src/d3d9/d3d9_swapchain.cpp
@@ -435,7 +435,7 @@ namespace dxvk {
       DEVMODEW devMode = DEVMODEW();
       devMode.dmSize = sizeof(devMode);
 
-      if (!GetMonitorDisplayMode(m_monitor, ENUM_CURRENT_SETTINGS, &devMode)) {
+      if (!GetMonitorDisplayMode(GetDefaultMonitor(), ENUM_CURRENT_SETTINGS, &devMode)) {
         Logger::err("D3D9SwapChainEx::GetDisplayModeEx: Failed to enum display settings");
         return D3DERR_INVALIDCALL;
       }


### PR DESCRIPTION
Should fix #1495.

This looks like a bit of a mess though. Previously this would use `m_monInfo`, which itself was initialized to contain monitor info of the *default* monitor. Meanwhile, `m_monitor` is `nullptr` unless in fullscreen mode, otherwise the default monitor. Why is this so weird?