### PR TITLE
Fix spelling error in the d3d9.strictConstantCopies description.

### DIFF
--- a/dxvk.conf
+++ b/dxvk.conf
@@ -253,7 +253,7 @@
 # Strict Constant Copies
 # 
 # Decides whether we should always copy defined constants to
-# the UBO when relative addresssing is used, or only when the
+# the UBO when relative addressing is used, or only when the
 # relative addressing starts a defined constant.
 #
 # Supported values:


### PR DESCRIPTION
Just a minor thing I noticed.