### PR TITLE
Don't use staging buffer for first uploads

### DIFF
--- a/src/d3d9/d3d9_common_buffer.h
+++ b/src/d3d9/d3d9_common_buffer.h
@@ -173,6 +173,15 @@ namespace dxvk {
      */
     bool NeedsUpload() { return m_desc.Pool != D3DPOOL_DEFAULT && !m_dirtyRange.IsDegenerate(); }
 
+    bool DoesStagingBufferUploads() const { return m_uploadUsingStaging; }
+
+    void EnableStagingBufferUploads() {
+      if (GetMapMode() != D3D9_COMMON_BUFFER_MAP_MODE_BUFFER)
+        return;
+
+      m_uploadUsingStaging = true;
+    }
+
     void PreLoad();
 
   private:
@@ -196,6 +205,7 @@ namespace dxvk {
     const D3D9_BUFFER_DESC      m_desc;
     DWORD                       m_mapFlags;
     bool                        m_wasWrittenByGPU = false;
+    bool                        m_uploadUsingStaging = false;
 
     Rc<DxvkBuffer>              m_buffer;
     Rc<DxvkBuffer>              m_stagingBuffer;

--- a/src/d3d9/d3d9_common_texture.h
+++ b/src/d3d9/d3d9_common_texture.h
@@ -358,6 +358,11 @@ namespace dxvk {
     bool NeedsUpload(UINT Subresource) const { return m_needsUpload.get(Subresource); }
     bool NeedsAnyUpload() { return m_needsUpload.any(); }
     void ClearNeedsUpload() { return m_needsUpload.clearAll();  }
+    bool DoesStagingBufferUploads(UINT Subresource) const { return m_uploadUsingStaging.get(Subresource); }
+
+    void EnableStagingBufferUploads(UINT Subresource) {
+      m_uploadUsingStaging.set(Subresource, true);
+    }
 
     void SetNeedsMipGen(bool value) { m_needsMipGen = value; }
     bool NeedsMipGen() const { return m_needsMipGen; }
@@ -441,6 +446,8 @@ namespace dxvk {
     D3D9SubresourceBitset         m_wasWrittenByGPU = { };
 
     D3D9SubresourceBitset         m_needsUpload = { };
+
+    D3D9SubresourceBitset         m_uploadUsingStaging = { };
 
     DWORD                         m_exposedMipLevels = 0;
 

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -4101,12 +4101,17 @@ namespace dxvk {
       // calling app promises not to overwrite data that is in use
       // or is reading. Remember! This will only trigger for MANAGED resources
       // that cannot get affected by GPU, therefore readonly is A-OK for NOT waiting.
-      const bool skipWait = scratch || managed || (systemmem && !wasWrittenByGPU);
+      const bool usesStagingBuffer = pResource->DoesStagingBufferUploads(Subresource);
+      const bool skipWait = (scratch || managed || (systemmem && !wasWrittenByGPU))
+        && (usesStagingBuffer || readOnly);
 
       if (alloced) {
         std::memset(physSlice.mapPtr, 0, physSlice.length);
       }
       else if (!skipWait) {
+        if (!(Flags & D3DLOCK_DONOTWAIT) && !WaitForResource(mappedBuffer, D3DLOCK_DONOTWAIT))
+          pResource->EnableStagingBufferUploads(Subresource);
+
         if (!WaitForResource(mappedBuffer, Flags))
           return D3DERR_WASSTILLDRAWING;
       }
@@ -4341,31 +4346,41 @@ namespace dxvk {
       scaledAlignedBoxExtent.height = std::min<uint32_t>(texLevelExtent.height - scaledBoxOffset.y, scaledAlignedBoxExtent.height);
       scaledAlignedBoxExtent.depth = std::min<uint32_t>(texLevelExtent.depth - scaledBoxOffset.z, scaledAlignedBoxExtent.depth);
 
-      VkDeviceSize dirtySize = scaledBoxExtentBlockCount.width * scaledBoxExtentBlockCount.height * scaledBoxExtentBlockCount.depth * formatInfo->elementSize;
-      D3D9BufferSlice slice = AllocTempBuffer<false>(dirtySize);
       VkOffset3D boxOffsetBlockCount = util::computeBlockOffset(scaledBoxOffset, formatInfo->blockSize);
       VkDeviceSize copySrcOffset = (boxOffsetBlockCount.z * texLevelExtentBlockCount.height * texLevelExtentBlockCount.width
           + boxOffsetBlockCount.y * texLevelExtentBlockCount.width
           + boxOffsetBlockCount.x)
           * formatInfo->elementSize;
 
-      VkDeviceSize pitch = align(texLevelExtentBlockCount.width * formatInfo->elementSize, 4);
-      void* srcData = reinterpret_cast<uint8_t*>(srcSlice.mapPtr) + copySrcOffset;
-      util::packImageData(
-        slice.mapPtr, srcData, scaledBoxExtentBlockCount, formatInfo->elementSize,
-        pitch, pitch * texLevelExtentBlockCount.height);
+      VkDeviceSize rowAlignment = 0;
+      DxvkBufferSlice copySrcSlice;
+      if (pResource->DoesStagingBufferUploads(Subresource)) {
+        VkDeviceSize dirtySize = scaledBoxExtentBlockCount.width * scaledBoxExtentBlockCount.height * scaledBoxExtentBlockCount.depth * formatInfo->elementSize;
+        VkDeviceSize pitch = align(texLevelExtentBlockCount.width * formatInfo->elementSize, 4);
+        D3D9BufferSlice slice = AllocTempBuffer<false>(dirtySize);
+        copySrcSlice = slice.slice;
+        void* srcData = reinterpret_cast<uint8_t*>(srcSlice.mapPtr) + copySrcOffset;
+        util::packImageData(
+          slice.mapPtr, srcData, scaledBoxExtentBlockCount, formatInfo->elementSize,
+          pitch, pitch * texLevelExtentBlockCount.height);
+      } else {
+        copySrcSlice = DxvkBufferSlice(pResource->GetBuffer(Subresource), copySrcOffset, srcSlice.length);
+        rowAlignment = 4;
+      }
 
       EmitCs([
-        cSrcSlice       = slice.slice,
+        cSrcSlice       = std::move(copySrcSlice),
         cDstImage       = image,
         cDstLayers      = dstLayers,
         cDstLevelExtent = scaledAlignedBoxExtent,
-        cOffset         = scaledBoxOffset
+        cOffset         = scaledBoxOffset,
+        cRowAlignment   = rowAlignment
       ] (DxvkContext* ctx) {
         ctx->copyBufferToImage(
           cDstImage,  cDstLayers,
           cOffset, cDstLevelExtent,
-          cSrcSlice.buffer(), cSrcSlice.offset(), 0, 0);
+          cSrcSlice.buffer(), cSrcSlice.offset(),
+          cRowAlignment, 0);
       });
     }
     else {
@@ -4376,6 +4391,7 @@ namespace dxvk {
       // TODO: PLEASE CLEAN ME
       texLevelExtentBlockCount.height *= std::min(convertFormat.PlaneCount, 2u);
 
+      // the converter can not handle the 4 aligned pitch so we always repack into a staging buffer
       D3D9BufferSlice slice = AllocTempBuffer<false>(srcSlice.length);
       VkDeviceSize pitch = align(texLevelExtentBlockCount.width * formatInfo->elementSize, 4);
 
@@ -4495,8 +4511,12 @@ namespace dxvk {
       const bool readOnly = Flags & D3DLOCK_READONLY;
       const bool noOverlap = !pResource->GPUReadingRange().Overlaps(lockRange);
       const bool noOverwrite = Flags & D3DLOCK_NOOVERWRITE;
-      const bool skipWait = (!wasWrittenByGPU && (readOnly || noOverlap)) || noOverwrite;
+      const bool usesStagingBuffer = pResource->DoesStagingBufferUploads();
+      const bool skipWait = (!wasWrittenByGPU && (usesStagingBuffer || readOnly || noOverlap)) || noOverwrite;
       if (!skipWait) {
+        if (!(Flags & D3DLOCK_DONOTWAIT) && !WaitForResource(mappingBuffer, D3DLOCK_DONOTWAIT))
+          pResource->EnableStagingBufferUploads();
+
         if (!WaitForResource(mappingBuffer, Flags))
           return D3DERR_WASSTILLDRAWING;
 
@@ -4532,13 +4552,19 @@ namespace dxvk {
 
     D3D9Range& range = pResource->DirtyRange();
 
-    D3D9BufferSlice slice = AllocTempBuffer<false>(range.max - range.min);
-    void* srcData = reinterpret_cast<uint8_t*>(srcSlice.mapPtr) + range.min;
-    memcpy(slice.mapPtr, srcData, range.max - range.min);
+    DxvkBufferSlice copySrcSlice;
+    if (pResource->DoesStagingBufferUploads()) {
+      D3D9BufferSlice slice = AllocTempBuffer<false>(range.max - range.min);
+      copySrcSlice = slice.slice;
+      void* srcData = reinterpret_cast<uint8_t*>(srcSlice.mapPtr) + range.min;
+      memcpy(slice.mapPtr, srcData, range.max - range.min);
+    } else {
+      copySrcSlice = DxvkBufferSlice(pResource->GetBuffer<D3D9_COMMON_BUFFER_TYPE_MAPPING>(), range.min, range.max - range.min);
+    }
 
     EmitCs([
       cDstSlice  = dstBuffer,
-      cSrcSlice  = slice.slice,
+      cSrcSlice  = copySrcSlice,
       cDstOffset = range.min,
       cLength    = range.max - range.min
     ] (DxvkContext* ctx) {


### PR DESCRIPTION
This change will make DXVK only use a staging buffer for D3D9 resources that have been locked twice before. It should improve memory usage in games that only copy data to their textures once. (which should be the vast majority of games)

It also contains a tiny optimization for buffer locking because once we hit the switch to use staging buffers, we can omit the CS thread sync point. (Supersedes #2039) 