### PR TITLE
[d3d9] Don't scale z to [0, 1] for POSITIONT

### DIFF
--- a/setup_dxvk.sh
+++ b/setup_dxvk.sh
@@ -52,6 +52,9 @@ fi
 
 # find wine executable
 export WINEDEBUG=-all
+# disable mscoree and mshtml to avoid downloading
+# wine gecko and mono
+export WINEDLLOVERRIDES="mscoree,mshtml="
 
 wine="wine"
 wine64="wine64"

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -6357,22 +6357,15 @@ namespace dxvk {
 
       m_ffZTest = IsZTestEnabled();
 
-      float zMin    = m_ffZTest ? vp.MinZ : 0.0f;
-      float zMax    = m_ffZTest ? vp.MaxZ : 0.0f;
-      float zExtent = zMax - zMin;
-      zExtent = zExtent != 0.0f
-              ? 1.0f / zExtent
-              : 0.0f;
-
       m_viewportInfo.inverseExtent = Vector4(
          2.0f / float(vp.Width),
         -2.0f / float(vp.Height),
-        zExtent,
+        m_ffZTest ? 1.0f : 0.0f,
         1.0f);
 
       m_viewportInfo.inverseOffset = Vector4(
         -float(vp.X), -float(vp.Y),
-        -zMin,          0.0f);
+         0.0f,         0.0f);
 
       m_viewportInfo.inverseOffset = m_viewportInfo.inverseOffset * m_viewportInfo.inverseExtent;
 


### PR DESCRIPTION
I originally thought the depth clipping region was always [0, 1] when I first implemented this nearly 2 years ago.

The depth clipping region is already in the viewport's depth range, so just don't do anything here if we are z-testing.

( We still need to keep the flattening around for when ztest is disabled though :( )

Fixes: #2056