### PR TITLE
[dxvk] Use image memory barriers for readback

### DIFF
--- a/src/dxvk/dxvk_context.h
+++ b/src/dxvk/dxvk_context.h
@@ -615,8 +615,12 @@ namespace dxvk {
      *
      * Use between draw calls if the fragment shader
      * reads one of the currently bound render targets.
+     * \param [in] image Image
+     * \param [in] subresources Image subresources
      */
-    void emitRenderTargetReadbackBarrier();
+    void emitRenderTargetReadbackBarrier(
+      const Rc<DxvkImage>&           image,
+      const VkImageSubresourceRange& subresources);
 
     /**
      * \brief Generates mip maps


### PR DESCRIPTION
Targets only the specific subresource of the bound color attachments.

From the Vulkan spec:
Each of the synchronization scopes and access scopes of a vkCmdPipelineBarrier2KHR or vkCmdPipelineBarrier command inside a render pass instance must be a subset of the scopes of one of the self-dependencies for the current subpass.