### PR TITLE
Optimize SPIRV shader compilation time

### DIFF
--- a/src/d3d9/d3d9_fixed_function.cpp
+++ b/src/d3d9/d3d9_fixed_function.cpp
@@ -895,7 +895,7 @@ namespace dxvk {
     info.pushConstOffset = m_pushConstOffset;
     info.pushConstSize = m_pushConstSize;
 
-    return new DxvkShader(info, m_module.compile());
+    return new DxvkShader(info, m_module);
   }
 
 

--- a/src/d3d9/d3d9_swvp_emu.cpp
+++ b/src/d3d9/d3d9_swvp_emu.cpp
@@ -284,7 +284,7 @@ namespace dxvk {
       info.bindings = &m_bufferBinding;
       info.inputMask = m_inputMask;
 
-      return new DxvkShader(info, m_module.compile());
+      return new DxvkShader(info, m_module);
     }
 
   private:

--- a/src/dxbc/dxbc_compiler.cpp
+++ b/src/dxbc/dxbc_compiler.cpp
@@ -271,7 +271,7 @@ namespace dxvk {
         info.xfbStrides[i] = m_moduleInfo.xfb->strides[i];
     }
 
-    return new DxvkShader(info, m_module.compile());
+    return new DxvkShader(info, m_module);
   }
   
   

--- a/src/dxso/dxso_compiler.cpp
+++ b/src/dxso/dxso_compiler.cpp
@@ -232,7 +232,7 @@ namespace dxvk {
     if (m_programInfo.type() == DxsoProgramTypes::PixelShader)
       info.flatShadingInputs = m_ps.flatShadingMask;
 
-    return new DxvkShader(info, m_module.compile());
+    return new DxvkShader(info, m_module);
   }
 
   void DxsoCompiler::emitInit() {

--- a/src/dxvk/dxvk_shader.cpp
+++ b/src/dxvk/dxvk_shader.cpp
@@ -497,8 +497,9 @@ namespace dxvk {
         if (numWords) {
           code.beginInsertion(ins.offset());
           code.erase(numWords);
+          code.endInsertion();
 
-          iter = SpirvInstructionIterator(code.data(), code.endInsertion(), code.dwords());
+          iter = SpirvInstructionIterator(code.data(), ins.offset(), code.dwords());
         }
       }
 

--- a/src/dxvk/dxvk_shader.cpp
+++ b/src/dxvk/dxvk_shader.cpp
@@ -163,8 +163,6 @@ namespace dxvk {
         break;
     }
 
-    gatherBindingOffsets(code, m_bindingOffsets);
-
     // Don't set pipeline library flag if the shader
     // doesn't actually support pipeline libraries
     m_needsLibraryCompile = canUsePipelineLibrary(true);
@@ -181,9 +179,12 @@ namespace dxvk {
     const DxvkShaderModuleCreateInfo& state) const {
     SpirvCodeBuffer spirvCode = m_code.decompress();
     uint32_t* code = spirvCode.data();
-    
+    std::vector<BindingOffsets> bindingOffsets;
+
+    gatherBindingOffsets(spirvCode, bindingOffsets);
+
     // Remap resource binding IDs
-    for (const auto& info : m_bindingOffsets) {
+    for (const auto& info : bindingOffsets) {
       auto mappedBinding = layout->lookupBinding(m_info.stage, info.bindingId);
 
       if (mappedBinding) {

--- a/src/dxvk/dxvk_shader.cpp
+++ b/src/dxvk/dxvk_shader.cpp
@@ -43,14 +43,14 @@ namespace dxvk {
   }
 
   void DxvkShader::gatherBindingOffsets(
-          const SpirvCodeBuffer &code,
-          std::vector<BindingOffsets> &offsets) {
+          SpirvCodeBuffer&             code,
+          std::vector<BindingOffsets>& offsets) {
     // Run an analysis pass over the SPIR-V code to gather some
     // info that we may need during pipeline compilation.
     std::vector<BindingOffsets> bindingOffsets;
     std::vector<uint32_t> varIds;
 
-    for (auto ins : code) {
+    for (const auto& ins : code) {
       if (ins.opCode() == spv::OpDecorate) {
         if (ins.arg(2) == spv::DecorationBinding) {
           uint32_t varId = ins.arg(1);

--- a/src/dxvk/dxvk_shader.h
+++ b/src/dxvk/dxvk_shader.h
@@ -261,7 +261,6 @@ namespace dxvk {
     std::atomic<bool>             m_needsLibraryCompile = { true };
 
     std::vector<char>             m_uniformData;
-    std::vector<BindingOffsets>   m_bindingOffsets;
 
     DxvkBindingLayout             m_bindings;
 

--- a/src/dxvk/dxvk_shader.h
+++ b/src/dxvk/dxvk_shader.h
@@ -257,9 +257,6 @@ namespace dxvk {
     DxvkShaderKey                 m_key;
     size_t                        m_hash = 0;
 
-    size_t                        m_o1IdxOffset = 0;
-    size_t                        m_o1LocOffset = 0;
-
     uint32_t                      m_specConstantMask = 0;
     std::atomic<bool>             m_needsLibraryCompile = { true };
 

--- a/src/dxvk/dxvk_shader.h
+++ b/src/dxvk/dxvk_shader.h
@@ -19,24 +19,6 @@ namespace dxvk {
   struct DxvkPipelineStats;
   
   /**
-   * \brief Shader flags
-   *
-   * Provides extra information about the features
-   * used by a shader.
-   */
-  enum DxvkShaderFlag : uint64_t {
-    HasSampleRateShading,
-    HasTransformFeedback,
-    ExportsPosition,
-    ExportsStencilRef,
-    ExportsViewportIndexLayerFromVertexStage,
-    UsesFragmentCoverage,
-    UsesSparseResidency,
-  };
-
-  using DxvkShaderFlags = Flags<DxvkShaderFlag>;
-  
-  /**
    * \brief Shader info
    */
   struct DxvkShaderCreateInfo {
@@ -102,6 +84,10 @@ namespace dxvk {
     DxvkShader(
       const DxvkShaderCreateInfo&   info,
             SpirvCodeBuffer&&       spirv);
+
+    DxvkShader(
+      const DxvkShaderCreateInfo& info,
+      const SpirvModule&          spirv);
 
     ~DxvkShader();
     

--- a/src/dxvk/dxvk_shader.h
+++ b/src/dxvk/dxvk_shader.h
@@ -92,6 +92,12 @@ namespace dxvk {
   class DxvkShader : public RcObject {
     
   public:
+
+    struct BindingOffsets {
+      uint32_t bindingId;
+      uint32_t bindingOffset;
+      uint32_t setOffset;
+    };
     
     DxvkShader(
       const DxvkShaderCreateInfo&   info,
@@ -244,12 +250,6 @@ namespace dxvk {
     
   private:
 
-    struct BindingOffsets {
-      uint32_t bindingId;
-      uint32_t bindingOffset;
-      uint32_t setOffset;
-    };
-
     DxvkShaderCreateInfo          m_info;
     SpirvCompressedBuffer         m_code;
     
@@ -277,6 +277,10 @@ namespace dxvk {
     static void emitFlatShadingDeclarations(
             SpirvCodeBuffer&          code,
             uint32_t                  inputMask);
+
+    static void gatherBindingOffsets(
+            SpirvCodeBuffer&             code,
+            std::vector<BindingOffsets>& offsets);
 
   };
   

--- a/src/spirv/spirv_code_buffer.cpp
+++ b/src/spirv/spirv_code_buffer.cpp
@@ -9,14 +9,12 @@ namespace dxvk {
   SpirvCodeBuffer::~SpirvCodeBuffer() { }
   
   
-  SpirvCodeBuffer::SpirvCodeBuffer(uint32_t size)
-  : m_ptr(size) {
+  SpirvCodeBuffer::SpirvCodeBuffer(uint32_t size) {
     m_code.resize(size);
   }
 
 
-  SpirvCodeBuffer::SpirvCodeBuffer(uint32_t size, const uint32_t* data)
-  : m_ptr(size) {
+  SpirvCodeBuffer::SpirvCodeBuffer(uint32_t size, const uint32_t* data) {
     m_code.resize(size);
     std::memcpy(m_code.data(), data, size * sizeof(uint32_t));
   }
@@ -35,18 +33,20 @@ namespace dxvk {
     m_code.resize(buffer.size() / sizeof(uint32_t));
     std::memcpy(reinterpret_cast<char*>(m_code.data()),
       buffer.data(), m_code.size() * sizeof(uint32_t));
-    
-    m_ptr = m_code.size();
   }
   
   
   uint32_t SpirvCodeBuffer::allocId() {
     constexpr size_t BoundIdsOffset = 3;
 
-    if (m_code.size() <= BoundIdsOffset)
+    if (this->dwords() <= BoundIdsOffset)
       return 0;
 
-    return m_code[BoundIdsOffset]++;
+    // If we are inserting, the buffers are swapped
+    if (m_ptr == not_inserting)
+      return m_code[BoundIdsOffset]++;
+    else
+      return m_insert[BoundIdsOffset]++;
   }
 
 
@@ -59,21 +59,18 @@ namespace dxvk {
       const uint32_t* src = other.m_code.data();
       
       std::memcpy(dst + size, src, other.size());
-      m_ptr += other.m_code.size();
     }
   }
   
   
-  void SpirvCodeBuffer::putWord(uint32_t word) {
-    m_code.insert(m_code.begin() + m_ptr, word);
-    m_ptr += 1;
-  }
-  
-  
   void SpirvCodeBuffer::erase(size_t size) {
-    m_code.erase(
-      m_code.begin() + m_ptr,
-      m_code.begin() + m_ptr + size);
+    if (m_ptr == not_inserting)
+      return;
+
+    // If we are inserting, the buffers are swapped
+    m_insert.erase(
+      m_insert.begin() + m_ptr,
+      m_insert.begin() + m_ptr + size);
   }
 
 

--- a/src/spirv/spirv_code_buffer.cpp
+++ b/src/spirv/spirv_code_buffer.cpp
@@ -70,68 +70,6 @@ namespace dxvk {
   }
   
   
-  void SpirvCodeBuffer::putIns(spv::Op opCode, uint16_t wordCount) {
-    this->putWord(
-        (static_cast<uint32_t>(opCode)    <<  0)
-      | (static_cast<uint32_t>(wordCount) << 16));
-  }
-  
-  
-  void SpirvCodeBuffer::putInt32(uint32_t word) {
-    this->putWord(word);
-  }
-  
-  
-  void SpirvCodeBuffer::putInt64(uint64_t value) {
-    this->putWord(value >>  0);
-    this->putWord(value >> 32);
-  }
-  
-  
-  void SpirvCodeBuffer::putFloat32(float value) {
-    uint32_t tmp;
-    static_assert(sizeof(tmp) == sizeof(value));
-    std::memcpy(&tmp, &value, sizeof(value));
-    this->putInt32(tmp);
-  }
-  
-  
-  void SpirvCodeBuffer::putFloat64(double value) {
-    uint64_t tmp;
-    static_assert(sizeof(tmp) == sizeof(value));
-    std::memcpy(&tmp, &value, sizeof(value));
-    this->putInt64(tmp);
-  }
-  
-  
-  void SpirvCodeBuffer::putStr(const char* str) {
-    uint32_t word = 0;
-    uint32_t nbit = 0;
-    
-    for (uint32_t i = 0; str[i] != '\0'; str++) {
-      word |= (static_cast<uint32_t>(str[i]) & 0xFF) << nbit;
-      
-      if ((nbit += 8) == 32) {
-        this->putWord(word);
-        word = 0;
-        nbit = 0;
-      }
-    }
-    
-    // Commit current word
-    this->putWord(word);
-  }
-  
-  
-  void SpirvCodeBuffer::putHeader(uint32_t version, uint32_t boundIds) {
-    this->putWord(spv::MagicNumber);
-    this->putWord(version);
-    this->putWord(0); // Generator
-    this->putWord(boundIds);
-    this->putWord(0); // Schema
-  }
-  
-  
   void SpirvCodeBuffer::erase(size_t size) {
     m_code.erase(
       m_code.begin() + m_ptr,
@@ -139,12 +77,6 @@ namespace dxvk {
   }
 
 
-  uint32_t SpirvCodeBuffer::strLen(const char* str) {
-    // Null-termination plus padding
-    return (std::strlen(str) + 4) / 4;
-  }
-  
-  
   void SpirvCodeBuffer::store(std::ostream& stream) const {
     stream.write(
       reinterpret_cast<const char*>(m_code.data()),

--- a/src/spirv/spirv_code_buffer.h
+++ b/src/spirv/spirv_code_buffer.h
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include "spirv_instruction.h"
+#include "spirv_writer.h"
 
 namespace dxvk {
   
@@ -15,7 +16,7 @@ namespace dxvk {
    * Stores arbitrary SPIR-V instructions in a
    * format that can be read by Vulkan drivers.
    */
-  class SpirvCodeBuffer {
+  class SpirvCodeBuffer : public SpirvWriter<SpirvCodeBuffer> {
     
   public:
     
@@ -99,56 +100,6 @@ namespace dxvk {
      * \param [in] word The word to append
      */
     void putWord(uint32_t word);
-    
-    /**
-     * \brief Appends an instruction word to the buffer
-     * 
-     * Adds a single word containing both the word count
-     * and the op code number for a single instruction.
-     * \param [in] opCode Operand code
-     * \param [in] wordCount Number of words
-     */
-    void putIns(spv::Op opCode, uint16_t wordCount);
-
-    /**
-     * \brief Appends a 32-bit integer to the buffer
-     * \param [in] value The number to add
-     */
-    void putInt32(uint32_t word);
-    
-    /**
-     * \brief Appends a 64-bit integer to the buffer
-     * 
-     * A 64-bit integer will take up two 32-bit words.
-     * \param [in] value 64-bit value to add
-     */
-    void putInt64(uint64_t value);
-    
-    /**
-     * \brief Appends a 32-bit float to the buffer
-     * \param [in] value The number to add
-     */
-    void putFloat32(float value);
-    
-    /**
-     * \brief Appends a 64-bit float to the buffer
-     * \param [in] value The number to add
-     */
-    void putFloat64(double value);
-    
-    /**
-     * \brief Appends a literal string to the buffer
-     * \param [in] str String to append to the buffer
-     */
-    void putStr(const char* str);
-    
-    /**
-     * \brief Adds the header to the buffer
-     *
-     * \param [in] version SPIR-V version
-     * \param [in] boundIds Number of bound IDs
-     */
-    void putHeader(uint32_t version, uint32_t boundIds);
 
     /**
      * \brief Erases given number of dwords
@@ -158,14 +109,6 @@ namespace dxvk {
      * \param [in] size Number of words to remove
      */
     void erase(size_t size);
-    
-    /**
-     * \brief Computes length of a literal string
-     * 
-     * \param [in] str The string to check
-     * \returns Number of words consumed by a string
-     */
-    uint32_t strLen(const char* str);
     
     /**
      * \brief Stores the SPIR-V module to a stream

--- a/src/spirv/spirv_compression.cpp
+++ b/src/spirv/spirv_compression.cpp
@@ -3,81 +3,28 @@
 namespace dxvk {
 
   SpirvCompressedBuffer::SpirvCompressedBuffer()
-  : m_size(0) {
+  : m_dwords(0) {
 
   }
 
 
-  SpirvCompressedBuffer::SpirvCompressedBuffer(SpirvCodeBuffer& code)
-  : m_size(code.dwords()) {
-    // The compression (detailed below) achieves roughly 55% of the
-    // original size on average and is very consistent, so an initial
-    // estimate of roughly 58% will be accurate most of the time.
-    const uint32_t* data = code.data();
-    m_code.reserve((m_size * 75) / 128);
+  SpirvCompressedBuffer::SpirvCompressedBuffer(
+    const SpirvCodeBuffer& code)
+  : m_dwords(code.dwords()) {
+    size_t dwords = m_dwords;
+    if (dwords == 0)
+      return;
 
-    std::array<uint32_t, 16> block;
-    uint32_t blockMask = 0;
-    uint32_t blockOffset = 0;
+    const uint32_t *src = code.data();
+    const uint32_t *end = src + dwords;
+    do {
+      uint32_t word = *src++;
+      m_code.push_back(word & 0x7f);
+      while (word >>= 7)
+        m_code.push_back((word & 0x7f) | 0x80);
+    } while (src != end);
 
-    // The algorithm used is a simple variable-to-fixed compression that
-    // encodes up to two consecutive SPIR-V tokens into one DWORD using
-    // a small number of different encodings. While not achieving great
-    // compression ratios, the main goal is to allow decompression code
-    // to be fast, with short dependency chains.
-    // Compressed tokens are stored in blocks of 16 DWORDs, each preceeded
-    // by a single DWORD which stores the layout for each DWORD, two bits
-    // each. The supported layouts, are as follows:
-    // 0x0: 1x 32-bit;  0x1: 1x 20-bit + 1x 12-bit
-    // 0x2: 2x 16-bit;  0x3: 1x 12-bit + 1x 20-bit
-    // These layouts are chosen to allow reasonably efficient encoding of
-    // opcode tokens, which usually fit into 20 bits, followed by type IDs,
-    // which tend to be low as well since most types are defined early.
-    for (size_t i = 0; i < m_size; ) {
-      if (likely(i + 1 < m_size)) {
-        uint32_t a = data[i];
-        uint32_t b = data[i + 1];
-        uint32_t schema;
-        uint32_t encode;
-
-        if (std::max(a, b) < (1u << 16)) {
-          schema = 0x2;
-          encode = a | (b << 16);
-        } else if (a < (1u << 20) && b < (1u << 12)) {
-          schema = 0x1;
-          encode = a | (b << 20);
-        } else if (a < (1u << 12) && b < (1u << 20)) {
-          schema = 0x3;
-          encode = a | (b << 12);
-        } else {
-          schema = 0x0;
-          encode = a;
-        }
-
-        block[blockOffset] = encode;
-        blockMask |= schema << (blockOffset << 1);
-        blockOffset += 1;
-
-        i += schema ? 2 : 1;
-      } else {
-        block[blockOffset] = data[i++];
-        blockOffset += 1;
-      }
-
-      if (unlikely(blockOffset == 16) || unlikely(i == m_size)) {
-        m_code.insert(m_code.end(), blockMask);
-        m_code.insert(m_code.end(), block.begin(), block.begin() + blockOffset);
-
-        blockMask = 0;
-        blockOffset = 0;
-      }
-    }
-
-    // Only shrink the array if we have lots of overhead for some reason.
-    // This should only happen on shaders where our initial estimate was
-    // too small. In general, we want to avoid reallocation here.
-    if (m_code.capacity() > (m_code.size() * 10) / 9)
-      m_code.shrink_to_fit();
+    m_code.shrink_to_fit();
   }
 
     
@@ -87,35 +34,24 @@ namespace dxvk {
 
 
   SpirvCodeBuffer SpirvCompressedBuffer::decompress() const {
-    SpirvCodeBuffer code(m_size);
-    uint32_t* data = code.data();
+    SpirvCodeBuffer code(m_dwords);
+    if (m_dwords == 0)
+      return code;
 
-    uint32_t srcOffset = 0;
-    uint32_t dstOffset = 0;
-
-    constexpr uint32_t shiftAmounts = 0x0c101420;
-
-    while (dstOffset < m_size) {
-      uint32_t blockMask = m_code[srcOffset];
-
-      for (uint32_t i = 0; i < 16 && dstOffset < m_size; i++) {
-        // Use 64-bit integers for some of the operands so we can
-        // shift by 32 bits and not handle it as a special cases
-        uint32_t schema = (blockMask >> (i << 1)) & 0x3;
-        uint32_t shift  = (shiftAmounts >> (schema << 3)) & 0xff;
-        uint64_t mask   = ~(~0ull << shift);
-        uint64_t encode = m_code[srcOffset + i + 1];
-
-        data[dstOffset] = encode & mask;
-
-        if (likely(schema))
-          data[dstOffset + 1] = encode >> shift;
-
-        dstOffset += schema ? 2 : 1;
-      }
-
-      srcOffset += 17;
-    }
+    uint32_t *dst = code.data();
+    const uint8_t *src = m_code.data();
+    const uint8_t *end = src + m_code.size();
+    do {
+      *dst = *src++;
+      if (src == end || !(*src & 0x80)) continue;
+      *dst |= (*src++ & 0x7f) << 7;
+      if (src == end || !(*src & 0x80)) continue;
+      *dst |= (*src++ & 0x7f) << 14;
+      if (src == end || !(*src & 0x80)) continue;
+      *dst |= (*src++ & 0x7f) << 21;
+      if (src == end || !(*src & 0x80)) continue;
+      *dst |= (*src++ & 0x7f) << 28;
+    } while (++dst, src != end);
 
     return code;
   }

--- a/src/spirv/spirv_compression.h
+++ b/src/spirv/spirv_compression.h
@@ -18,7 +18,7 @@ namespace dxvk {
 
     SpirvCompressedBuffer();
 
-    SpirvCompressedBuffer(SpirvCodeBuffer& code);
+    SpirvCompressedBuffer(const SpirvCodeBuffer& code);
     
     ~SpirvCompressedBuffer();
     
@@ -26,12 +26,8 @@ namespace dxvk {
 
   private:
 
-    size_t                m_size;
-    std::vector<uint32_t> m_code;
-
-    void encodeDword(uint32_t dw);
-
-    uint32_t decodeDword(size_t& offset) const;
+    uint32_t             m_dwords;
+    std::vector<uint8_t> m_code;
 
   };
 

--- a/src/spirv/spirv_compression.h
+++ b/src/spirv/spirv_compression.h
@@ -12,7 +12,7 @@ namespace dxvk {
    * Implements a fast in-memory compression
    * to keep memory footprint low.
    */
-  class SpirvCompressedBuffer {
+  class SpirvCompressedBuffer : public SpirvWriter<SpirvCompressedBuffer> {
 
   public:
 
@@ -22,6 +22,46 @@ namespace dxvk {
     
     ~SpirvCompressedBuffer();
     
+    void shrink() { m_code.shrink_to_fit(); }
+
+    /**
+     * \brief Code size, in dwords
+     * \returns Code size, in dwords
+     */
+    uint32_t dwords() const { return m_dwords; }
+
+    /**
+     * \brief Code size, in bytes
+     * \returns Code size, in bytes
+     */
+    size_t size() const { return m_code.size(); }
+
+    /**
+     * \brief Appends an 32-bit word to the buffer
+     * \param [in] word The word to append
+     */
+    void putWord(uint32_t word) {
+      m_code.push_back(word & 0x7f);
+      while (word >>= 7)
+        m_code.push_back((word & 0x7f) | 0x80);
+      m_dwords += 1;
+    }
+
+    /**
+     * \brief Merges two code buffers
+     *
+     * This is useful to generate declarations or
+     * the SPIR-V header at the same time as the
+     * code when doing so in advance is impossible.
+     * \param [in] other Code buffer to append
+     */
+    void append(const SpirvCompressedBuffer& other) {
+      m_code.insert(m_code.end(),
+                    other.m_code.begin(),
+                    other.m_code.end());
+      m_dwords += other.dwords();
+    }
+
     SpirvCodeBuffer decompress() const;
 
   private:

--- a/src/spirv/spirv_module.cpp
+++ b/src/spirv/spirv_module.cpp
@@ -40,12 +40,7 @@ namespace dxvk {
   
   bool SpirvModule::hasCapability(
           spv::Capability         capability) {
-    for (auto ins : m_capabilities) {
-      if (ins.opCode() == spv::OpCapability && ins.arg(1) == capability)
-        return true;
-    }
-
-    return false;
+    return m_enabledCaps.find(capability) != m_enabledCaps.end();
   }
 
   void SpirvModule::enableCapability(
@@ -55,6 +50,7 @@ namespace dxvk {
     if (!hasCapability(capability)) {
       m_capabilities.putIns (spv::OpCapability, 2);
       m_capabilities.putWord(capability);
+      m_enabledCaps.insert(capability);
     }
   }
   

--- a/src/spirv/spirv_module.cpp
+++ b/src/spirv/spirv_module.cpp
@@ -16,7 +16,7 @@ namespace dxvk {
   
   
   SpirvCompressedBuffer SpirvModule::compile() const {
-    SpirvCodeBuffer result;
+    SpirvCompressedBuffer result;
     result.putHeader(m_version, m_id);
     result.append(m_capabilities);
     result.append(m_extensions);
@@ -29,7 +29,8 @@ namespace dxvk {
     result.append(m_typeConstDefs);
     result.append(m_variables);
     result.append(m_code);
-    return SpirvCompressedBuffer(result);
+    result.shrink();
+    return result;
   }
   
   

--- a/src/spirv/spirv_module.cpp
+++ b/src/spirv/spirv_module.cpp
@@ -512,7 +512,7 @@ namespace dxvk {
   uint32_t SpirvModule::lateConst32(
           uint32_t                typeId) {
     uint32_t resultId = this->allocateId();
-    m_lateConsts.insert(resultId);
+    m_lateConsts[resultId] = m_typeConstDefs.getInsertionPtr();
 
     m_typeConstDefs.putIns (spv::OpConstant, 4);
     m_typeConstDefs.putWord(typeId);
@@ -525,19 +525,12 @@ namespace dxvk {
   void SpirvModule::setLateConst(
             uint32_t                constId,
       const uint32_t*               argIds) {
-    for (auto ins : m_typeConstDefs) {
-      if (ins.opCode() != spv::OpConstant
-       && ins.opCode() != spv::OpConstantComposite)
-        continue;
-      
-      if (ins.arg(2) != constId)
-        continue;
+    auto ins = SpirvInstruction(m_typeConstDefs.data(),
+                                m_lateConsts[constId],
+                                m_typeConstDefs.dwords());
 
-      for (uint32_t i = 3; i < ins.length(); i++)
-        ins.setArg(i, argIds[i - 3]);
-
-      return;
-    }
+    for (uint32_t i = 3; i < ins.length(); i++)
+      ins.setArg(i, argIds[i - 3]);
   }
 
 

--- a/src/spirv/spirv_module.cpp
+++ b/src/spirv/spirv_module.cpp
@@ -91,6 +91,7 @@ namespace dxvk {
     m_execModeInfo.putIns (spv::OpExecutionMode, 3);
     m_execModeInfo.putWord(entryPointId);
     m_execModeInfo.putWord(executionMode);
+    m_enabledModes.insert(executionMode);
   }
   
   

--- a/src/spirv/spirv_module.h
+++ b/src/spirv/spirv_module.h
@@ -3,9 +3,30 @@
 #include <unordered_set>
 
 #include "spirv_code_buffer.h"
+#include "spirv_compression.h"
+
+#include "../dxvk/dxvk_limits.h"
 
 namespace dxvk {
   
+  /**
+   * \brief Shader flags
+   *
+   * Provides extra information about the features
+   * used by a shader.
+   */
+  enum DxvkShaderFlag : uint64_t {
+    HasSampleRateShading,
+    HasTransformFeedback,
+    ExportsPosition,
+    ExportsStencilRef,
+    ExportsViewportIndexLayerFromVertexStage,
+    UsesFragmentCoverage,
+    UsesSparseResidency,
+  };
+
+  using DxvkShaderFlags = Flags<DxvkShaderFlag>;
+
   struct SpirvPhiLabel {
     uint32_t varId         = 0;
     uint32_t labelId       = 0;
@@ -59,7 +80,7 @@ namespace dxvk {
 
     ~SpirvModule();
     
-    SpirvCodeBuffer compile() const;
+    SpirvCompressedBuffer compile() const;
 
     size_t getInsertionPtr() {
       return m_code.getInsertionPtr();
@@ -1264,6 +1285,14 @@ namespace dxvk {
 
     void opEndInvocationInterlock();
 
+    DxvkShaderFlags getShaderFlags() const {
+      return m_shaderFlags;
+    }
+
+    uint32_t getSpecConstantMask() const {
+      return m_specConstantMask;
+    }
+
   private:
     
     uint32_t m_version;
@@ -1271,6 +1300,9 @@ namespace dxvk {
     uint32_t m_instExtGlsl450 = 0;
     uint32_t m_blockId        = 0;
     
+    DxvkShaderFlags m_shaderFlags;
+    uint32_t        m_specConstantMask = 0;
+
     SpirvCodeBuffer m_capabilities;
     SpirvCodeBuffer m_extensions;
     SpirvCodeBuffer m_instExt;

--- a/src/spirv/spirv_module.h
+++ b/src/spirv/spirv_module.h
@@ -1283,6 +1283,7 @@ namespace dxvk {
     SpirvCodeBuffer m_variables;
     SpirvCodeBuffer m_code;
 
+    std::unordered_set<spv::Capability>  m_enabledCaps;
     std::vector<size_t> m_typeLocs;
     std::vector<size_t> m_constLocs;
 

--- a/src/spirv/spirv_module.h
+++ b/src/spirv/spirv_module.h
@@ -1283,6 +1283,8 @@ namespace dxvk {
     SpirvCodeBuffer m_variables;
     SpirvCodeBuffer m_code;
 
+    std::vector<size_t> m_typeLocs;
+
     std::optional<uint32_t> m_typeVoid;
     std::optional<uint32_t> m_typeSampler;
     std::optional<uint32_t> m_typeBool[4];

--- a/src/spirv/spirv_module.h
+++ b/src/spirv/spirv_module.h
@@ -1284,6 +1284,7 @@ namespace dxvk {
     SpirvCodeBuffer m_code;
 
     std::vector<size_t> m_typeLocs;
+    std::vector<size_t> m_constLocs;
 
     std::optional<uint32_t> m_typeVoid;
     std::optional<uint32_t> m_typeSampler;

--- a/src/spirv/spirv_module.h
+++ b/src/spirv/spirv_module.h
@@ -1310,7 +1310,7 @@ namespace dxvk {
     std::unordered_map<float, uint32_t>    m_constFloat32;
     std::unordered_map<double, uint32_t>   m_constFloat64;
 
-    std::unordered_set<uint32_t> m_lateConsts;
+    std::unordered_map<uint32_t, size_t> m_lateConsts;
 
     std::vector<uint32_t> m_interfaceVars;
 

--- a/src/spirv/spirv_module.h
+++ b/src/spirv/spirv_module.h
@@ -1283,7 +1283,9 @@ namespace dxvk {
     SpirvCodeBuffer m_variables;
     SpirvCodeBuffer m_code;
 
-    std::unordered_set<spv::Capability>  m_enabledCaps;
+    std::unordered_set<spv::Capability>    m_enabledCaps;
+    std::unordered_set<spv::ExecutionMode> m_enabledModes;
+
     std::vector<size_t> m_typeLocs;
     std::vector<size_t> m_constLocs;
 

--- a/src/spirv/spirv_module.h
+++ b/src/spirv/spirv_module.h
@@ -1298,6 +1298,15 @@ namespace dxvk {
     std::optional<uint32_t> m_typeFloat32[4];
     std::optional<uint32_t> m_typeFloat64[4];
 
+    std::optional<uint32_t>                m_constBool[2];
+    std::unordered_map<uint32_t, uint32_t> m_constUndef;
+    std::unordered_map<int32_t, uint32_t>  m_constSInt32;
+    std::unordered_map<int64_t, uint32_t>  m_constSInt64;
+    std::unordered_map<uint32_t, uint32_t> m_constUInt32;
+    std::unordered_map<uint64_t, uint32_t> m_constUInt64;
+    std::unordered_map<float, uint32_t>    m_constFloat32;
+    std::unordered_map<double, uint32_t>   m_constFloat64;
+
     std::unordered_set<uint32_t> m_lateConsts;
 
     std::vector<uint32_t> m_interfaceVars;
@@ -1318,6 +1327,19 @@ namespace dxvk {
             uint32_t                argCount,
       const uint32_t*               argIds);
     
+    uint32_t defConstCached(
+            std::optional<uint32_t>&cache,
+            spv::Op                 op,
+            uint32_t                typeId,
+            uint32_t                argCount,
+      const uint32_t*               argIds);
+
+    uint32_t defConstUnique(
+            spv::Op                 op,
+            uint32_t                typeId,
+            uint32_t                argCount,
+      const uint32_t*               argIds);
+
     uint32_t defConst(
             spv::Op                 op,
             uint32_t                typeId,

--- a/src/spirv/spirv_module.h
+++ b/src/spirv/spirv_module.h
@@ -1283,9 +1283,35 @@ namespace dxvk {
     SpirvCodeBuffer m_variables;
     SpirvCodeBuffer m_code;
 
+    std::optional<uint32_t> m_typeVoid;
+    std::optional<uint32_t> m_typeSampler;
+    std::optional<uint32_t> m_typeBool[4];
+    std::optional<uint32_t> m_typeSInt8[4];
+    std::optional<uint32_t> m_typeSInt16[4];
+    std::optional<uint32_t> m_typeSInt32[4];
+    std::optional<uint32_t> m_typeSInt64[4];
+    std::optional<uint32_t> m_typeUInt8[4];
+    std::optional<uint32_t> m_typeUInt16[4];
+    std::optional<uint32_t> m_typeUInt32[4];
+    std::optional<uint32_t> m_typeUInt64[4];
+    std::optional<uint32_t> m_typeFloat16[4];
+    std::optional<uint32_t> m_typeFloat32[4];
+    std::optional<uint32_t> m_typeFloat64[4];
+
     std::unordered_set<uint32_t> m_lateConsts;
 
     std::vector<uint32_t> m_interfaceVars;
+
+    uint32_t defTypeCached(
+            std::optional<uint32_t>&cache,
+            spv::Op                 op,
+            uint32_t                argCount,
+      const uint32_t*               argIds);
+    
+    uint32_t defTypeUnique(
+            spv::Op                 op,
+            uint32_t                argCount,
+      const uint32_t*               argIds);
 
     uint32_t defType(
             spv::Op                 op, 

--- a/src/spirv/spirv_module.h
+++ b/src/spirv/spirv_module.h
@@ -1312,8 +1312,8 @@ namespace dxvk {
     SpirvCompressedBuffer m_debugNames;
     SpirvCompressedBuffer m_annotations;
     SpirvCodeBuffer       m_typeConstDefs;
-    SpirvCodeBuffer       m_variables;
-    SpirvCodeBuffer       m_code;
+    SpirvCompressedBuffer m_variables;
+    SpirvCompressedBuffer m_code;
 
     std::unordered_set<spv::Capability>    m_enabledCaps;
     std::unordered_set<spv::ExecutionMode> m_enabledModes;

--- a/src/spirv/spirv_module.h
+++ b/src/spirv/spirv_module.h
@@ -1303,17 +1303,17 @@ namespace dxvk {
     DxvkShaderFlags m_shaderFlags;
     uint32_t        m_specConstantMask = 0;
 
-    SpirvCodeBuffer m_capabilities;
-    SpirvCodeBuffer m_extensions;
-    SpirvCodeBuffer m_instExt;
-    SpirvCodeBuffer m_memoryModel;
-    SpirvCodeBuffer m_entryPoints;
-    SpirvCodeBuffer m_execModeInfo;
-    SpirvCodeBuffer m_debugNames;
-    SpirvCodeBuffer m_annotations;
-    SpirvCodeBuffer m_typeConstDefs;
-    SpirvCodeBuffer m_variables;
-    SpirvCodeBuffer m_code;
+    SpirvCompressedBuffer m_capabilities;
+    SpirvCompressedBuffer m_extensions;
+    SpirvCompressedBuffer m_instExt;
+    SpirvCompressedBuffer m_memoryModel;
+    SpirvCompressedBuffer m_entryPoints;
+    SpirvCompressedBuffer m_execModeInfo;
+    SpirvCompressedBuffer m_debugNames;
+    SpirvCompressedBuffer m_annotations;
+    SpirvCodeBuffer       m_typeConstDefs;
+    SpirvCodeBuffer       m_variables;
+    SpirvCodeBuffer       m_code;
 
     std::unordered_set<spv::Capability>    m_enabledCaps;
     std::unordered_set<spv::ExecutionMode> m_enabledModes;

--- a/src/spirv/spirv_writer.h
+++ b/src/spirv/spirv_writer.h
@@ -1,0 +1,125 @@
+#pragma once
+
+#include "spirv_instruction.h"
+
+namespace dxvk {
+  
+  /**
+   * \brief SPIR-V code buffer
+   * 
+   * Helper class for generating SPIR-V shaders.
+   * Stores arbitrary SPIR-V instructions in a
+   * format that can be read by Vulkan drivers.
+   */
+  template<class SpirvBuffer>
+  class SpirvWriter {
+    
+  public:
+    
+    /**
+     * \brief Appends an 32-bit word to the buffer
+     * \param [in] word The word to append
+     */
+    void putWord(uint32_t word) {
+      static_cast<SpirvBuffer*>(this)->putWord(word);
+    }
+    
+    /**
+     * \brief Appends an instruction word to the buffer
+     * 
+     * Adds a single word containing both the word count
+     * and the op code number for a single instruction.
+     * \param [in] opCode Operand code
+     * \param [in] wordCount Number of words
+     */
+    void putIns(spv::Op opCode, uint16_t wordCount) {
+      this->putWord(
+          (static_cast<uint32_t>(opCode)    <<  0)
+        | (static_cast<uint32_t>(wordCount) << 16));
+    }
+    
+    /**
+     * \brief Appends a 32-bit integer to the buffer
+     * \param [in] value The number to add
+     */
+    void putInt32(uint32_t word) {
+      this->putWord(word);
+    }
+    
+    /**
+     * \brief Appends a 64-bit integer to the buffer
+     * 
+     * A 64-bit integer will take up two 32-bit words.
+     * \param [in] value 64-bit value to add
+     */
+    void putInt64(uint64_t value) {
+      this->putWord(value >>  0);
+      this->putWord(value >> 32);
+    }
+    
+    /**
+     * \brief Appends a 32-bit float to the buffer
+     * \param [in] value The number to add
+     */
+    void putFloat32(float value) {
+      this->putInt32(bit::cast<uint32_t>(value));
+    }
+    
+    /**
+     * \brief Appends a 64-bit float to the buffer
+     * \param [in] value The number to add
+     */
+    void putFloat64(double value) {
+      this->putInt64(bit::cast<uint64_t>(value));
+    }
+    
+    /**
+     * \brief Appends a literal string to the buffer
+     * \param [in] str String to append to the buffer
+     */
+    void putStr(const char* str) {
+      uint32_t word = 0;
+      uint32_t nbit = 0;
+      
+      for (uint32_t i = 0; str[i] != '\0'; str++) {
+        word |= (static_cast<uint32_t>(str[i]) & 0xFF) << nbit;
+        
+        if ((nbit += 8) == 32) {
+          this->putWord(word);
+          word = 0;
+          nbit = 0;
+        }
+      }
+      
+      // Commit current word
+      this->putWord(word);
+    }
+    
+    /**
+     * \brief Adds the header to the buffer
+     *
+     * \param [in] version SPIR-V version
+     * \param [in] boundIds Number of bound IDs
+     */
+    void putHeader(uint32_t version, uint32_t boundIds) {
+      this->putWord(spv::MagicNumber);
+      this->putWord(version);
+      this->putWord(0); // Generator
+      this->putWord(boundIds);
+      this->putWord(0); // Schema
+    }
+    
+    /**
+     * \brief Computes length of a literal string
+     * 
+     * \param [in] str The string to check
+     * \returns Number of words consumed by a string
+     */
+    uint32_t strLen(const char* str)  {
+      // Null-termination plus padding
+      return (std::strlen(str) + 4) / 4;
+    }
+
+  };
+  
+}

--- a/src/util/util_raw_vector.h
+++ b/src/util/util_raw_vector.h
@@ -1,0 +1,137 @@
+#pragma once
+
+#include <type_traits>
+#include <memory>
+
+namespace dxvk {
+
+  /**
+   * \brief Uninitialized vector
+   *
+   * Implements a vector with uinitialized storage to avoid
+   * std::vector default initialization.
+   */
+  template<typename T>
+  class raw_vector {
+    struct deleter {
+      void operator()(void* p) const { std::free(p); }
+    };
+    using pointer_type = std::unique_ptr<T, deleter>;
+
+  public:
+
+    void reserve(size_t n) {
+      n = pick_capacity(n);
+      if (n > m_capacity)
+        reallocate(n);
+    }
+
+    void shrink_to_fit() {
+      size_t n = pick_capacity(m_size);
+      reallocate(n);
+    }
+
+    void resize(size_t n) {
+      if (n >= m_size) {
+        reserve(n);
+        std::uninitialized_default_construct(ptr(m_size), ptr(n));
+      }
+      m_size = n;
+    }
+
+    void push_back(const T& object) {
+      reserve(m_size + 1);
+      *ptr(m_size++) = object;
+    }
+
+    void push_back(T&& object) {
+      reserve(m_size + 1);
+      *ptr(m_size++) = std::move(object);
+    }
+
+    template<typename... Args>
+    void emplace_back(Args... args) {
+      reserve(m_size + 1);
+      *ptr(m_size++) = T(std::forward<Args>(args)...);
+    }
+
+    void erase(size_t idx) {
+      if (idx < m_size)
+        std::memmove(ptr(idx), ptr(idx + 1), (m_size - idx) * sizeof(T));
+      m_size -= 1;
+    }
+
+    void insert(const T* pos, const T* begin, const T* end) {
+      if (begin == end)
+        return;
+
+      size_t off = pos - ptr(0);
+      size_t size = m_size;
+      size_t count = (end - begin);
+      resize(size + count);
+
+      if (off < size)
+        std::memmove(ptr(off) + count, ptr(off),
+                     (size - off) * sizeof(T));
+      std::memcpy(ptr(off), begin, count * sizeof(T));
+    }
+
+    void pop_back() { m_size--; }
+
+    void clear() { m_size = 0; }
+
+    size_t size() const { return m_size; }
+
+    const T* data() const { return ptr(0); }
+          T* data()       { return ptr(0); }
+
+    const T* begin() const { return ptr(0); }
+          T* begin()       { return ptr(0); }
+
+    const T* end() const { return ptr(m_size); }
+          T* end()       { return ptr(m_size); }
+
+          T& operator [] (size_t idx)       { return *ptr(idx); }
+    const T& operator [] (size_t idx) const { return *ptr(idx); }
+
+          T& front()       { return *ptr(0); }
+    const T& front() const { return *ptr(0); }
+
+          T& back()       { return *ptr(m_size - 1); }
+    const T& back() const { return *ptr(m_size - 1); }
+
+  private:
+
+    pointer_type m_ptr = nullptr;
+    size_t       m_size = 0;
+    size_t       m_capacity = 0;
+
+    size_t pick_capacity(size_t n) {
+      size_t capacity = m_capacity;
+      if (capacity < 128)
+        capacity = 128;
+
+      while (capacity < n)
+        capacity *= 2;
+
+      return capacity;
+    }
+
+    void reallocate(size_t n) {
+      void* ptr = std::realloc(m_ptr.get(), n * sizeof(T));
+      m_ptr.release();
+      m_ptr.reset(static_cast<T*>(ptr));
+      m_capacity = n;
+    }
+
+    T* ptr(size_t idx) {
+      return reinterpret_cast<T*>(m_ptr.get()) + idx;
+    }
+
+    const T* ptr(size_t idx) const {
+      return reinterpret_cast<const T*>(m_ptr.get()) + idx;
+    }
+
+  };
+
+}


### PR DESCRIPTION
While working on Dishonored 2 stalls I spent some time optimizing the SPIRV shader compilation and ended up with this. It's not solving anything with the game stalls (which are because of new pipeline compilation during gameplay), but I could measure the game initial loading time going from ~10s to ~6s.

Feel free to take it or reject, I'd completely understand if that's not a super high priority as shader compilation is slow anyway and only supposed to happen during loading times.