### PR TITLE
[util]: Set enableRtOutputNaNFixup for Art of Rally

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -254,6 +254,10 @@ namespace dxvk {
     { R"(\\The Convenience Store Yakin Jiken\.exe$)", {{
       { "d3d11.enableRtOutputNanFixup",     "True" },
     }} },
+    /* Art of Rally                               */
+    { R"(\\artofrally(_demo)?\.exe$)", {{
+      { "d3d11.enableRtOutputNanFixup",     "True" },
+    }} },
 
     /**********************************************/
     /* D3D9 GAMES                                 */


### PR DESCRIPTION
Fixes the (Windows) Art of Rally demo.

See https://gitlab.freedesktop.org/mesa/mesa/-/issues/3562

I got the filename for the full version from here: https://steamdb.info/app/550320/config/ . I'll ask on the GitLab whether the workaround works for the full version.