### PR TITLE
Workaround F1 2020 artifact bug.

### DIFF
--- a/src/d3d11/d3d11_shader.cpp
+++ b/src/d3d11/d3d11_shader.cpp
@@ -20,7 +20,7 @@ namespace dxvk {
       reinterpret_cast<const char*>(pShaderBytecode),
       BytecodeLength);
     
-    DxbcModule module(reader);
+    DxbcModule module(reader, name);
     
     // If requested by the user, dump both the raw DXBC
     // shader and the compiled SPIR-V module to a file.

--- a/src/dxbc/dxbc_decoder.h
+++ b/src/dxbc/dxbc_decoder.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <array>
+#include <vector>
+#include <set>
 
 #include "dxbc_common.h"
 #include "dxbc_decoder.h"
@@ -453,6 +455,8 @@ namespace dxvk {
   class DxbcDecodeContext {
     
   public:
+    DxbcDecodeContext(std::string name) : m_name(std::move(name)), m_instr_num(0),
+                                          m_if_condition_saved(false), m_emitting_sync(0) {}
     
     /**
      * \brief Retrieves current instruction
@@ -481,6 +485,15 @@ namespace dxvk {
     std::array<DxbcRegister,  8> m_srcOperands;
     std::array<DxbcImmediate, 4> m_immOperands;
     std::array<DxbcRegister, 12> m_indices;
+
+    std::string m_name;
+    std::vector<uint32_t> m_if_stack;
+    size_t m_instr_num;
+    uint32_t m_new_temp;
+    bool m_if_condition_saved;
+    uint32_t m_emitting_sync;
+    std::set<uint32_t> m_written_buffers;
+    DxbcZeroTest m_zero_test;
     
     // Index into the indices array. Used when decoding
     // instruction operands with relative indexing.

--- a/src/dxbc/dxbc_module.cpp
+++ b/src/dxbc/dxbc_module.cpp
@@ -4,8 +4,8 @@
 
 namespace dxvk {
   
-  DxbcModule::DxbcModule(DxbcReader& reader)
-  : m_header(reader) {
+  DxbcModule::DxbcModule(DxbcReader& reader, std::string name)
+  : m_header(reader), m_name(std::move(name)) {
     for (uint32_t i = 0; i < m_header.numChunks(); i++) {
       
       // The chunk tag is stored at the beginning of each chunk
@@ -89,7 +89,7 @@ namespace dxvk {
   void DxbcModule::runAnalyzer(
           DxbcAnalyzer&       analyzer,
           DxbcCodeSlice       slice) const {
-    DxbcDecodeContext decoder;
+    DxbcDecodeContext decoder(m_name);
     
     while (!slice.atEnd()) {
       decoder.decodeInstruction(slice);
@@ -103,7 +103,7 @@ namespace dxvk {
   void DxbcModule::runCompiler(
           DxbcCompiler&       compiler,
           DxbcCodeSlice       slice) const {
-    DxbcDecodeContext decoder;
+    DxbcDecodeContext decoder(m_name);
     
     while (!slice.atEnd()) {
       decoder.decodeInstruction(slice);

--- a/src/dxbc/dxbc_module.h
+++ b/src/dxbc/dxbc_module.h
@@ -28,7 +28,7 @@ namespace dxvk {
     
   public:
     
-    DxbcModule(DxbcReader& reader);
+    DxbcModule(DxbcReader& reader, std::string name = "");
     ~DxbcModule();
     
     /**
@@ -82,6 +82,8 @@ namespace dxvk {
     Rc<DxbcIsgn> m_osgnChunk;
     Rc<DxbcIsgn> m_psgnChunk;
     Rc<DxbcShex> m_shexChunk;
+
+    std::string m_name;
     
     void runAnalyzer(
             DxbcAnalyzer&       analyzer,


### PR DESCRIPTION
This PR is an attempt to fix the artifacts in F1 2020. While developing it I was not aware of the TGSM barrier workaround, and I basically discovered the same trick independently. However, the TGSM barrier workaround as it is currently implemented in DXVK does not completely fix the issue, although it goes really close, so I would like to propose my solution as well. My current patch is definitely not ready for inclusion, so I am writing to know from DXVK developers their opinion on accepting a more complete solution for the F1 shader bugs.

### Context: what is the problem with the buggy shaders
I did this analysis on F1 2020; I guess the same is happening for earlier versions of F1, but I am not sure. A compute shader used to preprocess lighting divides the scene into a number of 16x16 tiles, and would like to compute for each tile the minumum (and maximum, but let us focus on the minimum) of an array of 64 values (which happen to be depth values for that tile). A thread group is spawned for each tile, and 64 threads are spawned in each thread group. In the interesting section, the 64 threads are executing along the lines of this pseudo-code:
```c
float x[64];    // the array for which we want to compute the minimum, which is in TGSM
if (thread_id < 32) {
    x[thread_id] = min(x[thread_id], x[thread_id+32]);
    x[thread_id] = min(x[thread_id], x[thread_id+16]);
    x[thread_id] = min(x[thread_id], x[thread_id+8]);
    x[thread_id] = min(x[thread_id], x[thread_id+4]);
    x[thread_id] = min(x[thread_id], x[thread_id+2]);
    x[thread_id] = min(x[thread_id], x[thread_id+1]);
}
float minimum = x[0];    // this is the result
```
This code is correct as long as the seven lines inside the `if` block are executed in lockstep and all writes are immediately visible to other threads, which is not enforced by the code. I don't know why it works with D3D11, but clearly it does not with Vulkan.

### Why the current solution does not completely fix the problem
The current solution simply causes a memory barrier to be inserted between the seven lines inside the `if` block in my pseudo-code, generating this pseudo-code:
```c
float x[64];    // the array for which we want to compute the minimum, which is in TGSM
if (thread_id < 32) {
    x[thread_id] = min(x[thread_id], x[thread_id+32]);
    memory_barrier();
    x[thread_id] = min(x[thread_id], x[thread_id+16]);
    memory_barrier();
    x[thread_id] = min(x[thread_id], x[thread_id+8]);
    memory_barrier();
    x[thread_id] = min(x[thread_id], x[thread_id+4]);
    memory_barrier();
    x[thread_id] = min(x[thread_id], x[thread_id+2]);
    memory_barrier();
    x[thread_id] = min(x[thread_id], x[thread_id+1]);
    memory_barrier();
}
float minimum = x[0];    // this is the result
```
This clearly helps a lot, but doesn't completely fix the problem, because, since they are not control barriers, a thread might be reading for the following line while another hasn't even issued to write for the previous line. So, even if writes are assumed to be immediately visible, the more advanced thread will miss the read. What we really need is a memory and control barrier between each line in the `if` block.

Unfortunately we cannot just change the memory barriers in control barriers, because control barriers cannot be inserted inside dynamic control flow.

The problem here is not just theoretical: I can still see some artifacts even with the TGSM barrier workaround enable. Sure, they are much much fewer and much much smaller, but still there they are (on my Intel iGPU I can see a few pixels worth of artifact every ~10 seconds).

### My solution
My solutions attempts to completely tackle the problem (and I couldn't observe any artifacts with it) by putting actual control barriers in the code and modifying control flow so that the resulting code is legal. In practice, the code above is changed to this:
```c
float x[64];    // the array for which we want to compute the minimum, which is in TGSM
int condition = thread_id < 32;
if (condition) {
    x[thread_id] = min(x[thread_id], x[thread_id+32]);
}
memory_and_control_barrier();
if (condition) {
    x[thread_id] = min(x[thread_id], x[thread_id+16]);
}
memory_and_control_barrier();
if (condition) {
    x[thread_id] = min(x[thread_id], x[thread_id+8]);
}
memory_and_control_barrier();
if (condition) {
    x[thread_id] = min(x[thread_id], x[thread_id+4]);
}
memory_and_control_barrier();
if (condition) {
    x[thread_id] = min(x[thread_id], x[thread_id+2]);
}
memory_and_control_barrier();
if (condition) {
    x[thread_id] = min(x[thread_id], x[thread_id+1]);
}
memory_and_control_barrier();
float minimum = x[0];    // this is the result
```
This should be correct both theoretically and practically. It is also very complicated, unfortunately, because it has to track at least to some degree the flow of the shader code. Also, for the moment it works by patching the DXBC code, not the SPIR-V code, hijacking the DXBC decoder in a very unclean way.

So the final question to DXVK authors is this: could you give me some suggestion on how to rework this patch in a way that can be accepted in DXVK? The hard part IMHO is how to manage the control flow: does DXVK have any facility to help with that?