### PR TITLE
Using wineopenxr to support OpenXR

### DIFF
--- a/src/d3d11/d3d11_device.cpp
+++ b/src/d3d11/d3d11_device.cpp
@@ -2531,7 +2531,8 @@ namespace dxvk {
       return S_OK;
     }
     
-    if (riid == __uuidof(IDXGIVkInteropDevice)) {
+    if (riid == __uuidof(IDXGIVkInteropDevice)
+     || riid == __uuidof(IDXGIVkInteropDevice1)) {
       *ppvObject = ref(&m_d3d11Interop);
       return S_OK;
     }

--- a/src/d3d11/d3d11_interop.h
+++ b/src/d3d11/d3d11_interop.h
@@ -8,7 +8,7 @@ namespace dxvk {
 
   class D3D11Device;
   
-  class D3D11VkInterop : public ComObject<IDXGIVkInteropDevice> {
+  class D3D11VkInterop : public ComObject<IDXGIVkInteropDevice1> {
     
   public:
     
@@ -46,6 +46,16 @@ namespace dxvk {
     void STDMETHODCALLTYPE LockSubmissionQueue();
     
     void STDMETHODCALLTYPE ReleaseSubmissionQueue();
+    
+    void STDMETHODCALLTYPE GetSubmissionQueue1(
+            VkQueue*              pQueue,
+            uint32_t*             pQueueIndex,
+            uint32_t*             pQueueFamilyIndex);
+    
+    HRESULT STDMETHODCALLTYPE CreateTexture2DFromVkImage(
+            const D3D11_TEXTURE2D_DESC1* pDesc,
+            VkImage                      vkImage,
+            ID3D11Texture2D**            ppTexture2D);
     
   private:
     

--- a/src/d3d11/d3d11_texture.cpp
+++ b/src/d3d11/d3d11_texture.cpp
@@ -7,7 +7,8 @@ namespace dxvk {
   D3D11CommonTexture::D3D11CommonTexture(
           D3D11Device*                pDevice,
     const D3D11_COMMON_TEXTURE_DESC*  pDesc,
-          D3D11_RESOURCE_DIMENSION    Dimension)
+          D3D11_RESOURCE_DIMENSION    Dimension,
+          VkImage                     vkImage)
   : m_device(pDevice), m_desc(*pDesc) {
     DXGI_VK_FORMAT_MODE   formatMode   = GetFormatMode();
     DXGI_VK_FORMAT_INFO   formatInfo   = m_device->LookupFormat(m_desc.Format, formatMode);
@@ -179,7 +180,10 @@ namespace dxvk {
                        | VK_MEMORY_PROPERTY_HOST_CACHED_BIT;
     }
     
-    m_image = m_device->GetDXVKDevice()->createImage(imageInfo, memoryProperties);
+    if (vkImage == VK_NULL_HANDLE)
+      m_image = m_device->GetDXVKDevice()->createImage(imageInfo, memoryProperties);
+    else
+      m_image = m_device->GetDXVKDevice()->createImageFromVkImage(imageInfo, vkImage);
   }
   
   
@@ -775,7 +779,7 @@ namespace dxvk {
   D3D11Texture1D::D3D11Texture1D(
           D3D11Device*                pDevice,
     const D3D11_COMMON_TEXTURE_DESC*  pDesc)
-  : m_texture (pDevice, pDesc, D3D11_RESOURCE_DIMENSION_TEXTURE1D),
+  : m_texture (pDevice, pDesc, D3D11_RESOURCE_DIMENSION_TEXTURE1D, VK_NULL_HANDLE),
     m_interop (this, &m_texture),
     m_surface (this, &m_texture),
     m_resource(this),
@@ -877,7 +881,20 @@ namespace dxvk {
   D3D11Texture2D::D3D11Texture2D(
           D3D11Device*                pDevice,
     const D3D11_COMMON_TEXTURE_DESC*  pDesc)
-  : m_texture (pDevice, pDesc, D3D11_RESOURCE_DIMENSION_TEXTURE2D),
+  : m_texture (pDevice, pDesc, D3D11_RESOURCE_DIMENSION_TEXTURE2D, VK_NULL_HANDLE),
+    m_interop (this, &m_texture),
+    m_surface (this, &m_texture),
+    m_resource(this),
+    m_d3d10   (this) {
+    
+  }
+
+
+  D3D11Texture2D::D3D11Texture2D(
+          D3D11Device*                pDevice,
+    const D3D11_COMMON_TEXTURE_DESC*  pDesc,
+          VkImage vkImage)
+  : m_texture (pDevice, pDesc, D3D11_RESOURCE_DIMENSION_TEXTURE2D, vkImage),
     m_interop (this, &m_texture),
     m_surface (this, &m_texture),
     m_resource(this),
@@ -997,7 +1014,7 @@ namespace dxvk {
   D3D11Texture3D::D3D11Texture3D(
           D3D11Device*                pDevice,
     const D3D11_COMMON_TEXTURE_DESC*  pDesc)
-  : m_texture (pDevice, pDesc, D3D11_RESOURCE_DIMENSION_TEXTURE3D),
+  : m_texture (pDevice, pDesc, D3D11_RESOURCE_DIMENSION_TEXTURE3D, VK_NULL_HANDLE),
     m_interop (this, &m_texture),
     m_resource(this),
     m_d3d10   (this) {

--- a/src/d3d11/d3d11_texture.h
+++ b/src/d3d11/d3d11_texture.h
@@ -62,7 +62,8 @@ namespace dxvk {
     D3D11CommonTexture(
             D3D11Device*                pDevice,
       const D3D11_COMMON_TEXTURE_DESC*  pDesc,
-            D3D11_RESOURCE_DIMENSION    Dimension);
+            D3D11_RESOURCE_DIMENSION    Dimension,
+            VkImage                     vkImage);
     
     ~D3D11CommonTexture();
     
@@ -421,6 +422,11 @@ namespace dxvk {
     D3D11Texture2D(
             D3D11Device*                pDevice,
       const D3D11_COMMON_TEXTURE_DESC*  pDesc);
+
+    D3D11Texture2D(
+            D3D11Device*                pDevice,
+      const D3D11_COMMON_TEXTURE_DESC*  pDesc,
+            VkImage                     vkImage);
     
     ~D3D11Texture2D();
     

--- a/src/dxgi/dxgi_interfaces.h
+++ b/src/dxgi/dxgi_interfaces.h
@@ -287,6 +287,31 @@ IDXGIVkInteropDevice : public IUnknown {
   virtual void STDMETHODCALLTYPE ReleaseSubmissionQueue() = 0;
 };
 
+struct D3D11_TEXTURE2D_DESC1;
+class ID3D11Texture2D;
+
+/**
+ * \brief See IDXGIVkInteropDevice.
+ */
+MIDL_INTERFACE("e2ef5fa5-dc21-4af7-90c4-f67ef6a09324")
+IDXGIVkInteropDevice1 : public IDXGIVkInteropDevice {
+  /**
+   * \brief Queries the rendering queue used by DXVK
+   * 
+   * \param [out] pQueue The Vulkan queue handle
+   * \param [out] pQueueIndex Queue index
+   * \param [out] pQueueFamilyIndex Queue family index
+   */
+  virtual void STDMETHODCALLTYPE GetSubmissionQueue1(
+          VkQueue*              pQueue,
+          uint32_t*             pQueueIndex,
+          uint32_t*             pQueueFamilyIndex) = 0;
+
+  virtual HRESULT STDMETHODCALLTYPE CreateTexture2DFromVkImage(
+          const D3D11_TEXTURE2D_DESC1 *pDesc,
+          VkImage vkImage,
+          ID3D11Texture2D **ppTexture2D) = 0;
+};
 
 /**
  * \brief DXGI adapter interface for Vulkan interop
@@ -332,6 +357,7 @@ struct __declspec(uuid("92a5d77b-b6e1-420a-b260-fdd701272827")) IDXGIDXVKDevice;
 struct __declspec(uuid("c06a236f-5be3-448a-8943-89c611c0c2c1")) IDXGIVkMonitorInfo;
 struct __declspec(uuid("3a6d8f2c-b0e8-4ab4-b4dc-4fd24891bfa5")) IDXGIVkInteropAdapter;
 struct __declspec(uuid("e2ef5fa5-dc21-4af7-90c4-f67ef6a09323")) IDXGIVkInteropDevice;
+struct __declspec(uuid("e2ef5fa5-dc21-4af7-90c4-f67ef6a09324")) IDXGIVkInteropDevice1;
 struct __declspec(uuid("5546cf8c-77e7-4341-b05d-8d4d5000e77d")) IDXGIVkInteropSurface;
 struct __declspec(uuid("104001a6-7f36-4957-b932-86ade9567d91")) IDXGIVkSwapChain;
 struct __declspec(uuid("53cb4ff0-c25a-4164-a891-0e83db0a7aac")) IWineDXGISwapChainFactory;
@@ -341,6 +367,7 @@ __CRT_UUID_DECL(IDXGIDXVKDevice,           0x92a5d77b,0xb6e1,0x420a,0xb2,0x60,0x
 __CRT_UUID_DECL(IDXGIVkMonitorInfo,        0xc06a236f,0x5be3,0x448a,0x89,0x43,0x89,0xc6,0x11,0xc0,0xc2,0xc1);
 __CRT_UUID_DECL(IDXGIVkInteropAdapter,     0x3a6d8f2c,0xb0e8,0x4ab4,0xb4,0xdc,0x4f,0xd2,0x48,0x91,0xbf,0xa5);
 __CRT_UUID_DECL(IDXGIVkInteropDevice,      0xe2ef5fa5,0xdc21,0x4af7,0x90,0xc4,0xf6,0x7e,0xf6,0xa0,0x93,0x23);
+__CRT_UUID_DECL(IDXGIVkInteropDevice1,     0xe2ef5fa5,0xdc21,0x4af7,0x90,0xc4,0xf6,0x7e,0xf6,0xa0,0x93,0x24);
 __CRT_UUID_DECL(IDXGIVkInteropSurface,     0x5546cf8c,0x77e7,0x4341,0xb0,0x5d,0x8d,0x4d,0x50,0x00,0xe7,0x7d);
 __CRT_UUID_DECL(IDXGIVkSwapChain,          0x104001a6,0x7f36,0x4957,0xb9,0x32,0x86,0xad,0xe9,0x56,0x7d,0x91);
 __CRT_UUID_DECL(IWineDXGISwapChainFactory, 0x53cb4ff0,0xc25a,0x4164,0xa8,0x91,0x0e,0x83,0xdb,0x0a,0x7a,0xac);

--- a/src/dxvk/dxvk_device.cpp
+++ b/src/dxvk/dxvk_device.cpp
@@ -142,6 +142,12 @@ namespace dxvk {
   }
   
   
+  Rc<DxvkImage> DxvkDevice::createImageFromVkImage(
+    const DxvkImageCreateInfo&  createInfo,
+          VkImage               image) {
+    return new DxvkImage(m_vkd, createInfo, image);
+  }
+  
   Rc<DxvkImageView> DxvkDevice::createImageView(
     const Rc<DxvkImage>&            image,
     const DxvkImageViewCreateInfo&  createInfo) {

--- a/src/dxvk/dxvk_device.h
+++ b/src/dxvk/dxvk_device.h
@@ -304,6 +304,17 @@ namespace dxvk {
     Rc<DxvkImage> createImage(
       const DxvkImageCreateInfo&  createInfo,
             VkMemoryPropertyFlags memoryType);
+
+    /**
+     * \brief Creates an image object for an existing VkImage
+     * 
+     * \param [in] createInfo Image create info
+     * \param [in] image Vulkan image to wrap
+     * \returns The image object
+     */
+    Rc<DxvkImage> createImageFromVkImage(
+      const DxvkImageCreateInfo&  createInfo,
+            VkImage               image);
     
     /**
      * \brief Creates an image view

--- a/src/dxvk/dxvk_instance.cpp
+++ b/src/dxvk/dxvk_instance.cpp
@@ -2,6 +2,7 @@
 
 #include "dxvk_instance.h"
 #include "dxvk_openvr.h"
+#include "dxvk_openxr.h"
 #include "dxvk_platform_exts.h"
 
 #include <algorithm>
@@ -22,6 +23,9 @@ namespace dxvk {
 
     if (m_options.enableOpenVR)
       m_extProviders.push_back(&VrInstance::s_instance);
+
+    if (m_options.enableOpenXR)
+      m_extProviders.push_back(&DxvkXrProvider::s_instance);
 
     Logger::info("Built-in extension providers:");
     for (const auto& provider : m_extProviders)

--- a/src/dxvk/dxvk_openxr.cpp
+++ b/src/dxvk/dxvk_openxr.cpp
@@ -1,0 +1,168 @@
+#include "dxvk_instance.h"
+#include "dxvk_openxr.h"
+
+#ifdef __GNUC__
+#pragma GCC diagnostic ignored "-Wnon-virtual-dtor"
+#endif
+
+using PFN___wineopenxr_GetVulkanInstanceExtensions = int (WINAPI *)(uint32_t, uint32_t *, char *);
+using PFN___wineopenxr_GetVulkanDeviceExtensions = int (WINAPI *)(uint32_t, uint32_t *, char *);
+
+namespace dxvk {
+  
+  struct WineXrFunctions {
+    PFN___wineopenxr_GetVulkanInstanceExtensions __wineopenxr_GetVulkanInstanceExtensions = nullptr;
+    PFN___wineopenxr_GetVulkanDeviceExtensions __wineopenxr_GetVulkanDeviceExtensions = nullptr;
+  };
+  
+  WineXrFunctions g_winexrFunctions;
+  DxvkXrProvider DxvkXrProvider::s_instance;
+
+  DxvkXrProvider:: DxvkXrProvider() { }
+
+  DxvkXrProvider::~DxvkXrProvider() { }
+
+
+  std::string_view DxvkXrProvider::getName() {
+    return "OpenXR";
+  }
+  
+  
+  DxvkNameSet DxvkXrProvider::getInstanceExtensions() {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    return m_insExtensions;
+  }
+
+
+  DxvkNameSet DxvkXrProvider::getDeviceExtensions(uint32_t adapterId) {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    return m_devExtensions;
+  }
+
+
+  void DxvkXrProvider::initInstanceExtensions() {
+    std::lock_guard<std::mutex> lock(m_mutex);
+
+    if (!m_wineOxr)
+      m_wineOxr = this->loadLibrary();
+
+    if (!m_wineOxr || m_initializedInsExt)
+      return;
+
+    if (!this->loadFunctions()) {
+      this->shutdown();
+      return;
+    }
+
+    m_insExtensions = this->queryInstanceExtensions();
+    m_initializedInsExt = true;
+  }
+
+
+  bool DxvkXrProvider::loadFunctions() {
+    g_winexrFunctions.__wineopenxr_GetVulkanInstanceExtensions =
+        reinterpret_cast<PFN___wineopenxr_GetVulkanInstanceExtensions>(this->getSym("__wineopenxr_GetVulkanInstanceExtensions"));
+    g_winexrFunctions.__wineopenxr_GetVulkanDeviceExtensions =
+        reinterpret_cast<PFN___wineopenxr_GetVulkanDeviceExtensions>(this->getSym("__wineopenxr_GetVulkanDeviceExtensions"));
+    return g_winexrFunctions.__wineopenxr_GetVulkanInstanceExtensions != nullptr
+      && g_winexrFunctions.__wineopenxr_GetVulkanDeviceExtensions != nullptr;
+  }
+
+
+  void DxvkXrProvider::initDeviceExtensions(const DxvkInstance* instance) {
+    std::lock_guard<std::mutex> lock(m_mutex);
+
+    if (!m_wineOxr || m_initializedDevExt)
+      return;
+    
+    m_devExtensions = this->queryDeviceExtensions();
+    m_initializedDevExt = true;
+
+    this->shutdown();
+  }
+
+
+  DxvkNameSet DxvkXrProvider::queryInstanceExtensions() const {
+    int res;
+    uint32_t len;
+
+    res = g_winexrFunctions.__wineopenxr_GetVulkanInstanceExtensions(0, &len, nullptr);
+    if (res != 0) {
+      Logger::warn("OpenXR: Unable to get required Vulkan instance extensions size");
+      return DxvkNameSet();
+    }
+
+    std::vector<char> extensionList(len);
+    res = g_winexrFunctions.__wineopenxr_GetVulkanInstanceExtensions(len, &len, &extensionList[0]);
+    if (res != 0) {
+      Logger::warn("OpenXR: Unable to get required Vulkan instance extensions");
+      return DxvkNameSet();
+    }
+
+    return parseExtensionList(std::string(extensionList.data(), len));
+  }
+  
+  
+  DxvkNameSet DxvkXrProvider::queryDeviceExtensions() const {
+    int res;
+
+    uint32_t len;
+    res = g_winexrFunctions.__wineopenxr_GetVulkanDeviceExtensions(0, &len, nullptr);
+    if (res != 0) {
+      Logger::warn("OpenXR: Unable to get required Vulkan Device extensions size");
+      return DxvkNameSet();
+    }
+
+    std::vector<char> extensionList(len);
+    res = g_winexrFunctions.__wineopenxr_GetVulkanDeviceExtensions(len, &len, &extensionList[0]);
+    if (res != 0) {
+      Logger::warn("OpenXR: Unable to get required Vulkan Device extensions");
+      return DxvkNameSet();
+    }
+
+    return parseExtensionList(std::string(extensionList.data(), len));
+  }
+  
+  
+  DxvkNameSet DxvkXrProvider::parseExtensionList(const std::string& str) const {
+    DxvkNameSet result;
+    
+    std::stringstream strstream(str);
+    std::string       section;
+    
+    while (std::getline(strstream, section, ' '))
+      result.add(section.c_str());
+    
+    return result;
+  }
+  
+  
+  void DxvkXrProvider::shutdown() {
+    if (m_loadedOxrApi)
+      this->freeLibrary();
+    
+    m_loadedOxrApi      = false;
+    m_wineOxr = nullptr;
+  }
+
+
+  SoHandle DxvkXrProvider::loadLibrary() {
+    SoHandle handle = nullptr;
+    if (!(handle = ::GetModuleHandle("wineopenxr.dll"))) {
+      handle = ::LoadLibrary("wineopenxr.dll");
+      m_loadedOxrApi = handle != nullptr;
+    }
+    return handle;
+  }
+
+
+  void DxvkXrProvider::freeLibrary() {
+    ::FreeLibrary(m_wineOxr);
+  }
+
+  
+  void* DxvkXrProvider::getSym(const char* sym) {
+    return reinterpret_cast<void*>(
+      ::GetProcAddress(m_wineOxr, sym));
+  }
+}

--- a/src/dxvk/dxvk_openxr.h
+++ b/src/dxvk/dxvk_openxr.h
@@ -1,0 +1,75 @@
+#pragma once
+
+#include <mutex>
+#include <vector>
+
+#include "dxvk_extension_provider.h"
+
+#ifdef __WINE__
+using SoHandle = void*;
+#else
+using SoHandle = HMODULE;
+#endif
+
+namespace dxvk {
+
+  class DxvkInstance;
+
+  /**
+   * \brief OpenXR instance
+   * 
+   * Loads OpenXR to provide access to Vulkan extension queries.
+   */
+  class DxvkXrProvider : public DxvkExtensionProvider {
+    
+  public:
+    
+    DxvkXrProvider();
+    ~DxvkXrProvider();
+
+    std::string_view getName();
+
+    DxvkNameSet getInstanceExtensions();
+
+    DxvkNameSet getDeviceExtensions(
+            uint32_t      adapterId);
+    
+    void initInstanceExtensions();
+
+    void initDeviceExtensions(
+      const DxvkInstance* instance);
+
+    static DxvkXrProvider s_instance;
+
+  private:
+
+    std::mutex            m_mutex;
+    SoHandle              m_wineOxr     = nullptr;
+
+    bool m_loadedOxrApi      = false;
+    bool m_initializedInsExt = false;
+    bool m_initializedDevExt = false;
+
+    DxvkNameSet              m_insExtensions;
+    DxvkNameSet              m_devExtensions;
+    
+    DxvkNameSet queryInstanceExtensions() const;
+
+    DxvkNameSet queryDeviceExtensions() const;
+
+    DxvkNameSet parseExtensionList(
+      const std::string&              str) const;
+    
+    bool loadFunctions();
+
+    void shutdown();
+
+    SoHandle loadLibrary();
+
+    void freeLibrary();
+
+    void* getSym(const char* sym);
+    
+  };
+  
+}

--- a/src/dxvk/dxvk_options.cpp
+++ b/src/dxvk/dxvk_options.cpp
@@ -5,6 +5,7 @@ namespace dxvk {
   DxvkOptions::DxvkOptions(const Config& config) {
     enableStateCache      = config.getOption<bool>    ("dxvk.enableStateCache",       true);
     enableOpenVR          = config.getOption<bool>    ("dxvk.enableOpenVR",           true);
+    enableOpenXR          = config.getOption<bool>    ("dxvk.enableOpenXR",           true);
     numCompilerThreads    = config.getOption<int32_t> ("dxvk.numCompilerThreads",     0);
     useRawSsbo            = config.getOption<Tristate>("dxvk.useRawSsbo",             Tristate::Auto);
     useEarlyDiscard       = config.getOption<Tristate>("dxvk.useEarlyDiscard",        Tristate::Auto);

--- a/src/dxvk/dxvk_options.h
+++ b/src/dxvk/dxvk_options.h
@@ -14,6 +14,9 @@ namespace dxvk {
     /// Enables OpenVR loading
     bool enableOpenVR;
 
+    /// Enables OpenXR loading
+    bool enableOpenXR;
+
     /// Number of compiler threads
     /// when using the state cache
     int32_t numCompilerThreads;

--- a/src/dxvk/meson.build
+++ b/src/dxvk/meson.build
@@ -81,6 +81,7 @@ dxvk_src = files([
   'dxvk_meta_pack.cpp',
   'dxvk_meta_resolve.cpp',
   'dxvk_openvr.cpp',
+  'dxvk_openxr.cpp',
   'dxvk_options.cpp',
   'dxvk_pipecache.cpp',
   'dxvk_pipelayout.cpp',


### PR DESCRIPTION
Two commits here to support OpenXR with DXVK.

The first commit extends the interop interfaces to provide a couple more methods that our OpenXR wrapper needs. We need the queue index, not the queue handle, for [XrGraphicsBindingVulkanKHR](https://www.khronos.org/registry/OpenXR/specs/1.0/man/html/openxr.html#_xrgraphicsbindingvulkankhr3), so I added a new method to retrieve that. Also, [OpenXR returns VkImages](https://www.khronos.org/registry/OpenXR/specs/1.0/man/html/openxr.html#xrEnumerateSwapchainImages) which the application should render to. We need a method to wrap that in an ID3D11Texture to return to the application in [XrSwapchainImageD3D11KHR](https://www.khronos.org/registry/OpenXR/specs/1.0/man/html/openxr.html#XrSwapchainImageD3D11KHR).

_(Review note: Is this the correct way to extend the interop interfaces? How should the new IID be generated?)_

The second commit adds a new extension provider for OpenXR. Unfortunately SteamVR's OpenXR implementation is very picky. Notably, you cannot create two XrInstances simultaneously. That means we can't use the method we use for OpenVR where we create and destroy an instance, as the application may have already created an instance. For that reason, I added two methods that are specific to wineopenxr to retrieve the required Vulkan instance and device extensions. That means this support is limited to wineopenxr and won't work with other OpenXR implementations.

Are you interested in merging this, or something like it? If not, it could instead live in the Proton DXVK fork.