### PR TITLE
[util] set enableRtOutputNanFixup for VRChat

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -419,6 +419,10 @@ namespace dxvk {
     { R"(\\eqgame\.exe$)", {{
       { "d3d9.apitraceMode",                "True" },
     }} },
+    /* VRChat                                    */
+    { R"(\\VRChat\.exe$)", {{
+      { "d3d11.enableRtOutputNanFixup",     "True" },
+    }} },
   }};
 
 


### PR DESCRIPTION
Fixes rendering issues with RADV.