### PR TITLE
Refactor spinning on device locks / busy resources

### DIFF
--- a/src/d3d10/d3d10_include.h
+++ b/src/d3d10/d3d10_include.h
@@ -1,7 +1,9 @@
 #pragma once
 
 #include "../dxgi/dxgi_include.h"
+
 #include "../util/sync/sync_spinlock.h"
+#include "../util/sync/sync_recursive.h"
 
 #include <d3d10_1.h>
 #include <d3d11_1.h>

--- a/src/d3d10/d3d10_multithread.cpp
+++ b/src/d3d10/d3d10_multithread.cpp
@@ -2,38 +2,6 @@
 
 namespace dxvk {
 
-  void D3D10DeviceMutex::lock() {
-    while (!try_lock())
-      dxvk::this_thread::yield();
-  }
-
-
-  void D3D10DeviceMutex::unlock() {
-    if (likely(m_counter == 0))
-      m_owner.store(0, std::memory_order_release);
-    else
-      m_counter -= 1;
-  }
-
-
-  bool D3D10DeviceMutex::try_lock() {
-    uint32_t threadId = GetCurrentThreadId();
-    uint32_t expected = 0;
-
-    bool status = m_owner.compare_exchange_weak(
-      expected, threadId, std::memory_order_acquire);
-    
-    if (status)
-      return true;
-    
-    if (expected != threadId)
-      return false;
-    
-    m_counter += 1;
-    return true;
-  }
-
-
   D3D10Multithread::D3D10Multithread(
           IUnknown*             pParent,
           BOOL                  Protected)

--- a/src/d3d10/d3d10_multithread.h
+++ b/src/d3d10/d3d10_multithread.h
@@ -5,30 +5,6 @@
 namespace dxvk {
   
   /**
-   * \brief Device mutex
-   * 
-   * Effectively implements a recursive spinlock
-   * which is used to lock the D3D10 device.
-   */
-  class D3D10DeviceMutex {
-
-  public:
-
-    void lock();
-
-    void unlock();
-
-    bool try_lock();
-
-  private:
-
-    std::atomic<uint32_t> m_owner   = { 0u };
-    uint32_t              m_counter = { 0u };
-    
-  };
-
-
-  /**
    * \brief Device lock
    * 
    * Lightweight RAII wrapper that implements
@@ -43,7 +19,7 @@ namespace dxvk {
     D3D10DeviceLock()
     : m_mutex(nullptr) { }
 
-    D3D10DeviceLock(D3D10DeviceMutex& mutex)
+    D3D10DeviceLock(sync::RecursiveSpinlock& mutex)
     : m_mutex(&mutex) {
       mutex.lock();
     }
@@ -69,7 +45,7 @@ namespace dxvk {
 
   private:
 
-    D3D10DeviceMutex* m_mutex;
+    sync::RecursiveSpinlock* m_mutex;
     
   };
 
@@ -120,7 +96,7 @@ namespace dxvk {
     IUnknown* m_parent;
     BOOL      m_protected;
 
-    D3D10DeviceMutex m_mutex;
+    sync::RecursiveSpinlock m_mutex;
 
   };
 

--- a/src/d3d11/d3d11_context_imm.cpp
+++ b/src/d3d11/d3d11_context_imm.cpp
@@ -616,8 +616,7 @@ namespace dxvk {
         Flush();
         SynchronizeCsThread();
         
-        while (Resource->isInUse(access))
-          dxvk::this_thread::yield();
+        Resource->waitIdle(access);
       }
     }
     

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -3779,8 +3779,7 @@ namespace dxvk {
         Flush();
         SynchronizeCsThread();
 
-        while (Resource->isInUse(access))
-          dxvk::this_thread::yield();
+        Resource->waitIdle(access);
       }
     }
 

--- a/src/d3d9/d3d9_include.h
+++ b/src/d3d9/d3d9_include.h
@@ -30,6 +30,8 @@
 #include "../util/rc/util_rc.h"
 #include "../util/rc/util_rc_ptr.h"
 
+#include "../util/sync/sync_recursive.h"
+
 #include "../util/util_env.h"
 #include "../util/util_enum.h"
 #include "../util/util_error.h"

--- a/src/d3d9/d3d9_multithread.cpp
+++ b/src/d3d9/d3d9_multithread.cpp
@@ -2,38 +2,6 @@
 
 namespace dxvk {
 
-  void D3D9DeviceMutex::lock() {
-    while (!try_lock())
-      dxvk::this_thread::yield();
-  }
-
-
-  void D3D9DeviceMutex::unlock() {
-    if (likely(m_counter == 0))
-      m_owner.store(0, std::memory_order_release);
-    else
-      m_counter -= 1;
-  }
-
-
-  bool D3D9DeviceMutex::try_lock() {
-    uint32_t threadId = GetCurrentThreadId();
-    uint32_t expected = 0;
-
-    bool status = m_owner.compare_exchange_weak(
-      expected, threadId, std::memory_order_acquire);
-    
-    if (status)
-      return true;
-    
-    if (expected != threadId)
-      return false;
-    
-    m_counter += 1;
-    return true;
-  }
-
-
   D3D9Multithread::D3D9Multithread(
           BOOL                  Protected)
     : m_protected( Protected ) { }

--- a/src/d3d9/d3d9_multithread.h
+++ b/src/d3d9/d3d9_multithread.h
@@ -5,30 +5,6 @@
 namespace dxvk {
 
   /**
-   * \brief Device mutex
-   *
-   * Effectively implements a recursive spinlock
-   * which is used to lock the D3D9 device.
-   */
-  class D3D9DeviceMutex {
-
-  public:
-
-    void lock();
-
-    void unlock();
-
-    bool try_lock();
-
-  private:
-
-    std::atomic<uint32_t> m_owner = { 0u };
-    uint32_t              m_counter = { 0u };
-
-  };
-
-
-  /**
    * \brief Device lock
    *
    * Lightweight RAII wrapper that implements
@@ -43,7 +19,7 @@ namespace dxvk {
     D3D9DeviceLock()
       : m_mutex(nullptr) { }
 
-    D3D9DeviceLock(D3D9DeviceMutex& mutex)
+    D3D9DeviceLock(sync::RecursiveSpinlock& mutex)
       : m_mutex(&mutex) {
       mutex.lock();
     }
@@ -69,7 +45,7 @@ namespace dxvk {
 
   private:
 
-    D3D9DeviceMutex* m_mutex;
+    sync::RecursiveSpinlock* m_mutex;
 
   };
 
@@ -94,7 +70,7 @@ namespace dxvk {
 
     BOOL            m_protected;
 
-    D3D9DeviceMutex m_mutex;
+    sync::RecursiveSpinlock m_mutex;
 
   };
 

--- a/src/dxvk/dxvk_resource.h
+++ b/src/dxvk/dxvk_resource.h
@@ -69,6 +69,19 @@ namespace dxvk {
           : m_useCountW) -= 1;
       }
     }
+
+    /**
+     * \brief Waits for resource to become unused
+     *
+     * Blocks calling thread until the GPU finishes
+     * using the resource with the given access type.
+     * \param [in] access Access type to check for
+     */
+    void waitIdle(DxvkAccess access = DxvkAccess::Read) const {
+      sync::spin(50000, [this, access] {
+        return !isInUse(access);
+      });
+    }
     
   private:
     

--- a/src/util/meson.build
+++ b/src/util/meson.build
@@ -16,6 +16,8 @@ util_src = files([
   
   'sha1/sha1.c',
   'sha1/sha1_util.cpp',
+
+  'sync/sync_recursive.cpp',
 ])
 
 util_lib = static_library('util', util_src,

--- a/src/util/sync/sync_recursive.cpp
+++ b/src/util/sync/sync_recursive.cpp
@@ -1,0 +1,36 @@
+#include "sync_recursive.h"
+#include "sync_spinlock.h"
+
+namespace dxvk::sync {
+
+  void RecursiveSpinlock::lock() {
+    spin(2000, [this] { return try_lock(); });
+  }
+
+
+  void RecursiveSpinlock::unlock() {
+    if (likely(m_counter == 0))
+      m_owner.store(0, std::memory_order_release);
+    else
+      m_counter -= 1;
+  }
+
+
+  bool RecursiveSpinlock::try_lock() {
+    uint32_t threadId = GetCurrentThreadId();
+    uint32_t expected = 0;
+
+    bool status = m_owner.compare_exchange_weak(
+      expected, threadId, std::memory_order_acquire);
+    
+    if (status)
+      return true;
+    
+    if (expected != threadId)
+      return false;
+    
+    m_counter += 1;
+    return true;
+  }
+
+}

--- a/src/util/sync/sync_recursive.h
+++ b/src/util/sync/sync_recursive.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <atomic>
+
+#include "../com/com_include.h"
+
+namespace dxvk::sync {
+
+  /**
+   * \brief Recursive spinlock
+   * 
+   * Implements a spinlock that can be acquired
+   * by the same thread multiple times.
+   */
+  class RecursiveSpinlock {
+
+  public:
+
+    void lock();
+
+    void unlock();
+
+    bool try_lock();
+
+  private:
+
+    std::atomic<uint32_t> m_owner   = { 0u };
+    uint32_t              m_counter = { 0u };
+    
+  };
+
+}

--- a/src/util/thread.h
+++ b/src/util/thread.h
@@ -141,7 +141,7 @@ namespace dxvk {
 
   namespace this_thread {
     inline void yield() {
-      Sleep(0);
+      SwitchToThread();
     }
   }
 }


### PR DESCRIPTION
Let's reduce the `yield()` spam since that can be pretty bad.