### PR TITLE
[d3d11] Clamp bound constant buffer range

### DIFF
--- a/src/d3d11/d3d11_context.h
+++ b/src/d3d11/d3d11_context.h
@@ -764,10 +764,6 @@ namespace dxvk {
     
     void BindConstantBuffer(
             UINT                              Slot,
-            D3D11Buffer*                      pBuffer);
-    
-    void BindConstantBuffer1(
-            UINT                              Slot,
             D3D11Buffer*                      pBuffer,
             UINT                              Offset,
             UINT                              Length);


### PR DESCRIPTION
NFS Heat binds a 1048576 byte constant buffer.
So as discussed on Discord, we just bind the range of it thats legal.

```
VUID-VkWriteDescriptorSet-descriptorType-00332(ERROR / SPEC): msgNum: -1974202905 - Validation Error: [ VUID-VkWriteDescriptorSet-descriptorType-00332 ] Object 0: handle = 0x31ad1d0000107dcb, type = VK_OBJECT_TYPE_DESCRIPTOR_SET; | MessageID = 0x8a540de7 | vkUpdateDescriptorSetWithTemplate() failed write update validation for VkDescriptorSet 0x31ad1d0000107dcb[] with error: Write update to VkDescriptorSet VkDescriptorSet 0x31ad1d0000107dcb[] allocated with VkDescriptorSetLayout VkDescriptorSetLayout 0xcadcd00000000364[] binding #0 failed with error message: Attempted write update to buffer descriptor failed due to: For buffer VkBuffer 0x9fae5200000008cf[] VkDescriptorBufferInfo range is 1048576 which is greater than this device's maxUniformBufferRange (65536). The Vulkan spec states: If descriptorType is VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER or VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC, the range member of each element of pBufferInfo, or the effective range if range is VK_WHOLE_SIZE, must be less than or equal to VkPhysicalDeviceLimits::maxUniformBufferRange (https://vulkan.lunarg.com/doc/view/1.2.148.0/windows/1.2-extensions/vkspec.html#VUID-VkWriteDescriptorSet-descriptorType-00332)
    Objects: 1
        [0] 0x31ad1d0000107dcb, type: 23, name: NULL
```

Unfortunately this does not fix the issue in #1764.