### PR TITLE
[util] Enable d3d9.deferSurfaceCreation for Ninja Gaiden Sigma/Sigma 2

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -423,6 +423,10 @@ namespace dxvk {
     { R"(\\k2\.exe$)", {{
       { "d3d9.memoryTrackTest",             "True" },
     }} },
+    /* Ninja Gaiden Sigma 1/2                    */
+    { R"(\\NINJA GAIDEN SIGMA(2)?\.exe$)", {{
+      { "d3d9.deferSurfaceCreation",        "True" },
+    }} },
   }};
 
 


### PR DESCRIPTION
Fixes black screen on Ninja Gaiden Sigma and Sigma 2