### PR TITLE
[d3d9] Fix depth-stencil layouts

### DIFF
--- a/src/d3d9/d3d9_common_texture.h
+++ b/src/d3d9/d3d9_common_texture.h
@@ -325,12 +325,11 @@ namespace dxvk {
     }
 
     VkImageLayout DetermineDepthStencilLayout(bool hazardous) const {
-      VkImageLayout layout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
+      VkImageLayout layout = hazardous
+        ? VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL
+        : VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
 
-      if (unlikely(hazardous))
-        layout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL;
-
-      if (unlikely(m_image->info().tiling == VK_IMAGE_TILING_OPTIMAL))
+      if (unlikely(m_image->info().tiling != VK_IMAGE_TILING_OPTIMAL))
         layout = VK_IMAGE_LAYOUT_GENERAL;
 
       return layout;


### PR DESCRIPTION
Otherwise we're always using GENERAL for depth buffers.

Should fix #1514 .