### PR TITLE
[d3d9, dxso] Remove AlphaTestEnable spec constant

### DIFF
--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -5674,8 +5674,7 @@ namespace dxvk {
       : VK_COMPARE_OP_ALWAYS;
 
     EmitCs([cAlphaOp = alphaOp] (DxvkContext* ctx) {
-      ctx->setSpecConstant(VK_PIPELINE_BIND_POINT_GRAPHICS, D3D9SpecConstantId::AlphaTestEnable, cAlphaOp != VK_COMPARE_OP_ALWAYS);
-      ctx->setSpecConstant(VK_PIPELINE_BIND_POINT_GRAPHICS, D3D9SpecConstantId::AlphaCompareOp,  cAlphaOp);
+      ctx->setSpecConstant(VK_PIPELINE_BIND_POINT_GRAPHICS, D3D9SpecConstantId::AlphaCompareOp, cAlphaOp);
     });
   }
 

--- a/src/d3d9/d3d9_spec_constants.h
+++ b/src/d3d9/d3d9_spec_constants.h
@@ -5,19 +5,18 @@
 namespace dxvk {
 
   enum D3D9SpecConstantId : uint32_t {
-    AlphaTestEnable = 0,
-    AlphaCompareOp  = 1,
-    SamplerType     = 2,
-    FogEnabled      = 3,
-    VertexFogMode   = 4,
-    PixelFogMode    = 5,
+    AlphaCompareOp  = 0,
+    SamplerType     = 1,
+    FogEnabled      = 2,
+    VertexFogMode   = 3,
+    PixelFogMode    = 4,
 
-    PointMode       = 6,
-    ProjectionType  = 7,
+    PointMode       = 5,
+    ProjectionType  = 6,
 
-    VertexShaderBools = 8,
-    PixelShaderBools  = 9,
-    Fetch4            = 10
+    VertexShaderBools = 7,
+    PixelShaderBools  = 8,
+    Fetch4            = 9
   };
 
 }


### PR DESCRIPTION
Go based on the func we already have. Avoids wasting a spec const.