### PR TITLE
[build] Add ccache support

### DIFF
--- a/build-win32-ccache.txt
+++ b/build-win32-ccache.txt
@@ -1,0 +1,3 @@
+[binaries]
+c = ['ccache', 'i686-w64-mingw32-gcc']
+cpp = ['ccache', 'i686-w64-mingw32-g++']

--- a/build-win64-ccache.txt
+++ b/build-win64-ccache.txt
@@ -1,0 +1,3 @@
+[binaries]
+c = ['ccache', 'x86_64-w64-mingw32-gcc']
+cpp = ['ccache', 'x86_64-w64-mingw32-g++']

--- a/package-release.sh
+++ b/package-release.sh
@@ -23,6 +23,7 @@ shift 2
 
 opt_nopackage=0
 opt_devbuild=0
+opt_ccache=0
 
 crossfile="build-win"
 
@@ -34,6 +35,9 @@ while [ $# -gt 0 ]; do
   "--dev-build")
     opt_nopackage=1
     opt_devbuild=1
+    ;;
+  "--ccache")
+    opt_ccache=1
     ;;
   *)
     echo "Unrecognized option: $1" >&2
@@ -48,14 +52,18 @@ function build_arch {
   
   cd "$DXVK_SRC_DIR"
 
-  meson --cross-file "$DXVK_SRC_DIR/$crossfile$1.txt" \
-        --buildtype "release"                         \
-        --prefix "$DXVK_BUILD_DIR"                    \
-        --strip                                       \
-        --bindir "x$1"                                \
-        --libdir "x$1"                                \
-        -Denable_tests=false                          \
-        "$DXVK_BUILD_DIR/build.$1"
+  meson_args=(--cross-file "$DXVK_SRC_DIR/$crossfile$1.txt")
+  if [ $opt_ccache -eq 1 ]; then
+    meson_args+=(--cross-file "$DXVK_SRC_DIR/$crossfile$1-ccache.txt")
+  fi
+  meson_args+=(--buildtype "release"
+               --prefix "$DXVK_BUILD_DIR"
+               --strip
+               --bindir "x$1"
+               --libdir "x$1"
+               -Denable_tests=false
+               "$DXVK_BUILD_DIR/build.$1")
+  meson "${meson_args[@]}"
 
   cd "$DXVK_BUILD_DIR/build.$1"
   ninja install


### PR DESCRIPTION
Starting with meson 0.51 or so, it supports multiple `--cross-file` args and list values for `c` and `cpp` values in cross-files, so we can add supplementary cross-files that would override `c` and `cpp`, prepending `ccache` binary to actual compiler.
This adds a new option `--ccache` for `package-release.sh` to enable ccache.