### PR TITLE
[d3d9] Fix ColorFill with OffscreenPlainSurface

### DIFF
--- a/src/d3d9/d3d9_common_texture.cpp
+++ b/src/d3d9/d3d9_common_texture.cpp
@@ -383,6 +383,7 @@ namespace dxvk {
 
   VkImageType D3D9CommonTexture::GetImageTypeFromResourceType(D3DRESOURCETYPE Type) {
     switch (Type) {
+      case D3DRTYPE_SURFACE:
       case D3DRTYPE_TEXTURE:       return VK_IMAGE_TYPE_2D;
       case D3DRTYPE_VOLUMETEXTURE: return VK_IMAGE_TYPE_3D;
       case D3DRTYPE_CUBETEXTURE:   return VK_IMAGE_TYPE_2D;
@@ -395,6 +396,7 @@ namespace dxvk {
           D3DRESOURCETYPE  Dimension,
           UINT             Layer) {
     switch (Dimension) {
+      case D3DRTYPE_SURFACE:
       case D3DRTYPE_TEXTURE:       return VK_IMAGE_VIEW_TYPE_2D;
       case D3DRTYPE_VOLUMETEXTURE: return VK_IMAGE_VIEW_TYPE_3D;
       case D3DRTYPE_CUBETEXTURE:   return Layer == AllLayers

--- a/src/d3d9/d3d9_surface.cpp
+++ b/src/d3d9/d3d9_surface.cpp
@@ -12,7 +12,7 @@ namespace dxvk {
           IUnknown*                 pContainer)
     : D3D9SurfaceBase(
         pDevice,
-        new D3D9CommonTexture( pDevice, pDesc, D3DRTYPE_TEXTURE),
+        new D3D9CommonTexture( pDevice, pDesc, D3DRTYPE_SURFACE),
         0, 0,
         nullptr,
         pContainer) { }


### PR DESCRIPTION
Not 100% sure this is the correct fix, but this results in https://github.com/doitsujin/dxvk/blob/546bd6f462211ed531aa2778047b1fc31397683f/src/d3d9/d3d9_common_texture.cpp#L37  getting used.