### PR TITLE
Introduce custom sync primitives

### DIFF
--- a/src/d3d11/d3d11_initializer.cpp
+++ b/src/d3d11/d3d11_initializer.cpp
@@ -21,7 +21,7 @@ namespace dxvk {
 
 
   void D3D11Initializer::Flush() {
-    std::lock_guard<std::mutex> lock(m_mutex);
+    std::lock_guard<dxvk::mutex> lock(m_mutex);
 
     if (m_transferCommands != 0)
       FlushInternal();
@@ -54,7 +54,7 @@ namespace dxvk {
     if (!counterBuffer.defined())
       return;
 
-    std::lock_guard<std::mutex> lock(m_mutex);
+    std::lock_guard<dxvk::mutex> lock(m_mutex);
     m_transferCommands += 1;
 
     const uint32_t zero = 0;
@@ -69,7 +69,7 @@ namespace dxvk {
   void D3D11Initializer::InitDeviceLocalBuffer(
           D3D11Buffer*                pBuffer,
     const D3D11_SUBRESOURCE_DATA*     pInitialData) {
-    std::lock_guard<std::mutex> lock(m_mutex);
+    std::lock_guard<dxvk::mutex> lock(m_mutex);
 
     DxvkBufferSlice bufferSlice = pBuffer->GetBufferSlice();
 
@@ -118,7 +118,7 @@ namespace dxvk {
   void D3D11Initializer::InitDeviceLocalTexture(
           D3D11CommonTexture*         pTexture,
     const D3D11_SUBRESOURCE_DATA*     pInitialData) {
-    std::lock_guard<std::mutex> lock(m_mutex);
+    std::lock_guard<dxvk::mutex> lock(m_mutex);
     
     Rc<DxvkImage> image = pTexture->GetImage();
 
@@ -262,7 +262,7 @@ namespace dxvk {
     }
 
     // Initialize the image on the GPU
-    std::lock_guard<std::mutex> lock(m_mutex);
+    std::lock_guard<dxvk::mutex> lock(m_mutex);
 
     VkImageSubresourceRange subresources;
     subresources.aspectMask     = image->formatInfo()->aspectMask;

--- a/src/d3d11/d3d11_initializer.h
+++ b/src/d3d11/d3d11_initializer.h
@@ -40,7 +40,7 @@ namespace dxvk {
     
   private:
 
-    std::mutex        m_mutex;
+    dxvk::mutex       m_mutex;
 
     D3D11Device*      m_parent;
     Rc<DxvkDevice>    m_device;

--- a/src/d3d11/d3d11_shader.cpp
+++ b/src/d3d11/d3d11_shader.cpp
@@ -89,7 +89,7 @@ namespace dxvk {
           size_t              BytecodeLength,
           D3D11CommonShader*  pShader) {
     // Use the shader's unique key for the lookup
-    { std::unique_lock<std::mutex> lock(m_mutex);
+    { std::unique_lock<dxvk::mutex> lock(m_mutex);
       
       auto entry = m_modules.find(*pShaderKey);
       if (entry != m_modules.end()) {
@@ -113,7 +113,7 @@ namespace dxvk {
     // Insert the new module into the lookup table. If another thread
     // has compiled the same shader in the meantime, we should return
     // that object instead and discard the newly created module.
-    { std::unique_lock<std::mutex> lock(m_mutex);
+    { std::unique_lock<dxvk::mutex> lock(m_mutex);
       
       auto status = m_modules.insert({ *pShaderKey, module });
       if (!status.second) {

--- a/src/d3d11/d3d11_shader.h
+++ b/src/d3d11/d3d11_shader.h
@@ -146,7 +146,7 @@ namespace dxvk {
     
   private:
     
-    std::mutex m_mutex;
+    dxvk::mutex m_mutex;
     
     std::unordered_map<
       DxvkShaderKey,

--- a/src/d3d11/d3d11_state.h
+++ b/src/d3d11/d3d11_state.h
@@ -54,7 +54,7 @@ namespace dxvk {
      * \returns Pointer to the state object
      */
     T* Create(D3D11Device* device, const DescType& desc) {
-      std::lock_guard<std::mutex> lock(m_mutex);
+      std::lock_guard<dxvk::mutex> lock(m_mutex);
       
       auto entry = m_objects.find(desc);
       
@@ -70,7 +70,7 @@ namespace dxvk {
     
   private:
     
-    std::mutex                                 m_mutex;
+    dxvk::mutex                                m_mutex;
     std::unordered_map<DescType, T,
       D3D11StateDescHash, D3D11StateDescEqual> m_objects;
     

--- a/src/d3d9/d3d9_initializer.cpp
+++ b/src/d3d9/d3d9_initializer.cpp
@@ -18,7 +18,7 @@ namespace dxvk {
 
 
   void D3D9Initializer::Flush() {
-    std::lock_guard<std::mutex> lock(m_mutex);
+    std::lock_guard<dxvk::mutex> lock(m_mutex);
 
     if (m_transferCommands != 0)
       FlushInternal();
@@ -52,7 +52,7 @@ namespace dxvk {
 
   void D3D9Initializer::InitDeviceLocalBuffer(
           DxvkBufferSlice    Slice) {
-    std::lock_guard<std::mutex> lock(m_mutex);
+    std::lock_guard<dxvk::mutex> lock(m_mutex);
 
     m_transferCommands += 1;
 
@@ -79,7 +79,7 @@ namespace dxvk {
 
   void D3D9Initializer::InitDeviceLocalTexture(
           D3D9CommonTexture* pTexture) {
-    std::lock_guard<std::mutex> lock(m_mutex);
+    std::lock_guard<dxvk::mutex> lock(m_mutex);
 
     auto InitImage = [&](Rc<DxvkImage> image) {
       if (image == nullptr)

--- a/src/d3d9/d3d9_initializer.h
+++ b/src/d3d9/d3d9_initializer.h
@@ -33,7 +33,7 @@ namespace dxvk {
     
   private:
 
-    std::mutex        m_mutex;
+    dxvk::mutex       m_mutex;
 
     Rc<DxvkDevice>    m_device;
     Rc<DxvkContext>   m_context;

--- a/src/d3d9/d3d9_shader.cpp
+++ b/src/d3d9/d3d9_shader.cpp
@@ -117,7 +117,7 @@ namespace dxvk {
       Sha1Hash::compute(pShaderBytecode, info.bytecodeByteLength));
 
     // Use the shader's unique key for the lookup
-    { std::unique_lock<std::mutex> lock(m_mutex);
+    { std::unique_lock<dxvk::mutex> lock(m_mutex);
       
       auto entry = m_modules.find(lookupKey);
       if (entry != m_modules.end()) {
@@ -136,7 +136,7 @@ namespace dxvk {
     // Insert the new module into the lookup table. If another thread
     // has compiled the same shader in the meantime, we should return
     // that object instead and discard the newly created module.
-    { std::unique_lock<std::mutex> lock(m_mutex);
+    { std::unique_lock<dxvk::mutex> lock(m_mutex);
       
       auto status = m_modules.insert({ lookupKey, *pShaderModule });
       if (!status.second) {

--- a/src/d3d9/d3d9_shader.h
+++ b/src/d3d9/d3d9_shader.h
@@ -179,7 +179,7 @@ namespace dxvk {
     
   private:
     
-    std::mutex m_mutex;
+    dxvk::mutex m_mutex;
     
     std::unordered_map<
       DxvkShaderKey,

--- a/src/d3d9/d3d9_swapchain.cpp
+++ b/src/d3d9/d3d9_swapchain.cpp
@@ -15,7 +15,7 @@ namespace dxvk {
   };
 
 
-  static std::recursive_mutex g_windowProcMapMutex;
+  static dxvk::recursive_mutex g_windowProcMapMutex;
   static std::unordered_map<HWND, D3D9WindowData> g_windowProcMap;
 
 

--- a/src/d3d9/d3d9_swvp_emu.cpp
+++ b/src/d3d9/d3d9_swvp_emu.cpp
@@ -311,7 +311,7 @@ namespace dxvk {
     auto& elements = pDecl->GetElements();
 
     // Use the shader's unique key for the lookup
-    { std::unique_lock<std::mutex> lock(m_mutex);
+    { std::unique_lock<dxvk::mutex> lock(m_mutex);
       
       auto entry = m_modules.find(elements);
       if (entry != m_modules.end())
@@ -346,7 +346,7 @@ namespace dxvk {
     // Insert the new module into the lookup table. If another thread
     // has compiled the same shader in the meantime, we should return
     // that object instead and discard the newly created module.
-    { std::unique_lock<std::mutex> lock(m_mutex);
+    { std::unique_lock<dxvk::mutex> lock(m_mutex);
       
       auto status = m_modules.insert({ elements, shader });
       if (!status.second)

--- a/src/d3d9/d3d9_swvp_emu.h
+++ b/src/d3d9/d3d9_swvp_emu.h
@@ -27,7 +27,7 @@ namespace dxvk {
 
   private:
 
-    std::mutex                                m_mutex;
+    dxvk::mutex                               m_mutex;
 
     std::unordered_map<
       D3D9VertexElements, Rc<DxvkShader>,

--- a/src/dxgi/dxgi_adapter.cpp
+++ b/src/dxgi/dxgi_adapter.cpp
@@ -67,7 +67,7 @@ namespace dxvk {
   
   DxgiAdapter::~DxgiAdapter() {
     if (m_eventThread.joinable()) {
-      std::unique_lock<std::mutex> lock(m_mutex);
+      std::unique_lock<dxvk::mutex> lock(m_mutex);
       m_eventCookie = ~0u;
       m_cond.notify_one();
 
@@ -406,7 +406,7 @@ namespace dxvk {
     if (!hEvent || !pdwCookie)
       return E_INVALIDARG;
 
-    std::unique_lock<std::mutex> lock(m_mutex);
+    std::unique_lock<dxvk::mutex> lock(m_mutex);
     DWORD cookie = ++m_eventCookie;
 
     m_eventMap.insert({ cookie, hEvent });
@@ -431,7 +431,7 @@ namespace dxvk {
 
   void STDMETHODCALLTYPE DxgiAdapter::UnregisterVideoMemoryBudgetChangeNotification(
           DWORD                         dwCookie) {
-    std::unique_lock<std::mutex> lock(m_mutex);
+    std::unique_lock<dxvk::mutex> lock(m_mutex);
     m_eventMap.erase(dwCookie);
   }
 
@@ -449,7 +449,7 @@ namespace dxvk {
   void DxgiAdapter::runEventThread() {
     env::setThreadName(str::format("dxvk-adapter-", m_index));
 
-    std::unique_lock<std::mutex> lock(m_mutex);
+    std::unique_lock<dxvk::mutex> lock(m_mutex);
     DxvkAdapterMemoryInfo memoryInfoOld = m_adapter->getMemoryHeapInfo();
 
     while (true) {

--- a/src/dxgi/dxgi_adapter.h
+++ b/src/dxgi/dxgi_adapter.h
@@ -115,8 +115,8 @@ namespace dxvk {
     UINT              m_index;
     UINT64            m_memReservation[2] = { 0, 0 };
 
-    std::mutex                        m_mutex;
-    std::condition_variable           m_cond;
+    dxvk::mutex                       m_mutex;
+    dxvk::condition_variable          m_cond;
 
     DWORD                             m_eventCookie = 0;
     std::unordered_map<DWORD, HANDLE> m_eventMap;

--- a/src/dxgi/dxgi_monitor.cpp
+++ b/src/dxgi/dxgi_monitor.cpp
@@ -36,7 +36,7 @@ namespace dxvk {
     if (!hMonitor || !pData)
       return E_INVALIDARG;
     
-    std::lock_guard<std::mutex> lock(m_monitorMutex);
+    std::lock_guard<dxvk::mutex> lock(m_monitorMutex);
     auto result = m_monitorData.insert({ hMonitor, *pData });
 
     return result.second ? S_OK : E_INVALIDARG;

--- a/src/dxgi/dxgi_monitor.h
+++ b/src/dxgi/dxgi_monitor.h
@@ -39,7 +39,7 @@ namespace dxvk {
 
     IUnknown* m_parent;
 
-    std::mutex                                         m_monitorMutex;
+    dxvk::mutex                                        m_monitorMutex;
     std::unordered_map<HMONITOR, DXGI_VK_MONITOR_DATA> m_monitorData;
 
   };

--- a/src/dxgi/dxgi_swapchain.cpp
+++ b/src/dxgi/dxgi_swapchain.cpp
@@ -165,7 +165,7 @@ namespace dxvk {
   
   
   HRESULT STDMETHODCALLTYPE DxgiSwapChain::GetFrameStatistics(DXGI_FRAME_STATISTICS* pStats) {
-    std::lock_guard<std::recursive_mutex> lock(m_lockWindow);
+    std::lock_guard<dxvk::recursive_mutex> lock(m_lockWindow);
 
     if (!pStats)
       return E_INVALIDARG;
@@ -261,8 +261,8 @@ namespace dxvk {
     if (SyncInterval > 4)
       return DXGI_ERROR_INVALID_CALL;
 
-    std::lock_guard<std::recursive_mutex> lockWin(m_lockWindow);
-    std::lock_guard<std::mutex> lockBuf(m_lockBuffer);
+    std::lock_guard<dxvk::recursive_mutex> lockWin(m_lockWindow);
+    std::lock_guard<dxvk::mutex> lockBuf(m_lockBuffer);
 
     try {
       HRESULT hr = m_presenter->Present(SyncInterval, PresentFlags, nullptr);
@@ -290,7 +290,7 @@ namespace dxvk {
     if ((m_desc.Flags & PreserveFlags) != (SwapChainFlags & PreserveFlags))
       return DXGI_ERROR_INVALID_CALL;
     
-    std::lock_guard<std::mutex> lock(m_lockBuffer);
+    std::lock_guard<dxvk::mutex> lock(m_lockBuffer);
     m_desc.Width  = Width;
     m_desc.Height = Height;
     
@@ -327,7 +327,7 @@ namespace dxvk {
 
 
   HRESULT STDMETHODCALLTYPE DxgiSwapChain::ResizeTarget(const DXGI_MODE_DESC* pNewTargetParameters) {
-    std::lock_guard<std::recursive_mutex> lock(m_lockWindow);
+    std::lock_guard<dxvk::recursive_mutex> lock(m_lockWindow);
 
     if (pNewTargetParameters == nullptr)
       return DXGI_ERROR_INVALID_CALL;
@@ -387,7 +387,7 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE DxgiSwapChain::SetFullscreenState(
           BOOL          Fullscreen,
           IDXGIOutput*  pTarget) {
-    std::lock_guard<std::recursive_mutex> lock(m_lockWindow);
+    std::lock_guard<dxvk::recursive_mutex> lock(m_lockWindow);
 
     if (!Fullscreen && pTarget)
       return DXGI_ERROR_INVALID_CALL;
@@ -436,7 +436,7 @@ namespace dxvk {
     if (!(m_desc.Flags & DXGI_SWAP_CHAIN_FLAG_FRAME_LATENCY_WAITABLE_OBJECT))
       return DXGI_ERROR_INVALID_CALL;
 
-    std::lock_guard<std::recursive_mutex> lock(m_lockWindow);
+    std::lock_guard<dxvk::recursive_mutex> lock(m_lockWindow);
     *pMaxLatency = m_presenter->GetFrameLatency();
     return S_OK;
   }
@@ -465,7 +465,7 @@ namespace dxvk {
     if (!(m_desc.Flags & DXGI_SWAP_CHAIN_FLAG_FRAME_LATENCY_WAITABLE_OBJECT))
       return DXGI_ERROR_INVALID_CALL;
 
-    std::lock_guard<std::recursive_mutex> lock(m_lockWindow);
+    std::lock_guard<dxvk::recursive_mutex> lock(m_lockWindow);
     return m_presenter->SetFrameLatency(MaxLatency);
   }
 
@@ -546,7 +546,7 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE DxgiSwapChain::SetGammaControl(
           UINT                      NumPoints,
     const DXGI_RGB*                 pGammaCurve) {
-    std::lock_guard<std::mutex> lockBuf(m_lockBuffer);
+    std::lock_guard<dxvk::mutex> lockBuf(m_lockBuffer);
     return m_presenter->SetGammaControl(NumPoints, pGammaCurve);
   }
 

--- a/src/dxgi/dxgi_swapchain.h
+++ b/src/dxgi/dxgi_swapchain.h
@@ -175,8 +175,8 @@ namespace dxvk {
       RECT rect    = { 0, 0, 0, 0 };
     };
     
-    std::recursive_mutex            m_lockWindow;
-    std::mutex                      m_lockBuffer;
+    dxvk::recursive_mutex           m_lockWindow;
+    dxvk::mutex                     m_lockBuffer;
 
     Com<IDXGIFactory>               m_factory;
     Com<IDXGIAdapter>               m_adapter;

--- a/src/dxso/dxso_util.cpp
+++ b/src/dxso/dxso_util.cpp
@@ -37,14 +37,14 @@ namespace dxvk {
   }
 
 
-  std::mutex                   g_linkerSlotMutex;
+  dxvk::mutex                  g_linkerSlotMutex;
   uint32_t                     g_linkerSlotCount = 0;
   std::array<DxsoSemantic, 32> g_linkerSlots;
 
   uint32_t RegisterLinkerSlot(DxsoSemantic semantic) {
     // Lock, because games could be trying
     // to make multiple shaders at a time.
-    std::lock_guard<std::mutex> lock(g_linkerSlotMutex);
+    std::lock_guard<dxvk::mutex> lock(g_linkerSlotMutex);
 
     // Need to chose a slot that maps nicely and similarly
     // between vertex and pixel shaders

--- a/src/dxvk/dxvk_cs.cpp
+++ b/src/dxvk/dxvk_cs.cpp
@@ -102,7 +102,7 @@ namespace dxvk {
   
   
   DxvkCsThread::~DxvkCsThread() {
-    { std::unique_lock<std::mutex> lock(m_mutex);
+    { std::unique_lock<dxvk::mutex> lock(m_mutex);
       m_stopped.store(true);
     }
     
@@ -112,7 +112,7 @@ namespace dxvk {
   
   
   void DxvkCsThread::dispatchChunk(DxvkCsChunkRef&& chunk) {
-    { std::unique_lock<std::mutex> lock(m_mutex);
+    { std::unique_lock<dxvk::mutex> lock(m_mutex);
       m_chunksQueued.push(std::move(chunk));
       m_chunksPending += 1;
     }
@@ -122,7 +122,7 @@ namespace dxvk {
   
   
   void DxvkCsThread::synchronize() {
-    std::unique_lock<std::mutex> lock(m_mutex);
+    std::unique_lock<dxvk::mutex> lock(m_mutex);
     
     m_condOnSync.wait(lock, [this] {
       return !m_chunksPending.load();
@@ -137,7 +137,7 @@ namespace dxvk {
 
     try {
       while (!m_stopped.load()) {
-        { std::unique_lock<std::mutex> lock(m_mutex);
+        { std::unique_lock<dxvk::mutex> lock(m_mutex);
           if (chunk) {
             if (--m_chunksPending == 0)
               m_condOnSync.notify_one();

--- a/src/dxvk/dxvk_cs.h
+++ b/src/dxvk/dxvk_cs.h
@@ -419,9 +419,9 @@ namespace dxvk {
     const Rc<DxvkContext>       m_context;
     
     std::atomic<bool>           m_stopped = { false };
-    std::mutex                  m_mutex;
-    std::condition_variable     m_condOnAdd;
-    std::condition_variable     m_condOnSync;
+    dxvk::mutex                 m_mutex;
+    dxvk::condition_variable    m_condOnAdd;
+    dxvk::condition_variable    m_condOnSync;
     std::queue<DxvkCsChunkRef>  m_chunksQueued;
     std::atomic<uint32_t>       m_chunksPending = { 0u };
     dxvk::thread                m_thread;

--- a/src/dxvk/dxvk_gpu_query.cpp
+++ b/src/dxvk/dxvk_gpu_query.cpp
@@ -180,7 +180,7 @@ namespace dxvk {
 
   
   DxvkGpuQueryHandle DxvkGpuQueryAllocator::allocQuery() {
-    std::lock_guard<std::mutex> lock(m_mutex);
+    std::lock_guard<dxvk::mutex> lock(m_mutex);
 
     if (m_handles.size() == 0)
       this->createQueryPool();
@@ -195,7 +195,7 @@ namespace dxvk {
 
 
   void DxvkGpuQueryAllocator::freeQuery(DxvkGpuQueryHandle handle) {
-    std::lock_guard<std::mutex> lock(m_mutex);
+    std::lock_guard<dxvk::mutex> lock(m_mutex);
     m_handles.push_back(handle);
   }
 

--- a/src/dxvk/dxvk_gpu_query.h
+++ b/src/dxvk/dxvk_gpu_query.h
@@ -280,7 +280,7 @@ namespace dxvk {
     VkQueryType       m_queryType;
     uint32_t          m_queryPoolSize;
     
-    std::mutex                      m_mutex;
+    dxvk::mutex                     m_mutex;
     std::vector<DxvkGpuQueryHandle> m_handles;
     std::vector<VkQueryPool>        m_pools;
 

--- a/src/dxvk/dxvk_memory.cpp
+++ b/src/dxvk/dxvk_memory.cpp
@@ -215,7 +215,7 @@ namespace dxvk {
     const VkMemoryDedicatedAllocateInfo&    dedAllocInfo,
           VkMemoryPropertyFlags             flags,
           float                             priority) {
-    std::lock_guard<std::mutex> lock(m_mutex);
+    std::lock_guard<dxvk::mutex> lock(m_mutex);
 
     // Try to allocate from a memory type which supports the given flags exactly
     auto dedAllocPtr = dedAllocReq.prefersDedicatedAllocation ? &dedAllocInfo : nullptr;
@@ -386,7 +386,7 @@ namespace dxvk {
 
   void DxvkMemoryAllocator::free(
     const DxvkMemory&           memory) {
-    std::lock_guard<std::mutex> lock(m_mutex);
+    std::lock_guard<dxvk::mutex> lock(m_mutex);
     memory.m_type->heap->stats.memoryUsed -= memory.m_length;
 
     if (memory.m_chunk != nullptr) {

--- a/src/dxvk/dxvk_memory.h
+++ b/src/dxvk/dxvk_memory.h
@@ -282,7 +282,7 @@ namespace dxvk {
     const VkPhysicalDeviceProperties       m_devProps;
     const VkPhysicalDeviceMemoryProperties m_memProps;
     
-    std::mutex                                      m_mutex;
+    dxvk::mutex                                     m_mutex;
     std::array<DxvkMemoryHeap, VK_MAX_MEMORY_HEAPS> m_memHeaps;
     std::array<DxvkMemoryType, VK_MAX_MEMORY_TYPES> m_memTypes;
 

--- a/src/dxvk/dxvk_meta_blit.cpp
+++ b/src/dxvk/dxvk_meta_blit.cpp
@@ -248,7 +248,7 @@ namespace dxvk {
           VkImageViewType       viewType,
           VkFormat              viewFormat,
           VkSampleCountFlagBits samples) {
-    std::lock_guard<std::mutex> lock(m_mutex);
+    std::lock_guard<dxvk::mutex> lock(m_mutex);
     
     DxvkMetaBlitPipelineKey key;
     key.viewType   = viewType;

--- a/src/dxvk/dxvk_meta_blit.h
+++ b/src/dxvk/dxvk_meta_blit.h
@@ -199,7 +199,7 @@ namespace dxvk {
     VkShaderModule m_shaderFrag2D = VK_NULL_HANDLE;
     VkShaderModule m_shaderFrag3D = VK_NULL_HANDLE;
     
-    std::mutex m_mutex;
+    dxvk::mutex m_mutex;
     
     std::unordered_map<
       DxvkMetaBlitRenderPassKey,

--- a/src/dxvk/dxvk_meta_copy.cpp
+++ b/src/dxvk/dxvk_meta_copy.cpp
@@ -240,7 +240,7 @@ namespace dxvk {
           VkImageViewType       viewType,
           VkFormat              dstFormat,
           VkSampleCountFlagBits dstSamples) {
-    std::lock_guard<std::mutex> lock(m_mutex);
+    std::lock_guard<dxvk::mutex> lock(m_mutex);
 
     DxvkMetaCopyPipelineKey key;
     key.viewType = viewType;
@@ -258,7 +258,7 @@ namespace dxvk {
 
 
   DxvkMetaCopyPipeline DxvkMetaCopyObjects::getCopyBufferImagePipeline() {
-    std::lock_guard<std::mutex> lock(m_mutex);
+    std::lock_guard<dxvk::mutex> lock(m_mutex);
 
     if (!m_copyBufferImagePipeline.pipeHandle)
       m_copyBufferImagePipeline = createCopyBufferImagePipeline();

--- a/src/dxvk/dxvk_meta_copy.h
+++ b/src/dxvk/dxvk_meta_copy.h
@@ -171,7 +171,7 @@ namespace dxvk {
     FragShaders m_depth;
     FragShaders m_depthStencil;
 
-    std::mutex m_mutex;
+    dxvk::mutex m_mutex;
 
     std::unordered_map<
       DxvkMetaCopyPipelineKey,

--- a/src/dxvk/dxvk_meta_resolve.cpp
+++ b/src/dxvk/dxvk_meta_resolve.cpp
@@ -330,7 +330,7 @@ namespace dxvk {
           VkSampleCountFlagBits     samples,
           VkResolveModeFlagBitsKHR  depthResolveMode,
           VkResolveModeFlagBitsKHR  stencilResolveMode) {
-    std::lock_guard<std::mutex> lock(m_mutex);
+    std::lock_guard<dxvk::mutex> lock(m_mutex);
 
     DxvkMetaResolvePipelineKey key;
     key.format  = format;

--- a/src/dxvk/dxvk_meta_resolve.h
+++ b/src/dxvk/dxvk_meta_resolve.h
@@ -151,7 +151,7 @@ namespace dxvk {
     VkShaderModule m_shaderFragD = VK_NULL_HANDLE;
     VkShaderModule m_shaderFragDS = VK_NULL_HANDLE;
 
-    std::mutex m_mutex;
+    dxvk::mutex m_mutex;
 
     std::unordered_map<
       DxvkMetaResolvePipelineKey,

--- a/src/dxvk/dxvk_openvr.cpp
+++ b/src/dxvk/dxvk_openvr.cpp
@@ -46,13 +46,13 @@ namespace dxvk {
   
   
   DxvkNameSet VrInstance::getInstanceExtensions() {
-    std::lock_guard<std::mutex> lock(m_mutex);
+    std::lock_guard<dxvk::mutex> lock(m_mutex);
     return m_insExtensions;
   }
 
 
   DxvkNameSet VrInstance::getDeviceExtensions(uint32_t adapterId) {
-    std::lock_guard<std::mutex> lock(m_mutex);
+    std::lock_guard<dxvk::mutex> lock(m_mutex);
     
     if (adapterId < m_devExtensions.size())
       return m_devExtensions[adapterId];
@@ -62,7 +62,7 @@ namespace dxvk {
 
 
   void VrInstance::initInstanceExtensions() {
-    std::lock_guard<std::mutex> lock(m_mutex);
+    std::lock_guard<dxvk::mutex> lock(m_mutex);
 
     if (m_no_vr || m_initializedDevExt)
         return;
@@ -87,7 +87,7 @@ namespace dxvk {
 
 
   void VrInstance::initDeviceExtensions(const DxvkInstance* instance) {
-    std::lock_guard<std::mutex> lock(m_mutex);
+    std::lock_guard<dxvk::mutex> lock(m_mutex);
 
     if (m_no_vr || (!m_vr_key && !m_compositor) || m_initializedDevExt)
       return;

--- a/src/dxvk/dxvk_openvr.h
+++ b/src/dxvk/dxvk_openvr.h
@@ -49,7 +49,7 @@ namespace dxvk {
 
   private:
 
-    std::mutex            m_mutex;
+    dxvk::mutex           m_mutex;
     HKEY                  m_vr_key     = nullptr;
     vr::IVRCompositor*    m_compositor = nullptr;
     SoHandle              m_ovrApi     = nullptr;

--- a/src/dxvk/dxvk_openxr.cpp
+++ b/src/dxvk/dxvk_openxr.cpp
@@ -29,19 +29,19 @@ namespace dxvk {
   
   
   DxvkNameSet DxvkXrProvider::getInstanceExtensions() {
-    std::lock_guard<std::mutex> lock(m_mutex);
+    std::lock_guard<dxvk::mutex> lock(m_mutex);
     return m_insExtensions;
   }
 
 
   DxvkNameSet DxvkXrProvider::getDeviceExtensions(uint32_t adapterId) {
-    std::lock_guard<std::mutex> lock(m_mutex);
+    std::lock_guard<dxvk::mutex> lock(m_mutex);
     return m_devExtensions;
   }
 
 
   void DxvkXrProvider::initInstanceExtensions() {
-    std::lock_guard<std::mutex> lock(m_mutex);
+    std::lock_guard<dxvk::mutex> lock(m_mutex);
 
     if (!m_wineOxr)
       m_wineOxr = this->loadLibrary();
@@ -70,7 +70,7 @@ namespace dxvk {
 
 
   void DxvkXrProvider::initDeviceExtensions(const DxvkInstance* instance) {
-    std::lock_guard<std::mutex> lock(m_mutex);
+    std::lock_guard<dxvk::mutex> lock(m_mutex);
 
     if (!m_wineOxr || m_initializedDevExt)
       return;

--- a/src/dxvk/dxvk_openxr.h
+++ b/src/dxvk/dxvk_openxr.h
@@ -43,7 +43,7 @@ namespace dxvk {
 
   private:
 
-    std::mutex            m_mutex;
+    dxvk::mutex           m_mutex;
     SoHandle              m_wineOxr     = nullptr;
 
     bool m_loadedOxrApi      = false;

--- a/src/dxvk/dxvk_pipemanager.cpp
+++ b/src/dxvk/dxvk_pipemanager.cpp
@@ -26,7 +26,7 @@ namespace dxvk {
     if (shaders.cs == nullptr)
       return nullptr;
     
-    std::lock_guard<std::mutex> lock(m_mutex);
+    std::lock_guard<dxvk::mutex> lock(m_mutex);
     
     auto pair = m_computePipelines.find(shaders);
     if (pair != m_computePipelines.end())
@@ -45,7 +45,7 @@ namespace dxvk {
     if (shaders.vs == nullptr)
       return nullptr;
     
-    std::lock_guard<std::mutex> lock(m_mutex);
+    std::lock_guard<dxvk::mutex> lock(m_mutex);
     
     auto pair = m_graphicsPipelines.find(shaders);
     if (pair != m_graphicsPipelines.end())

--- a/src/dxvk/dxvk_pipemanager.h
+++ b/src/dxvk/dxvk_pipemanager.h
@@ -99,7 +99,7 @@ namespace dxvk {
     std::atomic<uint32_t>     m_numComputePipelines  = { 0 };
     std::atomic<uint32_t>     m_numGraphicsPipelines = { 0 };
     
-    std::mutex m_mutex;
+    dxvk::mutex m_mutex;
     
     std::unordered_map<
       DxvkComputePipelineShaders,

--- a/src/dxvk/dxvk_queue.h
+++ b/src/dxvk/dxvk_queue.h
@@ -173,18 +173,18 @@ namespace dxvk {
     std::atomic<uint32_t>   m_pending = { 0u };
     std::atomic<uint64_t>   m_gpuIdle = { 0ull };
 
-    std::mutex              m_mutex;
-    std::mutex              m_mutexQueue;
+    dxvk::mutex                 m_mutex;
+    dxvk::mutex                 m_mutexQueue;
     
-    std::condition_variable m_appendCond;
-    std::condition_variable m_submitCond;
-    std::condition_variable m_finishCond;
+    dxvk::condition_variable    m_appendCond;
+    dxvk::condition_variable    m_submitCond;
+    dxvk::condition_variable    m_finishCond;
 
     std::queue<DxvkSubmitEntry> m_submitQueue;
     std::queue<DxvkSubmitEntry> m_finishQueue;
 
-    dxvk::thread            m_submitThread;
-    dxvk::thread            m_finishThread;
+    dxvk::thread                m_submitThread;
+    dxvk::thread                m_finishThread;
 
     VkResult submitToQueue(
       const DxvkSubmitInfo& submission);

--- a/src/dxvk/dxvk_recycler.h
+++ b/src/dxvk/dxvk_recycler.h
@@ -29,7 +29,7 @@ namespace dxvk {
      * \return An object, or \c nullptr
      */
     Rc<T> retrieveObject() {
-      std::lock_guard<std::mutex> lock(m_mutex);
+      std::lock_guard<dxvk::mutex> lock(m_mutex);
       
       if (m_objectId == 0)
         return nullptr;
@@ -46,7 +46,7 @@ namespace dxvk {
      * \param [in] object The object to return
      */
     void returnObject(const Rc<T>& object) {
-      std::lock_guard<std::mutex> lock(m_mutex);
+      std::lock_guard<dxvk::mutex> lock(m_mutex);
       
       if (m_objectId < N)
         m_objects.at(m_objectId++) = object;
@@ -54,7 +54,7 @@ namespace dxvk {
     
   private:
     
-    std::mutex           m_mutex;
+    dxvk::mutex          m_mutex;
     std::array<Rc<T>, N> m_objects;
     size_t               m_objectId = 0;
     

--- a/src/dxvk/dxvk_renderpass.cpp
+++ b/src/dxvk/dxvk_renderpass.cpp
@@ -278,7 +278,7 @@ namespace dxvk {
   
   
   DxvkRenderPass* DxvkRenderPassPool::getRenderPass(const DxvkRenderPassFormat& fmt) {
-    std::lock_guard<std::mutex> lock(m_mutex);
+    std::lock_guard<dxvk::mutex> lock(m_mutex);
 
     auto entry = m_renderPasses.find(fmt);
     if (entry != m_renderPasses.end())

--- a/src/dxvk/dxvk_renderpass.h
+++ b/src/dxvk/dxvk_renderpass.h
@@ -219,7 +219,7 @@ namespace dxvk {
     
     const Rc<vk::DeviceFn> m_vkd;
     
-    std::mutex                      m_mutex;
+    dxvk::mutex                     m_mutex;
     std::unordered_map<
       DxvkRenderPassFormat,
       DxvkRenderPass,

--- a/src/dxvk/dxvk_state_cache.h
+++ b/src/dxvk/dxvk_state_cache.h
@@ -94,7 +94,7 @@ namespace dxvk {
     std::vector<DxvkStateCacheEntry>  m_entries;
     std::atomic<bool>                 m_stopThreads = { false };
 
-    std::mutex                        m_entryLock;
+    dxvk::mutex                       m_entryLock;
 
     std::unordered_multimap<
       DxvkStateCacheKey, size_t,
@@ -108,14 +108,14 @@ namespace dxvk {
       DxvkShaderKey, Rc<DxvkShader>,
       DxvkHash, DxvkEq> m_shaderMap;
 
-    std::mutex                        m_workerLock;
-    std::condition_variable           m_workerCond;
+    dxvk::mutex                       m_workerLock;
+    dxvk::condition_variable          m_workerCond;
     std::queue<WorkerItem>            m_workerQueue;
     std::atomic<uint32_t>             m_workerBusy;
     std::vector<dxvk::thread>         m_workerThreads;
 
-    std::mutex                        m_writerLock;
-    std::condition_variable           m_writerCond;
+    dxvk::mutex                       m_writerLock;
+    dxvk::condition_variable          m_writerCond;
     std::queue<WriterItem>            m_writerQueue;
     dxvk::thread                      m_writerThread;
 

--- a/src/util/log/log.cpp
+++ b/src/util/log/log.cpp
@@ -50,7 +50,7 @@ namespace dxvk {
   
   void Logger::emitMsg(LogLevel level, const std::string& message) {
     if (level >= m_minLevel) {
-      std::lock_guard<std::mutex> lock(m_mutex);
+      std::lock_guard<dxvk::mutex> lock(m_mutex);
       
       static std::array<const char*, 5> s_prefixes
         = {{ "trace: ", "debug: ", "info:  ", "warn:  ", "err:   " }};

--- a/src/util/log/log.h
+++ b/src/util/log/log.h
@@ -3,8 +3,9 @@
 #include <array>
 #include <fstream>
 #include <iostream>
-#include <mutex>
 #include <string>
+
+#include "../thread.h"
 
 namespace dxvk {
   
@@ -47,7 +48,7 @@ namespace dxvk {
     
     const LogLevel m_minLevel;
     
-    std::mutex    m_mutex;
+    dxvk::mutex   m_mutex;
     std::ofstream m_fileStream;
     
     void emitMsg(LogLevel level, const std::string& message);

--- a/src/util/sync/sync_signal.h
+++ b/src/util/sync/sync_signal.h
@@ -1,10 +1,10 @@
 #pragma once
 
 #include <atomic>
-#include <condition_variable>
-#include <mutex>
 
 #include "../rc/util_rc.h"
+
+#include "../thread.h"
 
 namespace dxvk::sync {
   
@@ -70,13 +70,13 @@ namespace dxvk::sync {
     }
 
     void signal(uint64_t value) {
-      std::unique_lock<std::mutex> lock(m_mutex);
+      std::unique_lock<dxvk::mutex> lock(m_mutex);
       m_value.store(value, std::memory_order_release);
       m_cond.notify_all();
     }
     
     void wait(uint64_t value) {
-      std::unique_lock<std::mutex> lock(m_mutex);
+      std::unique_lock<dxvk::mutex> lock(m_mutex);
       m_cond.wait(lock, [this, value] {
         return value <= m_value.load(std::memory_order_acquire);
       });
@@ -84,9 +84,9 @@ namespace dxvk::sync {
 
   private:
 
-    std::atomic<uint64_t>   m_value;
-    std::mutex              m_mutex;
-    std::condition_variable m_cond;
+    std::atomic<uint64_t>    m_value;
+    dxvk::mutex              m_mutex;
+    dxvk::condition_variable m_cond;
 
   };
   

--- a/src/util/sync/sync_signal_win32.h
+++ b/src/util/sync/sync_signal_win32.h
@@ -41,7 +41,7 @@ namespace dxvk::sync {
      * \param [in] value Value to set signal to
      */
     void signal(uint64_t value) {
-      std::unique_lock<std::mutex> lock(m_mutex);
+      std::unique_lock<dxvk::mutex> lock(m_mutex);
       m_value.store(value, std::memory_order_release);
       m_cond.notify_all();
 
@@ -60,7 +60,7 @@ namespace dxvk::sync {
      * \param [in] value The value to wait for
      */
     void wait(uint64_t value) {
-      std::unique_lock<std::mutex> lock(m_mutex);
+      std::unique_lock<dxvk::mutex> lock(m_mutex);
       m_cond.wait(lock, [this, value] {
         return value <= m_value.load(std::memory_order_acquire);
       });
@@ -77,7 +77,7 @@ namespace dxvk::sync {
      * \param [in] value Requested signal value
      */
     void setEvent(HANDLE event, uint64_t value) {
-      std::unique_lock<std::mutex> lock(m_mutex);
+      std::unique_lock<dxvk::mutex> lock(m_mutex);
 
       if (value > this->value())
         m_events.push_back({ event, value });
@@ -87,9 +87,9 @@ namespace dxvk::sync {
 
   private:
 
-    std::atomic<uint64_t>   m_value;
-    std::mutex              m_mutex;
-    std::condition_variable m_cond;
+    std::atomic<uint64_t>    m_value;
+    dxvk::mutex              m_mutex;
+    dxvk::condition_variable m_cond;
 
     std::list<std::pair<HANDLE, uint64_t>> m_events;
 

--- a/src/util/thread.h
+++ b/src/util/thread.h
@@ -1,6 +1,9 @@
 #pragma once
 
+#include <chrono>
+#include <condition_variable>
 #include <functional>
+#include <mutex>
 
 #include "util_error.h"
 
@@ -145,4 +148,179 @@ namespace dxvk {
       SwitchToThread();
     }
   }
+
+
+  /**
+   * \brief SRW-based mutex implementation
+   *
+   * Drop-in replacement for \c std::mutex that uses Win32
+   * SRW locks, which are implemented with \c futex in wine.
+   */
+  class mutex {
+
+  public:
+
+    using native_handle_type = PSRWLOCK;
+
+    mutex() { }
+
+    mutex(const mutex&) = delete;
+    mutex& operator = (const mutex&) = delete;
+
+    void lock() {
+      AcquireSRWLockExclusive(&m_lock);
+    }
+
+    void unlock() {
+      ReleaseSRWLockExclusive(&m_lock);
+    }
+
+    bool try_lock() {
+      return TryAcquireSRWLockExclusive(&m_lock);
+    }
+
+    native_handle_type native_handle() {
+      return &m_lock;
+    }
+
+  private:
+
+    SRWLOCK m_lock = SRWLOCK_INIT;
+
+  };
+
+
+  /**
+   * \brief Recursive mutex implementation
+   *
+   * Drop-in replacement for \c std::recursive_mutex that
+   * uses Win32 critical sections.
+   */
+  class recursive_mutex {
+
+  public:
+
+    using native_handle_type = PCRITICAL_SECTION;
+
+    recursive_mutex() {
+      InitializeCriticalSection(&m_lock);
+    }
+
+    ~recursive_mutex() {
+      DeleteCriticalSection(&m_lock);
+    }
+
+    recursive_mutex(const recursive_mutex&) = delete;
+    recursive_mutex& operator = (const recursive_mutex&) = delete;
+
+    void lock() {
+      EnterCriticalSection(&m_lock);
+    }
+
+    void unlock() {
+      LeaveCriticalSection(&m_lock);
+    }
+
+    bool try_lock() {
+      return TryEnterCriticalSection(&m_lock);
+    }
+
+    native_handle_type native_handle() {
+      return &m_lock;
+    }
+
+  private:
+
+    CRITICAL_SECTION m_lock;
+
+  };
+
+
+  /**
+   * \brief SRW-based condition variable implementation
+   *
+   * Drop-in replacement for \c std::condition_variable that
+   * uses Win32 condition variables on SRW locks.
+   */
+  class condition_variable {
+
+  public:
+
+    using native_handle_type = PCONDITION_VARIABLE;
+
+    condition_variable() {
+      InitializeConditionVariable(&m_cond);
+    }
+
+    condition_variable(condition_variable&) = delete;
+
+    condition_variable& operator = (condition_variable&) = delete;
+
+    void notify_one() {
+      WakeConditionVariable(&m_cond);
+    }
+
+    void notify_all() {
+      WakeAllConditionVariable(&m_cond);
+    }
+
+    void wait(std::unique_lock<dxvk::mutex>& lock) {
+      auto srw = lock.mutex()->native_handle();
+      SleepConditionVariableSRW(&m_cond, srw, INFINITE, 0);
+    }
+
+    template<typename Predicate>
+    void wait(std::unique_lock<dxvk::mutex>& lock, Predicate pred) {
+      while (!pred())
+        wait(lock);
+    }
+
+    template<typename Clock, typename Duration>
+    std::cv_status wait_until(std::unique_lock<dxvk::mutex>& lock, const std::chrono::time_point<Clock, Duration>& time) {
+      auto now = Clock::now();
+
+      return (now < time)
+        ? wait_for(lock, now - time)
+        : std::cv_status::timeout;
+    }
+
+    template<typename Clock, typename Duration, typename Predicate>
+    bool wait_until(std::unique_lock<dxvk::mutex>& lock, const std::chrono::time_point<Clock, Duration>& time, Predicate pred) {
+      if (pred())
+        return true;
+
+      auto now = Clock::now();
+      return now < time && wait_for(lock, now - time, pred);
+    }
+
+    template<typename Rep, typename Period>
+    std::cv_status wait_for(std::unique_lock<dxvk::mutex>& lock, const std::chrono::duration<Rep, Period>& timeout) {
+      auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(timeout);
+      auto srw = lock.mutex()->native_handle();
+
+      return SleepConditionVariableSRW(&m_cond, srw, ms.count(), 0)
+        ? std::cv_status::no_timeout
+        : std::cv_status::timeout;
+    }
+
+    template<typename Rep, typename Period, typename Predicate>
+    bool wait_for(std::unique_lock<dxvk::mutex>& lock, const std::chrono::duration<Rep, Period>& timeout, Predicate pred) {
+      bool result = pred();
+
+      if (!result && wait_for(lock, timeout) == std::cv_status::no_timeout)
+        result = pred();
+
+      return result;
+    }
+
+    native_handle_type native_handle() {
+      return &m_cond;
+    }
+
+  private:
+
+    CONDITION_VARIABLE m_cond;
+
+  };
+
 }

--- a/src/util/util_fps_limiter.cpp
+++ b/src/util/util_fps_limiter.cpp
@@ -29,7 +29,7 @@ namespace dxvk {
 
 
   void FpsLimiter::setTargetFrameRate(double frameRate) {
-    std::lock_guard<std::mutex> lock(m_mutex);
+    std::lock_guard<dxvk::mutex> lock(m_mutex);
 
     if (!m_envOverride) {
       m_targetInterval = frameRate > 0.0
@@ -43,7 +43,7 @@ namespace dxvk {
 
 
   void FpsLimiter::setDisplayRefreshRate(double refreshRate) {
-    std::lock_guard<std::mutex> lock(m_mutex);
+    std::lock_guard<dxvk::mutex> lock(m_mutex);
 
     m_refreshInterval = refreshRate > 0.0
       ? NtTimerDuration(int64_t(double(NtTimerDuration::period::den) / refreshRate))
@@ -52,7 +52,7 @@ namespace dxvk {
 
 
   void FpsLimiter::delay(bool vsyncEnabled) {
-    std::lock_guard<std::mutex> lock(m_mutex);
+    std::lock_guard<dxvk::mutex> lock(m_mutex);
 
     if (!isEnabled())
       return;

--- a/src/util/util_fps_limiter.h
+++ b/src/util/util_fps_limiter.h
@@ -1,7 +1,6 @@
 #pragma once
 
-#include <mutex>
-
+#include "thread.h"
 #include "util_time.h"
 
 namespace dxvk {
@@ -66,7 +65,7 @@ namespace dxvk {
     using NtSetTimerResolutionProc = UINT (WINAPI *) (ULONG, BOOL, ULONG*);
     using NtDelayExecutionProc = UINT (WINAPI *) (BOOL, LARGE_INTEGER*);
 
-    std::mutex      m_mutex;
+    dxvk::mutex     m_mutex;
 
     NtTimerDuration m_targetInterval  = NtTimerDuration::zero();
     NtTimerDuration m_refreshInterval = NtTimerDuration::zero();

--- a/src/util/util_lazy.h
+++ b/src/util/util_lazy.h
@@ -32,7 +32,7 @@ namespace dxvk {
 
   private:
 
-    std::mutex         m_mutex;
+    dxvk::mutex        m_mutex;
     std::unique_ptr<T> m_object;
 
   };

--- a/src/util/util_luid.cpp
+++ b/src/util/util_luid.cpp
@@ -9,10 +9,10 @@
 namespace dxvk {
 
   LUID GetAdapterLUID(UINT Adapter) {
-    static std::mutex        s_mutex;
+    static dxvk::mutex       s_mutex;
     static std::vector<LUID> s_luids;
 
-    std::lock_guard<std::mutex> lock(s_mutex);
+    std::lock_guard<dxvk::mutex> lock(s_mutex);
     uint32_t newLuidCount = Adapter + 1;
 
     while (s_luids.size() < newLuidCount) {


### PR DESCRIPTION
This mostly aims to reduce potential inefficiencies with the winpthread implementation.
- Uses SRW locks for `mutex`.
- Uses Critical Sections for `recursive_mutex`.
- Uses Win32 condition variables for `condition_variable`.

All of these use `futex` on wine.

Note that this does *not* remove the winpthreads dependency, so MinGW builds with threading support are still required.