### PR TITLE
[d3d9] Do implicit discard when locking system memory resources

### DIFF
--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -4004,7 +4004,7 @@ namespace dxvk {
 
       if (alloced)
         std::memset(physSlice.mapPtr, 0, physSlice.length);
-      else if (managed && !skipWait) {
+      else if ((managed || systemmem) && !skipWait) {
         if (!WaitForResource(mappedBuffer, D3DLOCK_DONOTWAIT)) {
           // if the mapped buffer is currently being copied to image
           // we can just avoid a stall by allocating a new slice and copying the existing contents
@@ -4350,7 +4350,7 @@ namespace dxvk {
                             quickRead                     ||
                             (boundsCheck && !pResource->DirtyRange().Overlaps(pResource->LockRange()));
       if (!skipWait) {
-        if (IsPoolManaged(desc.Pool)) {
+        if (IsPoolManaged(desc.Pool) || desc.Pool == D3DPOOL_SYSTEMMEM) {
           if (!WaitForResource(mappingBuffer, D3DLOCK_DONOTWAIT)) {
             // if the mapped buffer is currently being copied to the primary buffer
             // we can just avoid a stall by allocating a new slice and copying the existing contents


### PR DESCRIPTION
Fixes #1419 
Superseeds #1713 

GTA IV locks the same D3DPOOL_SYSTEMMEMORY texture multiple times per frame without DISCARD or NOOVERWRITE and uses that to update multiple D3DPOOL_DEFAULT textures with UpdateTexture.
That means that we have to sync with the GPU and wait for the previous copies to finish on subsequent Lock calls.

This PR extends the implicit discard we do for managed resources to system memory resources. So if the game tries to lock a system memory texture and it's currently in use we automatically allocate a new backing slice and copy the existing contents over to that.