### PR TITLE
[util] Enable d3d9.memoryTrackTest for Anarchy Online

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -231,6 +231,10 @@ namespace dxvk {
       { "d3d9.strictPow",                   "False" },
       { "d3d9.lenientClear",                "True" },
     }} },
+    /* Anarchy Online                             */
+    { R"(\\anarchyonline\.exe$)", {{
+      { "d3d9.memoryTrackTest",             "True" },
+    }} },
     /* Borderlands 2 and The Pre Sequel!           */
     { R"(\\Borderlands(2|PreSequel)\.exe$)", {{
       { "d3d9.lenientClear",                "True" },


### PR DESCRIPTION
Prevents the game from consuming all system memory.

Signed-off-by: Kevin Schmidt <kevin.patrick.schmidt@googlemail.com>