### PR TITLE
[util] Enable apitraceMode for a couple of CryEngine games

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -196,6 +196,14 @@ namespace dxvk {
     { R"(\\MonsterHunterWorld\.exe$)", {{
       { "d3d11.apitraceMode",               "True" },
     }} },
+    /* Kingdome Come: Deliverance                 */
+    { R"(\\KingdomCome\.exe$)", {{
+      { "d3d11.apitraceMode",               "True" },
+    }} },
+    /* Sniper Ghost Warrior Contracts             */
+    { R"(\\SGWContracts\.exe$)", {{
+      { "d3d11.apitraceMode",               "True" },
+    }} },
     /* Shadow of the Tomb Raider - invariant      *
      * position breaks character rendering on NV  */
     { R"(\\SOTTR\.exe$)", {{


### PR DESCRIPTION
Enable apitraceMode for Kingdom Come: Deliverance and Sniper Ghost Warrior Contracts for a large performance increase.

Here are some benchmarks showing the performance improvements, all done on a Ryzen 5900x + RX 6800 with Mesa ACO git.

Kingdom Come: Deliverance, without apitraceMode, High settings, 2560x1440:
![KCD no apitraceMode](https://i.imgur.com/0J1oGJQ.jpg)

and with apitraceMode:
![KCD with apitraceMode](https://i.imgur.com/t14c43y.jpg)

Sniper Ghost Warrior Contracts, without apitraceMode, Medium settings, 2560x1440:
![SGWC no apitraceMode](https://i.imgur.com/w8Bw991.jpg)

and with apitraceMode:
![SGWC with apitraceMode](https://i.imgur.com/hkF4fqU.jpg)

I tested some other Cryengine games like Ryse: Son of Rome, and Sniper Ghost Warrior 2, but there was no effect there. I suspect it's just Cryengine games from 2018/2019 and maybe later (although I don't have any of the latter to test). 