### PR TITLE
[dxvk] Fix resource tracking in attachment transitions

### DIFF
--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -4063,6 +4063,8 @@ namespace dxvk {
         attachment.view->imageInfo().layout,
         attachment.view->imageInfo().stages,
         attachment.view->imageInfo().access);
+
+      m_cmd->trackResource<DxvkAccess::Write>(attachment.view->image());
     }
   }
 
@@ -4082,6 +4084,8 @@ namespace dxvk {
         attachment.view->imageInfo().layout,
         attachment.view->imageInfo().stages,
         attachment.view->imageInfo().access);
+
+      m_cmd->trackResource<DxvkAccess::Write>(attachment.view->image());
     }
   }
 


### PR DESCRIPTION
Fixes a crash in Portal 2 on DXVK native in which an old depth stencil is used after free after a device reset.