### PR TITLE
[d3d9] Mark texture dirty on SetLod

### DIFF
--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -5817,8 +5817,13 @@ namespace dxvk {
     m_dirtyTextures = 0;
   }
 
-  void D3D9DeviceEx::MarkSamplersDirty() {
-    m_dirtySamplerStates = 0x001fffff; // 21 bits.
+  void D3D9DeviceEx::MarkTextureBindingDirty(IDirect3DBaseTexture9* texture) {
+    D3D9DeviceLock lock = LockDevice();
+
+    for (uint32_t i = 0; i < m_state.textures.size(); i++) {
+      if (m_state.textures[i] == texture)
+        m_dirtyTextures |= 1u << i;
+    }
   }
 
 

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -840,7 +840,7 @@ namespace dxvk {
 
     void UndirtyTextures();
 
-    void MarkSamplersDirty();
+    void MarkTextureBindingDirty(IDirect3DBaseTexture9* texture);
 
     D3D9DrawInfo GenerateDrawInfo(
       D3DPRIMITIVETYPE PrimitiveType,

--- a/src/d3d9/d3d9_texture.h
+++ b/src/d3d9/d3d9_texture.h
@@ -60,7 +60,7 @@ namespace dxvk {
 
       m_texture.CreateSampleView(LODNew);
       if (this->GetPrivateRefCount() > 0)
-        this->m_parent->MarkSamplersDirty();
+        this->m_parent->MarkTextureBindingDirty(this);
 
       return oldLod;
     }


### PR DESCRIPTION
Previously the image view was not updated. Fixes wine tests.