### PR TITLE
[d3d9] Handle edge cases around implicit discard

### DIFF
--- a/src/d3d9/d3d9_common_buffer.h
+++ b/src/d3d9/d3d9_common_buffer.h
@@ -153,6 +153,7 @@ namespace dxvk {
 
       return --m_lockCount;
     }
+    uint32_t GetLockCount() const { return m_lockCount; }
 
     void MarkUploaded()      { m_needsUpload = false; }
     void MarkNeedsUpload()   { m_needsUpload = true; }

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -4004,7 +4004,7 @@ namespace dxvk {
 
       if (alloced)
         std::memset(physSlice.mapPtr, 0, physSlice.length);
-      else if ((managed || systemmem) && !skipWait) {
+      else if ((managed || (systemmem && !dirty)) && !(Flags & D3DLOCK_DONOTWAIT) && !skipWait) {
         if (!WaitForResource(mappedBuffer, D3DLOCK_DONOTWAIT)) {
           // if the mapped buffer is currently being copied to image
           // we can just avoid a stall by allocating a new slice and copying the existing contents
@@ -4350,7 +4350,7 @@ namespace dxvk {
                             quickRead                     ||
                             (boundsCheck && !pResource->DirtyRange().Overlaps(pResource->LockRange()));
       if (!skipWait) {
-        if (IsPoolManaged(desc.Pool) || desc.Pool == D3DPOOL_SYSTEMMEM) {
+        if ((IsPoolManaged(desc.Pool) || desc.Pool == D3DPOOL_SYSTEMMEM) && !(Flags & D3DLOCK_DONOTWAIT) && pResource->GetLockCount() == 0) {
           if (!WaitForResource(mappingBuffer, D3DLOCK_DONOTWAIT)) {
             // if the mapped buffer is currently being copied to the primary buffer
             // we can just avoid a stall by allocating a new slice and copying the existing contents


### PR DESCRIPTION
Fixes #1727 

I originally thought, you could not modify POOL_SYSTEMMEM textures on the GPU. Turns out, you can with `GetRenderTargetData`.
So we need to check if the surface is dirty before for the implicit discard to work.

I also handle locks with `D3DLOCK_DONOTWAIT` now (no need to discard if the game passes that) and cleaned up handling of multiple buffer locks.