### PR TITLE
[d3d9] Respect D3DLOCK_NOOVERWRITE for pools other than DEFAULT

### DIFF
--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -4276,11 +4276,10 @@ namespace dxvk {
     if (unlikely((Flags & (D3DLOCK_DISCARD | D3DLOCK_NOOVERWRITE)) == (D3DLOCK_DISCARD | D3DLOCK_NOOVERWRITE)))
       Flags &= ~D3DLOCK_DISCARD;
 
-    // Ignore DISCARD and NOOVERWRITE if the buffer is not DEFAULT pool (tests + Halo 2)
     // The docs say DISCARD and NOOVERWRITE are ignored if the buffer is not DYNAMIC
     // but tests say otherwise!
     if (desc.Pool != D3DPOOL_DEFAULT)
-      Flags &= ~(D3DLOCK_DISCARD | D3DLOCK_NOOVERWRITE);
+      Flags &= ~D3DLOCK_DISCARD;
 
     // Ignore READONLY if we are a WRITEONLY resource.
     if (desc.Usage & D3DUSAGE_WRITEONLY)


### PR DESCRIPTION
Should hopefully improve #1730 

Konosuba uses a big buffer and locks part of that with NOOVERWRITE before almost every draw call.