### PR TITLE
[build] Add optional build-id

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -26,6 +26,12 @@ if dxvk_compiler.get_id() == 'clang'
   endif
 endif
 
+if get_option('build_id') and dxvk_compiler.get_id() != 'msvc'
+  if dxvk_compiler.has_link_argument('-Wl,--build-id')
+    add_global_link_arguments('-Wl,--build-id', language: 'cpp')
+  endif
+endif
+
 dxvk_include_path = include_directories('./include')
 
 if (cpu_family == 'x86_64')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -3,3 +3,4 @@ option('enable_dxgi',  type : 'boolean', value : true, description: 'Build DXGI'
 option('enable_d3d9',  type : 'boolean', value : true, description: 'Build D3D9')
 option('enable_d3d10', type : 'boolean', value : true, description: 'Build D3D10')
 option('enable_d3d11', type : 'boolean', value : true, description: 'Build D3D11')
+option('build_id',     type : 'boolean', value : false)

--- a/package-release.sh
+++ b/package-release.sh
@@ -23,6 +23,7 @@ shift 2
 
 opt_nopackage=0
 opt_devbuild=0
+opt_buildid=false
 
 crossfile="build-win"
 
@@ -34,6 +35,9 @@ while [ $# -gt 0 ]; do
   "--dev-build")
     opt_nopackage=1
     opt_devbuild=1
+    ;;
+  "--build-id")
+    opt_buildid=true
     ;;
   *)
     echo "Unrecognized option: $1" >&2
@@ -55,6 +59,7 @@ function build_arch {
         --bindir "x$1"                                \
         --libdir "x$1"                                \
         -Denable_tests=false                          \
+        -Dbuild_id=$opt_buildid                       \
         "$DXVK_BUILD_DIR/build.$1"
 
   cd "$DXVK_BUILD_DIR/build.$1"


### PR DESCRIPTION
Build-ids are required for doing certain kinds of performance tracing.
For example build-ids let Linux perf find the correct objects and
transfer them to other machines via "perf archive".

This adds an option to add -Wl,--build-id to the linker. It can be
enabled by passing -Dbuild_id=true to meson or --build-id to
package-release.sh.

Signed-off-by: Nicholas Fraser <nfraser@codeweavers.com>