### PR TITLE
[d3d9] Make sure clear extent does not exceed rt size

### DIFF
--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -1472,6 +1472,9 @@ namespace dxvk {
 
     auto rtSize = m_state.renderTargets[0]->GetSurfaceExtent();
 
+    extent.width = std::min(rtSize.width - offset.x, extent.width);
+    extent.height = std::min(rtSize.height - offset.y, extent.height);
+
     bool extentMatches = align(extent.width,  alignment) == align(rtSize.width,  alignment)
                       && align(extent.height, alignment) == align(rtSize.height, alignment);
 


### PR DESCRIPTION
Might help with #2110

Mirrors Edge calls a clear with the extents 1600x1200 on a RT that is only 1600x900.