### PR TITLE
Initial winelib support (for hangover)

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -66,8 +66,10 @@ dxvk_extradep = [ ]
 if dxvk_is_msvc
   wrc = find_program('rc')
 else
-  add_global_link_arguments('-static', '-static-libgcc', language: 'c')
-  add_global_link_arguments('-static', '-static-libgcc', '-static-libstdc++', language: 'cpp')
+  if not dxvk_is_winelib
+    add_global_link_arguments('-static', '-static-libgcc', language: 'c')
+    add_global_link_arguments('-static', '-static-libgcc', '-static-libstdc++', language: 'cpp')
+  endif
 
   wrc = find_program('windres')
 endif

--- a/meson.build
+++ b/meson.build
@@ -120,6 +120,12 @@ endif
 
 def_spec_ext = '.def'
 
+if dxvk_is_winelib
+  library_ext = 'dll.so'
+else
+  library_ext = []
+endif
+
 glsl_compiler = find_program('glslangValidator')
 glsl_args = [ '-V', '--vn', '@BASENAME@', '@INPUT@', '-o', '@OUTPUT@' ]
 if run_command(glsl_compiler, [ '--quiet', '--version' ]).returncode() == 0

--- a/meson.build
+++ b/meson.build
@@ -142,7 +142,7 @@ if dxvk_is_msvc
 else
   wrc_generator = generator(wrc,
   output    : [ '@BASENAME@' + res_ext ],
-  arguments : [ '-i', '@INPUT@', '-o', '@OUTPUT@' ])
+  arguments : meson.get_cross_property('windres_args', []) + [ '-i', '@INPUT@', '-o', '@OUTPUT@' ])
 endif
 
 dxvk_version = vcs_tag(

--- a/meson.build
+++ b/meson.build
@@ -7,6 +7,16 @@ add_project_arguments('-DNOMINMAX', language : 'cpp')
 dxvk_compiler = meson.get_compiler('cpp')
 dxvk_is_msvc = dxvk_compiler.get_id() == 'msvc'
 
+dxvk_is_winelib = dxvk_compiler.compiles('''
+#ifndef __WINE__
+int foo[-1];
+#endif
+''', name : 'is winelib')
+
+if dxvk_is_winelib
+  warning('DXVK winelib is experimental and not supported')
+endif
+
 # c++17 was added in 15.3, older version needs c++latest
 if dxvk_is_msvc and dxvk_compiler.version().version_compare('<15.3')
   dxvk_cpp_std='c++latest'

--- a/meson.build
+++ b/meson.build
@@ -53,7 +53,9 @@ endif
 
 dxvk_include_path = include_directories('./include')
 
-if (cpu_family == 'x86_64')
+if dxvk_is_winelib
+  dxvk_library_path = []
+elif cpu_family == 'x86_64'
   dxvk_library_path = meson.source_root() + '/lib'
 else
   dxvk_library_path = meson.source_root() + '/lib32'
@@ -93,9 +95,13 @@ lib_vulkan  = dxvk_compiler.find_library('vulkan-1', dirs : dxvk_library_path)
 lib_d3d9    = dxvk_compiler.find_library('d3d9')
 lib_d3d11   = dxvk_compiler.find_library('d3d11')
 lib_dxgi    = dxvk_compiler.find_library('dxgi')
-lib_d3dcompiler_43 = dxvk_compiler.find_library('d3dcompiler_43', dirs : dxvk_library_path)
+if dxvk_is_winelib
+  lib_d3dcompiler_43 = dxvk_compiler.find_library('d3dcompiler')
+else
+  lib_d3dcompiler_43 = dxvk_compiler.find_library('d3dcompiler_43', dirs : dxvk_library_path)
+endif
 
-if dxvk_is_msvc
+if dxvk_is_msvc or dxvk_is_winelib
   lib_d3dcompiler_47 = dxvk_compiler.find_library('d3dcompiler')
 else
   lib_d3dcompiler_47 = dxvk_compiler.find_library('d3dcompiler_47')

--- a/src/d3d10/meson.build
+++ b/src/d3d10/meson.build
@@ -18,7 +18,8 @@ d3d10_core_dll = shared_library('d3d10core'+dll_ext, d3d10_core_src, d3d10_core_
   include_directories : dxvk_include_path,
   install             : true,
   vs_module_defs      : 'd3d10core'+def_spec_ext,
-  override_options    : ['cpp_std='+dxvk_cpp_std])
+  override_options    : ['cpp_std='+dxvk_cpp_std],
+  name_suffix         : library_ext)
 
 d3d10_core_dep = declare_dependency(
   link_with           : [ d3d10_core_dll ])
@@ -31,7 +32,8 @@ d3d10_dll = shared_library('d3d10'+dll_ext, d3d10_main_src, d3d10_res,
   include_directories : dxvk_include_path,
   install             : true,
   vs_module_defs      : 'd3d10'+def_spec_ext,
-  override_options    : ['cpp_std='+dxvk_cpp_std])
+  override_options    : ['cpp_std='+dxvk_cpp_std],
+  name_suffix         : library_ext)
 
 d3d10_1_dll = shared_library('d3d10_1'+dll_ext, d3d10_main_src, d3d10_1_res,
   name_prefix         : '',
@@ -39,7 +41,8 @@ d3d10_1_dll = shared_library('d3d10_1'+dll_ext, d3d10_main_src, d3d10_1_res,
   include_directories : dxvk_include_path,
   install             : true,
   vs_module_defs      : 'd3d10_1'+def_spec_ext,
-  override_options    : ['cpp_std='+dxvk_cpp_std])
+  override_options    : ['cpp_std='+dxvk_cpp_std],
+  name_suffix         : library_ext)
 
 d3d10_dep = declare_dependency(
   link_with           : [ d3d10_dll, d3d10_1_dll, d3d10_core_dll ],

--- a/src/d3d11/d3d11_include.h
+++ b/src/d3d11/d3d11_include.h
@@ -25,7 +25,7 @@
 // directly, although others from the same header work.
 // Some structures are missing from the mingw headers.
 #ifndef _MSC_VER
-#if !defined(__MINGW64_VERSION_MAJOR) || __MINGW64_VERSION_MAJOR < 9
+#if !defined (__WINE__) && (!defined(__MINGW64_VERSION_MAJOR) || __MINGW64_VERSION_MAJOR < 9)
 typedef enum D3D11_FORMAT_SUPPORT2 { 
   D3D11_FORMAT_SUPPORT2_UAV_ATOMIC_ADD                                = 0x1,
   D3D11_FORMAT_SUPPORT2_UAV_ATOMIC_BITWISE_OPS                        = 0x2,

--- a/src/d3d11/d3d11_shader.cpp
+++ b/src/d3d11/d3d11_shader.cpp
@@ -27,7 +27,7 @@ namespace dxvk {
     const std::string dumpPath = env::getEnvVar("DXVK_SHADER_DUMP_PATH");
     
     if (dumpPath.size() != 0) {
-      reader.store(std::ofstream(str::tows(str::format(dumpPath, "/", name, ".dxbc").c_str()).c_str(),
+      reader.store(std::ofstream(str::filename(str::format(dumpPath, "/", name, ".dxbc")).c_str(),
         std::ios_base::binary | std::ios_base::trunc));
     }
     
@@ -47,7 +47,7 @@ namespace dxvk {
     
     if (dumpPath.size() != 0) {
       std::ofstream dumpStream(
-        str::tows(str::format(dumpPath, "/", name, ".spv").c_str()).c_str(),
+        str::filename(str::format(dumpPath, "/", name, ".spv")).c_str(),
         std::ios_base::binary | std::ios_base::trunc);
       
       m_shader->dump(dumpStream);

--- a/src/d3d11/meson.build
+++ b/src/d3d11/meson.build
@@ -71,7 +71,8 @@ d3d11_dll = shared_library('d3d11'+dll_ext, dxgi_common_src + d3d11_src + d3d10_
   include_directories : dxvk_include_path,
   install             : true,
   vs_module_defs      : 'd3d11'+def_spec_ext,
-  override_options    : ['cpp_std='+dxvk_cpp_std])
+  override_options    : ['cpp_std='+dxvk_cpp_std],
+  name_suffix         : library_ext)
 
 d3d11_dep = declare_dependency(
   link_with           : [ d3d11_dll ],

--- a/src/d3d9/d3d9_fixed_function.cpp
+++ b/src/d3d9/d3d9_fixed_function.cpp
@@ -2362,7 +2362,7 @@ namespace dxvk {
 
     if (dumpPath.size() != 0) {
       std::ofstream dumpStream(
-        str::tows(str::format(dumpPath, "/", Name, ".spv").c_str()).c_str(),
+        str::filename(str::format(dumpPath, "/", Name, ".spv")).c_str(),
         std::ios_base::binary | std::ios_base::trunc);
       
       m_shader->dump(dumpStream);

--- a/src/d3d9/d3d9_include.h
+++ b/src/d3d9/d3d9_include.h
@@ -10,12 +10,7 @@
 #include <stdint.h>
 #include <d3d9.h>
 
-//for some reason we need to specify __declspec(dllexport) for MinGW
-#if defined(__WINE__)
-#define DLLEXPORT __attribute__((visibility("default")))
-#else
 #define DLLEXPORT
-#endif
 
 
 #include "../util/com/com_guid.h"

--- a/src/d3d9/d3d9_shader.cpp
+++ b/src/d3d9/d3d9_shader.cpp
@@ -30,7 +30,7 @@ namespace dxvk {
       DxsoReader reader(
         reinterpret_cast<const char*>(pShaderBytecode));
 
-      reader.store(std::ofstream(str::tows(str::format(dumpPath, "/", name, ".dxso").c_str()).c_str(),
+      reader.store(std::ofstream(str::filename(str::format(dumpPath, "/", name, ".dxso")).c_str(),
         std::ios_base::binary | std::ios_base::trunc), bytecodeLength);
 
       char comment[2048];
@@ -42,7 +42,7 @@ namespace dxvk {
         &blob);
       
       if (SUCCEEDED(hr)) {
-        std::ofstream disassembledOut(str::tows(str::format(dumpPath, "/", name, ".dxso.dis").c_str()).c_str(), std::ios_base::binary | std::ios_base::trunc);
+        std::ofstream disassembledOut(str::filename(str::format(dumpPath, "/", name, ".dxso.dis")).c_str(), std::ios_base::binary | std::ios_base::trunc);
         disassembledOut.write(
           reinterpret_cast<const char*>(blob->GetBufferPointer()),
           blob->GetBufferSize());
@@ -80,7 +80,7 @@ namespace dxvk {
     
     if (dumpPath.size() != 0) {
       std::ofstream dumpStream(
-        str::tows(str::format(dumpPath, "/", name, ".spv").c_str()).c_str(),
+        str::filename(str::format(dumpPath, "/", name, ".spv")).c_str(),
         std::ios_base::binary | std::ios_base::trunc);
       
       m_shaders[0]->dump(dumpStream);

--- a/src/d3d9/meson.build
+++ b/src/d3d9/meson.build
@@ -47,7 +47,8 @@ d3d9_dll = shared_library('d3d9'+dll_ext, d3d9_src, glsl_generator.process(d3d9_
   include_directories : dxvk_include_path,
   install             : true,
   vs_module_defs      : 'd3d9'+def_spec_ext,
-  override_options    : ['cpp_std='+dxvk_cpp_std])
+  override_options    : ['cpp_std='+dxvk_cpp_std],
+  name_suffix         : library_ext)
 
 d3d9_dep = declare_dependency(
   link_with           : [ d3d9_dll ],

--- a/src/dxgi/dxgi_include.h
+++ b/src/dxgi/dxgi_include.h
@@ -1,9 +1,7 @@
 #pragma once
 
 //for some reason we need to specify __declspec(dllexport) for MinGW
-#if defined(__WINE__)
-  #define DLLEXPORT __attribute__((visibility("default")))
-#elif defined(_MSC_VER)
+#if defined(_MSC_VER) || defined(__WINE__)
   #define DLLEXPORT
 #else
   #define DLLEXPORT __declspec(dllexport)

--- a/src/dxgi/meson.build
+++ b/src/dxgi/meson.build
@@ -18,7 +18,8 @@ dxgi_dll = shared_library('dxgi'+dll_ext, dxgi_src, dxgi_res,
   include_directories : dxvk_include_path,
   install             : true,
   vs_module_defs      : 'dxgi'+def_spec_ext,
-  override_options    : ['cpp_std='+dxvk_cpp_std])
+  override_options    : ['cpp_std='+dxvk_cpp_std],
+  name_suffix         : library_ext)
 
 dxgi_dep = declare_dependency(
   link_with           : [ dxgi_dll ],

--- a/src/dxvk/dxvk_openvr.cpp
+++ b/src/dxvk/dxvk_openvr.cpp
@@ -5,7 +5,18 @@
 #pragma GCC diagnostic ignored "-Wnon-virtual-dtor"
 #endif
 
+#ifdef __WINE__
+
+#pragma push_macro("_WIN32")
+// don't use dllimport with winelib, it's useless
+#undef _WIN32
+#endif
+
 #include <openvr/openvr.hpp>
+
+#ifdef __WINE__
+#pragma pop_macro("_WIN32")
+#endif
 
 using VR_InitInternalProc        = vr::IVRSystem* (VR_CALLTYPE *)(vr::EVRInitError*, vr::EVRApplicationType);
 using VR_ShutdownInternalProc    = void  (VR_CALLTYPE *)();

--- a/src/dxvk/dxvk_state_cache.cpp
+++ b/src/dxvk/dxvk_state_cache.cpp
@@ -161,12 +161,12 @@ namespace dxvk {
       Logger::warn("DXVK: Creating new state cache file");
 
       // Start with an empty file
-      std::ofstream file(getCacheFileName().c_str(),
+      std::ofstream file(str::filename(getCacheFileName()).c_str(),
         std::ios_base::binary |
         std::ios_base::trunc);
 
       if (!file && env::createDirectory(getCacheDir())) {
-        file = std::ofstream(getCacheFileName().c_str(),
+        file = std::ofstream(str::filename(getCacheFileName()).c_str(),
           std::ios_base::binary |
           std::ios_base::trunc);
       }
@@ -382,7 +382,7 @@ namespace dxvk {
 
   bool DxvkStateCache::readCacheFile() {
     // Open state file and just fail if it doesn't exist
-    std::ifstream ifile(getCacheFileName().c_str(), std::ios_base::binary);
+    std::ifstream ifile(str::filename(getCacheFileName()).c_str(), std::ios_base::binary);
 
     if (!ifile) {
       Logger::warn("DXVK: No state cache file found");
@@ -969,7 +969,7 @@ namespace dxvk {
       }
 
       if (!file) {
-        file = std::ofstream(getCacheFileName().c_str(),
+        file = std::ofstream(str::filename(getCacheFileName()).c_str(),
           std::ios_base::binary |
           std::ios_base::app);
       }
@@ -979,7 +979,7 @@ namespace dxvk {
   }
 
 
-  std::wstring DxvkStateCache::getCacheFileName() const {
+  std::string DxvkStateCache::getCacheFileName() const {
     std::string path = getCacheDir();
 
     if (!path.empty() && *path.rbegin() != '/')
@@ -987,7 +987,7 @@ namespace dxvk {
     
     std::string exeName = env::getExeBaseName();
     path += exeName + ".dxvk-cache";
-    return str::tows(path.c_str());
+    return path;
   }
 
 

--- a/src/dxvk/dxvk_state_cache.h
+++ b/src/dxvk/dxvk_state_cache.h
@@ -176,7 +176,7 @@ namespace dxvk {
 
     void writerFunc();
 
-    std::wstring getCacheFileName() const;
+    std::string getCacheFileName() const;
     
     std::string getCacheDir() const;
 

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -649,7 +649,7 @@ namespace dxvk {
       filePath = "dxvk.conf";
     
     // Open the file if it exists
-    std::ifstream stream(str::tows(filePath.c_str()).c_str());
+    std::ifstream stream(str::filename(filePath).c_str());
 
     if (!stream)
       return config;

--- a/src/util/log/log.cpp
+++ b/src/util/log/log.cpp
@@ -10,7 +10,7 @@ namespace dxvk {
       auto path = getFileName(file_name);
 
       if (!path.empty())
-        m_fileStream = std::ofstream(str::tows(path.c_str()).c_str());
+        m_fileStream = std::ofstream(str::filename(path).c_str());
     }
   }
   

--- a/src/util/util_string.h
+++ b/src/util/util_string.h
@@ -18,6 +18,17 @@ namespace dxvk::str {
   }
 
   std::wstring tows(const char* mbs);
+
+  // Convert the given UTF-8 string to a format suitable to pass to functions
+  // expecting a filename. On MSVC and MinGW the standard char * variants use
+  // the system's code page instead of UTF-8 and there are non-standard
+  // overloads which take a wchar_t, however winelib uses the host's libstdc++
+  // which doesn't have the wchar_t overload and uses UTF-8.
+#ifdef __WINE__
+  static inline std::string filename(std::string s) { return s; }
+#else
+  static inline std::wstring filename(std::string s) { return tows(s.c_str()); }
+#endif
   
   inline void format1(std::stringstream&) { }
 


### PR DESCRIPTION
For bringing up DXVK on hangover, we want to compile it in the host for performance reasons, and that entails compiling it as a winelib since there is no usable aarch64 mingw toolchain. This MR adds back support for winelib. However using it requires using a winegcc built with some patches I just sent to wine-devel https://www.winehq.org/pipermail/wine-devel/2021-July/190100.html. If you also don't like applying patches from mailing lists, they're available at https://github.com/cwabbott0/wine/tree/winegcc-meson.

This just gets things building on x86 as a first step. Later I will fix compilation with aarch64, and we also need to somehow deal with https://github.com/AndreRH/hangover/issues/28#issuecomment-749122396.