### PR TITLE
Low-latency frame latency

### DIFF
--- a/src/d3d11/d3d11_swapchain.cpp
+++ b/src/d3d11/d3d11_swapchain.cpp
@@ -178,9 +178,8 @@ namespace dxvk {
       return DXGI_ERROR_INVALID_CALL;
 
     m_frameLatency = MaxLatency;
-    m_frameLatencySignal->wait(m_frameId - GetActualFrameLatency());
 
-    SignalFrameLatencyEvent();
+    SyncFrameLatency();
     return S_OK;
   }
 
@@ -241,10 +240,6 @@ namespace dxvk {
     // Flush pending rendering commands before
     auto immediateContext = static_cast<D3D11ImmediateContext*>(deviceContext.ptr());
     immediateContext->Flush();
-
-    // Wait for the sync event so that we respect the maximum frame latency
-    uint64_t frameId = ++m_frameId;
-    m_frameLatencySignal->wait(frameId - GetActualFrameLatency());
     
     for (uint32_t i = 0; i < SyncInterval || i < 1; i++) {
       SynchronizePresent();
@@ -283,12 +278,15 @@ namespace dxvk {
         m_hud->render(m_context, info.format, info.imageExtent);
       
       if (i + 1 >= SyncInterval)
-        m_context->signal(m_frameLatencySignal, frameId);
+        m_context->signal(m_frameLatencySignal, m_frameId);
 
       SubmitPresent(immediateContext, sync, i);
     }
 
-    SignalFrameLatencyEvent();
+    // Bump our frame id.
+    ++m_frameId;
+
+    SyncFrameLatency();
     return S_OK;
   }
 
@@ -536,7 +534,10 @@ namespace dxvk {
   }
 
 
-  void D3D11SwapChain::SignalFrameLatencyEvent() {
+  void D3D11SwapChain::SyncFrameLatency() {
+    // Wait for the sync event so that we respect the maximum frame latency
+    m_frameLatencySignal->wait(m_frameId - GetActualFrameLatency());
+
     if (m_frameLatencyEvent) {
       // Signal event with the same value that we'd wait for during the next present.
       m_frameLatencySignal->setEvent(m_frameLatencyEvent, m_frameId - GetActualFrameLatency() + 1);

--- a/src/d3d11/d3d11_swapchain.h
+++ b/src/d3d11/d3d11_swapchain.h
@@ -134,7 +134,7 @@ namespace dxvk {
 
     void DestroyFrameLatencyEvent();
 
-    void SignalFrameLatencyEvent();
+    void SyncFrameLatency();
 
     uint32_t GetActualFrameLatency();
     

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -3343,6 +3343,8 @@ namespace dxvk {
 
     m_frameLatency = MaxLatency;
 
+    m_implicitSwapchain->SyncFrameLatency();
+
     return D3D_OK;
   }
 

--- a/src/d3d9/d3d9_swapchain.h
+++ b/src/d3d9/d3d9_swapchain.h
@@ -76,6 +76,8 @@ namespace dxvk {
 
     const D3DPRESENT_PARAMETERS* GetPresentParams() const { return &m_presentParams; }
 
+    void SyncFrameLatency();
+
   private:
 
     enum BindingIds : uint32_t {


### PR DESCRIPTION
Move image aquisition to  after presentation rather than before to avoid stalling when the game wants to present when we could be waiting on WSI crap.