### PR TITLE
Implement global D3DPERF_ annotations

### DIFF
--- a/src/d3d11/d3d11_annotation.cpp
+++ b/src/d3d11/d3d11_annotation.cpp
@@ -6,13 +6,41 @@
 
 namespace dxvk {
 
+  template <bool Register>
+  static void RegisterUserDefinedAnnotation(IDXVKUserDefinedAnnotation* annotation) {
+    using RegistrationFunctionType = void(__stdcall *)(IDXVKUserDefinedAnnotation*);
+    static const int16_t RegisterOrdinal = 28257;
+    static const int16_t UnregisterOrdinal = 28258;
+
+    HMODULE d3d9Module = ::LoadLibraryA("d3d9.dll");
+    if (!d3d9Module) {
+      Logger::info("Unable to find d3d9, some annotations may be missed.");
+      return;
+    }
+
+    const int16_t ordinal = Register ? UnregisterOrdinal : RegisterOrdinal;
+    auto registrationFunction = reinterpret_cast<RegistrationFunctionType>(::GetProcAddress(d3d9Module,
+      reinterpret_cast<const char*>(static_cast<uintptr_t>(ordinal))));
+
+    if (!registrationFunction) {
+      Logger::info("Unable to find DXVK_RegisterAnnotation, some annotations may be missed.");
+      return;
+    }
+
+    registrationFunction(annotation);
+  }
+
   D3D11UserDefinedAnnotation::D3D11UserDefinedAnnotation(D3D11DeviceContext* ctx)
   : m_container(ctx),
-    m_eventDepth(0) { }
+    m_eventDepth(0) {
+    if (m_container->IsAnnotationEnabled())
+      RegisterUserDefinedAnnotation<true>(this);
+  }
 
 
   D3D11UserDefinedAnnotation::~D3D11UserDefinedAnnotation() {
-
+    if (m_container->IsAnnotationEnabled())
+      RegisterUserDefinedAnnotation<false>(this);
   }
 
 

--- a/src/d3d11/d3d11_annotation.cpp
+++ b/src/d3d11/d3d11_annotation.cpp
@@ -2,6 +2,8 @@
 #include "d3d11_context.h"
 #include "d3d11_device.h"
 
+#include "../util/util_misc.h"
+
 namespace dxvk {
 
   D3D11UserDefinedAnnotation::D3D11UserDefinedAnnotation(D3D11DeviceContext* ctx)
@@ -32,19 +34,17 @@ namespace dxvk {
   
 
   INT STDMETHODCALLTYPE D3D11UserDefinedAnnotation::BeginEvent(
+          D3DCOLOR                Color,
           LPCWSTR                 Name) {
     if (!m_container->IsAnnotationEnabled())
       return -1;
 
-    m_container->EmitCs([labelName = dxvk::str::fromws(Name)](DxvkContext *ctx) {
+    m_container->EmitCs([color = Color, labelName = dxvk::str::fromws(Name)](DxvkContext *ctx) {
       VkDebugUtilsLabelEXT label;
       label.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_LABEL_EXT;
       label.pNext = nullptr;
       label.pLabelName = labelName.c_str();
-      label.color[0] = 1.0f;
-      label.color[1] = 1.0f;
-      label.color[2] = 1.0f;
-      label.color[3] = 1.0f;
+      DecodeD3DCOLOR(color, label.color);
 
       ctx->beginDebugLabel(&label);
     });
@@ -66,19 +66,17 @@ namespace dxvk {
 
 
   void STDMETHODCALLTYPE D3D11UserDefinedAnnotation::SetMarker(
+          D3DCOLOR                Color,
           LPCWSTR                 Name) {
     if (!m_container->IsAnnotationEnabled())
       return;
 
-    m_container->EmitCs([labelName = dxvk::str::fromws(Name)](DxvkContext *ctx) {
+    m_container->EmitCs([color = Color, labelName = dxvk::str::fromws(Name)](DxvkContext *ctx) {
       VkDebugUtilsLabelEXT label;
       label.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_LABEL_EXT;
       label.pNext = nullptr;
       label.pLabelName = labelName.c_str();
-      label.color[0] = 1.0f;
-      label.color[1] = 1.0f;
-      label.color[2] = 1.0f;
-      label.color[3] = 1.0f;
+      DecodeD3DCOLOR(color, label.color);
 
       ctx->insertDebugLabel(&label);
     });

--- a/src/d3d11/d3d11_annotation.h
+++ b/src/d3d11/d3d11_annotation.h
@@ -6,7 +6,7 @@ namespace dxvk {
 
   class D3D11DeviceContext;
 
-  class D3D11UserDefinedAnnotation : ID3DUserDefinedAnnotation {
+  class D3D11UserDefinedAnnotation final : public ID3DUserDefinedAnnotation {
 
   public:
 

--- a/src/d3d11/d3d11_annotation.h
+++ b/src/d3d11/d3d11_annotation.h
@@ -1,12 +1,13 @@
 #pragma once
 
 #include "d3d11_include.h"
+#include "../dxvk/dxvk_annotation.h"
 
 namespace dxvk {
 
   class D3D11DeviceContext;
 
-  class D3D11UserDefinedAnnotation final : public ID3DUserDefinedAnnotation {
+  class D3D11UserDefinedAnnotation final : public IDXVKUserDefinedAnnotation {
 
   public:
 
@@ -22,11 +23,13 @@ namespace dxvk {
             void**                  ppvObject);
     
     INT STDMETHODCALLTYPE BeginEvent(
+            D3DCOLOR                Color,
             LPCWSTR                 Name);
 
     INT STDMETHODCALLTYPE EndEvent();
 
     void STDMETHODCALLTYPE SetMarker(
+            D3DCOLOR                Color,
             LPCWSTR                 Name);
 
     BOOL STDMETHODCALLTYPE GetStatus();

--- a/src/d3d11/d3d11_context.cpp
+++ b/src/d3d11/d3d11_context.cpp
@@ -52,7 +52,8 @@ namespace dxvk {
       return S_OK;
     }
     
-    if (riid == __uuidof(ID3DUserDefinedAnnotation)) {
+    if (riid == __uuidof(ID3DUserDefinedAnnotation)
+     || riid == __uuidof(IDXVKUserDefinedAnnotation)) {
       *ppvObject = ref(&m_annotation);
       return S_OK;
     }

--- a/src/d3d9/d3d9.def
+++ b/src/d3d9/d3d9.def
@@ -20,3 +20,6 @@ EXPORTS
 
   Direct3DCreate9 @ 37
   Direct3DCreate9Ex @ 38
+
+  DXVK_RegisterAnnotation @ 28257 NONAME
+  DXVK_UnRegisterAnnotation @ 28258 NONAME

--- a/src/d3d9/d3d9_annotation.cpp
+++ b/src/d3d9/d3d9_annotation.cpp
@@ -1,0 +1,95 @@
+#include "d3d9_annotation.h"
+
+namespace dxvk {
+
+  ////////////////////////////
+  // D3D9GlobalAnnotationList
+  ////////////////////////////
+
+  D3D9GlobalAnnotationList::D3D9GlobalAnnotationList()
+    : m_shouldAnnotate(false)
+    , m_eventDepth(0)
+  {}
+
+
+  D3D9GlobalAnnotationList::~D3D9GlobalAnnotationList()
+  {}
+
+
+  void D3D9GlobalAnnotationList::RegisterAnnotator(IDXVKUserDefinedAnnotation* annotation) {
+    auto lock = std::unique_lock(m_mutex);
+    m_shouldAnnotate = true;
+    m_annotations.push_back(annotation);
+  }
+
+
+  void D3D9GlobalAnnotationList::UnregisterAnnotator(IDXVKUserDefinedAnnotation* annotation) {
+    auto lock = std::unique_lock(m_mutex);
+    auto iter = std::find(m_annotations.begin(), m_annotations.end(), annotation);
+    if (iter != m_annotations.end())
+        m_annotations.erase(iter);
+  }
+
+
+  INT D3D9GlobalAnnotationList::BeginEvent(D3DCOLOR color, LPCWSTR name) {
+    if (!m_shouldAnnotate)
+      return 0;
+
+    auto lock = std::unique_lock(m_mutex);
+    for (auto* annotation : m_annotations)
+      annotation->BeginEvent(color, name);
+
+    return m_eventDepth++;
+  }
+
+
+  INT D3D9GlobalAnnotationList::EndEvent() {
+    if (!m_shouldAnnotate)
+      return 0;
+
+    auto lock = std::unique_lock(m_mutex);
+    for (auto* annotation : m_annotations)
+      annotation->EndEvent();
+
+    return m_eventDepth--;
+  }
+
+
+  void D3D9GlobalAnnotationList::SetMarker(D3DCOLOR color, LPCWSTR name) {
+    if (!m_shouldAnnotate)
+      return;
+
+    auto lock = std::unique_lock(m_mutex);
+    for (auto* annotation : m_annotations)
+      annotation->SetMarker(color, name);
+  }
+
+
+  void D3D9GlobalAnnotationList::SetRegion(D3DCOLOR color, LPCWSTR name) {
+    // This, by the documentation, does nothing.
+  }
+
+
+  BOOL D3D9GlobalAnnotationList::QueryRepeatFrame() const {
+    // This, by the documentation, does nothing.
+    // It's meant to return TRUE if the profiler/debugger
+    // wants a frame to be repeated, but we never need that.
+    return FALSE;
+  }
+
+
+  void D3D9GlobalAnnotationList::SetOptions(DWORD options) {
+    // This is used to say that the app should
+    // not be debugged/profiled.
+  }
+
+
+  DWORD D3D9GlobalAnnotationList::GetStatus() const {
+    // This returns whether the app is being
+    // profiled / debugged.
+    // Some apps may rely on this to emit
+    // debug markers.
+    return m_shouldAnnotate ? 1 : 0;
+  }
+
+}

--- a/src/d3d9/d3d9_annotation.h
+++ b/src/d3d9/d3d9_annotation.h
@@ -52,4 +52,37 @@ namespace dxvk {
 
   };
 
+  class D3D9UserDefinedAnnotation final : public IDXVKUserDefinedAnnotation {
+
+  public:
+
+    D3D9UserDefinedAnnotation(D3D9DeviceEx* device);
+    ~D3D9UserDefinedAnnotation();
+
+    ULONG STDMETHODCALLTYPE AddRef();
+
+    ULONG STDMETHODCALLTYPE Release();
+
+    HRESULT STDMETHODCALLTYPE QueryInterface(
+            REFIID                  riid,
+            void**                  ppvObject);
+
+    INT STDMETHODCALLTYPE BeginEvent(
+            D3DCOLOR                Color,
+            LPCWSTR                 Name);
+
+    INT STDMETHODCALLTYPE EndEvent();
+
+    void STDMETHODCALLTYPE SetMarker(
+            D3DCOLOR                Color,
+            LPCWSTR                 Name);
+
+    BOOL STDMETHODCALLTYPE GetStatus();
+
+  private:
+
+    D3D9DeviceEx* m_container;
+
+  };
+
 }

--- a/src/d3d9/d3d9_annotation.h
+++ b/src/d3d9/d3d9_annotation.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include "d3d9_device.h"
+#include "d3d9_include.h"
+#include "../dxvk/dxvk_annotation.h"
+
+#include <atomic>
+#include <mutex>
+#include <vector>
+
+namespace dxvk {
+
+  class D3D9GlobalAnnotationList {
+
+  public:
+
+    D3D9GlobalAnnotationList();
+    ~D3D9GlobalAnnotationList();
+
+    void RegisterAnnotator(IDXVKUserDefinedAnnotation* annotation);
+    void UnregisterAnnotator(IDXVKUserDefinedAnnotation* annotation);
+
+    INT BeginEvent(D3DCOLOR color, LPCWSTR name);
+    INT EndEvent();
+
+    void SetMarker(D3DCOLOR color, LPCWSTR name);
+
+    void SetRegion(D3DCOLOR color, LPCWSTR name);
+
+    BOOL QueryRepeatFrame() const;
+
+    void SetOptions(DWORD options);
+
+    DWORD GetStatus() const;
+
+    static D3D9GlobalAnnotationList& Instance() {
+      return s_instance;
+    }
+
+  private:
+
+    static D3D9GlobalAnnotationList s_instance;
+
+    std::atomic<bool> m_shouldAnnotate;
+
+    std::mutex m_mutex;
+    std::vector<IDXVKUserDefinedAnnotation*> m_annotations;
+
+    // Provide our own event depth as we
+    // may have multiple annotators which could get out of sync.
+    int32_t m_eventDepth;
+
+  };
+
+}

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -59,6 +59,9 @@ namespace dxvk {
     if (canSWVP)
       Logger::info("D3D9DeviceEx: Using extended constant set for software vertex processing.");
 
+    if (m_dxvkDevice->instance()->extensions().extDebugUtils)
+      m_annotation = new D3D9UserDefinedAnnotation(this);
+
     m_initializer      = new D3D9Initializer(m_dxvkDevice);
     m_converter        = new D3D9FormatHelper(m_dxvkDevice);
 
@@ -87,6 +90,9 @@ namespace dxvk {
   D3D9DeviceEx::~D3D9DeviceEx() {
     Flush();
     SynchronizeCsThread();
+
+    if (m_annotation)
+      delete m_annotation;
 
     delete m_initializer;
     delete m_converter;

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -1,5 +1,6 @@
 #include "d3d9_device.h"
 
+#include "d3d9_annotation.h"
 #include "d3d9_interface.h"
 #include "d3d9_swapchain.h"
 #include "d3d9_caps.h"

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -41,6 +41,7 @@ namespace dxvk {
   class D3D9Query;
   class D3D9StateBlock;
   class D3D9FormatHelper;
+  class D3D9UserDefinedAnnotation;
 
   enum class D3D9DeviceFlag : uint32_t {
     DirtyFramebuffer,
@@ -101,6 +102,7 @@ namespace dxvk {
     constexpr static uint32_t NullStreamIdx = caps::MaxStreams;
 
     friend class D3D9SwapChainEx;
+    friend class D3D9UserDefinedAnnotation;
   public:
 
     D3D9DeviceEx(
@@ -1071,6 +1073,8 @@ namespace dxvk {
 
     D3D9ConstantLayout              m_vsLayout;
     D3D9ConstantLayout              m_psLayout;
+
+    D3D9UserDefinedAnnotation*      m_annotation = nullptr;
 
     void DetermineConstantLayouts(bool canSWVP);
 

--- a/src/d3d9/d3d9_main.cpp
+++ b/src/d3d9/d3d9_main.cpp
@@ -3,11 +3,14 @@
 #include "d3d9_interface.h"
 #include "d3d9_shader_validator.h"
 
+#include "../d3d9/d3d9_annotation.h"
+
 class D3DFE_PROCESSVERTICES;
 using PSGPERRORID = UINT;
 
 namespace dxvk {
   Logger Logger::s_instance("d3d9.log");
+  D3D9GlobalAnnotationList D3D9GlobalAnnotationList::s_instance;
 
   HRESULT CreateD3D9(
           bool           Extended,
@@ -19,6 +22,7 @@ namespace dxvk {
     return D3D_OK;
   }
 }
+
 
 extern "C" {
 
@@ -34,28 +38,31 @@ extern "C" {
   }
 
   DLLEXPORT int __stdcall D3DPERF_BeginEvent(D3DCOLOR col, LPCWSTR wszName) {
-    return 0;
+    return dxvk::D3D9GlobalAnnotationList::Instance().BeginEvent(col, wszName);
   }
 
   DLLEXPORT int __stdcall D3DPERF_EndEvent(void) {
-    return 0;
+    return dxvk::D3D9GlobalAnnotationList::Instance().EndEvent();
   }
 
   DLLEXPORT void __stdcall D3DPERF_SetMarker(D3DCOLOR col, LPCWSTR wszName) {
+    dxvk::D3D9GlobalAnnotationList::Instance().SetMarker(col, wszName);
   }
 
   DLLEXPORT void __stdcall D3DPERF_SetRegion(D3DCOLOR col, LPCWSTR wszName) {
+    dxvk::D3D9GlobalAnnotationList::Instance().SetRegion(col, wszName);
   }
 
   DLLEXPORT BOOL __stdcall D3DPERF_QueryRepeatFrame(void) {
-    return FALSE;
+    return dxvk::D3D9GlobalAnnotationList::Instance().QueryRepeatFrame();
   }
 
   DLLEXPORT void __stdcall D3DPERF_SetOptions(DWORD dwOptions) {
+    dxvk::D3D9GlobalAnnotationList::Instance().SetOptions(dwOptions);
   }
 
   DLLEXPORT DWORD __stdcall D3DPERF_GetStatus(void) {
-    return 0;
+    return dxvk::D3D9GlobalAnnotationList::Instance().GetStatus();
   }
 
 

--- a/src/d3d9/d3d9_main.cpp
+++ b/src/d3d9/d3d9_main.cpp
@@ -90,4 +90,12 @@ extern "C" {
     return 0;
   }
 
+  DLLEXPORT void __stdcall DXVK_RegisterAnnotation(IDXVKUserDefinedAnnotation* annotation) {
+    dxvk::D3D9GlobalAnnotationList::Instance().RegisterAnnotator(annotation);
+  }
+
+  DLLEXPORT void __stdcall DXVK_UnRegisterAnnotation(IDXVKUserDefinedAnnotation* annotation) {
+    dxvk::D3D9GlobalAnnotationList::Instance().UnregisterAnnotator(annotation);
+  }
+
 }

--- a/src/d3d9/d3d9_util.h
+++ b/src/d3d9/d3d9_util.h
@@ -8,6 +8,7 @@
 #include "../dxvk/dxvk_device.h"
 
 #include "../util/util_matrix.h"
+#include "../util/util_misc.h"
 
 #include <d3dcommon.h>
 
@@ -100,14 +101,6 @@ namespace dxvk {
   VkFormatFeatureFlags GetImageFormatFeatures(DWORD Usage);
 
   VkImageUsageFlags GetImageUsageFlags(DWORD Usage);
-
-  inline void DecodeD3DCOLOR(D3DCOLOR color, float* rgba) {
-    // Encoded in D3DCOLOR as argb
-    rgba[3] = (float)((color & 0xff000000) >> 24) / 255.0f;
-    rgba[0] = (float)((color & 0x00ff0000) >> 16) / 255.0f;
-    rgba[1] = (float)((color & 0x0000ff00) >> 8)  / 255.0f;
-    rgba[2] = (float)((color & 0x000000ff))       / 255.0f;
-  }
 
   inline VkFormat PickSRGB(VkFormat format, VkFormat srgbFormat, bool srgb) {
     return srgb ? srgbFormat : format;

--- a/src/d3d9/meson.build
+++ b/src/d3d9/meson.build
@@ -38,7 +38,8 @@ d3d9_src = [
   'd3d9_names.cpp',
   'd3d9_swvp_emu.cpp',
   'd3d9_format_helpers.cpp',
-  'd3d9_hud.cpp'
+  'd3d9_hud.cpp',
+  'd3d9_annotation.cpp',
 ]
 
 d3d9_dll = shared_library('d3d9'+dll_ext, d3d9_src, glsl_generator.process(d3d9_shaders), d3d9_res,

--- a/src/dxvk/dxvk_annotation.h
+++ b/src/dxvk/dxvk_annotation.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <d3d11_1.h>
+#include <d3d9.h>
+
+MIDL_INTERFACE("7f2c2f72-1cc8-4979-8d9c-7e3faeddecde")
+IDXVKUserDefinedAnnotation : public ID3DUserDefinedAnnotation {
+
+public:
+
+  INT STDMETHODCALLTYPE BeginEvent(
+          LPCWSTR                 Name) final {
+    return this->BeginEvent(0, Name);
+  }
+
+  void STDMETHODCALLTYPE SetMarker(
+          LPCWSTR                 Name) final {
+    this->SetMarker(0, Name);
+  }
+
+  virtual INT STDMETHODCALLTYPE BeginEvent(
+          D3DCOLOR                Color,
+          LPCWSTR                 Name) = 0;
+
+  virtual void STDMETHODCALLTYPE SetMarker(
+          D3DCOLOR                Color,
+          LPCWSTR                 Name) = 0;
+
+};
+
+#ifdef _MSC_VER
+struct __declspec(uuid("7f2c2f72-1cc8-4979-8d9c-7e3faeddecde")) IDXVKUserDefinedAnnotation;
+#else
+__CRT_UUID_DECL(IDXVKUserDefinedAnnotation, 0x7f2c2f72,0x1cc8,0x4979,0x8d,0x9c,0x7e,0x3f,0xae,0xdd,0xec,0xde);
+#endif

--- a/src/util/util_misc.h
+++ b/src/util/util_misc.h
@@ -1,6 +1,16 @@
 #pragma once
 
+#include <d3d9types.h>
+
 namespace dxvk {
+
+  inline void DecodeD3DCOLOR(D3DCOLOR color, float* rgba) {
+    // Encoded in D3DCOLOR as argb
+    rgba[3] = (float)((color & 0xff000000) >> 24) / 255.0f;
+    rgba[0] = (float)((color & 0x00ff0000) >> 16) / 255.0f;
+    rgba[1] = (float)((color & 0x0000ff00) >> 8)  / 255.0f;
+    rgba[2] = (float)((color & 0x000000ff))       / 255.0f;
+  }
 
   template <typename T, size_t n>
   size_t countof(const T(&)[n]) { return n; }


### PR DESCRIPTION
This PR implements annotations for D3D9 apps and also allows D3D11 apps to use the `D3DPERF_` interfaces for emitting annotations.

It defines a common annotation interface, `IDXVKUserDefinedAnnotation` of which a global list of them is stored in `d3d9.dll`.
In D3D9, it's simple, it just adds to that list and removes it.
In D3D11, it accesses a couple of hidden exports in `d3d9.dll` at some way off ordinals to manage registering/unregistering the annotation interfaces.

The `D3DPERF_` interfaces act upon all devices/contexts that are currently instantiated.

None of this will be done if annotation is disabled.

Making this a draft initially as I imagine there will be a decent amount of discussion around it. :^)