### PR TITLE
[util] Set enableRtOutputNaNFixup for The Dungeon of Naheulbeuk

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -238,6 +238,10 @@ namespace dxvk {
     { R"(\\MonsterHunterWorld\.exe$)", {{
       { "d3d11.apitraceMode",               "True" },
     }} },
+    /* The Dungeon of Maheulbeuk                  */
+    { R"(\\Naheulbeuk\.exe$)", {{
+      { "d3d11.enableRtOutputNanFixup",     "True" },
+    }} },
 
     /**********************************************/
     /* D3D9 GAMES                                 */


### PR DESCRIPTION
Fixes rendering issues with RADV and AMDVLK (haven't tried -pro).