### PR TITLE
[dxvk] Only pass needed amount of clear values when binding a framebuffer

### DIFF
--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -3470,7 +3470,7 @@ namespace dxvk {
       this->renderPassBindFramebuffer(
         m_state.om.framebuffer,
         m_state.om.renderPassOps,
-        m_state.om.clearValues.size(),
+        m_state.om.framebuffer->numAttachments(),
         m_state.om.clearValues.data());
 
       // Track the final layout of each render target


### PR DESCRIPTION
Works around a Renderdoc bug and should hopefully make more sense.

The views are compacted in a framebuffer so it should be fine to do this.