### PR TITLE
[d3d9] Track dirty regions for UpdateTexture

### DIFF
--- a/src/d3d9/d3d9_common_texture.cpp
+++ b/src/d3d9/d3d9_common_texture.cpp
@@ -17,6 +17,10 @@ namespace dxvk {
                     ? D3D9Format::D32
                     : D3D9Format::X8R8G8B8;
 
+    for (uint32_t i = 0; i < m_updateDirtyBoxes.size(); i++) {
+      AddUpdateDirtyBox(nullptr, i);
+    }
+
     m_mapping = pDevice->LookupFormat(m_desc.Format);
 
     m_mapMode = DetermineMapMode();

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -5016,6 +5016,7 @@ namespace dxvk {
   
   void D3D9DeviceEx::MarkTextureMipsDirty(D3D9CommonTexture* pResource) {
     pResource->SetNeedsMipGen(true);
+    pResource->MarkAllDirty();
 
     for (uint32_t tex = m_activeTextures; tex; tex &= tex - 1) {
       // Guaranteed to not be nullptr...

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -646,6 +646,19 @@ namespace dxvk {
     if (unlikely(srcTextureInfo->Desc()->Format != dstTextureInfo->Desc()->Format))
       return D3DERR_INVALIDCALL;
 
+    if (dst->GetMipLevel() == 0) {
+      if (pSourceRect) {
+        D3DBOX updateDirtyRect = { UINT(pSourceRect->left), UINT(pSourceRect->top), UINT(pSourceRect->right), UINT(pSourceRect->bottom), 0, 1 };
+        if (pDestinationSurface) {
+          updateDirtyRect.Left = pDestPoint->x;
+          updateDirtyRect.Top = pDestPoint->y;
+        }
+        dstTextureInfo->AddUpdateDirtyBox(&updateDirtyRect, dst->GetFace());
+      } else {
+        dstTextureInfo->AddUpdateDirtyBox(nullptr, dst->GetFace());
+      }
+    }
+
     const DxvkFormatInfo* formatInfo = imageFormatInfo(dstTextureInfo->GetFormatMapping().FormatColor);
 
     VkOffset3D srcBlockOffset = { 0u, 0u, 0u };
@@ -723,27 +736,54 @@ namespace dxvk {
       return D3DERR_INVALIDCALL;
 
     const Rc<DxvkImage> dstImage  = dstTexInfo->GetImage();
-      
+    const DxvkFormatInfo* formatInfo = imageFormatInfo(dstTexInfo->GetFormatMapping().FormatColor);
     uint32_t mipLevels   = std::min(srcTexInfo->Desc()->MipLevels, dstTexInfo->Desc()->MipLevels);
     uint32_t arraySlices = std::min(srcTexInfo->Desc()->ArraySize, dstTexInfo->Desc()->ArraySize);
+
     for (uint32_t a = 0; a < arraySlices; a++) {
+      const D3DBOX& box = srcTexInfo->GetUpdateDirtyBox(a);
       for (uint32_t m = 0; m < mipLevels; m++) {
         Rc<DxvkBuffer> srcBuffer = srcTexInfo->GetBuffer(srcTexInfo->CalcSubresource(a, m));
-
         VkImageSubresourceLayers dstLayers = { VK_IMAGE_ASPECT_COLOR_BIT, m, a, 1 };
-        
-        VkExtent3D extent = dstImage->mipLevelExtent(m);
-        
+
+        VkOffset3D offset = {
+          alignDown(int32_t(box.Left)  >> m, int32_t(formatInfo->blockSize.width)),
+          alignDown(int32_t(box.Top)   >> m, int32_t(formatInfo->blockSize.height)),
+          alignDown(int32_t(box.Front) >> m, int32_t(formatInfo->blockSize.depth))
+        };
+        VkExtent3D extent = {
+          alignDown(uint32_t((box.Right - box.Left) >> m), formatInfo->blockSize.width),
+          alignDown(uint32_t((box.Bottom - box.Top) >> m), formatInfo->blockSize.height),
+          alignDown(uint32_t((box.Back - box.Front) >> m), formatInfo->blockSize.depth),
+        };
+
+        VkExtent3D levelExtent = dstImage->mipLevelExtent(m);
+        VkExtent3D blockCount  = util::computeBlockCount(levelExtent, formatInfo->blockSize);
+        VkOffset3D srcByteOffset = {
+          offset.x / int32_t(formatInfo->blockSize.width),
+          offset.y / int32_t(formatInfo->blockSize.height),
+          offset.z / int32_t(formatInfo->blockSize.depth)
+        };
+        VkDeviceSize srcOffset =  srcByteOffset.z * formatInfo->elementSize * blockCount.depth
+                                  + srcByteOffset.y * formatInfo->elementSize * blockCount.width
+                                  + srcByteOffset.x * formatInfo->elementSize;
+        VkExtent2D srcExtent = VkExtent2D{ blockCount.width  * formatInfo->blockSize.width,
+                                           blockCount.height * formatInfo->blockSize.height };
+
         EmitCs([
           cDstImage  = dstImage,
           cSrcBuffer = srcBuffer,
           cDstLayers = dstLayers,
-          cExtent    = extent
+          cExtent    = extent,
+          cOffset    = offset,
+          cSrcOffset = srcOffset,
+          cSrcExtent = srcExtent
         ] (DxvkContext* ctx) {
           ctx->copyBufferToImage(
             cDstImage,  cDstLayers,
-            VkOffset3D{ 0, 0, 0 }, cExtent,
-            cSrcBuffer, 0, { 0u, 0u });
+            cOffset, cExtent,
+            cSrcBuffer, cSrcOffset,
+            cSrcExtent);
         });
       }
     }
@@ -756,6 +796,8 @@ namespace dxvk {
     }
     else
       dstTexInfo->MarkAllDirty();
+
+    srcTexInfo->ClearUpdateDirtyBoxes();
 
     FlushImplicit(false);
 
@@ -3922,6 +3964,10 @@ namespace dxvk {
 
     if (unlikely((Flags & (D3DLOCK_DISCARD | D3DLOCK_NOOVERWRITE)) == (D3DLOCK_DISCARD | D3DLOCK_NOOVERWRITE)))
       Flags &= ~D3DLOCK_DISCARD;
+
+    if (!(Flags & D3DLOCK_NO_DIRTY_UPDATE) && !(Flags & D3DLOCK_READONLY)) {
+        pResource->AddUpdateDirtyBox(pBox, Face);
+    }
 
     auto& desc = *(pResource->Desc());
 

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -740,6 +740,12 @@ namespace dxvk {
     uint32_t mipLevels   = std::min(srcTexInfo->Desc()->MipLevels, dstTexInfo->Desc()->MipLevels);
     uint32_t arraySlices = std::min(srcTexInfo->Desc()->ArraySize, dstTexInfo->Desc()->ArraySize);
 
+    if (unlikely(srcTexInfo->IsAutomaticMip() && !dstTexInfo->IsAutomaticMip()))
+      return D3DERR_INVALIDCALL;
+
+    if (dstTexInfo->IsAutomaticMip())
+      mipLevels = 1;
+
     for (uint32_t a = 0; a < arraySlices; a++) {
       const D3DBOX& box = srcTexInfo->GetUpdateDirtyBox(a);
       for (uint32_t m = 0; m < mipLevels; m++) {
@@ -785,19 +791,14 @@ namespace dxvk {
             cSrcBuffer, cSrcOffset,
             cSrcExtent);
         });
+
+        dstTexInfo->SetDirty(dstTexInfo->CalcSubresource(a, m), true);
       }
     }
 
-    if (dstTexInfo->IsAutomaticMip()) {
-      for (uint32_t i = 0; i < dstTexInfo->Desc()->ArraySize; i++)
-        dstTexInfo->SetDirty(dstTexInfo->CalcSubresource(i, 0), true);
-
-      MarkTextureMipsDirty(dstTexInfo);
-    }
-    else
-      dstTexInfo->MarkAllDirty();
-
     srcTexInfo->ClearUpdateDirtyBoxes();
+    if (dstTexInfo->IsAutomaticMip() && mipLevels != dstTexInfo->Desc()->MipLevels)
+      MarkTextureMipsDirty(dstTexInfo);
 
     FlushImplicit(false);
 

--- a/src/d3d9/d3d9_texture.cpp
+++ b/src/d3d9/d3d9_texture.cpp
@@ -76,6 +76,12 @@ namespace dxvk {
 
 
   HRESULT STDMETHODCALLTYPE D3D9Texture2D::AddDirtyRect(CONST RECT* pDirtyRect) {
+    if (pDirtyRect) {
+      D3DBOX box = { UINT(pDirtyRect->left), UINT(pDirtyRect->top), UINT(pDirtyRect->right), UINT(pDirtyRect->bottom), 0, 1 };
+      m_texture.AddUpdateDirtyBox(&box, 0);
+    } else {
+      m_texture.AddUpdateDirtyBox(nullptr, 0);
+    }
     return D3D_OK;
   }
 
@@ -151,8 +157,8 @@ namespace dxvk {
     return GetSubresource(Level)->UnlockBox();
   }
 
-
   HRESULT STDMETHODCALLTYPE D3D9Texture3D::AddDirtyBox(CONST D3DBOX* pDirtyBox) {
+    m_texture.AddUpdateDirtyBox(pDirtyBox, 0);
     return D3D_OK;
   }
 
@@ -230,6 +236,12 @@ namespace dxvk {
 
 
   HRESULT STDMETHODCALLTYPE D3D9TextureCube::AddDirtyRect(D3DCUBEMAP_FACES Face, CONST RECT* pDirtyRect) {
+    if (pDirtyRect) {
+      D3DBOX box = { UINT(pDirtyRect->left), UINT(pDirtyRect->top), UINT(pDirtyRect->right), UINT(pDirtyRect->bottom), 0, 1 };
+      m_texture.AddUpdateDirtyBox(&box, Face);
+    } else {
+      m_texture.AddUpdateDirtyBox(nullptr, Face);
+    }
     return D3D_OK;
   }
 


### PR DESCRIPTION
Fixes #1757

Battle Engine Aquila relies on us not copying anything outside of the dirty regions that were set by `LockRect` and `AddDirtyRect`.

This could technically either be considered a game bug if the documentation is to be believed:
> If the source texture has dirty regions, the copy can be optimized by restricting the copy to only those regions. It is not guaranteed that only those bytes marked dirty will be copied.

This has serious potential for regressions and I have not yet tested it with a variety of games. I'd like to get some feedback on the implementation first.