### PR TITLE
[util] Use nvapiHack by default for Far Cry Primal

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -45,10 +45,6 @@ namespace dxvk {
     { R"(\\FarCry4\.exe$)", {{
       { "dxgi.nvapiHack",                   "False" },
     }} },
-    /* Far Cry Primal: Nvidia performance         */
-    { R"(\\FCPrimal\.exe$)", {{
-      { "dxgi.nvapiHack",                   "False" },
-    } }},
     /* Frostpunk: Renders one frame with D3D9     *
      * after creating the DXGI swap chain         */
     { R"(\\Frostpunk\.exe$)", {{


### PR DESCRIPTION
Remove nvapiHack=False default override for Far Cry Primal as the game is unplayable without an nvapi implementation and appears to now perform fine with nvapiHack.

For reference, here are the results of the in-game performance test with an Nvidia GPU on my machine.

Without nvapiHack or Wine Staging nvapi patches:
```
Minimum FPS: 1
Average FPS: 1
Maximum FPS: 2
Frames rendered: 56
```
With Wine Staging nvapi patches:
```
Minimum FPS: 55
Average FPS: 74
Maximum FPS: 76
Frames rendered: 3726
```
With nvapiHack:
```
Minimum FPS: 55
Average FPS: 75
Maximum FPS: 76
Frames rendered: 3731
```
I've also played the game for around an hour using nvapiHack and have not encountered any performance issues of note.