### PR TITLE
[d3d9] Disable primitive restart

### DIFF
--- a/src/d3d9/d3d9_util.cpp
+++ b/src/d3d9/d3d9_util.cpp
@@ -142,13 +142,13 @@ namespace dxvk {
         return { VK_PRIMITIVE_TOPOLOGY_LINE_LIST,      VK_FALSE, 0 };
 
       case D3DPT_LINESTRIP:
-        return { VK_PRIMITIVE_TOPOLOGY_LINE_STRIP,     VK_TRUE,  0 };
+        return { VK_PRIMITIVE_TOPOLOGY_LINE_STRIP,     VK_FALSE, 0 };
 
       case D3DPT_TRIANGLESTRIP:
-        return { VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP, VK_TRUE,  0 };
+        return { VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP, VK_FALSE, 0 };
 
       case D3DPT_TRIANGLEFAN:
-        return { VK_PRIMITIVE_TOPOLOGY_TRIANGLE_FAN,   VK_TRUE,  0 };
+        return { VK_PRIMITIVE_TOPOLOGY_TRIANGLE_FAN,   VK_FALSE, 0 };
     }
   }
 


### PR DESCRIPTION
There's a wine test that proves primitive restart does not exist for triangle strips and 16bit indices, and I guess that it does not exists in general because the docs recommend using degenerative triangles to restart a triangle strip. The question is if this correctness change is worth it, because it will probably invalidate a lot of the state cache. 