### PR TITLE
Texture Converter Fix 2

### DIFF
--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -4309,7 +4309,6 @@ namespace dxvk {
     auto convertFormat = pResource->GetFormatMapping().ConversionFormatInfo;
 
     if (likely(convertFormat.FormatType == D3D9ConversionFormat_None)) {
-      const DxvkFormatInfo* formatInfo = imageFormatInfo(pResource->GetFormatMapping().FormatColor);
       VkImageSubresourceLayers dstLayers = { VK_IMAGE_ASPECT_COLOR_BIT, subresource.mipLevel, subresource.arrayLayer, 1 };
 
       const D3DBOX& box = pResource->GetDirtyBox(subresource.arrayLayer);
@@ -4361,13 +4360,14 @@ namespace dxvk {
       });
     }
     else {
+      const DxvkFormatInfo* formatInfo = imageFormatInfo(pResource->GetFormatMapping().FormatColor);
       VkExtent3D texLevelExtent = image->mipLevelExtent(subresource.mipLevel);
       VkExtent3D texLevelExtentBlockCount = util::computeBlockCount(texLevelExtent, formatInfo->blockSize);
 
       D3D9BufferSlice slice = AllocTempBuffer<false>(srcSlice.length);
       VkDeviceSize pitch = align(texLevelExtentBlockCount.width * formatInfo->elementSize, 4);
       util::packImageData(
-        slice.mapPtr, srcSlice.mapPtr, texLevelExtent, formatInfo->elementSize,
+        slice.mapPtr, srcSlice.mapPtr, texLevelExtentBlockCount, formatInfo->elementSize,
         pitch, pitch * texLevelExtentBlockCount.height);
 
       Flush();

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -432,6 +432,10 @@ namespace dxvk {
     { R"(\\Demonstone\.exe$)", {{
       { "d3d9.maxFrameRate",                "60" },
     }} },
+    /* Far Cry 1 has worse water rendering when it detects AMD GPUs */
+    { R"(\\FarCry\.exe$)", {{
+      { "d3d9.customVendorId",              "10de" },
+    }} },
   }};
 
 


### PR DESCRIPTION
I did not account for cases where we convert to a texture format that's bigger than the original one.

On top of that I report a Nvidia GPU to Far Cry 1 to get the prettier water rendering.
Fixes #2112