### PR TITLE
[d3d11] Fix device ref counting from queries.

### DIFF
--- a/src/d3d11/d3d11_query.cpp
+++ b/src/d3d11/d3d11_query.cpp
@@ -126,7 +126,7 @@ namespace dxvk {
   
   
   void STDMETHODCALLTYPE D3D11Query::GetDevice(ID3D11Device **ppDevice) {
-    *ppDevice = ref(m_device);
+    *ppDevice = m_device.ref();
   }
   
   

--- a/src/d3d11/d3d11_query.h
+++ b/src/d3d11/d3d11_query.h
@@ -96,7 +96,7 @@ namespace dxvk {
     
   private:
     
-    D3D11Device* const m_device;
+    const Com<D3D11Device> m_device;
     D3D11_QUERY_DESC1  m_desc;
 
     D3D11_VK_QUERY_STATE m_state;


### PR DESCRIPTION
Fixes AO Tennis 2 crash on exit.

The crash is due to DxvkGpuQueryAllocator::freeQuery is called after the DxvkGpuQueryAllocator has been already freed, which is probably due to missing reference counting from d3d11 query to d3d11 device (device gets destroyed while there are still queries created from it). The similar crash is reproducible on Windows with dxvk.