### PR TITLE
Add DXVK_NVAPIHACK env variable

### DIFF
--- a/src/dxgi/dxgi_options.cpp
+++ b/src/dxgi/dxgi_options.cpp
@@ -41,6 +41,8 @@ namespace dxvk {
     this->maxSharedMemory = VkDeviceSize(config.getOption<int32_t>("dxgi.maxSharedMemory", 0)) << 20;
 
     this->nvapiHack   = config.getOption<bool>("dxgi.nvapiHack", true);
+    if (env::getEnvVar("DXVK_NVAPIHACK") == "0")
+      this->nvapiHack = false;
   }
   
 }


### PR DESCRIPTION
Use DXVK_NVAPIHACK=0 to disable nvapi workaround for nVidia adapters.

Is this a viable change for DXVK for use with DXVK_NVAPI that is included in Proton Experimental/Proton-GE?
This could avoid the need for a dxvk.conf file to disable nvapiHack if you want to use nvapi with a nVidia adapter. (Atleast for games that actually tries to do it right and not just use nvapi.dll regardless of GPU)

Eg: `PROTON_ENABLE_NVAPI=1 DXVK_NVAPIHACK=0 %command%`