### PR TITLE
[dxvk] Also initialize view formats when creating DxvkImage for existing VkImage.

### DIFF
--- a/src/dxvk/dxvk_image.cpp
+++ b/src/dxvk/dxvk_image.cpp
@@ -116,6 +116,10 @@ namespace dxvk {
           VkImage               image)
   : m_vkd(vkd), m_info(info), m_image({ image }) {
     
+    m_viewFormats.resize(info.viewFormatCount);
+    for (uint32_t i = 0; i < info.viewFormatCount; i++)
+      m_viewFormats[i] = info.viewFormats[i];
+    m_info.viewFormats = m_viewFormats.data();
   }
   
   


### PR DESCRIPTION
Those formats are initialized in the other version of DxvkImage constructor (the code is copied from there).

Fixes rendering in EVERSLAUGHT (VR, Steam App ID 1530750), otherwise the game fails to create views for XR swapchain textures (created from wineopenxr through CreateTexture2DFromVkImage(). The game won't go that far with the currently released Proton, needs a hack to wineopenxr (or XR_KHR_convert_timespec_time support in Steam Linux OpenXR runtime and then a fix to wineopenxr).