### PR TITLE
D3D9 readonly locking cleanup

### DIFF
--- a/src/d3d9/d3d9_common_buffer.cpp
+++ b/src/d3d9/d3d9_common_buffer.cpp
@@ -14,6 +14,9 @@ namespace dxvk {
       m_stagingBuffer = CreateStagingBuffer();
 
     m_sliceHandle = GetMapBuffer()->getSliceHandle();
+
+    if (m_desc.Pool != D3DPOOL_DEFAULT)
+      m_dirtyRange = D3D9Range(0, m_desc.Size);
   }
 
 

--- a/src/d3d9/d3d9_common_buffer.h
+++ b/src/d3d9/d3d9_common_buffer.h
@@ -168,9 +168,10 @@ namespace dxvk {
     }
     uint32_t GetLockCount() const { return m_lockCount; }
 
-    void MarkUploaded()      { m_needsUpload = false; }
-    void MarkNeedsUpload()   { m_needsUpload = true; }
-    bool NeedsUpload() const { return m_needsUpload; }
+    /**
+     * \brief Whether or not the staging buffer needs to be copied to the actual buffer
+     */
+    bool NeedsUpload() { return m_desc.Pool != D3DPOOL_DEFAULT && !m_dirtyRange.IsDegenerate(); }
 
     void PreLoad();
 
@@ -205,8 +206,6 @@ namespace dxvk {
     D3D9Range                   m_gpuReadingRange;
 
     uint32_t                    m_lockCount = 0;
-
-    bool                        m_needsUpload = false;
 
   };
 

--- a/src/d3d9/d3d9_common_buffer.h
+++ b/src/d3d9/d3d9_common_buffer.h
@@ -139,11 +139,25 @@ namespace dxvk {
 
     static HRESULT ValidateBufferProperties(const D3D9_BUFFER_DESC* pDesc);
 
-    D3D9Range& LockRange()  { return m_lockRange; }
-    D3D9Range& DirtyRange() { return m_dirtyRange; }
+    /**
+     * \brief The range of the buffer that was changed using Lock calls
+     */
+    D3D9Range& DirtyRange()  { return m_dirtyRange; }
 
-    bool GetReadLocked() const     { return m_readLocked; }
-    void SetReadLocked(bool state) { m_readLocked = state; }
+    /**
+     * \brief The range of the buffer that might currently be read by the GPU
+     */
+    D3D9Range& GPUReadingRange() { return m_gpuReadingRange; }
+
+    /**
+    * \brief Whether or not the buffer was written to by the GPU (in IDirect3DDevice9::ProcessVertices)
+    */
+    bool WasWrittenByGPU() const     { return m_wasWrittenByGPU; }
+
+    /**
+    * \brief Sets whether or not the buffer was written to by the GPU
+    */
+    void SetWrittenByGPU(bool state) { m_wasWrittenByGPU = state; }
 
     uint32_t IncrementLockCount() { return ++m_lockCount; }
     uint32_t DecrementLockCount() {
@@ -157,12 +171,6 @@ namespace dxvk {
     void MarkUploaded()      { m_needsUpload = false; }
     void MarkNeedsUpload()   { m_needsUpload = true; }
     bool NeedsUpload() const { return m_needsUpload; }
-
-    bool MarkLocked() {
-      bool locked = m_readLocked;
-      m_readLocked = true;
-      return locked;
-    }
 
     void PreLoad();
 
@@ -186,15 +194,15 @@ namespace dxvk {
     D3D9DeviceEx*               m_parent;
     const D3D9_BUFFER_DESC      m_desc;
     DWORD                       m_mapFlags;
-    bool                        m_readLocked = false;
+    bool                        m_wasWrittenByGPU = false;
 
     Rc<DxvkBuffer>              m_buffer;
     Rc<DxvkBuffer>              m_stagingBuffer;
 
     DxvkBufferSliceHandle       m_sliceHandle;
 
-    D3D9Range                   m_lockRange;
     D3D9Range                   m_dirtyRange;
+    D3D9Range                   m_gpuReadingRange;
 
     uint32_t                    m_lockCount = 0;
 

--- a/src/d3d9/d3d9_common_texture.cpp
+++ b/src/d3d9/d3d9_common_texture.cpp
@@ -21,6 +21,13 @@ namespace dxvk {
       AddDirtyBox(nullptr, i);
     }
 
+    if (m_desc.Pool != D3DPOOL_DEFAULT) {
+      const uint32_t subresources = CountSubresources();
+      for (uint32_t i = 0; i < subresources; i++) {
+        SetNeedsUpload(i, true);
+      }
+    }
+
     m_mapping = pDevice->LookupFormat(m_desc.Format);
 
     m_mapMode = DetermineMapMode();

--- a/src/d3d9/d3d9_common_texture.cpp
+++ b/src/d3d9/d3d9_common_texture.cpp
@@ -17,8 +17,8 @@ namespace dxvk {
                     ? D3D9Format::D32
                     : D3D9Format::X8R8G8B8;
 
-    for (uint32_t i = 0; i < m_updateDirtyBoxes.size(); i++) {
-      AddUpdateDirtyBox(nullptr, i);
+    for (uint32_t i = 0; i < m_dirtyBoxes.size(); i++) {
+      AddDirtyBox(nullptr, i);
     }
 
     m_mapping = pDevice->LookupFormat(m_desc.Format);
@@ -489,7 +489,7 @@ namespace dxvk {
     if (IsManaged()) {
       auto lock = m_device->LockDevice();
 
-      if (GetNeedsUpload(Subresource)) {
+      if (NeedsUpload(Subresource)) {
         m_device->FlushImage(this, Subresource);
         SetNeedsUpload(Subresource, false);
 

--- a/src/d3d9/d3d9_common_texture.h
+++ b/src/d3d9/d3d9_common_texture.h
@@ -376,6 +376,10 @@ namespace dxvk {
           || box.Back <= box.Front)
           return;
 
+        box.Right = std::min(box.Right, m_desc.Width);
+        box.Bottom = std::min(box.Bottom, m_desc.Height);
+        box.Back = std::min(box.Back, m_desc.Depth);
+
         D3DBOX& dirtyBox = m_dirtyBoxes[layer];
         if (dirtyBox.Left == dirtyBox.Right) {
           dirtyBox = box;

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -4463,12 +4463,8 @@ namespace dxvk {
 
     // We need to remove the READONLY flags from the map flags
     // if there was ever a non-readonly upload.
-    if (!(Flags & D3DLOCK_READONLY)) {
+    if (!(Flags & D3DLOCK_READONLY))
       oldFlags &= ~D3DLOCK_READONLY;
-
-      if (pResource->Desc()->Pool != D3DPOOL_DEFAULT)
-        pResource->MarkNeedsUpload();
-    }
 
     pResource->SetMapFlags(Flags | oldFlags);
     pResource->IncrementLockCount();
@@ -4496,7 +4492,6 @@ namespace dxvk {
 
     pResource->GPUReadingRange().Conjoin(pResource->DirtyRange());
     pResource->DirtyRange().Clear();
-    pResource->MarkUploaded();
 
 	  return D3D_OK;
   }

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -3980,7 +3980,18 @@ namespace dxvk {
       Flags &= ~D3DLOCK_DISCARD;
 
     if (!(Flags & D3DLOCK_NO_DIRTY_UPDATE) && !(Flags & D3DLOCK_READONLY)) {
+      if (pBox && MipLevel != 0) {
+        D3DBOX scaledBox = *pBox;
+        scaledBox.Left   <<= MipLevel;
+        scaledBox.Right    = std::min(scaledBox.Right << MipLevel, pResource->Desc()->Width);
+        scaledBox.Top    <<= MipLevel;
+        scaledBox.Bottom   = std::min(scaledBox.Bottom << MipLevel, pResource->Desc()->Height);
+        scaledBox.Back   <<= MipLevel;
+        scaledBox.Front    = std::min(scaledBox.Front << MipLevel, pResource->Desc()->Depth);
+        pResource->AddDirtyBox(&scaledBox, Face);
+      } else {
         pResource->AddDirtyBox(pBox, Face);
+      }
     }
 
     auto& desc = *(pResource->Desc());

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -3957,9 +3957,6 @@ namespace dxvk {
     if (unlikely((Flags & (D3DLOCK_DISCARD | D3DLOCK_READONLY)) == (D3DLOCK_DISCARD | D3DLOCK_READONLY)))
       return D3DERR_INVALIDCALL;
 
-    if (unlikely(!m_d3d9Options.allowLockFlagReadonly))
-      Flags &= ~D3DLOCK_READONLY;
-
     if (unlikely(!m_d3d9Options.allowDoNotWait))
       Flags &= ~D3DLOCK_DONOTWAIT;
 
@@ -4336,9 +4333,6 @@ namespace dxvk {
 
     if (unlikely(ppbData == nullptr))
       return D3DERR_INVALIDCALL;
-
-    if (!m_d3d9Options.allowLockFlagReadonly)
-      Flags &= ~D3DLOCK_READONLY;
 
     if (!m_d3d9Options.allowDiscard)
       Flags &= ~D3DLOCK_DISCARD;

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -5008,7 +5008,7 @@ namespace dxvk {
 
   void D3D9DeviceEx::UploadManagedTexture(D3D9CommonTexture* pResource) {
     for (uint32_t subresource = 0; subresource < pResource->CountSubresources(); subresource++) {
-      if (!pResource->NeedsUpload(subresource))
+      if (!pResource->NeedsUpload(subresource) || pResource->GetBuffer(subresource) == nullptr)
         continue;
 
       this->FlushImage(pResource, subresource);

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -659,9 +659,9 @@ namespace dxvk {
           updateDirtyRect.Left = pDestPoint->x;
           updateDirtyRect.Top = pDestPoint->y;
         }
-        dstTextureInfo->AddUpdateDirtyBox(&updateDirtyRect, dst->GetFace());
+        dstTextureInfo->AddDirtyBox(&updateDirtyRect, dst->GetFace());
       } else {
-        dstTextureInfo->AddUpdateDirtyBox(nullptr, dst->GetFace());
+        dstTextureInfo->AddDirtyBox(nullptr, dst->GetFace());
       }
     }
 
@@ -718,7 +718,7 @@ namespace dxvk {
         cSrcExtent);
     });
 
-    dstTextureInfo->SetDirty(dst->GetSubresource(), true);
+    dstTextureInfo->SetWrittenByGPU(dst->GetSubresource(), true);
 
     if (dstTextureInfo->IsAutomaticMip())
       MarkTextureMipsDirty(dstTextureInfo);
@@ -753,7 +753,7 @@ namespace dxvk {
       mipLevels = 1;
 
     for (uint32_t a = 0; a < arraySlices; a++) {
-      const D3DBOX& box = srcTexInfo->GetUpdateDirtyBox(a);
+      const D3DBOX& box = srcTexInfo->GetDirtyBox(a);
       if (box.Left >= box.Right || box.Top >= box.Bottom || box.Front >= box.Back)
         continue;
 
@@ -799,11 +799,11 @@ namespace dxvk {
             cSrcExtent);
         });
 
-        dstTexInfo->SetDirty(dstTexInfo->CalcSubresource(a, m), true);
+        dstTexInfo->SetWrittenByGPU(dstTexInfo->CalcSubresource(a, m), true);
       }
     }
 
-    srcTexInfo->ClearUpdateDirtyBoxes();
+    srcTexInfo->ClearDirtyBoxes();
     if (dstTexInfo->IsAutomaticMip() && mipLevels != dstTexInfo->Desc()->MipLevels)
       MarkTextureMipsDirty(dstTexInfo);
 
@@ -861,7 +861,7 @@ namespace dxvk {
         cLevelExtent);
     });
 
-    dstTexInfo->SetDirty(dst->GetSubresource(), true);
+    dstTexInfo->SetWrittenByGPU(dst->GetSubresource(), true);
 
     return D3D_OK;
   }
@@ -1071,7 +1071,7 @@ namespace dxvk {
       });
     }
 
-    dstTextureInfo->SetDirty(dst->GetSubresource(), true);
+    dstTextureInfo->SetWrittenByGPU(dst->GetSubresource(), true);
 
     if (dstTextureInfo->IsAutomaticMip())
       MarkTextureMipsDirty(dstTextureInfo);
@@ -1149,7 +1149,7 @@ namespace dxvk {
       });
     }
 
-    dstTextureInfo->SetDirty(dst->GetSubresource(), true);
+    dstTextureInfo->SetWrittenByGPU(dst->GetSubresource(), true);
 
     if (dstTextureInfo->IsAutomaticMip())
       MarkTextureMipsDirty(dstTextureInfo);
@@ -1242,7 +1242,7 @@ namespace dxvk {
       if (texInfo->IsAutomaticMip())
         texInfo->SetNeedsMipGen(true);
 
-      texInfo->SetDirty(rt->GetSubresource(), true);
+      texInfo->SetWrittenByGPU(rt->GetSubresource(), true);
     }
 
     if (originalAlphaSwizzleRTs != m_alphaSwizzleRTs)
@@ -3980,7 +3980,7 @@ namespace dxvk {
       Flags &= ~D3DLOCK_DISCARD;
 
     if (!(Flags & D3DLOCK_NO_DIRTY_UPDATE) && !(Flags & D3DLOCK_READONLY)) {
-        pResource->AddUpdateDirtyBox(pBox, Face);
+        pResource->AddDirtyBox(pBox, Face);
     }
 
     auto& desc = *(pResource->Desc());
@@ -4033,14 +4033,15 @@ namespace dxvk {
 
     bool renderable = desc.Usage & (D3DUSAGE_RENDERTARGET | D3DUSAGE_DEPTHSTENCIL);
 
-    // If we are dirty, then we need to copy -> buffer
+    // If we recently wrote to the texture on the gpu,
+    // then we need to copy -> buffer
     // We are also always dirty if we are a render target,
     // a depth stencil, or auto generate mipmaps.
-    bool dirty = pResource->GetDirty(Subresource) || renderable;
-    pResource->SetDirty(Subresource, false);
-      
+    bool wasWrittenByGPU = pResource->WasWrittenByGPU(Subresource) || renderable;
+    pResource->SetWrittenByGPU(Subresource, false);
+
     DxvkBufferSliceHandle physSlice;
-      
+
     if (Flags & D3DLOCK_DISCARD) {
       // We do not have to preserve the contents of the
       // buffer if the entire image gets discarded.
@@ -4064,9 +4065,9 @@ namespace dxvk {
       // calling app promises not to overwrite data that is in use
       // or is reading. Remember! This will only trigger for MANAGED resources
       // that cannot get affected by GPU, therefore readonly is A-OK for NOT waiting.
-      const bool skipWait = (readOnly && managed) || scratch || (readOnly && systemmem && !dirty);
+      const bool skipWait = (readOnly && managed) || scratch || (readOnly && systemmem && !wasWrittenByGPU);
 
-      bool doImplicitDiscard = (managed || (systemmem && !dirty)) && !doNotWait;
+      bool doImplicitDiscard = (managed || (systemmem && !wasWrittenByGPU)) && !doNotWait;
 
       doImplicitDiscard = doImplicitDiscard && m_d3d9Options.allowImplicitDiscard;
 
@@ -4097,7 +4098,7 @@ namespace dxvk {
     else {
       physSlice = mappedBuffer->getSliceHandle();
 
-      if (unlikely(dirty)) {
+      if (unlikely(wasWrittenByGPU)) {
         Rc<DxvkImage> resourceImage = pResource->GetImage();
 
         Rc<DxvkImage> mappedImage = resourceImage->info().sampleCount != 1
@@ -4166,7 +4167,7 @@ namespace dxvk {
         if (!WaitForResource(mappedBuffer, Flags))
           return D3DERR_WASSTILLDRAWING;
       } else if (alloced) {
-        // If we are a new alloc, and we weren't dirty
+        // If we are a new alloc, and we weren't written by the GPU
         // that means that we are a newly initialized
         // texture, and hence can just memset -> 0 and
         // avoid a wait here.
@@ -4251,7 +4252,7 @@ namespace dxvk {
 
     if (shouldToss) {
       pResource->DestroyBufferSubresource(Subresource);
-      pResource->SetDirty(Subresource, true);
+      pResource->SetWrittenByGPU(Subresource, true);
     }
 
     return D3D_OK;
@@ -5011,7 +5012,7 @@ namespace dxvk {
 
   void D3D9DeviceEx::UploadManagedTexture(D3D9CommonTexture* pResource) {
     for (uint32_t subresource = 0; subresource < pResource->CountSubresources(); subresource++) {
-      if (!pResource->GetNeedsUpload(subresource))
+      if (!pResource->NeedsUpload(subresource))
         continue;
 
       this->FlushImage(pResource, subresource);
@@ -5047,7 +5048,7 @@ namespace dxvk {
   
   void D3D9DeviceEx::MarkTextureMipsDirty(D3D9CommonTexture* pResource) {
     pResource->SetNeedsMipGen(true);
-    pResource->MarkAllDirty();
+    pResource->MarkAllWrittenByGPU();
 
     for (uint32_t tex = m_activeTextures; tex; tex &= tex - 1) {
       // Guaranteed to not be nullptr...
@@ -6662,7 +6663,7 @@ namespace dxvk {
       });
     }
 
-    dstTextureInfo->MarkAllDirty();
+    dstTextureInfo->MarkAllWrittenByGPU();
   }
 
 

--- a/src/d3d9/d3d9_options.cpp
+++ b/src/d3d9/d3d9_options.cpp
@@ -44,7 +44,6 @@ namespace dxvk {
     this->shaderModel                   = config.getOption<int32_t>     ("d3d9.shaderModel",                   3);
     this->evictManagedOnUnlock          = config.getOption<bool>        ("d3d9.evictManagedOnUnlock",          false);
     this->dpiAware                      = config.getOption<bool>        ("d3d9.dpiAware",                      true);
-    this->allowLockFlagReadonly         = config.getOption<bool>        ("d3d9.allowLockFlagReadonly",         true);
     this->strictConstantCopies          = config.getOption<bool>        ("d3d9.strictConstantCopies",          false);
     this->strictPow                     = config.getOption<bool>        ("d3d9.strictPow",                     true);
     this->lenientClear                  = config.getOption<bool>        ("d3d9.lenientClear",                  false);

--- a/src/d3d9/d3d9_options.h
+++ b/src/d3d9/d3d9_options.h
@@ -34,11 +34,6 @@ namespace dxvk {
 
     /// Whether or not to set the process as DPI aware in Windows when the API interface is created.
     bool dpiAware;
-    
-    /// Handle D3DLOCK_READONLY properly.
-    ///
-    /// Risen 1 writes to buffers mapped with readonly.
-    bool allowLockFlagReadonly;
 
     /// True:  Copy our constant set into UBO if we are relative indexing ever.
     /// False: Copy our constant set into UBO if we are relative indexing at the start of a defined constant

--- a/src/d3d9/d3d9_swapchain.cpp
+++ b/src/d3d9/d3d9_swapchain.cpp
@@ -462,7 +462,7 @@ namespace dxvk {
         cLevelExtent);
     });
     
-    dstTexInfo->SetDirty(dst->GetSubresource(), true);
+    dstTexInfo->SetWrittenByGPU(dst->GetSubresource(), true);
 
     return D3D_OK;
   }

--- a/src/d3d9/d3d9_texture.cpp
+++ b/src/d3d9/d3d9_texture.cpp
@@ -78,9 +78,9 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE D3D9Texture2D::AddDirtyRect(CONST RECT* pDirtyRect) {
     if (pDirtyRect) {
       D3DBOX box = { UINT(pDirtyRect->left), UINT(pDirtyRect->top), UINT(pDirtyRect->right), UINT(pDirtyRect->bottom), 0, 1 };
-      m_texture.AddUpdateDirtyBox(&box, 0);
+      m_texture.AddDirtyBox(&box, 0);
     } else {
-      m_texture.AddUpdateDirtyBox(nullptr, 0);
+      m_texture.AddDirtyBox(nullptr, 0);
     }
     return D3D_OK;
   }
@@ -158,7 +158,7 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D9Texture3D::AddDirtyBox(CONST D3DBOX* pDirtyBox) {
-    m_texture.AddUpdateDirtyBox(pDirtyBox, 0);
+    m_texture.AddDirtyBox(pDirtyBox, 0);
     return D3D_OK;
   }
 
@@ -238,9 +238,9 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE D3D9TextureCube::AddDirtyRect(D3DCUBEMAP_FACES Face, CONST RECT* pDirtyRect) {
     if (pDirtyRect) {
       D3DBOX box = { UINT(pDirtyRect->left), UINT(pDirtyRect->top), UINT(pDirtyRect->right), UINT(pDirtyRect->bottom), 0, 1 };
-      m_texture.AddUpdateDirtyBox(&box, Face);
+      m_texture.AddDirtyBox(&box, Face);
     } else {
-      m_texture.AddUpdateDirtyBox(nullptr, Face);
+      m_texture.AddDirtyBox(nullptr, Face);
     }
     return D3D_OK;
   }

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -236,17 +236,11 @@ namespace dxvk {
     }} },
     /* Gothic 3                                   */
     { R"(\\Gothic(3|3Final| III Forsaken Gods)\.exe$)", {{
-      { "d3d9.allowLockFlagReadonly",       "False" },
       { "d3d9.supportDFFormats",            "False" },
     }} },
     /* Risen                                      */
     { R"(\\Risen[23]?\.exe$)", {{
-      { "d3d9.allowLockFlagReadonly",       "False" },
       { "d3d9.invariantPosition",           "True" },
-    }} },
-    /* Nostale                                    */
-    { R"(\\NostaleClientX\.exe$)", {{
-      { "d3d9.allowLockFlagReadonly",       "False" },
     }} },
     /* Sonic Adventure 2                          */
     { R"(\\Sonic Adventure 2\\(launcher|sonic2app)\.exe$)", {{
@@ -276,10 +270,6 @@ namespace dxvk {
        of a 1x1 one if DF24 is NOT supported      */
     { R"(\\Dead Space\.exe$)", {{
       { "d3d9.supportDFFormats",                 "False" },
-    }} },
-    /* Burnout Paradise                           */
-    { R"(\\BurnoutParadise\.exe$)", {{
-      { "d3d9.allowLockFlagReadonly",       "False" },
     }} },
     /* Halo 2                                     */
     { R"(\\halo2\.exe$)", {{


### PR DESCRIPTION
This still needs a lot of testing and some cleanup (especially the commits) so it's a draft.
I've tested Risen, Burnout Paradise and Nostale. Those three games needed the hack before.

It does a couple of things to clean up locking:

## Buffers

- Give `dirtyRange`, `lockRange` and `readLocked` names that better explain their purpose.
- Remove `needsUpload` because the same thing is being tracked by `dirtyRange` (or formally `lockRange`) anyway.
- Mark non-default buffers as dirty by default. This combined with the upload on the first draw is what allows us to get rid of the hack to disable `D3DLOCK_READONLY`.

## Textures

- Mark the texture as `needsUpload` by default. We still need that one here because the dirty box only for mip 0.
- Fix a couple of issues with how we handle the dirty box.
- Rename `updateDirtyBox` to just `dirtyBox` as it's no longer only being used for `UpdateTexture`/`UpdateSurface`

## General

- Remove the hack that disables `D3DLOCK_READONLY`

After that we should try to just generally clean up the logic in the Lock* functions and also only copy dirty parts of managed resources.