### PR TITLE
[util] Enable d3d9.deferSurfaceCreation for Nights of Azure

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -170,6 +170,10 @@ namespace dxvk {
     { R"(\\FAIRY_TAIL\.exe$)", {{
       { "d3d9.deferSurfaceCreation",        "True" },
     }} },
+    /* Nights of Azure                            */
+    { R"(\\CNN\.exe$)", {{
+      { "d3d9.deferSurfaceCreation",        "True" },
+    }} },
     /* Star Wars Battlefront II: amdags issues    */
     { R"(\\starwarsbattlefrontii\.exe$)", {{
       { "dxgi.customVendorId",              "10de" },


### PR DESCRIPTION
Like other Gust games this uses dx11 and then requires `d3d9.deferSurfaceCreation` to be enabled or there will be a white screen shortly after starting a new game. The first cutscene works, but as soon as it gets past the intro video (See below) it will be white.

Some other issues I encountered:

* Only starts with dxvk
* Requires installing a native dotnet40 with winetricks.
* The `wmv` intro video fails to play and can be skipped by installing a native quartz and/or devenum or just moving the corresponding directory out of the way.