### PR TITLE
[d3d9] Convert window position relative to its parent.

### DIFF
--- a/src/d3d9/d3d9_swapchain.cpp
+++ b/src/d3d9/d3d9_swapchain.cpp
@@ -617,6 +617,7 @@ namespace dxvk {
       RECT oldRect = { 0, 0, 0, 0 };
       
       ::GetWindowRect(m_window, &oldRect);
+      ::MapWindowPoints(HWND_DESKTOP, ::GetParent(m_window), reinterpret_cast<POINT*>(&oldRect), 1);
       ::SetRect(&newRect, 0, 0, pPresentParams->BackBufferWidth, pPresentParams->BackBufferHeight);
       ::AdjustWindowRectEx(&newRect,
         ::GetWindowLongW(m_window, GWL_STYLE), FALSE,


### PR DESCRIPTION
When using child windows, GetWindowRect is in screen coordinates while MoveWindow expects parent-relative position.