### PR TITLE
[meta] Restore .a files removal on non-devbuilds.

### DIFF
--- a/package-release.sh
+++ b/package-release.sh
@@ -61,6 +61,8 @@ function build_arch {
   ninja install
 
   if [ $opt_devbuild -eq 0 ]; then
+    # get rid of some useless .a files
+    rm "$DXVK_BUILD_DIR/x$1/"*.!(dll)
     rm -R "$DXVK_BUILD_DIR/build.$1"
   fi
 }


### PR DESCRIPTION
This was -supposedly mistakenly- removed with 436357e28096f5e1e25aa8b72fceb77123ea8404