### PR TITLE
[d3d11] Fix forward declaration of ID3D11Texture2D

### DIFF
--- a/src/dxgi/dxgi_interfaces.h
+++ b/src/dxgi/dxgi_interfaces.h
@@ -288,7 +288,7 @@ IDXGIVkInteropDevice : public IUnknown {
 };
 
 struct D3D11_TEXTURE2D_DESC1;
-class ID3D11Texture2D;
+struct ID3D11Texture2D;
 
 /**
  * \brief See IDXGIVkInteropDevice.


### PR DESCRIPTION
This should be struct not class.

Silences warnings in MSVC.