### PR TITLE
Switch to the portable shebang to bash

### DIFF
--- a/package-release.sh
+++ b/package-release.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/setup_dxvk.sh
+++ b/setup_dxvk.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # default directories
 dxvk_lib32=${dxvk_lib32:-"x32"}


### PR DESCRIPTION
Hi.
We should go for the [portable shebang-form](https://en.wikipedia.org/w/index.php?title=Shebang_(Unix)&oldid=878552871#Portability) to get the bash environment. `/bin/bash` is also not a real thing on most distros anymore¹. This will bring compatiblity for distros who don't create the compat-symlink.


¹ Most distros:
```
file /bin
/bin: symbolic link to usr/bin
```