### PR TITLE
[d3d9] Add dirty texture tracking

### DIFF
--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -838,6 +838,8 @@ namespace dxvk {
 
     void UndirtySamplers();
 
+    void UndirtyTextures();
+
     void MarkSamplersDirty();
 
     D3D9DrawInfo GenerateDrawInfo(
@@ -919,6 +921,7 @@ namespace dxvk {
 
     D3D9DeviceFlags                 m_flags;
     uint32_t                        m_dirtySamplerStates = 0;
+    uint32_t                        m_dirtyTextures = 0;
 
     D3D9Adapter*                    m_adapter;
     Rc<DxvkDevice>                  m_dxvkDevice;


### PR DESCRIPTION
Reduces overhead from re-binding and unnecessary binding (srgb changes) in L4D2.

I go from about 750 -> 850-900 fps in c1m2_streets with this change.