### PR TITLE
[util] Rewrite Vector4 with SSE

### DIFF
--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -4807,12 +4807,12 @@ namespace dxvk {
       UploadSoftwareConstantSet(slice.mapPtr, Src, Layout, Shader);
 
     if (constSet.meta.needsConstantCopies) {
-      Vector4* data = reinterpret_cast<Vector4*>(slice.mapPtr);
+      float* data = reinterpret_cast<float*>(slice.mapPtr);
 
       auto& shaderConsts = GetCommonShader(Shader)->GetConstants();
 
       for (const auto& constant : shaderConsts)
-        data[constant.uboIdx] = *reinterpret_cast<const Vector4*>(constant.float32);
+        std::memcpy(&data[constant.uboIdx * 4], constant.float32, sizeof(float) * 4);
     }
   }
 

--- a/src/util/util_vector.h
+++ b/src/util/util_vector.h
@@ -107,7 +107,7 @@ namespace dxvk {
       return *this;
     }
 
-    union {
+    union alignas(16) {
       T data[4];
       struct {
         T x, y, z, w;
@@ -143,19 +143,194 @@ namespace dxvk {
     return os << "Vector4(" << v[0] << ", " << v[1] << ", " << v[2] << ", " << v[3] << ")";
   }
 
-  using Vector4  = Vector4Base<float>;
   using Vector4i = Vector4Base<int>;
 
-  static_assert(sizeof(Vector4)  == sizeof(float) * 4);
   static_assert(sizeof(Vector4i) == sizeof(int)   * 4);
+
+#ifdef __SSE2__
+  struct Vector4 {
+    inline Vector4() {
+      const __m128 zero = _mm_setzero_ps();
+      this->store(zero);
+    }
+
+    inline Vector4(float splat) {
+      const __m128 value = _mm_set_ps1(splat);
+      this->store(value);
+    }
+
+    inline Vector4(float x, float y, float z, float w)
+      : x(x), y(y), z(z), w(w) { }
+
+    inline Vector4(const float xyzw[4]) {
+      const __m128 value = _mm_loadu_ps(xyzw);
+      this->store(value);
+    }
+
+    inline Vector4(__m128 value) {
+      this->store(value);
+    }
+
+    inline void store(__m128 value) {
+      _mm_store_ps(this->data, value);
+    }
+
+    inline __m128 load() const {
+      return _mm_load_ps(this->data);
+    }
+
+    inline Vector4(const Vector4& other) = default;
+
+    inline       float& operator[](size_t index)       { return data[index]; }
+    inline const float& operator[](size_t index) const { return data[index]; }
+
+    inline bool operator==(const Vector4& other) const {
+      const __m128  value     = this->load();
+      const __m128  toCompare = other.load();
+      const __m128  mask      = _mm_cmpeq_ps(value, toCompare);
+      const __m128i imask     = _mm_castps_si128(mask);
+      const int     reduced   = _mm_movemask_epi8(imask);
+      return !reduced;
+    }
+
+    inline bool operator!=(const Vector4& other) const {
+      return !operator==(other);
+    }
+
+    inline Vector4 operator-() const {
+      const __m128 zero     = _mm_setzero_ps();
+      const __m128 value    = this->load();
+      const __m128 newValue = _mm_sub_ps(zero, value);
+      return { newValue };
+    }
+
+    inline Vector4 operator+(const Vector4& o) const {
+      const __m128 value  = this->load();
+      const __m128 other  = o.load();
+      const __m128 result = _mm_add_ps(value, other);
+      return { result };
+    }
+
+    inline Vector4 operator-(const Vector4& o) const {
+      const __m128 value  = this->load();
+      const __m128 other  = o.load();
+      const __m128 result = _mm_sub_ps(value, other);
+      return { result };
+    }
+
+    inline Vector4 operator*(float scalar) const {
+      const __m128 value  = this->load();
+      const __m128 other  = _mm_set_ps1(scalar);
+      const __m128 result = _mm_mul_ps(value, other);
+      return { result };
+    }
+
+    inline Vector4 operator*(const Vector4& o) const {
+      const __m128 value  = this->load();
+      const __m128 other  = o.load();
+      const __m128 result = _mm_mul_ps(value, other);
+      return { result };
+    }
+
+    inline Vector4 operator/(float scalar) const {
+      const __m128 value  = this->load();
+      const __m128 other  = _mm_set_ps1(scalar);
+      const __m128 result = _mm_div_ps(value, other);
+      return { result };
+    }
+
+    inline Vector4 operator/(const Vector4& o) const {
+      const __m128 value  = this->load();
+      const __m128 other  = o.load();
+      const __m128 result = _mm_div_ps(value, other);
+      return { result };
+    }
+
+    inline Vector4& operator+=(const Vector4& o) {
+      const __m128 value  = this->load();
+      const __m128 other  = o.load();
+      const __m128 result = _mm_add_ps(value, other);
+      this->store(result);
+
+      return *this;
+    }
+
+    inline Vector4& operator-=(const Vector4& o) {
+      const __m128 value  = this->load();
+      const __m128 other  = o.load();
+      const __m128 result = _mm_sub_ps(value, other);
+      this->store(result);
+
+      return *this;
+    }
+
+    inline Vector4& operator*=(int scalar) {
+      const __m128 value  = this->load();
+      const __m128 other  = _mm_set_ps1(scalar);
+      const __m128 result = _mm_mul_ps(value, other);
+      this->store(result);
+
+      return *this;
+    }
+
+    inline Vector4& operator/=(int scalar) {
+      const __m128 value  = this->load();
+      const __m128 other  = _mm_set_ps1(scalar);
+      const __m128 result = _mm_div_ps(value, other);
+      this->store(result);
+
+      return *this;
+    }
+
+
+    union alignas(16) {
+      float data[4];
+      struct {
+        float x, y, z, w;
+      };
+      struct {
+        float r, g, b, a;
+      };
+    };
+  };
+
+  inline Vector4 operator*(float scalar, const Vector4& vector) {
+    return vector * scalar;
+  }
+
+  inline float dot(const Vector4& a, const Vector4& b) {
+    return a.x * b.x + a.y * b.y + a.z * b.z + a.w * b.w;
+  }
+
+  inline float lengthSqr(const Vector4& a) { return dot(a, a); }
+
+  inline float length(const Vector4& a) { return std::sqrt(float(lengthSqr(a))); }
+
+  inline Vector4 normalize(const Vector4& a) { return a * float(1.0f / length(a)); }
+
+  inline std::ostream& operator<<(std::ostream& os, const Vector4& v) {
+    return os << "Vector4(" << v[0] << ", " << v[1] << ", " << v[2] << ", " << v[3] << ")";
+  }
+
+  inline Vector4 replaceNaN(Vector4 a) {
+    const __m128 value = a.load();
+    const __m128 mask  = _mm_cmpeq_ps(value, value);
+    const __m128 result = _mm_and_ps(value, mask);
+    return { result };
+  }
+#else
+  using Vector4 = Vector4Base<float>;
 
   inline Vector4 replaceNaN(Vector4 a) {
     Vector4 result;
-    __m128 value = _mm_load_ps(a.data);
-    __m128 mask  = _mm_cmpeq_ps(value, value);
-           value = _mm_and_ps(value, mask);
-    _mm_store_ps(result.data, value);
+
+    for (unsigned i = 0; i < 4; ++i) {
+        result.data[i] = a.data[i] == a.data[i] ? a.data[i] : 0.0f;
+    }
+
     return result;
   }
+#endif
 
+  static_assert(sizeof(Vector4)  == sizeof(float) * 4);
 }


### PR DESCRIPTION
Just putting this here so that I don't forget about it. It's fine on gcc (1-2% gain in some weird fixed function game) but to quote doitsujin
> The current implementation looks like it's going to make things worse in some cases because some compilers will not optimize redundant store->load pairs so this needs a lot more work.

some compilers apparently are msvc :frog: 