### PR TITLE
[util] Enable dxgi.customVendorId for Hitman 3

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -117,8 +117,8 @@ namespace dxvk {
     { R"(\\vr\.exe$)", {{
       { "d3d11.dcSingleUseMode",            "False" },
     }} },
-    /* Hitman 2 - requires AGS library            */
-    { R"(\\HITMAN2\.exe$)", {{
+    /* Hitman 2 and 3 - requires AGS library      */
+    { R"(\\HITMAN(2|3)\.exe$)", {{
       { "dxgi.customVendorId",              "10de" },
     }} },
     /* Modern Warfare Remastered                  */


### PR DESCRIPTION
Hitman 3 runs on pretty much the exact same engine as Hitman 2, except it's DirectX 12 only for some reason. It seems to crash on startup without either disabling nvapiHack or setting the vendor ID to NVIDIA.