### PR TITLE
Workaround Tomb Raider Legend buffer usages

### DIFF
--- a/src/d3d9/d3d9_common_buffer.cpp
+++ b/src/d3d9/d3d9_common_buffer.cpp
@@ -105,6 +105,11 @@ namespace dxvk {
       memoryFlags |= VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
     }
 
+    if (memoryFlags & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT && m_parent->GetOptions()->apitraceMode) {
+      memoryFlags |= VK_MEMORY_PROPERTY_HOST_COHERENT_BIT
+                  |  VK_MEMORY_PROPERTY_HOST_CACHED_BIT;
+    }
+
     return m_parent->GetDXVKDevice()->createBuffer(info, memoryFlags);
   }
 

--- a/src/d3d9/d3d9_common_buffer.cpp
+++ b/src/d3d9/d3d9_common_buffer.cpp
@@ -94,10 +94,8 @@ namespace dxvk {
         info.access |= VK_ACCESS_HOST_READ_BIT;
 
       memoryFlags |= VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT
-                  |  VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
-
-      if (m_desc.Size <= DeviceLocalThreshold)
-        memoryFlags |= VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
+                  |  VK_MEMORY_PROPERTY_HOST_COHERENT_BIT
+                  |  VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
     }
     else {
       info.stages |= VK_PIPELINE_STAGE_TRANSFER_BIT;

--- a/src/d3d9/d3d9_common_buffer.h
+++ b/src/d3d9/d3d9_common_buffer.h
@@ -68,7 +68,6 @@ namespace dxvk {
 
   class D3D9CommonBuffer {
     static constexpr VkDeviceSize BufferSliceAlignment = 64;
-    static constexpr VkDeviceSize DeviceLocalThreshold = 4096;
   public:
 
     D3D9CommonBuffer(

--- a/src/d3d9/d3d9_options.cpp
+++ b/src/d3d9/d3d9_options.cpp
@@ -73,6 +73,8 @@ namespace dxvk {
     this->tearFree              = config.getOption<Tristate>   ("d3d9.tearFree", Tristate::Auto);
     this->alphaTestWiggleRoom   = config.getOption<bool>       ("d3d9.alphaTestWiggleRoom", false);
 
+    this->apitraceMode = config.getOption<bool>("d3d9.apitraceMode", false);
+
     // If we are not Nvidia, enable general hazards.
     this->generalHazards = adapter == nullptr || !adapter->matchesDriver(DxvkGpuVendor::Nvidia, VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR, 0, 0);
     applyTristate(this->generalHazards, config.getOption<Tristate>("d3d9.generalHazards", Tristate::Auto));

--- a/src/d3d9/d3d9_options.h
+++ b/src/d3d9/d3d9_options.h
@@ -151,6 +151,9 @@ namespace dxvk {
     /// Workaround for games using alpha test == 1.0, etc due to wonky interpolation or
     /// misc. imprecision on some vendors
     bool alphaTestWiggleRoom;
+
+    /// Apitrace mode: Maps all buffers in cached memory.
+    bool apitraceMode;
   };
 
 }

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -410,6 +410,10 @@ namespace dxvk {
     { R"(\\EverQuest2.*\.exe$)", {{
       { "d3d9.alphaTestWiggleRoom", "True" },
     }} },
+    /* Tomb Raider: Legend                       */
+    { R"(\\trl\.exe$)", {{
+      { "d3d9.apitraceMode",                "True" },
+    }} },
   }};
 
 


### PR DESCRIPTION
I originally decided to restrict the usage of HOST_VISIBLE | DEVICE_LOCAL to dynamic buffers under a certain size to improve Tomb Raider Legend.

Turns out this negatively impacts other games. So instead, I decided to implement Apitrace Mode (I chose consistency with the D3D11 frontend over a better name here) and enabled that for the game.

Adding CACHED_BIT improves performance even further compared to the previous workaround that just removed DEVICE_LOCAL_BIT.

Here's some numbers:

With f3a82a0: ~240fps
With f3a82a0 reverted: ~120 fps
With apitrace mode (adding CACHED_BIT): ~310fps

So it appears that Tomb Raider Legend is reading from one or more D3DUSAGE_DYNAMIC | D3DUSAGE_WRITEONLY buffers. It gets even stranger though. It only ever maps those buffers with D3DLOCK_DISCARD.

Fixes #1851 