### PR TITLE
Fix for EvictManagedOnUnlock & SWTOR performance

### DIFF
--- a/src/d3d9/d3d9_common_texture.h
+++ b/src/d3d9/d3d9_common_texture.h
@@ -308,6 +308,8 @@ namespace dxvk {
 
     bool GetLocked(UINT Subresource) const { return m_locked.get(Subresource); }
 
+    bool IsAnySubresourceLocked() const { return m_locked.any(); }
+
     void SetWrittenByGPU(UINT Subresource, bool value) { m_wasWrittenByGPU.set(Subresource, value); }
 
     bool WasWrittenByGPU(UINT Subresource) const { return m_wasWrittenByGPU.get(Subresource); }

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -4166,10 +4166,12 @@ namespace dxvk {
           cPackedFormat = packedFormat
         ] (DxvkContext* ctx) {
           if (cSubresources.aspectMask != (VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT)) {
-            ctx->copyImageToBuffer(cImageBuffer, 0, 0, 0,
+            ctx->copyImageToBuffer(cImageBuffer, 0, 4, 0,
               cImage, cSubresources, VkOffset3D { 0, 0, 0 },
               cLevelExtent);
           } else {
+            // Copying DS to a packed buffer is only supported for D24S8 and D32S8
+            // right now so the 4 byte row alignment is guaranteed by the format size
             ctx->copyDepthStencilImageToPackedBuffer(
               cImageBuffer, 0,
               VkOffset2D { 0, 0 },

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -4223,7 +4223,7 @@ namespace dxvk {
       }
     }
 
-    if (pResource->IsManaged() && !m_d3d9Options.evictManagedOnUnlock && !readOnly) {
+    if (managed && !m_d3d9Options.evictManagedOnUnlock && !readOnly) {
       pResource->SetNeedsUpload(Subresource, true);
 
       for (uint32_t tex = m_activeTextures; tex; tex &= tex - 1) {
@@ -4275,7 +4275,7 @@ namespace dxvk {
 
     if (shouldFlush) {
         this->FlushImage(pResource, Subresource);
-        if (pResource->IsManaged())
+        if (!pResource->IsAnySubresourceLocked())
           pResource->ClearDirtyBoxes();
     }
 

--- a/src/util/util_bit.h
+++ b/src/util/util_bit.h
@@ -242,7 +242,7 @@ namespace dxvk::bit {
         m_dwords[i] = 0;
     }
 
-    constexpr bool any() {
+    constexpr bool any() const {
       for (size_t i = 0; i < Dwords; i++) {
         if (m_dwords[i] != 0)
           return true;


### PR DESCRIPTION
Fixes #2125

Borderlands 2 locks textures like this:
```
Lock(Mip 0)
Lock(Mip 1)
Unlock(Mip 0)
Unlock(Mip 1)
```
which leads to us clearing the dirty box too soon and not copying the smaller mip maps over.
______
Fixes #2130

SWTOR locks a 1024x1024 D3DPOOL_DEFAULT, D3DFORMAT_A8, USAGE_DYNAMIC texture very often. (Probably cached font glyphs?). It properly sets the dirty rect whenever it makes a change.

On current master we never clear the dirty so it stays at the initial 1024x1024 rect. That means we keep repacking (from 4 aligned pitch managed buffer into tightly packed staging buffer) the entire image a bunch of times per frame. That's really slow.
If we just clear the dirty box like we do for managed textures, all we have to repack and copy are <30x30 parts of the texture.