### PR TITLE
[d3d9] Fix and optimize hazard tracking

### DIFF
--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -3025,7 +3025,7 @@ namespace dxvk {
       m_psShaderMasks = FixedFunctionMask;
     }
 
-    UpdateActiveHazardsRT(UINT32_MAX, UINT32_MAX);
+    UpdateActiveHazardsRT(UINT32_MAX);
 
     return D3D_OK;
   }
@@ -4714,7 +4714,7 @@ namespace dxvk {
         m_state.renderStates[ColorWriteIndex(index)])
       m_activeRTs |= bit;
 
-    UpdateActiveHazardsRT(bit, UINT32_MAX);
+    UpdateActiveHazardsRT(bit);
   }
 
 
@@ -4740,15 +4740,15 @@ namespace dxvk {
         m_activeTexturesToUpload |= bit;
     }
 
-    UpdateActiveHazardsRT(UINT32_MAX, bit);
+    UpdateActiveHazardsRT(UINT32_MAX);
     UpdateActiveHazardsDS(bit);
   }
 
 
-  inline void D3D9DeviceEx::UpdateActiveHazardsRT(uint32_t rtMask, uint32_t texMask) {
+  inline void D3D9DeviceEx::UpdateActiveHazardsRT(uint32_t rtMask) {
     auto masks = m_psShaderMasks;
     masks.rtMask      &= m_activeRTs & rtMask;
-    masks.samplerMask &= m_activeRTTextures & texMask;
+    masks.samplerMask &= m_activeRTTextures;
 
     m_activeHazardsRT = m_activeHazardsRT & (~rtMask);
     for (uint32_t rt = masks.rtMask; rt; rt &= rt - 1) {

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -740,7 +740,7 @@ namespace dxvk {
 
     void UpdateActiveRTs(uint32_t index);
 
-    void UpdateActiveTextures(uint32_t index);
+    void UpdateActiveTextures(uint32_t index, DWORD combinedUsage);
 
     void UpdateActiveHazardsRT(uint32_t rtMask);
 

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -742,7 +742,7 @@ namespace dxvk {
 
     void UpdateActiveTextures(uint32_t index);
 
-    void UpdateActiveHazardsRT(uint32_t rtMask, uint32_t texMask);
+    void UpdateActiveHazardsRT(uint32_t rtMask);
 
     void UpdateActiveHazardsDS(uint32_t texMask);
 


### PR DESCRIPTION
Our hazard tracking for render targets is done in render target indices as opposed to texture indices for depth stencil tracking so `texMask` doesn't work for that reason, and the fact that even if it did, there is no relationship to an individual texture and a render target index that has a hazard.

This removes that flawed optimization of mine and replaces it with a better and simpler combined usage check.

We don't need to perform DS/RT hazard tracking updates if the texture we replaced and ourselves do not have those usages.