### PR TITLE
[d3d11] Initialize buffer flags in D3D11UnorderedAccessView::GetDescFromResource().

### DIFF
--- a/src/d3d11/d3d11_view_uav.cpp
+++ b/src/d3d11/d3d11_view_uav.cpp
@@ -214,6 +214,7 @@ namespace dxvk {
           pDesc->ViewDimension       = D3D11_UAV_DIMENSION_BUFFER;
           pDesc->Buffer.FirstElement = 0;
           pDesc->Buffer.NumElements  = bufferDesc.ByteWidth / bufferDesc.StructureByteStride;
+          pDesc->Buffer.Flags = 0;
           return S_OK;
         }
       } return E_INVALIDARG;


### PR DESCRIPTION
Fixes a glitch in Far Cry 5 (white areas seen right on game start) reproducible pseudo randomly depending on build flags or random commits.