### PR TITLE
[meta] Remove D3D10 HUD restriction in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ The `DXVK_HUD` environment variable controls a HUD which can display the framera
 - `memory`: Shows the amount of device memory allocated and used.
 - `gpuload`: Shows estimated GPU load. May be inaccurate.
 - `version`: Shows DXVK version.
-- `api`: Shows the D3D feature level used by the application. Does not work correctly for D3D10 at the moment.
+- `api`: Shows the D3D feature level used by the application.
 - `compiler`: Shows shader compiler activity
 - `samplers`: Shows the current number of sampler pairs used *[D3D9 Only]*
 


### PR DESCRIPTION
D3D10 in the HUD api option is identified correctly since https://github.com/doitsujin/dxvk/commit/be16da37d7c55fce5bfc7885f89a4047a336f4e2

Just a minor README improvement, thanks for all the hard work on DXVK!