### PR TITLE
[util] Disable explicit frontbuffer for VenusBlood FRONTIER Internati…

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -326,6 +326,10 @@ namespace dxvk {
     { R"(\\ZusiSim\.exe$)", {{
       { "d3d9.noExplicitFrontBuffer",       "True" },
     }} },
+    /* VenusBlood FRONTIER International          */
+    { R"(\\VBFI\.exe$)", {{
+      { "d3d9.noExplicitFrontBuffer",       "True" },
+    }} },
   }};
 
 


### PR DESCRIPTION
…onal

Fixes flickering inside the left pillarbox when switching from Windowed to Fullscreen. ~~RADV_DEBUG=zerovram is still required on Mesa / RADV to fully resolve the issue.~~

This closes #1481 