### PR TITLE
 Fix poor performance in Homefront The Revolution

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -209,6 +209,10 @@ namespace dxvk {
     { R"(\\KingdomCome\.exe$)", {{
       { "d3d11.apitraceMode",               "True" },
     }} },
+    /* Homefront: The Revolution                  */
+    { R"(\\Homefront2_Release\.exe$)", {{
+      { "d3d11.apitraceMode",               "True" },
+    }} },
     /* Sniper Ghost Warrior Contracts             */
     { R"(\\SGWContracts\.exe$)", {{
       { "d3d11.apitraceMode",               "True" },


### PR DESCRIPTION
 in certain places when displaying "wide open" and at long range it has a very poor performance of 35-45fps, but with this option it goes up to a stable 60fps on my GTX1060 6Gb

Tested on Windows and Linux with Proton 6.3 

_screenshots from Windows 10_

Thanks "Leopard" from Discord

Without d3d11.apitraceMode = True

![NoFixed](https://user-images.githubusercontent.com/49424816/129441567-ac3344b4-9765-4df1-bf20-766023430805.png)

with d3d11.apitraceMode = True 

![WindowsFixed](https://user-images.githubusercontent.com/49424816/129441579-9cd6a57c-b022-4514-9db1-a4e5d94fc35c.png)
