### PR TITLE
[util] Enable constant buffer range check for Secret World Legends

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -197,6 +197,10 @@ namespace dxvk {
     { R"(\\BLUE_REFLECTION\.exe$)", {{
       { "d3d11.constantBufferRangeCheck",   "True" },
     }} },
+    /* Secret World Legends                       */
+    { R"(\\SecretWorldLegendsDX11\.exe$)", {{
+      { "d3d11.constantBufferRangeCheck",   "True" },
+    }} },
 
     /**********************************************/
     /* D3D9 GAMES                                 */


### PR DESCRIPTION
This fixes black, stretched artifacts.