### PR TITLE
[d3d9] Don't mark mips as dirty when the texture doesn't have automatic mips

### DIFF
--- a/src/d3d9/d3d9_texture.h
+++ b/src/d3d9/d3d9_texture.h
@@ -80,7 +80,8 @@ namespace dxvk {
       auto lock = this->m_parent->LockDevice();
 
       m_texture.SetMipFilter(FilterType);
-      this->m_parent->MarkTextureMipsDirty(&m_texture);
+      if (m_texture.IsAutomaticMip())
+        this->m_parent->MarkTextureMipsDirty(&m_texture);
       return D3D_OK;
     }
 


### PR DESCRIPTION
Fixes some wine tests.