### PR TITLE
Handle casing correctly in finding cache/log name

### DIFF
--- a/src/dxvk/dxvk_state_cache.cpp
+++ b/src/dxvk/dxvk_state_cache.cpp
@@ -2,6 +2,8 @@
 #include "dxvk_pipemanager.h"
 #include "dxvk_state_cache.h"
 
+#include <cctype>
+
 namespace dxvk {
 
   static const Sha1Hash       g_nullHash      = Sha1Hash::compute(nullptr, 0);
@@ -986,6 +988,8 @@ namespace dxvk {
       path += '/';
     
     std::string exeName = env::getExeName();
+    std::transform(exeName.begin(), exeName.end(), exeName.begin(), std::tolower);
+
     auto extp = exeName.find_last_of('.');
     
     if (extp != std::string::npos && exeName.substr(extp + 1) == "exe")

--- a/src/util/log/log.cpp
+++ b/src/util/log/log.cpp
@@ -2,6 +2,8 @@
 
 #include "../util_env.h"
 
+#include <cctype>
+
 namespace dxvk {
   
   Logger::Logger(const std::string& file_name)
@@ -101,6 +103,8 @@ namespace dxvk {
       path += '/';
 
     std::string exeName = env::getExeName();
+    std::transform(exeName.begin(), exeName.end(), exeName.begin(), std::tolower);
+
     auto extp = exeName.find_last_of('.');
     
     if (extp != std::string::npos && exeName.substr(extp + 1) == "exe")


### PR DESCRIPTION
Otherwise any game that has a .EXE instead of a .exe or some other casing variant will generate a bad state cache name.

Closes: #2079