### PR TITLE
[util] Disable DF24 support for Borderlands 2

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -227,13 +227,10 @@ namespace dxvk {
       { "d3d9.strictPow",                   "False" },
       { "d3d9.lenientClear",                "True" },
     }} },
-    /* Borderlands: The Pre Sequel!               */
-    { R"(\\BorderlandsPreSequel\.exe$)", {{
+    /* Borderlands 2 and The Pre Sequel!           */
+    { R"(\\Borderlands(2|PreSequel)\.exe$)", {{
       { "d3d9.lenientClear",                "True" },
-    }} },
-    /* Borderlands 2                              */
-    { R"(\\Borderlands2\.exe$)", {{
-      { "d3d9.lenientClear",                "True" },
+      { "d3d9.supportDFFormats",            "False" },
     }} },
     /* Borderlands                                */
     { R"(\\Borderlands\.exe$)", {{


### PR DESCRIPTION
and The Pre Sequel! This fixes #1674 

This render path seems to be broken, the game itself actually disables DF24 support when running on AMD. The windows Intel drivers has an app profile to disable it so the same should be done here.