### PR TITLE
[build] Use --file-alignment=4096 with MinGW

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -5,15 +5,16 @@ cpu_family = target_machine.cpu_family()
 add_project_arguments('-DNOMINMAX', language : 'cpp')
 
 dxvk_compiler = meson.get_compiler('cpp')
-dxvk_msvc=dxvk_compiler.get_id() == 'msvc'
+dxvk_is_msvc = dxvk_compiler.get_id() == 'msvc'
+
 # c++17 was added in 15.3, older version needs c++latest
-if dxvk_compiler.get_id() == 'msvc' and dxvk_compiler.version().version_compare('<15.3')
+if dxvk_is_msvc and dxvk_compiler.version().version_compare('<15.3')
   dxvk_cpp_std='c++latest'
 else
   dxvk_cpp_std='c++17'
 endif
 
-if dxvk_compiler.get_id() == 'msvc'
+if dxvk_is_msvc
   add_project_arguments('/std:' + dxvk_cpp_std, language : 'cpp')
 endif
 
@@ -26,7 +27,7 @@ if dxvk_compiler.get_id() == 'clang'
   endif
 endif
 
-if dxvk_compiler.get_id() != 'msvc'
+if not dxvk_is_msvc
   if get_option('build_id') and dxvk_compiler.has_link_argument('-Wl,--build-id')
     add_global_link_arguments('-Wl,--build-id', language: 'cpp')
   endif
@@ -48,7 +49,7 @@ endif
 
 dxvk_extradep = [ ]
 
-if dxvk_compiler.get_id() == 'msvc'
+if dxvk_is_msvc
   wrc = find_program('rc')
 else
   add_global_link_arguments('-static', '-static-libgcc', language: 'c')
@@ -82,7 +83,7 @@ lib_d3d11   = dxvk_compiler.find_library('d3d11')
 lib_dxgi    = dxvk_compiler.find_library('dxgi')
 lib_d3dcompiler_43 = dxvk_compiler.find_library('d3dcompiler_43', dirs : dxvk_library_path)
 
-if dxvk_compiler.get_id() == 'msvc'
+if dxvk_is_msvc
   lib_d3dcompiler_47 = dxvk_compiler.find_library('d3dcompiler')
 else
   lib_d3dcompiler_47 = dxvk_compiler.find_library('d3dcompiler_47')
@@ -91,7 +92,7 @@ endif
 exe_ext = ''
 dll_ext = ''
 
-if dxvk_compiler.get_id() == 'msvc'
+if dxvk_is_msvc
   res_ext = '.res'
 else
   res_ext = '.o'
@@ -104,7 +105,7 @@ glsl_generator = generator(glsl_compiler,
   output    : [ '@BASENAME@.h' ],
   arguments : [ '-V', '--vn', '@BASENAME@', '@INPUT@', '-o', '@OUTPUT@' ])
 
-if dxvk_compiler.get_id() == 'msvc'
+if dxvk_is_msvc
   wrc_generator = generator(wrc,
   output    : [ '@BASENAME@' + res_ext ],
   arguments : [ '/fo', '@OUTPUT@', '@INPUT@' ])

--- a/meson.build
+++ b/meson.build
@@ -26,9 +26,15 @@ if dxvk_compiler.get_id() == 'clang'
   endif
 endif
 
-if get_option('build_id') and dxvk_compiler.get_id() != 'msvc'
-  if dxvk_compiler.has_link_argument('-Wl,--build-id')
+if dxvk_compiler.get_id() != 'msvc'
+  if get_option('build_id') and dxvk_compiler.has_link_argument('-Wl,--build-id')
     add_global_link_arguments('-Wl,--build-id', language: 'cpp')
+  endif
+
+  # We need to set the section alignment for debug symbols to
+  # work properly as well as avoiding a memcpy from the Wine loader.
+  if dxvk_compiler.has_link_argument('-Wl,--file-alignment=4096')
+    add_global_link_arguments('-Wl,--file-alignment=4096', language: 'cpp')
   endif
 endif
 

--- a/src/d3d10/meson.build
+++ b/src/d3d10/meson.build
@@ -17,7 +17,7 @@ d3d10_core_dll = shared_library('d3d10core'+dll_ext, d3d10_core_src, d3d10_core_
   dependencies        : [ d3d11_dep ],
   include_directories : dxvk_include_path,
   install             : true,
-  objects             : not dxvk_msvc ? 'd3d10core'+def_spec_ext : [],
+  objects             : not dxvk_is_msvc ? 'd3d10core'+def_spec_ext : [],
   vs_module_defs      : 'd3d10core'+def_spec_ext,
   override_options    : ['cpp_std='+dxvk_cpp_std])
 
@@ -31,7 +31,7 @@ d3d10_dll = shared_library('d3d10'+dll_ext, d3d10_main_src, d3d10_res,
   dependencies        : [ d3d10_deps ],
   include_directories : dxvk_include_path,
   install             : true,
-  objects             : not dxvk_msvc ? 'd3d10'+def_spec_ext : [],
+  objects             : not dxvk_is_msvc ? 'd3d10'+def_spec_ext : [],
   vs_module_defs      : 'd3d10'+def_spec_ext,
   override_options    : ['cpp_std='+dxvk_cpp_std])
 
@@ -40,7 +40,7 @@ d3d10_1_dll = shared_library('d3d10_1'+dll_ext, d3d10_main_src, d3d10_1_res,
   dependencies        : [ d3d10_deps ],
   include_directories : dxvk_include_path,
   install             : true,
-  objects             : not dxvk_msvc ? 'd3d10_1'+def_spec_ext : [],
+  objects             : not dxvk_is_msvc ? 'd3d10_1'+def_spec_ext : [],
   vs_module_defs      : 'd3d10_1'+def_spec_ext,
   override_options    : ['cpp_std='+dxvk_cpp_std])
 

--- a/src/d3d11/meson.build
+++ b/src/d3d11/meson.build
@@ -63,7 +63,7 @@ d3d11_dll = shared_library('d3d11'+dll_ext, dxgi_common_src + d3d11_src + d3d10_
   dependencies        : [ lib_dxgi, dxbc_dep, dxvk_dep ],
   include_directories : dxvk_include_path,
   install             : true,
-  objects             : not dxvk_msvc ? 'd3d11'+def_spec_ext : [],
+  objects             : not dxvk_is_msvc ? 'd3d11'+def_spec_ext : [],
   vs_module_defs      : 'd3d11'+def_spec_ext,
   override_options    : ['cpp_std='+dxvk_cpp_std])
 

--- a/src/d3d9/meson.build
+++ b/src/d3d9/meson.build
@@ -46,7 +46,7 @@ d3d9_dll = shared_library('d3d9'+dll_ext, d3d9_src, glsl_generator.process(d3d9_
   dependencies        : [ dxso_dep, dxvk_dep ],
   include_directories : dxvk_include_path,
   install             : true,
-  objects             : not dxvk_msvc ? 'd3d9'+def_spec_ext : [],
+  objects             : not dxvk_is_msvc ? 'd3d9'+def_spec_ext : [],
   vs_module_defs      : 'd3d9'+def_spec_ext,
   override_options    : ['cpp_std='+dxvk_cpp_std])
 

--- a/src/dxgi/meson.build
+++ b/src/dxgi/meson.build
@@ -18,7 +18,7 @@ dxgi_dll = shared_library('dxgi'+dll_ext, dxgi_src, dxgi_res,
   include_directories : dxvk_include_path,
   install             : true,
   vs_module_defs      : 'dxgi'+def_spec_ext,
-  objects             : not dxvk_msvc ? 'dxgi'+def_spec_ext : [],
+  objects             : not dxvk_is_msvc ? 'dxgi'+def_spec_ext : [],
   override_options    : ['cpp_std='+dxvk_cpp_std])
 
 dxgi_dep = declare_dependency(


### PR DESCRIPTION
Avoids a copy in the Wine loader as well as enables debug symbols to work in perf.