### PR TITLE
[vulkan] Don't use more images than necessary

### DIFF
--- a/src/vulkan/vulkan_presenter.cpp
+++ b/src/vulkan/vulkan_presenter.cpp
@@ -430,7 +430,7 @@ namespace dxvk::vk {
           uint32_t                  desired) {
     uint32_t count = caps.minImageCount;
     
-    if (presentMode != VK_PRESENT_MODE_IMMEDIATE_KHR)
+    if (presentMode == VK_PRESENT_MODE_MAILBOX_KHR)
       count = caps.minImageCount + 1;
     
     if (count < desired)


### PR DESCRIPTION
The +1 doesn't make sense for FIFO swapchains, because they behave
similarly to IMMEDIATE in that only one backbuffer is required. The
extra image only really makes sense for MAILBOX swapchains, because they
need an extra backbuffer to support flipping back and forth.

This improves latency by one frame when vsync is enabled.