### PR TITLE
[d3d9] Implicitly discard managed buffers to avoid stalls

### DIFF
--- a/src/d3d9/d3d9_buffer.h
+++ b/src/d3d9/d3d9_buffer.h
@@ -33,6 +33,10 @@ namespace dxvk {
       return m_buffer.Unlock();
     }
 
+    void STDMETHODCALLTYPE PreLoad() final {
+      m_buffer.PreLoad();
+    }
+
     D3D9CommonBuffer* GetCommonBuffer() {
       return &m_buffer;
     }

--- a/src/d3d9/d3d9_common_buffer.cpp
+++ b/src/d3d9/d3d9_common_buffer.cpp
@@ -50,6 +50,16 @@ namespace dxvk {
   }
 
 
+  void D3D9CommonBuffer::PreLoad() {
+    if (IsPoolManaged(m_desc.Pool)) {
+      auto lock = m_parent->LockDevice();
+
+      if (NeedsUpload())
+        m_parent->FlushBuffer(this);
+    }
+  }
+
+
   Rc<DxvkBuffer> D3D9CommonBuffer::CreateBuffer() const {
     DxvkBufferCreateInfo  info;
     info.size   = m_desc.Size;

--- a/src/d3d9/d3d9_common_buffer.h
+++ b/src/d3d9/d3d9_common_buffer.h
@@ -163,6 +163,8 @@ namespace dxvk {
       return locked;
     }
 
+    void PreLoad();
+
   private:
 
     Rc<DxvkBuffer> CreateBuffer() const;

--- a/src/d3d9/d3d9_common_texture.cpp
+++ b/src/d3d9/d3d9_common_texture.cpp
@@ -465,6 +465,27 @@ namespace dxvk {
   }
 
 
+  void D3D9CommonTexture::PreLoadAll() {
+    if (IsManaged()) {
+      auto lock = m_device->LockDevice();
+
+      m_device->UploadManagedTexture(this);
+    }
+  }
+
+
+  void D3D9CommonTexture::PreLoadSubresource(UINT Subresource) {
+    if (IsManaged()) {
+      auto lock = m_device->LockDevice();
+
+      if (GetNeedsUpload(Subresource)) {
+        m_device->FlushImage(this, Subresource);
+        SetNeedsUpload(Subresource, false);
+      }
+    }
+  }
+
+
   void D3D9CommonTexture::CreateSampleView(UINT Lod) {
     // This will be a no-op for SYSTEMMEM types given we
     // don't expose the cap to allow texturing with them.

--- a/src/d3d9/d3d9_common_texture.cpp
+++ b/src/d3d9/d3d9_common_texture.cpp
@@ -466,11 +466,12 @@ namespace dxvk {
 
 
   void D3D9CommonTexture::PreLoadAll() {
-    if (IsManaged()) {
-      auto lock = m_device->LockDevice();
+    if (!IsManaged())
+      return;
 
-      m_device->UploadManagedTexture(this);
-    }
+    auto lock = m_device->LockDevice();
+    m_device->UploadManagedTexture(this);
+    m_device->MarkTextureUploaded(this);
   }
 
 
@@ -481,6 +482,9 @@ namespace dxvk {
       if (GetNeedsUpload(Subresource)) {
         m_device->FlushImage(this, Subresource);
         SetNeedsUpload(Subresource, false);
+
+        if (!NeedsAnyUpload())
+          m_device->MarkTextureUploaded(this);
       }
     }
   }

--- a/src/d3d9/d3d9_common_texture.h
+++ b/src/d3d9/d3d9_common_texture.h
@@ -350,10 +350,6 @@ namespace dxvk {
             bool                   Srgb);
     D3D9SubresourceBitset& GetUploadBitmask() { return m_needsUpload; }
 
-    void SetUploading(UINT Subresource, bool uploading) { m_uploading.set(Subresource, uploading); }
-    void ClearUploading() { m_uploading.clearAll(); }
-    bool GetUploading(UINT Subresource) const { return m_uploading.get(Subresource); }
-
     void SetNeedsUpload(UINT Subresource, bool upload) { m_needsUpload.set(Subresource, upload); }
     bool GetNeedsUpload(UINT Subresource) const        { return m_needsUpload.get(Subresource); }
     bool NeedsAnyUpload() { return m_needsUpload.any(); }
@@ -404,7 +400,6 @@ namespace dxvk {
 
     D3D9SubresourceBitset         m_dirty = { };
 
-    D3D9SubresourceBitset         m_uploading = { };
     D3D9SubresourceBitset         m_needsUpload = { };
 
     DWORD                         m_exposedMipLevels = 0;

--- a/src/d3d9/d3d9_common_texture.h
+++ b/src/d3d9/d3d9_common_texture.h
@@ -355,6 +355,7 @@ namespace dxvk {
     bool GetUploading(UINT Subresource) const { return m_uploading.get(Subresource); }
 
     void SetNeedsUpload(UINT Subresource, bool upload) { m_needsUpload.set(Subresource, upload); }
+    bool GetNeedsUpload(UINT Subresource) const        { return m_needsUpload.get(Subresource); }
     bool NeedsAnyUpload() { return m_needsUpload.any(); }
     void ClearNeedsUpload() { return m_needsUpload.clearAll();  }
 
@@ -365,6 +366,9 @@ namespace dxvk {
 
     void SetMipFilter(D3DTEXTUREFILTERTYPE filter) { m_mipFilter = filter; }
     D3DTEXTUREFILTERTYPE GetMipFilter() const { return m_mipFilter; }
+
+    void PreLoadAll();
+    void PreLoadSubresource(UINT Subresource);
 
   private:
 

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -3988,16 +3988,13 @@ namespace dxvk {
       // calling app promises not to overwrite data that is in use
       // or is reading. Remember! This will only trigger for MANAGED resources
       // that cannot get affected by GPU, therefore readonly is A-OK for NOT waiting.
-      const bool uploading = pResource->GetUploading(Subresource);
-      const bool skipWait = (managed && !uploading) || (readOnly && managed) || scratch || (readOnly && systemmem && !dirty);
+      const bool skipWait = (readOnly && managed) || scratch || (readOnly && systemmem && !dirty);
 
       if (alloced)
         std::memset(physSlice.mapPtr, 0, physSlice.length);
       else if (!skipWait) {
         if (!WaitForResource(mappedBuffer, Flags))
           return D3DERR_WASSTILLDRAWING;
-
-        pResource->ClearUploading();
       }
     }
     else {
@@ -4188,8 +4185,6 @@ namespace dxvk {
       subresource.arrayLayer, 1 };
 
     auto convertFormat = pResource->GetFormatMapping().ConversionFormatInfo;
-
-    pResource->SetUploading(Subresource, true);
 
     if (likely(convertFormat.FormatType == D3D9ConversionFormat_None)) {
       EmitCs([

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -4219,6 +4219,9 @@ namespace dxvk {
 
   void D3D9DeviceEx::EmitGenerateMips(
     D3D9CommonTexture* pResource) {
+    if (pResource->IsManaged())
+      UploadManagedTexture(pResource);
+
     EmitCs([
       cImageView = pResource->GetSampleView(false),
       cFilter    = pResource->GetMipFilter()

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -758,6 +758,8 @@ namespace dxvk {
 
     void MarkTextureMipsUnDirty(D3D9CommonTexture* pResource);
 
+    void MarkTextureUploaded(D3D9CommonTexture* pResource);
+
     template <bool Points>
     void UpdatePointMode();
 

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -748,6 +748,8 @@ namespace dxvk {
 
     void MarkRenderHazards();
 
+    void UploadManagedTexture(D3D9CommonTexture* pResource);
+
     void UploadManagedTextures(uint32_t mask);
 
     void GenerateTextureMips(uint32_t mask);

--- a/src/d3d9/d3d9_resource.h
+++ b/src/d3d9/d3d9_resource.h
@@ -70,9 +70,6 @@ namespace dxvk {
       return m_priority;
     }
 
-    void STDMETHODCALLTYPE PreLoad() {
-    }
-
 
   protected:
 

--- a/src/d3d9/d3d9_subresource.h
+++ b/src/d3d9/d3d9_subresource.h
@@ -52,6 +52,10 @@ namespace dxvk {
       return this->GetDevice()->QueryInterface(riid, ppContainer);
     }
 
+    void STDMETHODCALLTYPE PreLoad() {
+      m_texture->PreLoadSubresource(GetSubresource());
+    }
+
     D3D9CommonTexture* GetCommonTexture() {
       return m_texture;
     }

--- a/src/d3d9/d3d9_texture.h
+++ b/src/d3d9/d3d9_texture.h
@@ -80,6 +80,7 @@ namespace dxvk {
       auto lock = this->m_parent->LockDevice();
 
       m_texture.SetMipFilter(FilterType);
+      this->m_parent->MarkTextureMipsDirty(&m_texture);
       return D3D_OK;
     }
 

--- a/src/d3d9/d3d9_texture.h
+++ b/src/d3d9/d3d9_texture.h
@@ -77,6 +77,8 @@ namespace dxvk {
       if (unlikely(FilterType == D3DTEXF_NONE))
         return D3DERR_INVALIDCALL;
 
+      auto lock = this->m_parent->LockDevice();
+
       m_texture.SetMipFilter(FilterType);
       return D3D_OK;
     }
@@ -88,6 +90,8 @@ namespace dxvk {
     void STDMETHODCALLTYPE GenerateMipSubLevels() final {
       if (!m_texture.NeedsMipGen())
         return;
+
+      auto lock = this->m_parent->LockDevice();
 
       this->m_parent->MarkTextureMipsUnDirty(&m_texture);
       this->m_parent->EmitGenerateMips(&m_texture);

--- a/src/d3d9/d3d9_texture.h
+++ b/src/d3d9/d3d9_texture.h
@@ -93,6 +93,10 @@ namespace dxvk {
       this->m_parent->EmitGenerateMips(&m_texture);
     }
 
+    void STDMETHODCALLTYPE PreLoad() final {
+      m_texture.PreLoadAll();
+    }
+
     D3D9CommonTexture* GetCommonTexture() {
       return &m_texture;
     }


### PR DESCRIPTION
I did some further investigating about the GH3 performance problem and tried the following:
- relying on the game to call PreLoad()
- flushing all managed textures & buffers on present
- flushing all managed textures & buffers before every draw call (Nine works that way)

Neither of those fixed the problem. Then I tried discarding managed buffers when they are currently in use and that did the trick.

Looks like Nine does something similar.
When flushing managed textures it calls `NineSurface9_UploadSelf` (https://github.com/anholt/mesa/blob/master/src/gallium/state_trackers/nine/basetexture9.c#L271).
This uses `nine_context_box_upload` (https://github.com/mesa3d/mesa/blob/master/src/gallium/frontends/nine/surface9.c#L774) which basically does a map with discard. (https://github.com/mesa3d/mesa/blob/a887ad7c84e14fdad7907037a39e9fee9d504bf3/src/gallium/frontends/nine/nine_state.c#L2531)

The changes are based on Joshs `PreLoad` implementation. (I made some changes to the last commit to IMO clean it up a little.)

Memory usage might be a problem with this approach. That's why I check if the mapped buffer is getting used atm before doing it. For most games this should hopefully result in the exact same behavior as before.
We could however restrict this to small mapping buffers but GH3 would need a limit of at least 61KB.

Risen for example (hi @DadSchoorse) doesn't discard any mapping buffers at all with those changes.
A Hat in Time discarded two buffers (in like 10 minutes of play time) with both only going up to 2 slices. One was 6.4kb, the other one 23kb.
