### PR TITLE
[util] Enable d3d11.invariantPosition for Star Wars Jedi: Fallen Order

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -213,6 +213,10 @@ namespace dxvk {
     { R"(\\Terminator-Win64-Shipping\.exe$)", {{
       { "d3d11.invariantPosition",          "True" },
     }} },
+    /* Star Wars Jedi: Fallen Order               */
+    { R"(\\starwarsjedifallenorder\.exe$)", {{
+      { "d3d11.invariantPosition",          "True" },
+    }} },
 
     /**********************************************/
     /* D3D9 GAMES                                 */


### PR DESCRIPTION
I'm starting to think that it might be a driver bug after all, but I have no time to investigate further now. Maybe we will revisit this in the future.