### PR TITLE
[d3d9] Only look at the last bit for D3DSAMP_SRGBTEXTURE

### DIFF
--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -5761,7 +5761,7 @@ namespace dxvk {
       DxsoBindingType::DepthImage, uint32_t(shaderSampler.second));
 
     const bool srgb =
-      m_state.samplerStates[StateSampler][D3DSAMP_SRGBTEXTURE];
+      m_state.samplerStates[StateSampler][D3DSAMP_SRGBTEXTURE] & 0x1;
 
     D3D9CommonTexture* commonTex =
       GetCommonTexture(m_state.textures[StateSampler]);


### PR DESCRIPTION
Fixes a wine test that was added for https://bugs.winehq.org/show_bug.cgi?id=37705.