### PR TITLE
[dxgi] Add dxgi.customDeviceDesc option

### DIFF
--- a/src/dxgi/dxgi_adapter.cpp
+++ b/src/dxgi/dxgi_adapter.cpp
@@ -242,13 +242,23 @@ namespace dxvk {
     auto memoryProp = m_adapter->memoryProperties();
     auto deviceId   = m_adapter->devicePropertiesExt().coreDeviceId;
     
-    // Custom Vendor / Device ID
+    // Custom Vendor / Device ID / Description
     if (options->customVendorId >= 0)
       deviceProp.vendorID = options->customVendorId;
     
     if (options->customDeviceId >= 0)
       deviceProp.deviceID = options->customDeviceId;
     
+    if (!options->customDeviceDesc.empty())
+      #ifdef __GNUC__
+      #pragma GCC diagnostic push
+      #pragma GCC diagnostic ignored "-Wstringop-truncation"
+      #endif // __GNUC__
+      std::strncpy(deviceProp.deviceName, options->customDeviceDesc.c_str(), sizeof(deviceProp.deviceName));
+      #ifdef __GNUC__
+      #pragma GCC diagnostic pop
+      #endif // __GNUC__
+
     // XXX nvapi workaround for a lot of Unreal Engine 4 games
     if (options->customVendorId < 0 && options->customDeviceId < 0
      && options->nvapiHack && deviceProp.vendorID == uint16_t(DxvkGpuVendor::Nvidia)) {

--- a/src/dxgi/dxgi_adapter.cpp
+++ b/src/dxgi/dxgi_adapter.cpp
@@ -250,14 +250,7 @@ namespace dxvk {
       deviceProp.deviceID = options->customDeviceId;
     
     if (!options->customDeviceDesc.empty())
-      #ifdef __GNUC__
-      #pragma GCC diagnostic push
-      #pragma GCC diagnostic ignored "-Wstringop-truncation"
-      #endif // __GNUC__
-      std::strncpy(deviceProp.deviceName, options->customDeviceDesc.c_str(), sizeof(deviceProp.deviceName));
-      #ifdef __GNUC__
-      #pragma GCC diagnostic pop
-      #endif // __GNUC__
+      std::strncpy(deviceProp.deviceName, options->customDeviceDesc.c_str(), sizeof(deviceProp.deviceName) - 1);
 
     // XXX nvapi workaround for a lot of Unreal Engine 4 games
     if (options->customVendorId < 0 && options->customDeviceId < 0

--- a/src/dxgi/dxgi_options.cpp
+++ b/src/dxgi/dxgi_options.cpp
@@ -31,6 +31,7 @@ namespace dxvk {
     // Fetch these as a string representing a hexadecimal number and parse it.
     this->customVendorId = parsePciId(config.getOption<std::string>("dxgi.customVendorId"));
     this->customDeviceId = parsePciId(config.getOption<std::string>("dxgi.customDeviceId"));
+    this->customDeviceDesc = config.getOption<std::string>("dxgi.customDeviceDesc");
     
     // Interpret the memory limits as Megabytes
     this->maxDeviceMemory = VkDeviceSize(config.getOption<int32_t>("dxgi.maxDeviceMemory", 0)) << 20;

--- a/src/dxgi/dxgi_options.h
+++ b/src/dxgi/dxgi_options.h
@@ -22,6 +22,7 @@ namespace dxvk {
     /// on a different GPU than they do and behave differently.
     int32_t customVendorId;
     int32_t customDeviceId;
+    std::string customDeviceDesc;
     
     /// Override maximum reported VRAM size. This may be
     /// useful for some 64-bit games which do not support


### PR DESCRIPTION
I thought also thought of setting RX 480 for NvAPI workaround but because that's enabled by default some people would be confused by games showing RX 480 on NVIDIA hardware