### PR TITLE
Add workarounds for RE8

### DIFF
--- a/src/dxgi/dxgi_adapter.h
+++ b/src/dxgi/dxgi_adapter.h
@@ -122,6 +122,8 @@ namespace dxvk {
     std::unordered_map<DWORD, HANDLE> m_eventMap;
     dxvk::thread                      m_eventThread;
 
+    std::vector<Com<DxgiOutput, false>> m_outputCache;
+
     void runEventThread();
     
     struct MonitorEnumInfo {

--- a/src/dxgi/dxgi_main.cpp
+++ b/src/dxgi/dxgi_main.cpp
@@ -1,11 +1,26 @@
 #include "dxgi_factory.h"
 #include "dxgi_include.h"
 
+#include "../util/util_env.h"
+
 namespace dxvk {
   
   Logger Logger::s_instance("dxgi.log");
-  
+
+  bool useGlobalFactory() {
+    static bool s_useGlobalFactory = env::getExeName() == "re8.exe";
+    return s_useGlobalFactory;
+  }
+
+  HRESULT getGlobalFactory(REFIID riid, void **ppFactory) {
+    static Com<DxgiFactory, false> s_factory = new DxgiFactory(0);
+    return s_factory->QueryInterface(riid, ppFactory);
+  }
+
   HRESULT createDxgiFactory(UINT Flags, REFIID riid, void **ppFactory) {
+    if (useGlobalFactory())
+      return getGlobalFactory(riid, ppFactory);
+
     try {
       Com<DxgiFactory> factory = new DxgiFactory(Flags);
       HRESULT hr = factory->QueryInterface(riid, ppFactory);

--- a/src/dxgi/dxgi_output.h
+++ b/src/dxgi/dxgi_output.h
@@ -3,6 +3,8 @@
 #include "dxgi_monitor.h"
 #include "dxgi_object.h"
 
+#include <mutex>
+
 namespace dxvk {
   
   class DxgiAdapter;
@@ -133,9 +135,17 @@ namespace dxvk {
     Com<DxgiAdapter> m_adapter = nullptr;
     HMONITOR         m_monitor = nullptr;
 
+    DXGI_FORMAT m_cachedModeFormat = DXGI_FORMAT_UNKNOWN;
+    std::vector<DXGI_MODE_DESC1> m_cachedModeList;
+    std::mutex m_cachedModeMutex;
+
     static void FilterModesByDesc(
             std::vector<DXGI_MODE_DESC1>& Modes,
       const DXGI_MODE_DESC1&              TargetMode);
+
+    UINT CacheModeList(
+            DXGI_FORMAT EnumFormat,
+            UINT        Flags);
     
   };
 


### PR DESCRIPTION
This PR adds a global DXGI factory for Resident Evil 8 as it spams `CreateDXGIFactory` calls.

This also caches display modes on DXGI outputs as the game also enumerates them every frame which was causing allocations for us due to the way this was handled previously.

Now the game gets put on a fast path where it just ends up returning the cached data constantly.