### PR TITLE
D3D9: Query stuff for Mass Effect 1

### DIFF
--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -6008,11 +6008,13 @@ namespace dxvk {
   void D3D9DeviceEx::End(D3D9Query* pQuery) {
     D3D9DeviceLock lock = LockDevice();
 
+    pQuery->NotifyEnd();
     if (unlikely(pQuery->IsEvent())) {
-      pQuery->NotifyEnd();
       pQuery->IsStalling()
         ? Flush()
         : FlushImplicit(TRUE);
+    } else if (pQuery->IsStalling()) {
+      FlushImplicit(FALSE);
     }
 
     EmitCs([cQuery = Com<D3D9Query, false>(pQuery)](DxvkContext* ctx) {

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -6008,6 +6008,10 @@ namespace dxvk {
   void D3D9DeviceEx::End(D3D9Query* pQuery) {
     D3D9DeviceLock lock = LockDevice();
 
+    EmitCs([cQuery = Com<D3D9Query, false>(pQuery)](DxvkContext* ctx) {
+      cQuery->End(ctx);
+    });
+
     pQuery->NotifyEnd();
     if (unlikely(pQuery->IsEvent())) {
       pQuery->IsStalling()
@@ -6016,10 +6020,6 @@ namespace dxvk {
     } else if (pQuery->IsStalling()) {
       FlushImplicit(FALSE);
     }
-
-    EmitCs([cQuery = Com<D3D9Query, false>(pQuery)](DxvkContext* ctx) {
-      cQuery->End(ctx);
-    });
   }
 
 

--- a/src/d3d9/d3d9_query.h
+++ b/src/d3d9/d3d9_query.h
@@ -10,6 +10,7 @@ namespace dxvk {
     D3D9_VK_QUERY_INITIAL,
     D3D9_VK_QUERY_BEGUN,
     D3D9_VK_QUERY_ENDED,
+    D3D9_VK_QUERY_CACHED
   };
 
   union D3D9_QUERY_DATA {
@@ -80,6 +81,8 @@ namespace dxvk {
     bool     m_stallFlag = false;
 
     std::atomic<uint32_t> m_resetCtr = { 0u };
+
+    D3D9_QUERY_DATA m_dataCache;
 
     UINT64 GetTimestampQueryFrequency() const;
 


### PR DESCRIPTION
Mass Effect 1 issues occlusion queries early in the frame and reads those in the next one.  So I extended the stall tracking to other query types but only do an implicit flush to make sure those queries are ready.
In the apitrace provided in #1845 you can see how the game is waiting for the first query of the batch to finish.

It also retrieves the data of its queries multiple times without issuing them inbetween, so I cache those results to avoid having to go through multiple Vulkan queries and the Vulkan event again.

And for the last commit, I moved the stalling query flush after the call to End (the way it is for D3D11 queries) so the query is actually done by the time we flush. :frog: