### PR TITLE
[util] Override default thread stack reserve size.

### DIFF
--- a/src/util/thread.h
+++ b/src/util/thread.h
@@ -40,8 +40,9 @@ namespace dxvk {
       // Reference for the thread function
       this->incRef();
 
-      m_handle = ::CreateThread(nullptr, 0,
-        ThreadFn::threadProc, this, 0, nullptr);
+      m_handle = ::CreateThread(nullptr, 0x100000,
+        ThreadFn::threadProc, this, STACK_SIZE_PARAM_IS_A_RESERVATION,
+        nullptr);
       
       if (m_handle == nullptr)
         throw DxvkError("Failed to create thread");


### PR DESCRIPTION
Some applications (Dragon Quest Builder 2 for instance) use an oversized
default thread stack reserve size (2G in this case), which causes every
DXVK thread to allocate as much memory, quickly exhausting system memory.

Explicitly specifying the desired stack reserve size overrides the default application setting.
