### PR TITLE
[d3d9] Only allow ColorFill on surfaces in D3DPOOL_DEFAULT

### DIFF
--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -1035,6 +1035,9 @@ namespace dxvk {
 
     D3D9CommonTexture* dstTextureInfo = dst->GetCommonTexture();
 
+    if (unlikely(dstTextureInfo->Desc()->Pool != D3DPOOL_DEFAULT))
+      return D3DERR_INVALIDCALL;
+
     VkExtent3D mipExtent = dstTextureInfo->GetExtentMip(dst->GetSubresource());
 
     VkOffset3D offset = VkOffset3D{ 0u, 0u, 0u };


### PR DESCRIPTION
Both nine and native nvidia d3d9 seems to do this,
this fixes a crash in spacemail by xplsv.