### PR TITLE
[d3d9] Do Discard in UpdateSurface/-Texture when there were stalls for the source texture

### DIFF
--- a/src/d3d9/d3d9_common_texture.h
+++ b/src/d3d9/d3d9_common_texture.h
@@ -366,6 +366,19 @@ namespace dxvk {
     void PreLoadAll();
     void PreLoadSubresource(UINT Subresource);
 
+    bool IsStalling() const {
+      return m_stallFlag;
+    }
+
+    void NotifyLocked() {
+      m_stallMask <<= 1;
+    }
+
+    void NotifyStall() {
+      m_stallMask |= 1;
+      m_stallFlag |= bit::popcnt(m_stallMask) >= 4;
+    }
+
   private:
 
     D3D9DeviceEx*                 m_device;
@@ -405,6 +418,12 @@ namespace dxvk {
     bool                          m_needsMipGen = false;
 
     D3DTEXTUREFILTERTYPE          m_mipFilter = D3DTEXF_LINEAR;
+
+    /* Stall flags for D3DPOOL_SYSTEMMEM textures
+     * Once we detect enough stalls, future UpdateSurface/UpdateTexture
+     * calls will use do an additional copy of the src data */
+    uint32_t                      m_stallMask = 0;
+    bool                          m_stallFlag = false;
 
     /**
      * \brief Mip level

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -90,6 +90,12 @@ namespace dxvk {
     void*           mapPtr = nullptr;
   };
 
+  enum class D3D9WaitForResourceResult {
+    InUse,
+    Available,
+    AvailableStalled
+  };
+
   class D3D9DeviceEx final : public ComObjectClamp<IDirect3DDevice9Ex> {
     constexpr static uint32_t DefaultFrameLatency = 3;
     constexpr static uint32_t MaxFrameLatency     = 20;
@@ -663,7 +669,7 @@ namespace dxvk {
     DxvkFormatInfo UnsupportedFormatInfo(
       D3D9Format            Format) const;
 
-    bool WaitForResource(
+    D3D9WaitForResourceResult WaitForResource(
       const Rc<DxvkResource>&                 Resource,
             DWORD                             MapFlags);
 


### PR DESCRIPTION
Ref #1419

GTA IV locks the same D3DPOOL_SYSTEMMEMORY texture multiple times per frame without DISCARD or NOOVERWRITE and uses that to update multiple D3DPOOL_DEFAULT textures with UpdateTexture.
That means that we have to sync with the GPU and wait for the previous copies to finish on subsequent Lock calls.

The way to work around this is to make another copy of the data in UpdateTexture so we're free to overwrite anything in the source texture. I implemented this by doing a simple Lock(Discard), memcpy, unlock. That would however mean more CPU work which obviously isn't great for D3D9 games.

So we could:
* Just always do it like this.
* Add another config option and enable it specifically for GTA IV.
* Detect stalls on system memory textures and turn it on for those

I implemented option 3 as a POC here. Adding even more complexity to both locking and the texture class is pretty awful but so would be adding another config option. The actual implementation pretty much copies what you've done with queries except that I put the threshold much lower because it didnt trigger otherwise in apitrace.

My PR does a Discard Lock on the destination texture in UpdateTexture. Alternatively you could allocate a new slice for the source buffer in UpdateTexture or do the same thing in Lock similar to what we're doing for managed textures.