### PR TITLE
for each bit cleanup

### DIFF
--- a/src/d3d11/d3d11_util.h
+++ b/src/d3d11/d3d11_util.h
@@ -12,11 +12,8 @@ namespace dxvk {
   UINT CompactSparseList(T* pData, UINT Mask) {
     uint32_t count = 0;
     
-    while (Mask != 0) {
-      uint32_t id = bit::tzcnt(Mask);
+    for (uint32_t id : bit::BitMask(Mask))
       pData[count++] = pData[id];
-      Mask &= Mask - 1;
-    }
 
     return count;
   }

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -1492,8 +1492,8 @@ namespace dxvk {
 
       // Clear render targets if we need to.
       if (Flags & D3DCLEAR_TARGET) {
-        for (uint32_t rt = m_boundRTs; rt; rt &= rt - 1) {
-          const auto& rts = m_state.renderTargets[bit::tzcnt(rt)];
+        for (uint32_t rt : bit::BitMask(m_boundRTs)) {
+          const auto& rts = m_state.renderTargets[rt];
           const auto& rtv = rts->GetRenderTargetView(srgb);
 
           if (likely(rtv != nullptr)) {
@@ -4299,9 +4299,8 @@ namespace dxvk {
     if (managed && !m_d3d9Options.evictManagedOnUnlock && !readOnly) {
       pResource->SetNeedsUpload(Subresource, true);
 
-      for (uint32_t tex = m_activeTextures; tex; tex &= tex - 1) {
+      for (uint32_t i : bit::BitMask(m_activeTextures)) {
         // Guaranteed to not be nullptr...
-        const uint32_t i = bit::tzcnt(tex);
         auto texInfo = GetCommonTexture(m_state.textures[i]);
 
         if (texInfo == pResource) {
@@ -5115,13 +5114,12 @@ namespace dxvk {
     masks.samplerMask &= m_activeRTTextures;
 
     m_activeHazardsRT = m_activeHazardsRT & (~rtMask);
-    for (uint32_t rt = masks.rtMask; rt; rt &= rt - 1) {
-      for (uint32_t sampler = masks.samplerMask; sampler; sampler &= sampler - 1) {
-        const uint32_t rtIdx = bit::tzcnt(rt);
+    for (uint32_t rtIdx : bit::BitMask(masks.rtMask)) {
+      for (uint32_t samplerIdx : bit::BitMask(masks.samplerMask)) {
         D3D9Surface* rtSurf = m_state.renderTargets[rtIdx].ptr();
 
         IDirect3DBaseTexture9* rtBase  = rtSurf->GetBaseTexture();
-        IDirect3DBaseTexture9* texBase = m_state.textures[bit::tzcnt(sampler)];
+        IDirect3DBaseTexture9* texBase = m_state.textures[samplerIdx];
 
         // HACK: Don't mark for hazards if we aren't rendering to mip 0!
         // Some games use screenspace passes like this for blurring
@@ -5142,9 +5140,7 @@ namespace dxvk {
     if (m_state.depthStencil != nullptr &&
         m_state.depthStencil->GetBaseTexture() != nullptr) {
       uint32_t samplerMask = m_activeDSTextures & texMask;
-      for (uint32_t sampler = samplerMask; sampler; sampler &= sampler - 1) {
-        const uint32_t samplerIdx = bit::tzcnt(sampler);
-
+      for (uint32_t samplerIdx : bit::BitMask(samplerMask)) {
         IDirect3DBaseTexture9* dsBase  = m_state.depthStencil->GetBaseTexture();
         IDirect3DBaseTexture9* texBase = m_state.textures[samplerIdx];
 
@@ -5158,9 +5154,9 @@ namespace dxvk {
 
 
   void D3D9DeviceEx::MarkRenderHazards() {
-    for (uint32_t rt = m_activeHazardsRT; rt; rt &= rt - 1) {
+    for (uint32_t rtIdx : bit::BitMask(m_activeHazardsRT)) {
       // Guaranteed to not be nullptr...
-      auto tex = m_state.renderTargets[bit::tzcnt(rt)]->GetCommonTexture();
+      auto tex = m_state.renderTargets[rtIdx]->GetCommonTexture();
       if (unlikely(!tex->MarkHazardous())) {
         TransitionImage(tex, VK_IMAGE_LAYOUT_GENERAL);
         m_flags.set(D3D9DeviceFlag::DirtyFramebuffer);
@@ -5184,17 +5180,17 @@ namespace dxvk {
 
   void D3D9DeviceEx::UploadManagedTextures(uint32_t mask) {
     // Guaranteed to not be nullptr...
-    for (uint32_t tex = mask; tex; tex &= tex - 1)
-      UploadManagedTexture(GetCommonTexture(m_state.textures[bit::tzcnt(tex)]));
+    for (uint32_t texIdx : bit::BitMask(mask))
+      UploadManagedTexture(GetCommonTexture(m_state.textures[texIdx]));
 
     m_activeTexturesToUpload &= ~mask;
   }
 
 
   void D3D9DeviceEx::GenerateTextureMips(uint32_t mask) {
-    for (uint32_t tex = mask; tex; tex &= tex - 1) {
+    for (uint32_t texIdx : bit::BitMask(mask)) {
       // Guaranteed to not be nullptr...
-      auto texInfo = GetCommonTexture(m_state.textures[bit::tzcnt(tex)]);
+      auto texInfo = GetCommonTexture(m_state.textures[texIdx]);
 
       if (texInfo->NeedsMipGen()) {
         this->EmitGenerateMips(texInfo);
@@ -5210,9 +5206,8 @@ namespace dxvk {
     pResource->SetNeedsMipGen(true);
     pResource->MarkAllWrittenByGPU();
 
-    for (uint32_t tex = m_activeTextures; tex; tex &= tex - 1) {
+    for (uint32_t i : bit::BitMask(m_activeTextures)) {
       // Guaranteed to not be nullptr...
-      const uint32_t i = bit::tzcnt(tex);
       auto texInfo = GetCommonTexture(m_state.textures[i]);
 
       if (texInfo == pResource) {
@@ -5227,9 +5222,8 @@ namespace dxvk {
   void D3D9DeviceEx::MarkTextureMipsUnDirty(D3D9CommonTexture* pResource) {
     pResource->SetNeedsMipGen(false);
 
-    for (uint32_t tex = m_activeTextures; tex; tex &= tex - 1) {
+    for (uint32_t i : bit::BitMask(m_activeTextures)) {
       // Guaranteed to not be nullptr...
-      const uint32_t i = bit::tzcnt(tex);
       auto texInfo = GetCommonTexture(m_state.textures[i]);
 
       if (texInfo == pResource)
@@ -5239,9 +5233,8 @@ namespace dxvk {
 
 
   void D3D9DeviceEx::MarkTextureUploaded(D3D9CommonTexture* pResource) {
-    for (uint32_t tex = m_activeTextures; tex; tex &= tex - 1) {
+    for (uint32_t i : bit::BitMask(m_activeTextures)) {
       // Guaranteed to not be nullptr...
-      const uint32_t i = bit::tzcnt(tex);
       auto texInfo = GetCommonTexture(m_state.textures[i]);
 
       if (texInfo == pResource)
@@ -5381,8 +5374,7 @@ namespace dxvk {
     // target bindings are updated. Set up the attachments.
     VkSampleCountFlagBits sampleCount = VK_SAMPLE_COUNT_FLAG_BITS_MAX_ENUM;
 
-    for (uint32_t rt = m_boundRTs; rt; rt &= rt - 1) {
-      uint32_t i = bit::tzcnt(rt);
+    for (uint32_t i : bit::BitMask(m_boundRTs)) {
       const DxvkImageCreateInfo& rtImageInfo = m_state.renderTargets[i]->GetCommonTexture()->GetImage()->info();
 
       if (likely(sampleCount == VK_SAMPLE_COUNT_FLAG_BITS_MAX_ENUM))
@@ -5846,16 +5838,16 @@ namespace dxvk {
 
 
   void D3D9DeviceEx::UndirtySamplers(uint32_t mask) {
-    for (uint32_t dirty = mask; dirty; dirty &= dirty - 1)
-      BindSampler(bit::tzcnt(dirty));
+    for (uint32_t i : bit::BitMask(mask))
+      BindSampler(i);
 
     m_dirtySamplerStates &= ~mask;
   }
 
 
   void D3D9DeviceEx::UndirtyTextures(uint32_t mask) {
-    for (uint32_t tex = mask; tex; tex &= tex - 1)
-      BindTexture(bit::tzcnt(tex));
+    for (uint32_t i : bit::BitMask(mask))
+      BindTexture(i);
   
     m_dirtyTextures &= ~mask;
   }
@@ -5863,8 +5855,7 @@ namespace dxvk {
   void D3D9DeviceEx::MarkTextureBindingDirty(IDirect3DBaseTexture9* texture) {
     D3D9DeviceLock lock = LockDevice();
 
-    for (uint32_t tex = m_activeTextures; tex; tex &= tex - 1) {
-      const uint32_t i = bit::tzcnt(tex);
+    for (uint32_t i : bit::BitMask(m_activeTextures)) {
       if (m_state.textures[i] == texture)
         m_dirtyTextures |= 1u << i;
     }

--- a/src/d3d9/d3d9_stateblock.h
+++ b/src/d3d9/d3d9_stateblock.h
@@ -175,11 +175,8 @@ namespace dxvk {
     template <typename Dst, typename Src>
     void ApplyOrCapture(Dst* dst, const Src* src) {
       if (m_captures.flags.test(D3D9CapturedStateFlag::StreamFreq)) {
-        for (uint32_t stream = m_captures.streamFreq.dword(0); stream; stream &= stream - 1) {
-          uint32_t idx = bit::tzcnt(stream);
-
+        for (uint32_t idx : bit::BitMask(m_captures.streamFreq.dword(0)))
           dst->SetStreamSourceFreq(idx, src->streamFreq[idx]);
-        }
       }
 
       if (m_captures.flags.test(D3D9CapturedStateFlag::Indices))
@@ -187,8 +184,8 @@ namespace dxvk {
 
       if (m_captures.flags.test(D3D9CapturedStateFlag::RenderStates)) {
         for (uint32_t i = 0; i < m_captures.renderStates.dwordCount(); i++) {
-          for (uint32_t rs = m_captures.renderStates.dword(i); rs; rs &= rs - 1) {
-            uint32_t idx = i * 32 + bit::tzcnt(rs);
+          for (uint32_t rs : bit::BitMask(m_captures.renderStates.dword(i))) {
+            uint32_t idx = i * 32 + rs;
 
             dst->SetRenderState(D3DRENDERSTATETYPE(idx), src->renderStates[idx]);
           }
@@ -196,21 +193,14 @@ namespace dxvk {
       }
 
       if (m_captures.flags.test(D3D9CapturedStateFlag::SamplerStates)) {
-        for (uint32_t sampler = m_captures.samplers.dword(0); sampler; sampler &= sampler - 1) {
-          uint32_t samplerIdx = bit::tzcnt(sampler);            
-
-          for (uint32_t state = m_captures.samplerStates[samplerIdx].dword(0); state; state &= state - 1) {
-            uint32_t stateIdx = bit::tzcnt(state);
-
+        for (uint32_t samplerIdx : bit::BitMask(m_captures.samplers.dword(0))) {
+          for (uint32_t stateIdx : bit::BitMask(m_captures.samplerStates[samplerIdx].dword(0)))
             dst->SetStateSamplerState(samplerIdx, D3DSAMPLERSTATETYPE(stateIdx), src->samplerStates[samplerIdx][stateIdx]);
-          }
         }
       }
 
       if (m_captures.flags.test(D3D9CapturedStateFlag::VertexBuffers)) {
-        for (uint32_t vb = m_captures.vertexBuffers.dword(0); vb; vb &= vb - 1) {
-          uint32_t idx = bit::tzcnt(vb);
-
+        for (uint32_t idx : bit::BitMask(m_captures.vertexBuffers.dword(0))) {
           const auto& vbo = src->vertexBuffers[idx];
           dst->SetStreamSource(
             idx,
@@ -224,11 +214,8 @@ namespace dxvk {
         dst->SetMaterial(&src->material);
 
       if (m_captures.flags.test(D3D9CapturedStateFlag::Textures)) {
-        for (uint32_t tex = m_captures.textures.dword(0); tex; tex &= tex - 1) {
-          uint32_t idx = bit::tzcnt(tex);
-
+        for (uint32_t idx : bit::BitMask(m_captures.textures.dword(0)))
           dst->SetStateTexture(idx, src->textures[idx]);
-        }
       }
 
       if (m_captures.flags.test(D3D9CapturedStateFlag::VertexShader))
@@ -239,8 +226,8 @@ namespace dxvk {
 
       if (m_captures.flags.test(D3D9CapturedStateFlag::Transforms)) {
         for (uint32_t i = 0; i < m_captures.transforms.dwordCount(); i++) {
-          for (uint32_t trans = m_captures.transforms.dword(i); trans; trans &= trans - 1) {
-            uint32_t idx = i * 32 + bit::tzcnt(trans);
+          for (uint32_t trans : bit::BitMask(m_captures.transforms.dword(i))) {
+            uint32_t idx = i * 32 + trans;
 
             dst->SetStateTransform(idx, reinterpret_cast<const D3DMATRIX*>(&src->transforms[idx]));
           }
@@ -248,14 +235,9 @@ namespace dxvk {
       }
 
       if (m_captures.flags.test(D3D9CapturedStateFlag::TextureStages)) {
-        for (uint32_t stage = m_captures.textureStages.dword(0); stage; stage &= stage - 1) {
-          uint32_t stageIdx = bit::tzcnt(stage);
-            
-          for (uint32_t state = m_captures.textureStageStates[stageIdx].dword(0); state; state &= state - 1) {
-            uint32_t stateIdx = bit::tzcnt(state);
-
+        for (uint32_t stageIdx : bit::BitMask(m_captures.textureStages.dword(0))) {
+          for (uint32_t stateIdx : bit::BitMask(m_captures.textureStageStates[stageIdx].dword(0)))
             dst->SetStateTextureStageState(stageIdx, D3D9TextureStageStateTypes(stateIdx), src->textureStages[stageIdx][stateIdx]);
-          }
         }
       }
 
@@ -266,25 +248,22 @@ namespace dxvk {
         dst->SetScissorRect(&src->scissorRect);
 
       if (m_captures.flags.test(D3D9CapturedStateFlag::ClipPlanes)) {
-        for (uint32_t plane = m_captures.clipPlanes.dword(0); plane; plane &= plane - 1) {
-          uint32_t idx = bit::tzcnt(plane);
-
+        for (uint32_t idx : bit::BitMask(m_captures.clipPlanes.dword(0)))
           dst->SetClipPlane(idx, src->clipPlanes[idx].coeff);
-        }
       }
 
       if (m_captures.flags.test(D3D9CapturedStateFlag::VsConstants)) {
         for (uint32_t i = 0; i < m_captures.vsConsts.fConsts.dwordCount(); i++) {
-          for (uint32_t consts = m_captures.vsConsts.fConsts.dword(i); consts; consts &= consts - 1) {
-            uint32_t idx = i * 32 + bit::tzcnt(consts);
+          for (uint32_t consts : bit::BitMask(m_captures.vsConsts.fConsts.dword(i))) {
+            uint32_t idx = i * 32 + consts;
 
             dst->SetVertexShaderConstantF(idx, (float*)&src->vsConsts.fConsts[idx], 1);
           }
         }
 
         for (uint32_t i = 0; i < m_captures.vsConsts.iConsts.dwordCount(); i++) {
-          for (uint32_t consts = m_captures.vsConsts.iConsts.dword(i); consts; consts &= consts - 1) {
-            uint32_t idx = i * 32 + bit::tzcnt(consts);
+          for (uint32_t consts : bit::BitMask(m_captures.vsConsts.iConsts.dword(i))) {
+            uint32_t idx = i * 32 + consts;
 
             dst->SetVertexShaderConstantI(idx, (int*)&src->vsConsts.iConsts[idx], 1);
           }
@@ -298,16 +277,16 @@ namespace dxvk {
 
       if (m_captures.flags.test(D3D9CapturedStateFlag::PsConstants)) {
         for (uint32_t i = 0; i < m_captures.psConsts.fConsts.dwordCount(); i++) {
-          for (uint32_t consts = m_captures.psConsts.fConsts.dword(i); consts; consts &= consts - 1) {
-            uint32_t idx = i * 32 + bit::tzcnt(consts);
+          for (uint32_t consts : bit::BitMask(m_captures.psConsts.fConsts.dword(i))) {
+            uint32_t idx = i * 32 + consts;
 
             dst->SetPixelShaderConstantF(idx, (float*)&src->psConsts.fConsts[idx], 1);
           }
         }
 
         for (uint32_t i = 0; i < m_captures.psConsts.iConsts.dwordCount(); i++) {
-          for (uint32_t consts = m_captures.psConsts.iConsts.dword(i); consts; consts &= consts - 1) {
-            uint32_t idx = i * 32 + bit::tzcnt(consts);
+          for (uint32_t consts : bit::BitMask(m_captures.psConsts.iConsts.dword(i))) {
+            uint32_t idx = i * 32 + consts;
 
             dst->SetPixelShaderConstantI(idx, (int*)&src->psConsts.iConsts[idx], 1);
           }

--- a/src/d3d9/d3d9_util.h
+++ b/src/d3d9/d3d9_util.h
@@ -199,11 +199,8 @@ namespace dxvk {
   UINT CompactSparseList(T* pData, UINT Mask) {
     uint32_t count = 0;
 
-    while (Mask != 0) {
-      uint32_t id = bit::tzcnt(Mask);
+    for (uint32_t id : bit::BitMask(Mask))
       pData[count++] = pData[id];
-      Mask &= Mask - 1;
-    }
 
     return count;
   }

--- a/src/dxbc/dxbc_compiler.cpp
+++ b/src/dxbc/dxbc_compiler.cpp
@@ -211,9 +211,7 @@ namespace dxvk {
     for (size_t i = 0; i < m_xfbVars.size(); i++)
       streamMask |= 1u << m_xfbVars[i].streamId;
     
-    for (uint32_t mask = streamMask; mask != 0; mask &= mask - 1) {
-      const uint32_t streamId = bit::tzcnt(mask);
-
+    for (uint32_t streamId : bit::BitMask(streamMask)) {
       emitXfbOutputSetup(streamId, true);
       m_module.opEmitVertex(m_module.constu32(streamId));
     }

--- a/src/dxvk/dxvk_shader.cpp
+++ b/src/dxvk/dxvk_shader.cpp
@@ -185,8 +185,8 @@ namespace dxvk {
       std::swap(code[m_o1IdxOffset], code[m_o1LocOffset]);
     
     // Replace undefined input variables with zero
-    for (uint32_t u = info.undefinedInputs; u; u &= u - 1)
-      eliminateInput(spirvCode, bit::tzcnt(u));
+    for (uint32_t u : bit::BitMask(info.undefinedInputs))
+      eliminateInput(spirvCode, u);
 
     return DxvkShaderModule(vkd, this, spirvCode);
   }

--- a/src/util/util_bit.h
+++ b/src/util/util_bit.h
@@ -17,6 +17,7 @@
 #include "util_math.h"
 
 #include <cstring>
+#include <iterator>
 #include <type_traits>
 
 namespace dxvk::bit {
@@ -291,5 +292,58 @@ namespace dxvk::bit {
     uint32_t m_dwords[Dwords];
 
   };
-  
+
+  class BitMask {
+
+  public:
+
+    class iterator: public std::iterator<std::input_iterator_tag,
+      uint32_t, uint32_t, const uint32_t*, uint32_t> {
+    public:
+
+      explicit iterator(uint32_t flags)
+        : m_mask(flags) { }
+
+      iterator& operator ++ () {
+        m_mask &= m_mask - 1;
+        return *this;
+      }
+
+      iterator operator ++ (int) {
+        iterator retval = *this;
+        m_mask &= m_mask - 1;
+        return retval;
+      }
+
+      uint32_t operator * () const {
+        return bsf(m_mask);
+      }
+
+      bool operator == (iterator other) const { return m_mask == other.m_mask; }
+      bool operator != (iterator other) const { return m_mask != other.m_mask; }
+
+    private:
+
+      uint32_t m_mask;
+
+    };
+
+    BitMask() { }
+
+    BitMask(uint32_t n)
+      : m_mask(n) { }
+
+    iterator begin() {
+      return iterator(m_mask);
+    }
+
+    iterator end() {
+      return iterator(0);
+    }
+
+  private:
+
+    uint32_t m_mask;
+
+  };
 }

--- a/src/util/util_bit.h
+++ b/src/util/util_bit.h
@@ -76,6 +76,25 @@ namespace dxvk::bit {
     #endif
   }
 
+  inline uint32_t bsf(uint32_t n) {
+    #if defined(_MSC_VER) && !defined(__clang__)
+    DWORD index;
+    _BitScanForward(&index, n);
+    return uint32_t(index);
+    #elif defined(__GNUC__) || defined(__clang__)
+    return __builtin_ctz(n);
+    #else
+    uint32_t r = 31;
+    n &= -n;
+    r -= (n & 0x0000FFFF) ? 16 : 0;
+    r -= (n & 0x00FF00FF) ?  8 : 0;
+    r -= (n & 0x0F0F0F0F) ?  4 : 0;
+    r -= (n & 0x33333333) ?  2 : 0;
+    r -= (n & 0x55555555) ?  1 : 0;
+    return r;
+    #endif
+  }
+
   inline uint32_t lzcnt(uint32_t n) {
     #if (defined(_MSC_VER) && !defined(__clang__)) || defined(__LZCNT__)
     return _lzcnt_u32(n);


### PR DESCRIPTION
Replaces manual for each bit loops with a `bit::BitMask` iterator solution. Supersedes #2228 
This should result in marginally better code because gcc now optimizes the tzcnt.