### PR TITLE
[d3d9] Early updates for textures

### DIFF
--- a/src/d3d9/d3d9_common_texture.h
+++ b/src/d3d9/d3d9_common_texture.h
@@ -300,9 +300,19 @@ namespace dxvk {
       return m_type;
     }
 
+    bool ShouldUpdateMappedBufferEarly() const {
+      // The texture has been locked very frequently.
+      // This indicates that it gets locked every frame
+      // and we should try our hardest to avoid the late copy to the mapping buffer.
+      return m_totalLockCount > 256;
+    }
+
     const D3D9_VK_FORMAT_MAPPING& GetMapping() { return m_mapping; }
 
-    void SetLocked(UINT Subresource, bool value) { m_locked.set(Subresource, value); }
+    void SetLocked(UINT Subresource, bool value) {
+      m_totalLockCount += 1;
+      m_locked.set(Subresource, value);
+    }
 
     bool GetLocked(UINT Subresource) const { return m_locked.get(Subresource); }
 
@@ -405,6 +415,8 @@ namespace dxvk {
     bool                          m_needsMipGen = false;
 
     D3DTEXTUREFILTERTYPE          m_mipFilter = D3DTEXF_LINEAR;
+
+    uint32_t                      m_totalLockCount = 0;
 
     /**
      * \brief Mip level

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -706,6 +706,10 @@ namespace dxvk {
             D3D9CommonTexture*      pResource,
             UINT                    Subresource);
 
+    void UpdateMappedBuffer(
+            D3D9CommonTexture*      pResource,
+            UINT                    Subresource);
+
     void EmitGenerateMips(
             D3D9CommonTexture* pResource);
 


### PR DESCRIPTION
Mass Effect locks 2 textures every frame and those are always dirty so the game has to queue a copy and synchronize the gpu immediately afterwards.

So I propose copying the UpdateMappedBufferEarly approach from D3D11 and updating the mapping buffer after most writing operations (except if it's used as an RT). I put it behind a super simple heurstic though..

@mirh Please test if this PR improves performance for you.