### PR TITLE
[d3d9] Avoid device local memory for big dynamic buffers + dynamic texture dirty flag fix

### DIFF
--- a/src/d3d9/d3d9_common_buffer.cpp
+++ b/src/d3d9/d3d9_common_buffer.cpp
@@ -92,10 +92,12 @@ namespace dxvk {
 
       if (!(m_desc.Usage & D3DUSAGE_WRITEONLY))
         info.access |= VK_ACCESS_HOST_READ_BIT;
-        
+
       memoryFlags |= VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT
-                  |  VK_MEMORY_PROPERTY_HOST_COHERENT_BIT
-                  |  VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
+                  |  VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
+
+      if (m_desc.Size <= DeviceLocalThreshold)
+        memoryFlags |= VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
     }
     else {
       info.stages |= VK_PIPELINE_STAGE_TRANSFER_BIT;

--- a/src/d3d9/d3d9_common_buffer.h
+++ b/src/d3d9/d3d9_common_buffer.h
@@ -68,6 +68,7 @@ namespace dxvk {
 
   class D3D9CommonBuffer {
     static constexpr VkDeviceSize BufferSliceAlignment = 64;
+    static constexpr VkDeviceSize DeviceLocalThreshold = 4096;
   public:
 
     D3D9CommonBuffer(


### PR DESCRIPTION
Fixes #1685
Fixes #1682

Tomb Raider Legend writes 1.3MB of data at the beginning of every frame to a couple of dynamic buffers.
(6 IndexBuffers with a size of 131070 bytes and one 524288 byte VertexBuffer)

DXVK currently puts those buffers into device local memory so this is very slow. I've changed it so DXVK only puts buffers into device local memory when they are smaller than 4KB. This value is a blind guess.

Even though it wasn't actually an issue with TR-Legend, I think the original commit is still useful because I couldn't find anything that says you're not allowed to render to USAGE_DYNAMIC textures. So we need to mark it as dirty anyway to copy it back to the mapping buffer on the next lock operation.

