### PR TITLE
Workaround flickering terrain for Just Cause 3 on RADV

### DIFF
--- a/src/dxbc/dxbc_compiler.h
+++ b/src/dxbc/dxbc_compiler.h
@@ -83,8 +83,9 @@ namespace dxvk {
   
   
   struct DxbcXreg {
-    uint32_t ccount = 0;
-    uint32_t varId  = 0;
+    uint32_t ccount  = 0;
+    uint32_t alength = 0;
+    uint32_t varId   = 0;
   };
   
   
@@ -1220,6 +1221,10 @@ namespace dxvk {
     
     bool isDoubleType(
             DxbcScalarType type) const;
+    
+    DxbcRegisterPointer getIndexableTempPtr(
+      const DxbcRegister&           operand,
+            DxbcRegisterValue       vectorId);
     
     ///////////////////////////
     // Type definition methods


### PR DESCRIPTION
A compute shader seems to expect out-of-bounds temporary array writes to be dropped. Out-of-bounds access seems to be undefined with D3D11 and SPIR-V, so this PR adds and uses an option to add bounds-checking to the writes

For small arrays, Mesa clamps the index, which causes flickering terrain in Just Cause 3: https://gitlab.freedesktop.org/mesa/mesa/-/issues/851