### PR TITLE
[dxvk] Fix fb resolve offset

### DIFF
--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -943,12 +943,12 @@ namespace dxvk {
         return D3DERR_INVALIDCALL;
     }
 
-    auto EmitResolveCS = [&](const Rc<DxvkImage>& resolveDst) {
+    auto EmitResolveCS = [&](const Rc<DxvkImage>& resolveDst, bool intermediate) {
       VkImageResolve region;
       region.srcSubresource = blitInfo.srcSubresource;
       region.srcOffset      = blitInfo.srcOffsets[0];
-      region.dstSubresource = blitInfo.dstSubresource;
-      region.dstOffset      = blitInfo.dstOffsets[0];
+      region.dstSubresource = intermediate ? blitInfo.srcSubresource : blitInfo.dstSubresource;
+      region.dstOffset      = intermediate ? blitInfo.srcOffsets[0]  : blitInfo.dstOffsets[0];
       region.extent         = srcCopyExtent;
 
       EmitCs([
@@ -972,7 +972,7 @@ namespace dxvk {
 
     if (fastPath) {
       if (needsResolve) {
-        EmitResolveCS(dstImage);
+        EmitResolveCS(dstImage, false);
       } else {
         EmitCs([
           cDstImage  = dstImage,
@@ -994,7 +994,7 @@ namespace dxvk {
       if (needsResolve) {
         auto resolveSrc = srcTextureInfo->GetResolveImage();
 
-        EmitResolveCS(resolveSrc);
+        EmitResolveCS(resolveSrc, true);
         srcImage = resolveSrc;
       }
 

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -3352,8 +3352,8 @@ namespace dxvk {
     
     // Perform the actual resolve operation
     VkOffset2D srcOffset = {
-      region.srcOffset.x,
-      region.srcOffset.y };
+      region.srcOffset.x - region.dstOffset.x,
+      region.srcOffset.y - region.dstOffset.y };
     
     m_cmd->cmdBeginRenderPass(&info, VK_SUBPASS_CONTENTS_INLINE);
     m_cmd->cmdBindPipeline(VK_PIPELINE_BIND_POINT_GRAPHICS, pipeInfo.pipeHandle);


### PR DESCRIPTION
gl_FragCoord is read in the fs shader, so we need to take into account the dstOffset here!