### PR TITLE
[d3d9] Allow aligned Vector4

### DIFF
--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -1152,16 +1152,16 @@ namespace dxvk {
           return D3DERR_INVALIDCALL;
 
         if constexpr (ConstantType == D3D9ConstantType::Float) {
-          auto begin = &set.fConsts[StartRegister];
-          auto end = &begin[Count];
+          const float* source = set.fConsts[StartRegister].data;
+          const size_t size   = Count * sizeof(Vector4);
 
-          std::copy(begin, end, reinterpret_cast<Vector4*>(pConstantData));
+          std::memcpy(pConstantData, source, size);
         }
         else if constexpr (ConstantType == D3D9ConstantType::Int) {
-          auto begin = &set.iConsts[StartRegister];
-          auto end = &begin[Count];
+          const int*  source = set.iConsts[StartRegister].data;
+          const size_t size  = Count * sizeof(Vector4i);
 
-          std::copy(begin, end, reinterpret_cast<Vector4i*>(pConstantData));
+          std::memcpy(pConstantData, source, size);
         }
         else {
           for (uint32_t i = 0; i < Count; i++) {

--- a/src/d3d9/d3d9_state.h
+++ b/src/d3d9/d3d9_state.h
@@ -245,19 +245,21 @@ namespace dxvk {
           bool                 FloatEmu) {
     auto UpdateHelper = [&] (auto& set) {
       if constexpr (ConstantType == D3D9ConstantType::Float) {
-        auto begin = reinterpret_cast<const Vector4*>(pConstantData);
-        auto end   = begin + Count;
 
-        if (!FloatEmu)
-          std::copy(begin, end, &set.fConsts[StartRegister]);
-        else
-          std::transform(begin, end, &set.fConsts[StartRegister], replaceNaN);
+        if (!FloatEmu) {
+          size_t size = Count * sizeof(Vector4);
+
+          std::memcpy(set.fConsts[StartRegister].data, pConstantData, size);
+        }
+        else {
+          for (UINT i = 0; i < Count; i++)
+            set.fConsts[StartRegister + i] = replaceNaN(pConstantData + (i * 4));
+        }
       }
       else if constexpr (ConstantType == D3D9ConstantType::Int) {
-        auto begin = reinterpret_cast<const Vector4i*>(pConstantData);
-        auto end   = begin + Count;
+        size_t size = Count * sizeof(Vector4i);
 
-        std::copy(begin, end, &set.iConsts[StartRegister]);
+        std::memcpy(set.iConsts[StartRegister].data, pConstantData, size);
       }
       else {
         for (uint32_t i = 0; i < Count; i++) {

--- a/src/d3d9/d3d9_util.h
+++ b/src/d3d9/d3d9_util.h
@@ -138,7 +138,7 @@ namespace dxvk {
     if (Matrix == nullptr) // Identity.
       return Matrix4();
 
-    return *(reinterpret_cast<const Matrix4*>(Matrix));
+    return Matrix4(Matrix->m);
   }
 
   uint32_t GetVertexCount(D3DPRIMITIVETYPE type, UINT count);

--- a/src/util/util_matrix.cpp
+++ b/src/util/util_matrix.cpp
@@ -2,33 +2,6 @@
 
 namespace dxvk {
 
-  // Identity
-  Matrix4::Matrix4() {
-    data[0] = { 1, 0, 0, 0 };
-    data[1] = { 0, 1, 0, 0 };
-    data[2] = { 0, 0, 1, 0 };
-    data[3] = { 0, 0, 0, 1 };
-  }
-
-  // Produces a scalar matrix, x * Identity
-  Matrix4::Matrix4(float x) {
-    data[0] = { x, 0, 0, 0 };
-    data[1] = { 0, x, 0, 0 };
-    data[2] = { 0, 0, x, 0 };
-    data[3] = { 0, 0, 0, x };
-  }
-
-  Matrix4::Matrix4(
-    const Vector4& v0,
-    const Vector4& v1,
-    const Vector4& v2,
-    const Vector4& v3) {
-    data[0] = v0;
-    data[1] = v1;
-    data[2] = v2;
-    data[3] = v3;
-  }
-
         Vector4& Matrix4::operator[](size_t index)       { return data[index]; }
   const Vector4& Matrix4::operator[](size_t index) const { return data[index]; }
 

--- a/src/util/util_matrix.cpp
+++ b/src/util/util_matrix.cpp
@@ -80,11 +80,15 @@ namespace dxvk {
   }
 
   Matrix4& Matrix4::operator+=(const Matrix4& other) {
-    return (*this = (*this) + other);
+    for (uint32_t i = 0; i < 4; i++)
+      data[i] += other.data[i];
+    return *this;
   }
 
   Matrix4& Matrix4::operator-=(const Matrix4& other) {
-    return (*this = (*this) - other);
+    for (uint32_t i = 0; i < 4; i++)
+      data[i] -= other.data[i];
+    return *this;
   }
 
   Matrix4& Matrix4::operator*=(const Matrix4& other) {

--- a/src/util/util_matrix.h
+++ b/src/util/util_matrix.h
@@ -68,6 +68,8 @@ namespace dxvk {
 
   };
 
+  static_assert(sizeof(Matrix4) == sizeof(Vector4) * 4);
+
   inline Matrix4 operator*(float scalar, const Matrix4& m) { return m * scalar; }
 
   Matrix4 transpose(const Matrix4& m);

--- a/src/util/util_matrix.h
+++ b/src/util/util_matrix.h
@@ -35,6 +35,13 @@ namespace dxvk {
       data[3] = v3;
     }
 
+    inline Matrix4(const float matrix[4][4]) {
+      data[0] = Vector4(matrix[0]);
+      data[1] = Vector4(matrix[1]);
+      data[2] = Vector4(matrix[2]);
+      data[3] = Vector4(matrix[3]);
+    }
+
     Matrix4(const Matrix4& other) = default;
 
     Vector4& operator[](size_t index);

--- a/src/util/util_matrix.h
+++ b/src/util/util_matrix.h
@@ -8,15 +8,32 @@ namespace dxvk {
 
     public:
 
-    Matrix4(); // Identity
+    // Identity
+    inline Matrix4() {
+      data[0] = { 1, 0, 0, 0 };
+      data[1] = { 0, 1, 0, 0 };
+      data[2] = { 0, 0, 1, 0 };
+      data[3] = { 0, 0, 0, 1 };
+    }
 
-    explicit Matrix4(float x); // Produces a scalar matrix, x * Identity
+    // Produces a scalar matrix, x * Identity
+    inline explicit Matrix4(float x) {
+      data[0] = { x, 0, 0, 0 };
+      data[1] = { 0, x, 0, 0 };
+      data[2] = { 0, 0, x, 0 };
+      data[3] = { 0, 0, 0, x };
+    }
 
-    Matrix4(
+    inline Matrix4(
       const Vector4& v0,
       const Vector4& v1,
       const Vector4& v2,
-      const Vector4& v3);
+      const Vector4& v3) {
+      data[0] = v0;
+      data[1] = v1;
+      data[2] = v2;
+      data[3] = v3;
+    }
 
     Matrix4(const Matrix4& other) = default;
 

--- a/src/util/util_vector.h
+++ b/src/util/util_vector.h
@@ -146,6 +146,9 @@ namespace dxvk {
   using Vector4  = Vector4Base<float>;
   using Vector4i = Vector4Base<int>;
 
+  static_assert(sizeof(Vector4)  == sizeof(float) * 4);
+  static_assert(sizeof(Vector4i) == sizeof(int)   * 4);
+
   inline Vector4 replaceNaN(Vector4 a) {
     Vector4 result;
     __m128 value = _mm_load_ps(a.data);

--- a/src/util/util_vector.h
+++ b/src/util/util_vector.h
@@ -18,7 +18,7 @@ namespace dxvk {
     Vector4Base(T x, T y, T z, T w)
       : x(x), y(y), z(z), w(w) { }
 
-    Vector4Base(T xyzw[4])
+    Vector4Base(const T xyzw[4])
       : x(xyzw[0]), y(xyzw[1]), z(xyzw[2]), w(xyzw[3]) { }
 
     Vector4Base(const Vector4Base<T>& other) = default;


### PR DESCRIPTION
GCC generates scalar assembly for the current code at `-O2`, so here's my attempt to fix that.

WIP because this requires testing. I only tested one Oblivion apitrace.
It's also my first time working with SSE intrinsics, so :frog: