### PR TITLE
[d3d9] Hook WM_NCCALCSIZE to get rid of fullscreen non-client areas.

### DIFF
--- a/src/d3d9/d3d9_swapchain.h
+++ b/src/d3d9/d3d9_swapchain.h
@@ -221,6 +221,10 @@ namespace dxvk {
 
     std::string GetApiName();
 
+    void HookWindowProc();
+
+    void ResetWindowProc();
+
   };
 
 }


### PR DESCRIPTION
I believe this should fix https://github.com/doitsujin/dxvk/issues/1358.

The issue is that the game restores a WS_BORDER window style after D9VK has cleared them. In theory D3D should not change window styles -or hook this WM_NCCALCSIZE fwiw- and some other internal mechanism would change full screen non-client areas size computations instead. Hooking this message seems to produce the same results.

Note that this can also be reproduced using D9VK to run the game on Windows (tested with Windows 10), and this PR also fixes that.