### PR TITLE
[util] Set enableRtOutputNaNFixup for Super Monkey and Yooka-Laylee

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -189,6 +189,14 @@ namespace dxvk {
     { R"(\\Subnautica\.exe$)", {{
       { "dxvk.enableOpenVR",                "False" },
     }} },
+    /* Super Monkey Ball: Banana Blitz HD         */
+    { R"(\\SMBBBHD\.exe$)", {{
+      { "d3d11.enableRtOutputNanFixup",     "True" },
+    }} },
+    /* Yooka-Laylee and the Impossible Lair       */
+    { R"(\\YLILWin64.exe\.exe$)", {{
+      { "d3d11.enableRtOutputNanFixup",     "True" },
+    }} },
 
     /**********************************************/
     /* D3D9 GAMES                                 */


### PR DESCRIPTION
Both games output NaNs that introduce glitches with RADV and
AMDVLK. Only tested with dxvk.conf.