### PR TITLE
[util] Enable apitrace mode for Everquest

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -415,6 +415,10 @@ namespace dxvk {
     { R"(\\trl\.exe$)", {{
       { "d3d9.apitraceMode",                "True" },
     }} },
+    /* Everquest                                 */
+    { R"(\\eqgame\.exe$)", {{
+      { "d3d9.apitraceMode",                "True" },
+    }} },
   }};
 
 


### PR DESCRIPTION
There was a report that reverting the original Tomb Raider Legend workaround made the game slower (comment in #1851).
I hope this will fix that.

@rsw0x Please test.