### PR TITLE
[util] Enable d3d11.invariantPosition for Mafia III: Definitive Edition

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -217,6 +217,10 @@ namespace dxvk {
     { R"(\\starwarsjedifallenorder\.exe$)", {{
       { "d3d11.invariantPosition",          "True" },
     }} },
+    /* Mafia III: Definitive Edition              */
+    { R"(\\Mafia3DefinitiveEdition\.exe$)", {{
+      { "d3d11.invariantPosition",          "True" },
+    }} },
 
     /**********************************************/
     /* D3D9 GAMES                                 */


### PR DESCRIPTION
This fixes rendering of the vegetation on RADV as reported here: https://gitlab.freedesktop.org/mesa/mesa/-/issues/2768

Note: Some users might renamed Mafia3DefinitiveEdition.exe to Launcher.exe to circumvent the appearance of the buggy game launcher. In this case this patch doesn't work. A workaround might be the following line in game launch options: ~/.steam/root/steamapps/common/'Proton 5.0'/proton waitforexitandrun ~/.steam/root/steamapps/common/'Mafia III'/Mafia3DefinitiveEdition.exe; echo %command%

Signed-off-by: Gregor Münch <gr.muench@gmail.com>