### PR TITLE
[util] Set enableRtOutputNanFixup for Empire of Sin

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -255,6 +255,10 @@ namespace dxvk {
     { R"(\\artofrally(_demo)?\.exe$)", {{
       { "d3d11.enableRtOutputNanFixup",     "True" },
     }} },
+    /* Empire of Sin                               */
+    { R"(\\EmpireOfSin\.exe$)", {{
+      { "d3d11.enableRtOutputNanFixup",     "True" },
+    }} },
 
     /**********************************************/
     /* D3D9 GAMES                                 */


### PR DESCRIPTION
Empire of Sin ([604540](https://store.steampowered.com/agecheck/app/604540/)) produces artifacts in certain scenes on RADV. These are most noticeable when entering maximum zoom levels inside of buildings. Setting `enableRtOutputNanFixup` to `True` in **_dxvk.conf_** file resolves those graphical issues.

We confirmed this resolved the issue on a RX 580 and 5700 XT using Mesa Git (https://gitlab.freedesktop.org/mesa/mesa/-/commit/e6a66201a7ada69d93c9c9eb2112b20f87695754) as well as Kisak's PPA release (20.3.1\~kisak1\~f).

| RADV | RADV w/ enableRtOutputNaNFixup |
| ---- | ---- |
|![EoS without enableRtOutputNaNFixup](https://user-images.githubusercontent.com/761853/102528383-7942d200-406c-11eb-9101-e0f037e321d6.png)|![EoS with enableRtOutputNaNFixup](https://user-images.githubusercontent.com/761853/102528396-7e078600-406c-11eb-8d00-3bf851ea7ce7.png)|