### PR TITLE
[d3d9] Only force AF on textures with mipmaps.

### DIFF
--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -3583,6 +3583,9 @@ namespace dxvk {
 
     UpdateActiveTextures(StateSampler, combinedUsage);
 
+    if (m_d3d9Options.samplerAnisotropy != -1)
+      m_dirtySamplerStates |= 1u << StateSampler;
+
     return D3D_OK;
   }
 
@@ -5480,11 +5483,17 @@ namespace dxvk {
     key.BorderColor   = D3DCOLOR(state[D3DSAMP_BORDERCOLOR]);
 
     if (m_d3d9Options.samplerAnisotropy != -1) {
-      if (key.MagFilter == D3DTEXF_LINEAR)
-        key.MagFilter = D3DTEXF_ANISOTROPIC;
+      DWORD level = 0;
+      if (m_state.textures[Sampler])
+        level = m_state.textures[Sampler]->GetLevelCount();
 
-      if (key.MinFilter == D3DTEXF_LINEAR)
-        key.MinFilter = D3DTEXF_ANISOTROPIC;
+      if (level > 1) {
+        if (key.MagFilter == D3DTEXF_LINEAR)
+          key.MagFilter = D3DTEXF_ANISOTROPIC;
+
+        if (key.MinFilter == D3DTEXF_LINEAR)
+          key.MinFilter = D3DTEXF_ANISOTROPIC;
+      }
 
       key.MaxAnisotropy = m_d3d9Options.samplerAnisotropy;
     }


### PR DESCRIPTION
This fixes some visual artifacts (#1666) on nvidia with UE3 when
anisotropic filtering is enabled through d3d9.samplerAnisotropy.