### PR TITLE
[d3d9] Fix swapchain surface refs once and for all

### DIFF
--- a/src/d3d9/d3d9_surface.cpp
+++ b/src/d3d9/d3d9_surface.cpp
@@ -30,7 +30,7 @@ namespace dxvk {
         pBaseTexture,
         pBaseTexture) { }
 
-  void D3D9Surface::AddRefPrivate(bool swapchain) {
+  void D3D9Surface::AddRefPrivate() {
     if (m_baseTexture != nullptr) {
       D3DRESOURCETYPE type = m_baseTexture->GetType();
       if (type == D3DRTYPE_TEXTURE)
@@ -40,15 +40,11 @@ namespace dxvk {
 
       return;
     }
-    else if (m_container != nullptr && !swapchain) {
-      // Container must be a swapchain if it isn't a base texture.
-      static_cast<D3D9SwapChainEx*>(m_container)->AddRefPrivate();
-    }
 
     D3D9SurfaceBase::AddRefPrivate();
   }
 
-  void D3D9Surface::ReleasePrivate(bool swapchain) {
+  void D3D9Surface::ReleasePrivate() {
     if (m_baseTexture != nullptr) {
       D3DRESOURCETYPE type = m_baseTexture->GetType();
       if (type == D3DRTYPE_TEXTURE)
@@ -57,10 +53,6 @@ namespace dxvk {
         static_cast<D3D9TextureCube*>(m_baseTexture)->ReleasePrivate();
 
       return;
-    }
-    else if (m_container != nullptr && !swapchain) {
-      // Container must be a swapchain if it isn't a base texture.
-      static_cast<D3D9SwapChainEx*>(m_container)->ReleasePrivate();
     }
 
     D3D9SurfaceBase::ReleasePrivate();
@@ -186,6 +178,11 @@ namespace dxvk {
       return hr;
 
     return D3D_OK;
+  }
+
+
+  void D3D9Surface::ClearContainer() {
+    m_container = nullptr;
   }
 
 }

--- a/src/d3d9/d3d9_surface.h
+++ b/src/d3d9/d3d9_surface.h
@@ -29,9 +29,9 @@ namespace dxvk {
             UINT                      MipLevel,
             IDirect3DBaseTexture9*    pBaseTexture);
 
-    void AddRefPrivate(bool swapchain = false);
+    void AddRefPrivate();
 
-    void ReleasePrivate(bool swapchain = false);
+    void ReleasePrivate();
 
     HRESULT STDMETHODCALLTYPE QueryInterface(REFIID riid, void** ppvObject);
 
@@ -55,6 +55,8 @@ namespace dxvk {
         std::max(1u, desc->Height >> GetMipLevel())
       };
     }
+
+    void ClearContainer();
 
   private:
 

--- a/src/d3d9/d3d9_swapchain.h
+++ b/src/d3d9/d3d9_swapchain.h
@@ -129,7 +129,7 @@ namespace dxvk {
     DxvkLogicOpState        m_loState;
     DxvkBlendMode           m_blendMode;
 
-    std::vector<D3D9Surface*> m_backBuffers;
+    std::vector<Com<D3D9Surface, false>> m_backBuffers;
     
     RECT                    m_srcRect;
     RECT                    m_dstRect;


### PR DESCRIPTION
The refcounting for d3d9 swapchain surfaces is very funny.
They don't actually hold any form of reference to their parent, unlike the surface->texture relationship.

When a swapchain is destroyed, the surfaces become orphans (like offscreen rendertargets) if they are still reffed.

Calling GetContainer on them when orphaned will return E_NOINTERFACE and nullptr for __uuidof(IDirect3DSwapChain)

Fixes some potential lingering refs on the device.