### PR TITLE
 [util] Enable d3d11.invariantPosition for Borderlands 3 and Terminator: Resistance 

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -205,6 +205,10 @@ namespace dxvk {
     { R"(\\Stars End\.exe$)", {{
       { "d3d11.enableRtOutputNanFixup",     "True" },
     }} },
+    /* Borderlands 3                              */
+    { R"(\\Borderlands3\.exe$)", {{
+      { "d3d11.invariantPosition",          "True" },
+    }} },
 
     /**********************************************/
     /* D3D9 GAMES                                 */

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -209,6 +209,10 @@ namespace dxvk {
     { R"(\\Borderlands3\.exe$)", {{
       { "d3d11.invariantPosition",          "True" },
     }} },
+    /* Terminator: Resistance                     */
+    { R"(\\Terminator-Win64-Shipping\.exe$)", {{
+      { "d3d11.invariantPosition",          "True" },
+    }} },
 
     /**********************************************/
     /* D3D9 GAMES                                 */


### PR DESCRIPTION
Seems to resolve https://gitlab.freedesktop.org/mesa/mesa/-/issues/2608