### PR TITLE
[util] Set enableRtOutputNaNFixup for Observation

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -225,6 +225,10 @@ namespace dxvk {
     { R"(\\Mafia3DefinitiveEdition\.exe$)", {{
       { "d3d11.invariantPosition",          "True" },
     }} },
+    /* Observation                                */
+    { R"(\\Observation\.exe$)", {{
+      { "d3d11.enableRtOutputNanFixup",     "True" },
+    }} },
 
     /**********************************************/
     /* D3D9 GAMES                                 */


### PR DESCRIPTION
Observation (906100) produces artifacts in certain scenes on RADV. Setting `enableRtOutputNaNFixup` to `True` in **_dxvk.conf_** file resolves those graphical issues.

This was reported by a Proton user: https://github.com/ValveSoftware/Proton/issues/3906

We confirmed this resolved the issue on a RX 580 and 5700 XT using Mesa Git (https://gitlab.freedesktop.org/mesa/mesa/-/commit/1938e2596f5110c81920a1ad5e5933ef3a007a99) as well as Kisak's PPA release (20.1.4\~kisak1\~f)

| RADV | RADV w/ enableRtOutputNaNFixup | Nvidia |
| ---- | ---- | ---- |
|![Observation - 906100 - ACO](https://user-images.githubusercontent.com/761853/89414664-cc893900-d6f8-11ea-890d-9ef14efe458b.png)|![Observation - 906100 - ACO with enableRtOutputNanFixup](https://user-images.githubusercontent.com/761853/89414693-d6ab3780-d6f8-11ea-9206-56b3141407e7.png)|![Observation - 906100 - Nvidia](https://user-images.githubusercontent.com/761853/89414754-eb87cb00-d6f8-11ea-8147-fd34b788eb51.png)|

Video: https://www.youtube.com/watch?v=8XMg5U-QIdM