### PR TITLE
[d3d9] Fix FlushBuffer

### DIFF
--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -697,8 +697,6 @@ namespace dxvk {
       pitch, pitch * texLevelBlockCount.height);
 
     Rc<DxvkImage>  dstImage  = dstTextureInfo->GetImage();
-    VkDeviceSize srcByteOffset = srcBlockOffset.y * formatInfo->elementSize * texLevelBlockCount.width
-                               + srcBlockOffset.x * formatInfo->elementSize;
 
     EmitCs([
       cDstImage   = std::move(dstImage),


### PR DESCRIPTION
Closes #2041 

Stupid oversight.

I also removed a unused variable somewhere else. I wish MSVC would show these warnings.