### PR TITLE
[d3d9] Allow D3DFMT_NULL as RenderTargetFormat in CheckDepthStencilMatch

### DIFF
--- a/src/d3d9/d3d9_adapter.cpp
+++ b/src/d3d9/d3d9_adapter.cpp
@@ -217,6 +217,9 @@ namespace dxvk {
     if (!IsDepthFormat(DepthStencilFormat))
       return D3DERR_NOTAVAILABLE;
 
+    if (RenderTargetFormat == dxvk::D3D9Format::NULL_FORMAT)
+      return D3D_OK;
+
     auto mapping = ConvertFormatUnfixed(RenderTargetFormat);
     if (mapping.FormatColor == VK_FORMAT_UNDEFINED)
       return D3DERR_NOTAVAILABLE;


### PR DESCRIPTION
This partially fixes shadows in Timeshift.