### PR TITLE
[d3d11] Don't use clamped constant buffer range for bounds checking

### DIFF
--- a/src/d3d11/d3d11_context.cpp
+++ b/src/d3d11/d3d11_context.cpp
@@ -3652,7 +3652,8 @@ namespace dxvk {
       UINT constantBound;
 
       if (likely(newBuffer != nullptr)) {
-        constantBound = std::min(newBuffer->Desc()->ByteWidth / 16, UINT(D3D11_REQ_CONSTANT_BUFFER_ELEMENT_COUNT));
+        UINT bufferConstantsCount = newBuffer->Desc()->ByteWidth / 16;
+        constantBound = std::min(bufferConstantsCount, UINT(D3D11_REQ_CONSTANT_BUFFER_ELEMENT_COUNT));
 
         if (likely(pFirstConstant && pNumConstants)) {
           constantOffset  = pFirstConstant[i];
@@ -3661,8 +3662,8 @@ namespace dxvk {
           if (unlikely(constantCount > D3D11_REQ_CONSTANT_BUFFER_ELEMENT_COUNT))
             continue;
 
-          constantBound = (constantOffset + constantCount > constantBound)
-            ? constantBound - std::min(constantOffset, constantBound)
+          constantBound = (constantOffset + constantCount > bufferConstantsCount)
+            ? bufferConstantsCount - std::min(constantOffset, bufferConstantsCount)
             : constantCount;
         } else {
           constantOffset  = 0;


### PR DESCRIPTION
4801fbe0980bb7e062b3223a10e57d56ed5c0aab causes a black screen in Need For Speed Heat because it clamps 'too early'.

constantBound is used to check whether pFirstConstant + pNumConstants exceeds
the constant buffer's bounds. The commit clamped that value before doing the bounds check, making it impossible to bind any range outside 0 - 4096 * 16.