### PR TITLE
Use new section for c/cpp args and link_args

### DIFF
--- a/build-win32.txt
+++ b/build-win32.txt
@@ -4,11 +4,13 @@ cpp = 'i686-w64-mingw32-g++'
 ar = 'i686-w64-mingw32-ar'
 strip = 'i686-w64-mingw32-strip'
 
-[properties]
+[built-in options]
 c_args=['-msse', '-msse2']
 cpp_args=['-msse', '-msse2']
 c_link_args = ['-static', '-static-libgcc']
 cpp_link_args = ['-static', '-static-libgcc', '-static-libstdc++']
+
+[properties]
 needs_exe_wrapper = true
 
 [host_machine]

--- a/build-win64.txt
+++ b/build-win64.txt
@@ -4,9 +4,11 @@ cpp = 'x86_64-w64-mingw32-g++'
 ar = 'x86_64-w64-mingw32-ar'
 strip = 'x86_64-w64-mingw32-strip'
 
-[properties]
+[built-in options]
 c_link_args = ['-static', '-static-libgcc']
 cpp_link_args = ['-static', '-static-libgcc', '-static-libstdc++']
+
+[properties]
 needs_exe_wrapper = true
 
 [host_machine]


### PR DESCRIPTION
Using lang_args and lang_link_args in the [properties] section has been deprecated in Meson 0.56.
[built-in options] section should be used instead.

Fixes #1877