### PR TITLE
[util] Enable d3d9.deferSurfaceCreation for Fairy Tail

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -168,6 +168,10 @@ namespace dxvk {
     { R"(\\Atelier_(Lulua|Lydie_and_Suelle|Ryza)\.exe$)", {{
       { "d3d9.deferSurfaceCreation",        "True" },
     }} },
+    /* Fairy Tail                                 */
+    { R"(\\FAIRY_TAIL\.exe$)", {{
+      { "d3d9.deferSurfaceCreation",        "True" },
+    }} },
     /* Star Wars Battlefront II: amdags issues    */
     { R"(\\starwarsbattlefrontii\.exe$)", {{
       { "dxgi.customVendorId",              "10de" },


### PR DESCRIPTION
Another KT game requires d3d9.deferSurfaceCreation enabled in order to display something other than a white screen