### PR TITLE
[util] Set dxgi.syncInterval to 0 for Earth Defense Force 5

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -436,6 +436,11 @@ namespace dxvk {
     { R"(\\FarCry\.exe$)", {{
       { "d3d9.customVendorId",              "10de" },
     }} },
+    /* Earth Defense Force 5 */
+    { R"(\\EDF5\.exe$)", {{
+      { "dxgi.tearFree",                    "False" },
+      { "dxgi.syncInterval",                "1"     },
+    }} },
   }};
 
 


### PR DESCRIPTION
The game stutters heavily with vsync enabled, even on windows, and
offers no option to disable it.

Tested on Wayland (sway) and xorg (Plasma) with both 60 and 144 Hz, and got the same behavior in all cases.
Tbf, I don't know if this is really "just" normal stutter or whatever the game is doing, since MangoHud does not even show the framerate correctly.
Either way, setting dxgi.syncInterval to 0 makes the game run fine again.

![edf5](https://user-images.githubusercontent.com/18437660/123543934-6ce8b180-d740-11eb-8427-70745d3d6861.png)
![edf2](https://user-images.githubusercontent.com/18437660/123550109-73d0ed80-d75b-11eb-97c5-abc56dc3969e.png)
