### PR TITLE
Add option and version check for NVIDIA HVV workaround

### DIFF
--- a/dxvk.conf
+++ b/dxvk.conf
@@ -206,6 +206,20 @@
 # dxvk.useEarlyDiscard = Auto
 
 
+# Controls workaround for NVIDIA HVV Heap bug.
+#
+# Limits the budget of NVIDIA's HVV (host-visible,
+# device-local) heap to be half of the reported size. This is
+# needed to avoid NVIDIA driver bug 3114283, and defaults to
+# being enabled on all affected drivers.
+#
+# Supported values:
+# - Auto: Don't change the default
+# - True, False: Always enable / disable
+
+# dxvk.halveNvidiaHVVHeap = Auto
+
+
 # Sets enabled HUD elements
 # 
 # Behaves like the DXVK_HUD environment variable if the

--- a/src/dxvk/dxvk_memory.cpp
+++ b/src/dxvk/dxvk_memory.cpp
@@ -180,7 +180,16 @@ namespace dxvk {
     /* Work around an issue on Nvidia drivers where using the entire
      * device_local | host_visible heap can cause crashes, presumably
      * due to subsequent internal driver allocations failing */
-    bool nvidiaBug3114283Active = true;
+    bool nvidiaBug3114283Active = false;
+
+    // Fix is available in mainline drivers starting with the 465 driver series.
+    if (device->adapter()->matchesDriver(DxvkGpuVendor::Nvidia,
+                                         VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR,
+                                         0,
+                                         VK_MAKE_VERSION(465, 0, 0))) {
+      nvidiaBug3114283Active = true;
+    }
+
     applyTristate(nvidiaBug3114283Active, device->config().halveNvidiaHVVHeap);
 
     if ((m_device->properties().core.properties.vendorID == uint16_t(DxvkGpuVendor::Nvidia))

--- a/src/dxvk/dxvk_memory.cpp
+++ b/src/dxvk/dxvk_memory.cpp
@@ -180,7 +180,11 @@ namespace dxvk {
     /* Work around an issue on Nvidia drivers where using the entire
      * device_local | host_visible heap can cause crashes, presumably
      * due to subsequent internal driver allocations failing */
-    if (m_device->properties().core.properties.vendorID == uint16_t(DxvkGpuVendor::Nvidia)) {
+    bool nvidiaBug3114283Active = true;
+    applyTristate(nvidiaBug3114283Active, device->config().halveNvidiaHVVHeap);
+
+    if ((m_device->properties().core.properties.vendorID == uint16_t(DxvkGpuVendor::Nvidia))
+     && (nvidiaBug3114283Active)) {
       for (uint32_t i = 0; i < m_memProps.memoryTypeCount; i++) {
         constexpr VkMemoryPropertyFlags flags = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT | VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT;
 

--- a/src/dxvk/dxvk_options.cpp
+++ b/src/dxvk/dxvk_options.cpp
@@ -9,6 +9,7 @@ namespace dxvk {
     numCompilerThreads    = config.getOption<int32_t> ("dxvk.numCompilerThreads",     0);
     useRawSsbo            = config.getOption<Tristate>("dxvk.useRawSsbo",             Tristate::Auto);
     useEarlyDiscard       = config.getOption<Tristate>("dxvk.useEarlyDiscard",        Tristate::Auto);
+    halveNvidiaHVVHeap    = config.getOption<Tristate>("dxvk.halveNvidiaHVVHeap",     Tristate::Auto);
     hud                   = config.getOption<std::string>("dxvk.hud", "");
   }
 

--- a/src/dxvk/dxvk_options.h
+++ b/src/dxvk/dxvk_options.h
@@ -25,6 +25,12 @@ namespace dxvk {
     Tristate useRawSsbo;
     Tristate useEarlyDiscard;
 
+    /// Workaround for NVIDIA driver
+    /// bug 3114283. Cut usable HVV
+    /// (Host-Visible Vidmem) heap
+    /// in half to avoid crash
+    Tristate halveNvidiaHVVHeap;
+
     /// HUD elements
     std::string hud;
   };


### PR DESCRIPTION
NVIDIA Driver bug 3114283 is fixed in the latest Vulkan Developer Beta Driver [455.50.10](https://developer.nvidia.com/vulkan-driver) and will be fixed in the upcoming 465 driver series.

This PR adds an option for developers to disable the workaround in DXVK which limits the budget to half of the heap’s size, as well as adding a version check to disable this workaround starting with the 465 driver series.