### PR TITLE
Fix HUD version info for Github Actions builds

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -12,6 +12,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         submodules: recursive
+        fetch-depth: 0
 
     - name: Setup problem matcher
       uses: Joshua-Ashton/gcc-problem-matcher@v1


### PR DESCRIPTION
This fixes the HUD not showing the full DXVK version when using builds from GitHub actions (for example, only showing up `v1.9` instead of `v1.9-62-g11bbc07e`).

Explanation:
By default, the "checkout" step only clones the repository with a depth of 1. This causes `git describe` to fail in Meson, and makes it fall back to the project version number specified in `meson.build` instead.

Of course this change makes the checkout step slower in theory, but it's still only 3 seconds even when cloning the full tree. Personally I think this is a worthy tradeoff considering that it's pretty useful to have the Git commit in the HUD when bisecting.