### PR TITLE
[build] fix clang errors

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -17,6 +17,15 @@ if dxvk_compiler.get_id() == 'msvc'
   add_project_arguments('/std:' + dxvk_cpp_std, language : 'cpp')
 endif
 
+if dxvk_compiler.get_id() == 'clang'
+  if dxvk_compiler.has_argument('-Wno-unused-private-field')
+    add_project_arguments('-Wno-unused-private-field', language: 'cpp')
+  endif
+  if dxvk_compiler.has_argument('-Wno-microsoft-exception-spec')
+    add_project_arguments('-Wno-microsoft-exception-spec', language: 'cpp')
+  endif
+endif
+
 dxvk_include_path = include_directories('./include')
 
 if (cpu_family == 'x86_64')

--- a/src/d3d9/d3d9_swvp_emu.h
+++ b/src/d3d9/d3d9_swvp_emu.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <unordered_map>
+
 #include "d3d9_include.h"
 
 #include "../dxvk/dxvk_shader.h"


### PR DESCRIPTION
  File changes:

  * meson.build: add -Wno-unused-private-field and -Wno-microsoft-exception-spec option to suppress clang compiler warnings
  * d3d9/d3d9_swvp_emu.h: include unordered_map for std::unordered_map
