### PR TITLE
Implement ID3DUserDefinedAnnotations for D3D11

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ The following environment variables can be used for **debugging** purposes.
 - `DXVK_LOG_LEVEL=none|error|warn|info|debug` Controls message logging.
 - `DXVK_LOG_PATH=/some/directory` Changes path where log files are stored. Set to `none` to disable log file creation entirely, without disabling logging.
 - `DXVK_CONFIG_FILE=/xxx/dxvk.conf` Sets path to the configuration file.
+- `DXVK_PERF_EVENTS=1` Enables use of the VK_EXT_debug_utils extension for translating performance event markers.
 
 ## Troubleshooting
 DXVK requires threading support from your mingw-w64 build environment. If you

--- a/src/d3d11/d3d11_annotation.cpp
+++ b/src/d3d11/d3d11_annotation.cpp
@@ -1,9 +1,12 @@
 #include "d3d11_annotation.h"
+#include "d3d11_context.h"
+#include "d3d11_device.h"
 
 namespace dxvk {
 
-  D3D11UserDefinedAnnotation::D3D11UserDefinedAnnotation(ID3D11DeviceContext* ctx)
-  : m_container(ctx) { }
+  D3D11UserDefinedAnnotation::D3D11UserDefinedAnnotation(D3D11DeviceContext* ctx)
+  : m_container(ctx),
+    m_eventDepth(0) { }
 
 
   D3D11UserDefinedAnnotation::~D3D11UserDefinedAnnotation() {
@@ -30,26 +33,60 @@ namespace dxvk {
 
   INT STDMETHODCALLTYPE D3D11UserDefinedAnnotation::BeginEvent(
           LPCWSTR                 Name) {
-    // Currently not implemented
-    return -1;
+    if (!m_container->IsAnnotationEnabled())
+      return -1;
+
+    m_container->EmitCs([labelName = dxvk::str::fromws(Name)](DxvkContext *ctx) {
+      VkDebugUtilsLabelEXT label;
+      label.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_LABEL_EXT;
+      label.pNext = nullptr;
+      label.pLabelName = labelName.c_str();
+      label.color[0] = 1.0f;
+      label.color[1] = 1.0f;
+      label.color[2] = 1.0f;
+      label.color[3] = 1.0f;
+
+      ctx->beginDebugLabel(&label);
+    });
+
+    return m_eventDepth++;
   }
 
 
   INT STDMETHODCALLTYPE D3D11UserDefinedAnnotation::EndEvent() {
-    // Currently not implemented
-    return -1;
+    if (!m_container->IsAnnotationEnabled())
+      return -1;
+
+    m_container->EmitCs([](DxvkContext *ctx) {
+      ctx->endDebugLabel();
+    });
+
+    return m_eventDepth--;
   }
 
 
   void STDMETHODCALLTYPE D3D11UserDefinedAnnotation::SetMarker(
           LPCWSTR                 Name) {
-    // Currently not implemented
+    if (!m_container->IsAnnotationEnabled())
+      return;
+
+    m_container->EmitCs([labelName = dxvk::str::fromws(Name)](DxvkContext *ctx) {
+      VkDebugUtilsLabelEXT label;
+      label.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_LABEL_EXT;
+      label.pNext = nullptr;
+      label.pLabelName = labelName.c_str();
+      label.color[0] = 1.0f;
+      label.color[1] = 1.0f;
+      label.color[2] = 1.0f;
+      label.color[3] = 1.0f;
+
+      ctx->insertDebugLabel(&label);
+    });
   }
 
 
   BOOL STDMETHODCALLTYPE D3D11UserDefinedAnnotation::GetStatus() {
-    // Currently not implemented
-    return FALSE;
+    return m_container->IsAnnotationEnabled();
   }
 
 }

--- a/src/d3d11/d3d11_annotation.h
+++ b/src/d3d11/d3d11_annotation.h
@@ -4,11 +4,13 @@
 
 namespace dxvk {
 
+  class D3D11DeviceContext;
+
   class D3D11UserDefinedAnnotation : ID3DUserDefinedAnnotation {
 
   public:
 
-    D3D11UserDefinedAnnotation(ID3D11DeviceContext* ctx);
+    D3D11UserDefinedAnnotation(D3D11DeviceContext* ctx);
     ~D3D11UserDefinedAnnotation();
 
     ULONG STDMETHODCALLTYPE AddRef();
@@ -31,8 +33,10 @@ namespace dxvk {
 
   private:
 
-    ID3D11DeviceContext*  m_container;
+    D3D11DeviceContext*  m_container;
 
+    // Stack depth for non-finalized BeginEvent calls
+    int32_t m_eventDepth;
   };
 
 }

--- a/src/d3d11/d3d11_context.cpp
+++ b/src/d3d11/d3d11_context.cpp
@@ -3064,8 +3064,7 @@ namespace dxvk {
 
 
   BOOL STDMETHODCALLTYPE D3D11DeviceContext::IsAnnotationEnabled() {
-    // Not implemented in the backend
-    return FALSE;
+    return m_device->instance()->extensions().extDebugUtils;
   }
 
 

--- a/src/d3d11/d3d11_context.h
+++ b/src/d3d11/d3d11_context.h
@@ -19,6 +19,8 @@ namespace dxvk {
   
   class D3D11DeviceContext : public D3D11DeviceChild<ID3D11DeviceContext4> {
     friend class D3D11DeviceContextExt;
+    // Needed in order to call EmitCs for pushing markers
+    friend class D3D11UserDefinedAnnotation;
   public:
     
     D3D11DeviceContext(

--- a/src/dxvk/dxvk_cmdlist.cpp
+++ b/src/dxvk/dxvk_cmdlist.cpp
@@ -6,6 +6,7 @@ namespace dxvk {
   DxvkCommandList::DxvkCommandList(DxvkDevice* device)
   : m_device        (device),
     m_vkd           (device->vkd()),
+    m_vki           (device->instance()->vki()),
     m_cmdBuffersUsed(0),
     m_descriptorPoolTracker(device) {
     const auto& graphicsQueue = m_device->queues().graphics;
@@ -206,4 +207,15 @@ namespace dxvk {
     return m_vkd->vkQueueSubmit(queue, 1, &submitInfo, fence);
   }
   
+  void DxvkCommandList::cmdBeginDebugUtilsLabel(VkDebugUtilsLabelEXT *pLabelInfo) {
+    m_vki->vkCmdBeginDebugUtilsLabelEXT(m_execBuffer, pLabelInfo);
+  }
+
+  void DxvkCommandList::cmdEndDebugUtilsLabel() {
+    m_vki->vkCmdEndDebugUtilsLabelEXT(m_execBuffer);
+  }
+
+  void DxvkCommandList::cmdInsertDebugUtilsLabel(VkDebugUtilsLabelEXT *pLabelInfo) {
+    m_vki->vkCmdInsertDebugUtilsLabelEXT(m_execBuffer, pLabelInfo);
+  }
 }

--- a/src/dxvk/dxvk_cmdlist.h
+++ b/src/dxvk/dxvk_cmdlist.h
@@ -762,10 +762,17 @@ namespace dxvk {
         pipelineStage, queryPool, query);
     }
     
+    void cmdBeginDebugUtilsLabel(VkDebugUtilsLabelEXT *pLabelInfo);
+
+    void cmdEndDebugUtilsLabel();
+
+    void cmdInsertDebugUtilsLabel(VkDebugUtilsLabelEXT *pLabelInfo);
+
   private:
     
     DxvkDevice*         m_device;
     Rc<vk::DeviceFn>    m_vkd;
+    Rc<vk::InstanceFn>  m_vki;
     
     VkFence             m_fence;
     

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -2485,6 +2485,27 @@ namespace dxvk {
   void DxvkContext::trimStagingBuffers() {
     m_staging.trim();
   }
+
+  void DxvkContext::beginDebugLabel(VkDebugUtilsLabelEXT *label) {
+    if (!m_device->instance()->extensions().extDebugUtils)
+      return;
+
+    m_cmd->cmdBeginDebugUtilsLabel(label);
+  }
+
+  void DxvkContext::endDebugLabel() {
+    if (!m_device->instance()->extensions().extDebugUtils)
+      return;
+
+    m_cmd->cmdEndDebugUtilsLabel();
+  }
+
+  void DxvkContext::insertDebugLabel(VkDebugUtilsLabelEXT *label) {
+    if (!m_device->instance()->extensions().extDebugUtils)
+      return;
+
+    m_cmd->cmdInsertDebugUtilsLabel(label);
+  }
   
   
   void DxvkContext::blitImageFb(

--- a/src/dxvk/dxvk_context.h
+++ b/src/dxvk/dxvk_context.h
@@ -981,7 +981,32 @@ namespace dxvk {
      * given context are rare.
      */
     void trimStagingBuffers();
-    
+   
+    /**
+     * \brief Begins a debug label region
+     * \param [in] label The debug label
+     *
+     * Marks the start of a debug label region. Used by debugging/profiling
+     * tools to mark different workloads within a frame.
+     */
+    void beginDebugLabel(VkDebugUtilsLabelEXT *label);
+
+    /**
+     * \brief Ends a debug label region
+     *
+     * Marks the close of a debug label region. Used by debugging/profiling
+     * tools to mark different workloads within a frame.
+     */
+    void endDebugLabel();
+
+    /**
+     * \brief Inserts a debug label
+     * \param [in] label The debug label
+     *
+     * Inserts an instantaneous debug label. Used by debugging/profiling
+     * tools to mark different workloads within a frame.
+     */
+    void insertDebugLabel(VkDebugUtilsLabelEXT *label);
   private:
     
     Rc<DxvkDevice>          m_device;

--- a/src/dxvk/dxvk_extensions.h
+++ b/src/dxvk/dxvk_extensions.h
@@ -292,6 +292,7 @@ namespace dxvk {
    * used by DXVK if supported by the implementation.
    */
   struct DxvkInstanceExtensions {
+    DxvkExt extDebugUtils                   = { VK_EXT_DEBUG_UTILS_EXTENSION_NAME,                      DxvkExtMode::Optional };
     DxvkExt khrGetSurfaceCapabilities2      = { VK_KHR_GET_SURFACE_CAPABILITIES_2_EXTENSION_NAME,       DxvkExtMode::Optional };
     DxvkExt khrSurface                      = { VK_KHR_SURFACE_EXTENSION_NAME,                          DxvkExtMode::Required };
   };

--- a/src/dxvk/dxvk_instance.cpp
+++ b/src/dxvk/dxvk_instance.cpp
@@ -91,10 +91,16 @@ namespace dxvk {
   VkInstance DxvkInstance::createInstance() {
     DxvkInstanceExtensions insExtensions;
 
-    std::array<DxvkExt*, 2> insExtensionList = {{
+    std::vector<DxvkExt*> insExtensionList = {{
       &insExtensions.khrGetSurfaceCapabilities2,
       &insExtensions.khrSurface,
     }};
+
+    // Hide VK_EXT_debug_utils behind an environment variable. This extension
+    // adds additional overhead to winevulkan
+    if (env::getEnvVar("DXVK_PERF_EVENTS") == "1") {
+        insExtensionList.push_back(&insExtensions.extDebugUtils);
+    }
 
     DxvkNameSet extensionsEnabled;
     DxvkNameSet extensionsAvailable = DxvkNameSet::enumInstanceExtensions(m_vkl);

--- a/src/dxvk/dxvk_instance.cpp
+++ b/src/dxvk/dxvk_instance.cpp
@@ -105,6 +105,8 @@ namespace dxvk {
           extensionsEnabled))
       throw DxvkError("DxvkInstance: Failed to create instance");
 
+    m_extensions = insExtensions;
+
     // Enable additional extensions if necessary
     for (const auto& provider : m_extProviders)
       extensionsEnabled.merge(provider->getInstanceExtensions());

--- a/src/dxvk/dxvk_instance.h
+++ b/src/dxvk/dxvk_instance.h
@@ -97,14 +97,23 @@ namespace dxvk {
     const DxvkOptions& options() const {
       return m_options;
     }
+
+    /**
+     * \brief Enabled instance extensions
+     * \returns Enabled instance extensions
+     */
+    const DxvkInstanceExtensions& extensions() const {
+      return m_extensions;
+    }
     
   private:
 
     Config              m_config;
     DxvkOptions         m_options;
 
-    Rc<vk::LibraryFn>   m_vkl;
-    Rc<vk::InstanceFn>  m_vki;
+    Rc<vk::LibraryFn>       m_vkl;
+    Rc<vk::InstanceFn>      m_vki;
+    DxvkInstanceExtensions  m_extensions;
 
     std::vector<DxvkExtensionProvider*> m_extProviders;
     std::vector<Rc<DxvkAdapter>> m_adapters;

--- a/src/vulkan/vulkan_loader.h
+++ b/src/vulkan/vulkan_loader.h
@@ -140,6 +140,12 @@ namespace dxvk::vk {
     VULKAN_FN(vkDebugReportMessageEXT);
     #endif
 
+    #ifdef VK_EXT_debug_utils
+    VULKAN_FN(vkCmdBeginDebugUtilsLabelEXT);
+    VULKAN_FN(vkCmdEndDebugUtilsLabelEXT);
+    VULKAN_FN(vkCmdInsertDebugUtilsLabelEXT);
+    #endif
+
     #ifdef VK_EXT_full_screen_exclusive
     VULKAN_FN(vkGetPhysicalDeviceSurfacePresentModes2EXT);
     #endif


### PR DESCRIPTION
I plan to follow-up with the D3D9-era `D3DPERF_*` implementation in a separate PR. That implementation isn't quite a straight-forward given that those functions are global and operate outside of any device/instance context.