### PR TITLE
[dxvk] Fix incorrect logic in resolveDepthStencilImage

### DIFF
--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -1774,7 +1774,7 @@ namespace dxvk {
               || !srcImage->isFullSubresource(region.srcSubresource, region.extent)
               || dstImage->info().format != srcImage->info().format;
     
-    if (useFb) {
+    if (!useFb) {
       // Additionally, the given mode combination must be supported.
       const auto& properties = m_device->properties().khrDepthStencilResolve;
 


### PR DESCRIPTION
This fallbath check path should be triggered if we aren't currently using the fb.

Impacts #1537