### PR TITLE
[d3d9] Only respect relevant bits of D3DRS_STENCILREF

### DIFF
--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -5682,7 +5682,7 @@ namespace dxvk {
   void D3D9DeviceEx::BindDepthStencilRefrence() {
     auto& rs = m_state.renderStates;
 
-    uint32_t ref = uint32_t(rs[D3DRS_STENCILREF]);
+    uint32_t ref = uint32_t(rs[D3DRS_STENCILREF]) & 0xff;
 
     EmitCs([cRef = ref] (DxvkContext* ctx) {
       ctx->setStencilReference(cRef);


### PR DESCRIPTION
Fixes a wine test.