### PR TITLE
[dxso] Fix gradient instructions for cube maps

### DIFF
--- a/src/dxso/dxso_compiler.cpp
+++ b/src/dxso/dxso_compiler.cpp
@@ -2732,7 +2732,7 @@ void DxsoCompiler::emitControlFlowGenericLoop(
       }
 
       if (opcode == DxsoOpcode::TexLdd) {
-        DxsoRegMask gradMask(true, true, false, false);
+        DxsoRegMask gradMask(true, true, sampler.dimensions == 3, false);
         imageOperands.flags |= spv::ImageOperandsGradMask;
         imageOperands.sGradX = emitRegisterLoad(ctx.src[2], gradMask).id;
         imageOperands.sGradY = emitRegisterLoad(ctx.src[3], gradMask).id;


### PR DESCRIPTION
See #2255, not sure if it'll actually fix the bug but does fix the SPIR-V validation errors.