### PR TITLE
[d3d9] Fix swap chain surface ref counting

### DIFF
--- a/src/d3d9/d3d9_surface.cpp
+++ b/src/d3d9/d3d9_surface.cpp
@@ -31,34 +31,36 @@ namespace dxvk {
         pBaseTexture) { }
 
   void D3D9Surface::AddRefPrivate(bool RefContainer) {
-    if (m_baseTexture) {
-      D3DRESOURCETYPE type = m_baseTexture->GetType();
-      if (type == D3DRTYPE_TEXTURE)
-        static_cast<D3D9Texture2D*>(m_baseTexture)->AddRefPrivate();
-      else //if (type == D3DRTYPE_CUBETEXTURE)
-        static_cast<D3D9TextureCube*>(m_baseTexture)->AddRefPrivate();
-      return;
-    }
-    else if (m_container && RefContainer) {
-      // Container must be a swapchain if it isn't a base texture.
-      static_cast<D3D9SwapChainEx*>(m_container)->AddRefPrivate();
+    if (RefContainer) {
+      if (m_baseTexture) {
+        D3DRESOURCETYPE type = m_baseTexture->GetType();
+        if (type == D3DRTYPE_TEXTURE)
+          static_cast<D3D9Texture2D*>(m_baseTexture)->AddRefPrivate();
+        else //if (type == D3DRTYPE_CUBETEXTURE)
+          static_cast<D3D9TextureCube*>(m_baseTexture)->AddRefPrivate();
+      }
+      else if (m_container) {
+        // Container must be a swapchain if it isn't a base texture.
+        static_cast<D3D9SwapChainEx*>(m_container)->AddRefPrivate();
+      }
     }
 
     D3D9SurfaceBase::AddRefPrivate();
   }
 
   void D3D9Surface::ReleasePrivate(bool RefContainer) {
-    if (m_baseTexture) {
-      D3DRESOURCETYPE type = m_baseTexture->GetType();
-      if (type == D3DRTYPE_TEXTURE)
-        static_cast<D3D9Texture2D*>(m_baseTexture)->ReleasePrivate();
-      else //if (type == D3DRTYPE_CUBETEXTURE)
-        static_cast<D3D9TextureCube*>(m_baseTexture)->ReleasePrivate();
-      return;
-    }
-    else if (m_container && RefContainer) {
-      // Container must be a swapchain if it isn't a base texture.
-      static_cast<D3D9SwapChainEx*>(m_container)->ReleasePrivate();
+    if (RefContainer) {
+      if (m_baseTexture) {
+        D3DRESOURCETYPE type = m_baseTexture->GetType();
+        if (type == D3DRTYPE_TEXTURE)
+          static_cast<D3D9Texture2D*>(m_baseTexture)->ReleasePrivate();
+        else //if (type == D3DRTYPE_CUBETEXTURE)
+          static_cast<D3D9TextureCube*>(m_baseTexture)->ReleasePrivate();
+      }
+      else if (m_container) {
+        // Container must be a swapchain if it isn't a base texture.
+        static_cast<D3D9SwapChainEx*>(m_container)->ReleasePrivate();
+      }
     }
 
     D3D9SurfaceBase::ReleasePrivate();

--- a/src/d3d9/d3d9_surface.cpp
+++ b/src/d3d9/d3d9_surface.cpp
@@ -30,47 +30,35 @@ namespace dxvk {
         pBaseTexture,
         pBaseTexture) { }
 
-  void D3D9Surface::AddRefPrivate() {
-    IDirect3DBaseTexture9* pBaseTexture = this->m_baseTexture;
-    IUnknown*              pSwapChain   = this->m_container;
-
-    if (pBaseTexture != nullptr) {
-      D3DRESOURCETYPE type = pBaseTexture->GetType();
+  void D3D9Surface::AddRefPrivate(bool RefContainer) {
+    if (m_baseTexture) {
+      D3DRESOURCETYPE type = m_baseTexture->GetType();
       if (type == D3DRTYPE_TEXTURE)
-        reinterpret_cast<D3D9Texture2D*>  (pBaseTexture)->AddRefPrivate();
+        static_cast<D3D9Texture2D*>(m_baseTexture)->AddRefPrivate();
       else //if (type == D3DRTYPE_CUBETEXTURE)
-        reinterpret_cast<D3D9TextureCube*>(pBaseTexture)->AddRefPrivate();
-
+        static_cast<D3D9TextureCube*>(m_baseTexture)->AddRefPrivate();
       return;
     }
-    else if (pSwapChain != nullptr) {
+    else if (m_container && RefContainer) {
       // Container must be a swapchain if it isn't a base texture.
-      reinterpret_cast<D3D9SwapChainEx*>(pSwapChain)->AddRefPrivate();
-
-      return;
+      static_cast<D3D9SwapChainEx*>(m_container)->AddRefPrivate();
     }
 
     D3D9SurfaceBase::AddRefPrivate();
   }
 
-  void D3D9Surface::ReleasePrivate() {
-    IDirect3DBaseTexture9* pBaseTexture = this->m_baseTexture;
-    IUnknown*              pSwapChain   = this->m_container;
-
-    if (pBaseTexture != nullptr) {
-      D3DRESOURCETYPE type = pBaseTexture->GetType();
+  void D3D9Surface::ReleasePrivate(bool RefContainer) {
+    if (m_baseTexture) {
+      D3DRESOURCETYPE type = m_baseTexture->GetType();
       if (type == D3DRTYPE_TEXTURE)
-        reinterpret_cast<D3D9Texture2D*>  (pBaseTexture)->ReleasePrivate();
+        static_cast<D3D9Texture2D*>(m_baseTexture)->ReleasePrivate();
       else //if (type == D3DRTYPE_CUBETEXTURE)
-        reinterpret_cast<D3D9TextureCube*>(pBaseTexture)->ReleasePrivate();
-
+        static_cast<D3D9TextureCube*>(m_baseTexture)->ReleasePrivate();
       return;
     }
-    else if (pSwapChain != nullptr) {
+    else if (m_container && RefContainer) {
       // Container must be a swapchain if it isn't a base texture.
-      reinterpret_cast<D3D9SwapChainEx*>(pSwapChain)->ReleasePrivate();
-
-      return;
+      static_cast<D3D9SwapChainEx*>(m_container)->ReleasePrivate();
     }
 
     D3D9SurfaceBase::ReleasePrivate();

--- a/src/d3d9/d3d9_surface.h
+++ b/src/d3d9/d3d9_surface.h
@@ -29,9 +29,9 @@ namespace dxvk {
             UINT                      MipLevel,
             IDirect3DBaseTexture9*    pBaseTexture);
 
-    void AddRefPrivate();
+    void AddRefPrivate(bool RefContainer  = true);
 
-    void ReleasePrivate();
+    void ReleasePrivate(bool RefContainer = true);
 
     HRESULT STDMETHODCALLTYPE QueryInterface(REFIID riid, void** ppvObject);
 

--- a/src/d3d9/d3d9_swapchain.h
+++ b/src/d3d9/d3d9_swapchain.h
@@ -129,7 +129,7 @@ namespace dxvk {
     DxvkLogicOpState        m_loState;
     DxvkBlendMode           m_blendMode;
 
-    std::vector<std::unique_ptr<D3D9Surface>> m_backBuffers;
+    std::vector<D3D9Surface*> m_backBuffers;
     
     RECT                    m_srcRect;
     RECT                    m_dstRect;
@@ -170,9 +170,14 @@ namespace dxvk {
     void CreateBackBuffers(
             uint32_t            NumBackBuffers);
 
+    D3D9Surface* CreateBackBuffer(
+      const D3D9_COMMON_TEXTURE_DESC& desc);
+
     void CreateGammaTexture(
             UINT                NumControlPoints,
       const D3D9_VK_GAMMA_CP*   pControlPoints);
+
+    void DestroyBackBuffers();
 
     void DestroyGammaTexture();
 

--- a/src/d3d9/d3d9_volume.cpp
+++ b/src/d3d9/d3d9_volume.cpp
@@ -30,29 +30,17 @@ namespace dxvk {
         pContainer) { }
 
 
-  void D3D9Volume::AddRefPrivate() {
-    IDirect3DBaseTexture9* pContainer = this->m_baseTexture;
-
-    // Can't have a swapchain container for a volume.
-
-    if (pContainer != nullptr) {
-      reinterpret_cast<D3D9Texture3D*> (pContainer)->AddRefPrivate();
-      return;
-    }
+  void D3D9Volume::AddRefPrivate(bool RefContainer) {
+    if (RefContainer && m_baseTexture)
+      static_cast<D3D9Texture3D*>(m_baseTexture)->AddRefPrivate();
 
     D3D9VolumeBase::AddRefPrivate();
   }
 
 
-  void D3D9Volume::ReleasePrivate() {
-    IDirect3DBaseTexture9* pContainer = this->m_baseTexture;
-
-    // Can't have a swapchain container for a volume.
-
-    if (pContainer != nullptr) {
-      reinterpret_cast<D3D9Texture3D*> (pContainer)->ReleasePrivate();
-      return;
-    }
+  void D3D9Volume::ReleasePrivate(bool RefContainer) {
+    if (RefContainer && m_baseTexture)
+      reinterpret_cast<D3D9Texture3D*>(m_baseTexture)->ReleasePrivate();
 
     D3D9VolumeBase::ReleasePrivate();
   }

--- a/src/d3d9/d3d9_volume.h
+++ b/src/d3d9/d3d9_volume.h
@@ -22,9 +22,9 @@ namespace dxvk {
             UINT                      MipLevel,
             IDirect3DBaseTexture9*    pContainer);
 
-    void AddRefPrivate();
+    void AddRefPrivate(bool RefContainer = true);
 
-    void ReleasePrivate();
+    void ReleasePrivate(bool RefContainer = true);
 
     HRESULT STDMETHODCALLTYPE QueryInterface(REFIID riid, void** ppvObject);
 


### PR DESCRIPTION
Does away with the `unique_ptr` and `aligned_storage` for surface objects. The former is an issue for swap chains because a call to `Reset` can destroy the back buffers while the app still holds a reference to them or they are bound as a render target.

In order to avoid circular references, the container which owns the object in question will increase **only** the surface ref count, not the container's ref count.

Should fix #1571.