### PR TITLE
[d3d11] Init D3D11ContextState in D3D11DeviceContextState's constructor

### DIFF
--- a/src/d3d11/d3d11_state_object.cpp
+++ b/src/d3d11/d3d11_state_object.cpp
@@ -4,7 +4,7 @@ namespace dxvk {
 
   D3D11DeviceContextState::D3D11DeviceContextState(
           ID3D11Device*         pDevice)
-  : m_device(pDevice) {
+  : m_device(pDevice), m_state() {
 
   }
 


### PR DESCRIPTION
SwapDeviceContextState could be called with freshly created
D3D11DeviceContextState and RestoreState would crash if internal
D3D11ContextState is not initialized.

Closes: #1511

@tanty Does this fix the issue for you? It works for me with your trace.