### PR TITLE
[util] Set invariantPosition for Devil May Cry 5

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -79,6 +79,7 @@ namespace dxvk {
     /* Devil May Cry 5                            */
     { R"(\\DevilMayCry5\.exe$)", {{
       { "d3d11.relaxedBarriers",            "True" },
+      { "d3d11.invariantPosition",          "True" },
     }} },
     /* Call of Duty WW2                           */
     { R"(\\s2_sp64_ship\.exe$)", {{


### PR DESCRIPTION
Fixes some missing/shifting geometry on GFX10.3 and RADV/ACO.

Tested using dxvk.conf and DXVK 1.7.3.