### PR TITLE
Implement DXVK pieces required for DX11 DLSS support.

### DIFF
--- a/src/d3d11/d3d11_context.cpp
+++ b/src/d3d11/d3d11_context.cpp
@@ -48,7 +48,8 @@ namespace dxvk {
       return S_OK;
     }
     
-    if (riid == __uuidof(ID3D11VkExtContext)) {
+    if (riid == __uuidof(ID3D11VkExtContext)
+     || riid == __uuidof(ID3D11VkExtContext1)) {
       *ppvObject = ref(&m_contextExt);
       return S_OK;
     }

--- a/src/d3d11/d3d11_context_ext.cpp
+++ b/src/d3d11/d3d11_context_ext.cpp
@@ -1,3 +1,10 @@
+#include <vector>
+#include <utility>
+#include <cstring>
+
+#include "d3d11_device.h"
+#include "../util/log/log.h"
+
 #include "d3d11_context.h"
 
 namespace dxvk {
@@ -136,5 +143,76 @@ namespace dxvk {
       ctx->setBarrierControl(cFlags);
     });
   }
-  
+
+
+  class CubinShaderLaunchInfo {
+  public:
+    Com<CubinShaderWrapper> cuShader;
+    std::vector<uint8_t> Params;
+    size_t ParamSize;
+    VkCuLaunchInfoNVX nvxLaunchInfo = { VK_STRUCTURE_TYPE_CU_LAUNCH_INFO_NVX };
+    const void* CuLaunchConfig[5];
+    std::vector<std::pair<Rc<DxvkBuffer>, DxvkAccessFlags>> buffers;
+    std::vector<std::pair<Rc<DxvkImage>, DxvkAccessFlags>> images;
+  };
+
+
+  bool STDMETHODCALLTYPE D3D11DeviceContextExt::LaunchCubinShaderNVX(IUnknown* hShader, uint32_t GridX, uint32_t GridY, uint32_t GridZ, const void* pParams, uint32_t ParamSize, const void** pReadResources, uint32_t NumReadResources, const void** pWriteResources, uint32_t NumWriteResources) {
+    D3D10DeviceLock lock = m_ctx->LockContext();
+
+    CubinShaderWrapper* cubinShader = (CubinShaderWrapper*)hShader;
+    auto rcLaunchInfo = new CubinShaderLaunchInfo();
+
+    const uint32_t maxResources = NumReadResources + NumWriteResources;
+    rcLaunchInfo->buffers.reserve(maxResources);
+    rcLaunchInfo->images.reserve(maxResources);
+
+    auto InsertResource =
+    [&images = rcLaunchInfo->images,
+     &buffers = rcLaunchInfo->buffers](ID3D11Resource* res, DxvkAccessFlags access) {
+      auto buffer = GetCommonBuffer(res);
+      auto texture = GetCommonTexture(res);
+      if (buffer) buffers.emplace_back(std::make_pair(buffer->GetBuffer(), access));
+      else if (texture) images.emplace_back(std::make_pair(texture->GetImage(), access));
+    };
+
+    for (uint32_t i = 0; i < NumReadResources; i++) {
+      InsertResource(const_cast<ID3D11Resource*>(static_cast<const ID3D11Resource*>(pReadResources[i])), DxvkAccess::Read);
+    }
+    for (uint32_t i = 0; i < NumWriteResources; i++) {
+      InsertResource(const_cast<ID3D11Resource*>(static_cast<const ID3D11Resource*>(pWriteResources[i])), DxvkAccess::Write);
+    }
+
+    rcLaunchInfo->ParamSize = ParamSize;
+    rcLaunchInfo->Params.resize(rcLaunchInfo->ParamSize);
+    std::memcpy(rcLaunchInfo->Params.data(), pParams, ParamSize);
+
+    rcLaunchInfo->CuLaunchConfig[0] = reinterpret_cast<void*>(0x01); // CU_LAUNCH_PARAM_BUFFER_POINTER
+    rcLaunchInfo->CuLaunchConfig[1] = rcLaunchInfo->Params.data();
+    rcLaunchInfo->CuLaunchConfig[2] = reinterpret_cast<void*>(0x02); // CU_LAUNCH_PARAM_BUFFER_SIZE
+    rcLaunchInfo->CuLaunchConfig[3] = &rcLaunchInfo->ParamSize; // yes, this actually requires a pointer to a size_t containing the parameter size
+    rcLaunchInfo->CuLaunchConfig[4] = reinterpret_cast<void*>(0x00); // CU_LAUNCH_PARAM_END
+
+    rcLaunchInfo->nvxLaunchInfo.function       = cubinShader->Function;
+    rcLaunchInfo->nvxLaunchInfo.gridDimX       = GridX;
+    rcLaunchInfo->nvxLaunchInfo.gridDimY       = GridY;
+    rcLaunchInfo->nvxLaunchInfo.gridDimZ       = GridZ;
+    rcLaunchInfo->nvxLaunchInfo.blockDimX      = cubinShader->BlockDimX;
+    rcLaunchInfo->nvxLaunchInfo.blockDimY      = cubinShader->BlockDimY;
+    rcLaunchInfo->nvxLaunchInfo.blockDimZ      = cubinShader->BlockDimZ;
+    rcLaunchInfo->nvxLaunchInfo.sharedMemBytes = 0;
+    rcLaunchInfo->nvxLaunchInfo.paramCount     = 0;
+    rcLaunchInfo->nvxLaunchInfo.pParams        = nullptr;
+    rcLaunchInfo->nvxLaunchInfo.extraCount     = 1;
+    rcLaunchInfo->nvxLaunchInfo.pExtras        = &rcLaunchInfo->CuLaunchConfig[0];
+
+    rcLaunchInfo->cuShader = cubinShader;
+
+    m_ctx->EmitCs([cRcLaunchInfo = rcLaunchInfo] (DxvkContext* ctx) {
+        ctx->launchCuKernelNVX(cRcLaunchInfo->nvxLaunchInfo, cRcLaunchInfo->buffers, cRcLaunchInfo->images);
+        delete cRcLaunchInfo;
+    });
+
+    return true;
+  }
 }

--- a/src/d3d11/d3d11_context_ext.cpp
+++ b/src/d3d11/d3d11_context_ext.cpp
@@ -184,7 +184,7 @@ namespace dxvk {
     launchInfo.nvxLaunchInfo.paramCount     = 0;
     launchInfo.nvxLaunchInfo.pParams        = nullptr;
     launchInfo.nvxLaunchInfo.extraCount     = 1;
-    launchInfo.nvxLaunchInfo.pExtras        = &launchInfo.cuLaunchConfig[0];
+    launchInfo.nvxLaunchInfo.pExtras        = launchInfo.cuLaunchConfig.data();
 
     launchInfo.shader = cubinShader;
 

--- a/src/d3d11/d3d11_context_ext.cpp
+++ b/src/d3d11/d3d11_context_ext.cpp
@@ -147,7 +147,7 @@ namespace dxvk {
 
 
   bool STDMETHODCALLTYPE D3D11DeviceContextExt::LaunchCubinShaderNVX(IUnknown* hShader, uint32_t GridX, uint32_t GridY, uint32_t GridZ,
-      const void* pParams, uint32_t ParamSize, const void** pReadResources, uint32_t NumReadResources, const void** pWriteResources, uint32_t NumWriteResources) {
+      const void* pParams, uint32_t ParamSize, void* const* pReadResources, uint32_t NumReadResources, void* const* pWriteResources, uint32_t NumWriteResources) {
     D3D10DeviceLock lock = m_ctx->LockContext();
 
     CubinShaderWrapper* cubinShader = static_cast<CubinShaderWrapper*>(hShader);

--- a/src/d3d11/d3d11_context_ext.h
+++ b/src/d3d11/d3d11_context_ext.h
@@ -6,7 +6,7 @@ namespace dxvk {
   
   class D3D11DeviceContext;
 
-  class D3D11DeviceContextExt : public ID3D11VkExtContext {
+  class D3D11DeviceContextExt : public ID3D11VkExtContext1 {
     
   public:
     
@@ -56,11 +56,23 @@ namespace dxvk {
     
     void STDMETHODCALLTYPE SetBarrierControl(
             UINT                    ControlFlags);
-    
+
+    bool STDMETHODCALLTYPE LaunchCubinShaderNVX(
+            IUnknown*               hShader,
+            uint32_t                GridX,
+            uint32_t                GridY,
+            uint32_t                GridZ,
+            const void*             pParams,
+            uint32_t                paramSize,
+            const void**            pReadResources,
+            uint32_t                NumReadResources,
+            const void**            pWriteResources,
+            uint32_t                NumWriteResources);
+
   private:
     
     D3D11DeviceContext* m_ctx;
-    
+
   };
 
 }

--- a/src/d3d11/d3d11_context_ext.h
+++ b/src/d3d11/d3d11_context_ext.h
@@ -64,9 +64,9 @@ namespace dxvk {
             uint32_t                GridZ,
             const void*             pParams,
             uint32_t                paramSize,
-            const void**            pReadResources,
+            void* const*            pReadResources,
             uint32_t                NumReadResources,
-            const void**            pWriteResources,
+            void* const*            pWriteResources,
             uint32_t                NumWriteResources);
 
   private:

--- a/src/d3d11/d3d11_cuda.cpp
+++ b/src/d3d11/d3d11_cuda.cpp
@@ -1,0 +1,51 @@
+#include "d3d11_cuda.h"
+
+namespace dxvk {
+
+  CubinShaderWrapper::CubinShaderWrapper(const Rc<dxvk::DxvkDevice>& dxvkDevice, VkCuModuleNVX cuModule, VkCuFunctionNVX cuFunction, VkExtent3D blockDim)
+  : m_dxvkDevice(dxvkDevice), m_module(cuModule), m_function(cuFunction), m_blockDim(blockDim) { };
+
+
+  CubinShaderWrapper::~CubinShaderWrapper() {
+    VkDevice vkDevice = m_dxvkDevice->handle();
+    m_dxvkDevice->vkd()->vkDestroyCuFunctionNVX(vkDevice, m_function, nullptr);
+    m_dxvkDevice->vkd()->vkDestroyCuModuleNVX(vkDevice, m_module, nullptr);
+  };
+
+
+  HRESULT STDMETHODCALLTYPE CubinShaderWrapper::QueryInterface(REFIID riid, void **ppvObject) {
+    if (riid == __uuidof(IUnknown)) {
+      *ppvObject = ref(this);
+      return S_OK;
+    }
+
+    Logger::warn("CubinShaderWrapper::QueryInterface: Unknown interface query");
+    Logger::warn(str::format(riid));
+    return E_NOINTERFACE;
+  }
+
+
+  void CubinShaderLaunchInfo::insertResource(ID3D11Resource* pResource, DxvkAccessFlags access) {
+    auto img = GetCommonTexture(pResource);
+    auto buf = GetCommonBuffer(pResource);
+
+    if (img)
+      insertUniqueResource(images, img->GetImage(), access);
+    if (buf)
+      insertUniqueResource(buffers, buf->GetBuffer(), access);
+  }
+
+
+  template<typename T>
+  void CubinShaderLaunchInfo::insertUniqueResource(std::vector<std::pair<T, DxvkAccessFlags>>& list, const T& resource, DxvkAccessFlags access) {
+    for (auto& entry : list) {
+      if (entry.first == resource) {
+        entry.second.set(access);
+        return;
+      }
+    }
+
+    list.push_back({ resource, access });
+  }
+
+}

--- a/src/d3d11/d3d11_cuda.h
+++ b/src/d3d11/d3d11_cuda.h
@@ -45,11 +45,31 @@ namespace dxvk {
 
 
   struct CubinShaderLaunchInfo {
+
+    CubinShaderLaunchInfo() = default;
+
+    CubinShaderLaunchInfo(CubinShaderLaunchInfo&& other) {
+      shader         = std::move(other.shader);
+      params         = std::move(other.params);
+      paramSize      = std::move(other.paramSize);
+      nvxLaunchInfo  = std::move(other.nvxLaunchInfo);
+      cuLaunchConfig = other.cuLaunchConfig;
+      buffers        = std::move(other.buffers);
+      images         = std::move(other.images);
+      other.cuLaunchConfig[1] = nullptr;
+      other.cuLaunchConfig[3] = nullptr;
+      other.nvxLaunchInfo.pExtras = nullptr;
+      // fix-up internally-pointing pointers
+      cuLaunchConfig[1] = params.data();
+      cuLaunchConfig[3] = &paramSize;
+      nvxLaunchInfo.pExtras = cuLaunchConfig.data();
+    }
+
     Com<CubinShaderWrapper> shader;
     std::vector<uint8_t>    params;
     size_t                  paramSize;
     VkCuLaunchInfoNVX       nvxLaunchInfo = { VK_STRUCTURE_TYPE_CU_LAUNCH_INFO_NVX };
-    const void*             cuLaunchConfig[5];
+    std::array<void*, 5>    cuLaunchConfig;
 
     std::vector<std::pair<Rc<DxvkBuffer>, DxvkAccessFlags>> buffers;
     std::vector<std::pair<Rc<DxvkImage>, DxvkAccessFlags>> images;

--- a/src/d3d11/d3d11_cuda.h
+++ b/src/d3d11/d3d11_cuda.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include <utility>
+#include <vector>
+
+#include "../dxvk/dxvk_resource.h"
+
+#include "../util/com/com_guid.h"
+#include "../util/com/com_object.h"
+
+#include "d3d11_buffer.h"
+#include "d3d11_texture.h"
+
+namespace dxvk {
+
+  class CubinShaderWrapper : public ComObject<IUnknown> {
+
+  public:
+
+    CubinShaderWrapper(const Rc<dxvk::DxvkDevice>& dxvkDevice, VkCuModuleNVX cuModule, VkCuFunctionNVX cuFunction, VkExtent3D blockDim);
+    ~CubinShaderWrapper();
+
+    HRESULT STDMETHODCALLTYPE QueryInterface(REFIID riid, void **ppvObject);
+
+    VkCuModuleNVX cuModule() const {
+      return m_module;
+    }
+
+    VkCuFunctionNVX cuFunction() const {
+      return m_function;
+    }
+
+    VkExtent3D blockDim() const {
+      return m_blockDim;
+    }
+
+  private:
+
+    Rc<DxvkDevice>  m_dxvkDevice;
+    VkCuModuleNVX   m_module;
+    VkCuFunctionNVX m_function;
+    VkExtent3D      m_blockDim;
+
+  };
+
+
+  struct CubinShaderLaunchInfo {
+    Com<CubinShaderWrapper> shader;
+    std::vector<uint8_t>    params;
+    size_t                  paramSize;
+    VkCuLaunchInfoNVX       nvxLaunchInfo = { VK_STRUCTURE_TYPE_CU_LAUNCH_INFO_NVX };
+    const void*             cuLaunchConfig[5];
+
+    std::vector<std::pair<Rc<DxvkBuffer>, DxvkAccessFlags>> buffers;
+    std::vector<std::pair<Rc<DxvkImage>, DxvkAccessFlags>> images;
+
+    void insertResource(ID3D11Resource* pResource, DxvkAccessFlags access);
+
+    template<typename T>
+    static void insertUniqueResource(std::vector<std::pair<T, DxvkAccessFlags>>& list, const T& resource, DxvkAccessFlags access);
+  };
+
+}

--- a/src/d3d11/d3d11_device.cpp
+++ b/src/d3d11/d3d11_device.cpp
@@ -2404,7 +2404,7 @@ namespace dxvk {
   D3D11DeviceExt::D3D11DeviceExt(
           D3D11DXGIDevice*        pContainer,
           D3D11Device*            pDevice)
-  : m_container(pContainer), m_device(pDevice) {
+  : m_container(pContainer), m_device(pDevice), m_multithreadMapsLock(this, false) {
     
   }
   
@@ -2445,12 +2445,332 @@ namespace dxvk {
       case D3D11_VK_EXT_DEPTH_BOUNDS:
         return deviceFeatures.core.features.depthBounds;
 
+      case D3D11_VK_NVX_IMAGE_VIEW_HANDLE:
+        return deviceExtensions.nvxImageViewHandle;
+
+      case D3D11_VK_NVX_BINARY_IMPORT:
+        return deviceExtensions.nvxBinaryImport;
+
       default:
         return false;
     }
   }
   
   
+
+  // Maintain mappings from opaque uint32 handles to
+  // resources.
+  //
+  // Doesn't keep the resource ref'd; the app is responsible
+  // for keeping the underlying resource alive as long as it
+  // wants to use the handle.
+  // No attempt to shrink or depopulate the maps; number of
+  // entries is expected to be very limited and using a
+  // dangling handle is an app bug.
+  void D3D11DeviceExt::AddSamplerAndHandleNVX(ID3D11SamplerState* sampler, uint32_t handle) {
+    auto mapslock = m_multithreadMapsLock.AcquireLock();
+    m_SamplerHandleToPtr[handle] = sampler;
+  }
+  ID3D11SamplerState* D3D11DeviceExt::HandleToSamplerNVX(uint32_t handle) {
+    auto mapLock = m_multithreadMapsLock.AcquireLock();
+    auto got = m_SamplerHandleToPtr.find(handle);
+    if (got == m_SamplerHandleToPtr.end())
+      return nullptr;
+    return (ID3D11SamplerState*)got->second;
+  }
+  void D3D11DeviceExt::AddSrvAndHandleNVX(ID3D11ShaderResourceView* srv_imageview, uint32_t handle) {
+    auto mapLock = m_multithreadMapsLock.AcquireLock();
+    m_SrvHandleToPtr[handle] = srv_imageview;
+  }
+  ID3D11ShaderResourceView* D3D11DeviceExt::HandleToSrvNVX(uint32_t handle) {
+    auto mapLock = m_multithreadMapsLock.AcquireLock();
+    auto got = m_SrvHandleToPtr.find(handle);
+    if (got == m_SrvHandleToPtr.end())
+      return nullptr;
+    return (ID3D11ShaderResourceView*)got->second;
+  }
+
+
+  bool STDMETHODCALLTYPE D3D11DeviceExt::GetCudaTextureObjectNVX(uint32_t srvDriverHandle, uint32_t samplerDriverHandle, uint32_t* pCudaTextureHandle) {
+    ID3D11ShaderResourceView* srv = HandleToSrvNVX(srvDriverHandle);
+    if (!srv) {
+      Logger::warn(str::format("GetCudaTextureObjectNVX() failure - srv handle wasn't found: ", srvDriverHandle));
+      return false;
+    }
+
+    ID3D11SamplerState* samplerState = HandleToSamplerNVX(samplerDriverHandle);
+    if (!samplerState) {
+      Logger::warn(str::format("GetCudaTextureObjectNVX() failure - sampler handle wasn't found: ", samplerDriverHandle));
+      return false;
+    }
+
+    D3D11SamplerState* pSS = static_cast<D3D11SamplerState*>(samplerState);
+    Rc<DxvkSampler> pDSS = pSS->GetDXVKSampler();
+    VkSampler vkSampler = pDSS->handle();
+
+    D3D11ShaderResourceView* pSRV = static_cast<D3D11ShaderResourceView*>(srv);
+    Rc<DxvkImageView> pIV = pSRV->GetImageView();
+    VkImageView vkImageView = pIV->handle();
+
+    VkImageViewHandleInfoNVX imageViewHandleInfo = {VK_STRUCTURE_TYPE_IMAGE_VIEW_HANDLE_INFO_NVX};
+    imageViewHandleInfo.imageView = vkImageView;
+    imageViewHandleInfo.sampler = vkSampler;
+    imageViewHandleInfo.descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+
+    // note: there's no implicit lifetime management here; it's up to the
+    // app to keep the sampler and SRV alive as long as it wants to use this
+    // derived handle.
+
+    VkDevice vkDevice = m_device->GetDXVKDevice()->handle();
+    *pCudaTextureHandle = m_device->GetDXVKDevice()->vkd()->vkGetImageViewHandleNVX(vkDevice, &imageViewHandleInfo);
+
+    if (!*pCudaTextureHandle) {
+      Logger::warn("GetCudaTextureObjectNVX() handle==0 - failed");
+      return false;
+    }
+
+    return true;
+  }
+  
+
+  bool STDMETHODCALLTYPE D3D11DeviceExt::CreateCubinComputeShaderWithNameNVX(const void* pCubin, uint32_t size, uint32_t blockX, uint32_t blockY, uint32_t blockZ, const char* pShaderName, IUnknown** phShader) {
+    Rc<DxvkDevice> dxvkDevice = m_device->GetDXVKDevice();
+    VkDevice vkDevice = dxvkDevice->handle();
+
+    VkCuModuleCreateInfoNVX moduleCreateInfo = { VK_STRUCTURE_TYPE_CU_MODULE_CREATE_INFO_NVX };
+    moduleCreateInfo.pData = pCubin;
+    moduleCreateInfo.dataSize = size;
+
+    VkCuModuleNVX cuModule;
+    VkCuFunctionNVX cuFunction;
+    VkResult result = dxvkDevice->vkd()->vkCreateCuModuleNVX(vkDevice, &moduleCreateInfo, NULL, &cuModule);
+    if (result != VK_SUCCESS) {
+      Logger::warn(str::format("CreateCubinComputeShaderWithNameNVX() - failure to create module - result=", result, " pcubindata=", pCubin, " cubinsize=", size));
+      return false; // failure
+    }
+
+    VkCuFunctionCreateInfoNVX functionCreateInfo = { VK_STRUCTURE_TYPE_CU_FUNCTION_CREATE_INFO_NVX };
+    functionCreateInfo.module = cuModule;
+    functionCreateInfo.pName = pShaderName;
+
+    result = dxvkDevice->vkd()->vkCreateCuFunctionNVX(vkDevice, &functionCreateInfo, NULL, &cuFunction);
+    if (result != VK_SUCCESS) {
+      dxvkDevice->vkd()->vkDestroyCuModuleNVX(vkDevice, cuModule, nullptr);
+      Logger::warn(str::format("CreateCubinComputeShaderWithNameNVX() - failure to create function - result=", result));
+      return false; // failure
+    }
+
+    CubinShaderWrapper* cubinShader = new CubinShaderWrapper(dxvkDevice);
+    cubinShader->Module    = cuModule;
+    cubinShader->Function  = cuFunction;
+    // Have to squirrel these away because the d3d11 NvAPI for this is a
+    // bit wacky compared to the Vk equivalents
+    cubinShader->BlockDimX = blockX;
+    cubinShader->BlockDimY = blockY;
+    cubinShader->BlockDimZ = blockZ;
+
+    *phShader = cubinShader;
+
+    return true; // success
+  }
+
+
+  bool STDMETHODCALLTYPE D3D11DeviceExt::GetResourceHandleGPUVirtualAddressAndSizeNVX(void* hObject, uint64_t* gpuVAStart, uint64_t* gpuVASize) {
+    // The hObject 'opaque driver handle' is really just a straight cast
+    // of the corresponding ID3D11Resource* in dxvk/dxvknvapi
+    ID3D11Resource* pResource = static_cast<ID3D11Resource*>(hObject);
+
+    D3D11_COMMON_RESOURCE_DESC resourceDesc;
+    if (FAILED(GetCommonResourceDesc(pResource, &resourceDesc))) {
+      Logger::warn("GetResourceHandleGPUVirtualAddressAndSize() - GetCommonResourceDesc() failed");
+      return false;
+    }
+
+    switch (resourceDesc.Dim) {
+    case D3D11_RESOURCE_DIMENSION_BUFFER:
+    case D3D11_RESOURCE_DIMENSION_TEXTURE2D:
+      // okay - we can deal with those two dimensions
+      break;
+    case D3D11_RESOURCE_DIMENSION_TEXTURE1D:
+    case D3D11_RESOURCE_DIMENSION_TEXTURE3D:
+    case D3D11_RESOURCE_DIMENSION_UNKNOWN:
+    default:
+      Logger::warn(str::format("GetResourceHandleGPUVirtualAddressAndSize(?) - failure - unsupported dimension: ", resourceDesc.Dim));
+      return false;
+    }
+
+    Rc<DxvkDevice> dxvkDevice = m_device->GetDXVKDevice();
+    VkDevice vkDevice = dxvkDevice->handle();
+
+    if (resourceDesc.Dim == D3D11_RESOURCE_DIMENSION_TEXTURE2D) {
+      D3D11CommonTexture *texture = GetCommonTexture(pResource);
+      Rc<DxvkImage> dxvkImage = texture->GetImage();
+      if (0 == (dxvkImage->info().usage & (VK_IMAGE_USAGE_STORAGE_BIT | VK_IMAGE_USAGE_SAMPLED_BIT))) {
+        Logger::warn(str::format("GetResourceHandleGPUVirtualAddressAndSize(res=", pResource,") image info missing required usage bit(s); can't be used for vkGetImageViewHandleNVX - failure"));
+        return false;
+      }
+
+      // The d3d11 nvapi provides us a texture but vulkan only lets us get the GPU address from an imageview.  So, make a private imageview and get the address from that...
+
+      D3D11_SHADER_RESOURCE_VIEW_DESC resourceViewDesc;
+
+      const D3D11_COMMON_TEXTURE_DESC *texDesc = texture->Desc();
+      if (texDesc->ArraySize != 1) {
+        Logger::debug(str::format("GetResourceHandleGPUVirtualAddressAndSize(?) - unexpected array size: ", texDesc->ArraySize));
+      }
+      resourceViewDesc.Format = texDesc->Format;
+      resourceViewDesc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2D;
+      resourceViewDesc.Texture2D.MostDetailedMip = 0;
+      resourceViewDesc.Texture2D.MipLevels = texDesc->MipLevels;
+
+      Com<ID3D11ShaderResourceView> pNewSRV;
+      HRESULT hr = m_device->CreateShaderResourceView(pResource, &resourceViewDesc, &pNewSRV);
+      if (FAILED(hr)) {
+        Logger::warn("GetResourceHandleGPUVirtualAddressAndSize() - private CreateShaderResourceView() failed");
+        return false;
+      }
+
+      Rc<DxvkImageView> dxvkImageView = static_cast<D3D11ShaderResourceView*>(pNewSRV.ptr())->GetImageView();
+      VkImageView vkImageView = dxvkImageView->handle();
+
+      VkImageViewAddressPropertiesNVX imageViewAddressProperties = {VK_STRUCTURE_TYPE_IMAGE_VIEW_ADDRESS_PROPERTIES_NVX};
+
+      VkResult res = dxvkDevice->vkd()->vkGetImageViewAddressNVX(vkDevice, vkImageView, &imageViewAddressProperties);
+      if (res != VK_SUCCESS) {
+        Logger::warn(str::format("GetResourceHandleGPUVirtualAddressAndSize(): vkGetImageViewAddressNVX() result is failure: ", res));
+        return false;
+      }
+
+      *gpuVAStart = imageViewAddressProperties.deviceAddress;
+      *gpuVASize = imageViewAddressProperties.size;
+    }
+    else if (resourceDesc.Dim == D3D11_RESOURCE_DIMENSION_BUFFER) {
+      D3D11Buffer *buffer = GetCommonBuffer(pResource);
+      const DxvkBufferSliceHandle bufSliceHandle = buffer->GetBuffer()->getSliceHandle();
+      VkBuffer vkBuffer = bufSliceHandle.handle;
+
+      VkBufferDeviceAddressInfoKHR bdaInfo = { VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_INFO_KHR };
+      bdaInfo.buffer = vkBuffer;
+      VkDeviceAddress bufAddr = dxvkDevice->vkd()->vkGetBufferDeviceAddressKHR(vkDevice, &bdaInfo);
+      *gpuVAStart = uint64_t(bufAddr) + bufSliceHandle.offset;
+      *gpuVASize = bufSliceHandle.length;
+    }
+
+    if (!*gpuVAStart)
+        Logger::warn("GetResourceHandleGPUVirtualAddressAndSize() addr==0 - unexpected"); // ... but not explicitly a failure; continue
+
+    return true;
+  }
+
+
+  bool STDMETHODCALLTYPE D3D11DeviceExt::CreateUnorderedAccessViewAndGetDriverHandleNVX(ID3D11Resource* pResource, const D3D11_UNORDERED_ACCESS_VIEW_DESC*  pDesc, ID3D11UnorderedAccessView** ppUAV, uint32_t* pDriverHandle) {
+    D3D11_COMMON_RESOURCE_DESC resourceDesc;
+    if (!SUCCEEDED(GetCommonResourceDesc(pResource, &resourceDesc))) {
+      Logger::warn("CreateUnorderedAccessViewAndGetDriverHandleNVX() - GetCommonResourceDesc() failed");
+      return false;
+    }
+    if (resourceDesc.Dim != D3D11_RESOURCE_DIMENSION_TEXTURE2D) {
+      Logger::warn(str::format("CreateUnorderedAccessViewAndGetDriverHandleNVX() - failure - unsupported dimension: ", resourceDesc.Dim));
+      return false;
+    }
+
+    auto texture = GetCommonTexture(pResource);
+    Rc<DxvkImage> dxvkImage = texture->GetImage();
+    if (0 == (dxvkImage->info().usage & (VK_IMAGE_USAGE_STORAGE_BIT | VK_IMAGE_USAGE_SAMPLED_BIT))) {
+      Logger::warn(str::format("CreateUnorderedAccessViewAndGetDriverHandleNVX(res=", pResource, ") image info missing required usage bit(s); can't be used for vkGetImageViewHandleNVX - failure"));
+      return false;
+    }
+
+    if (!SUCCEEDED(m_device->CreateUnorderedAccessView(pResource, pDesc, ppUAV))) {
+      return false;
+    }
+
+    D3D11UnorderedAccessView *pUAV = static_cast<D3D11UnorderedAccessView *>(*ppUAV);
+    Rc<DxvkDevice> dxvkDevice = m_device->GetDXVKDevice();
+    VkDevice vkDevice = dxvkDevice->handle();
+
+    VkImageViewHandleInfoNVX imageViewHandleInfo = {VK_STRUCTURE_TYPE_IMAGE_VIEW_HANDLE_INFO_NVX};
+    Rc<DxvkImageView> dxvkImageView = pUAV->GetImageView();
+    VkImageView vkImageView = dxvkImageView->handle();
+
+    imageViewHandleInfo.imageView = vkImageView;
+    imageViewHandleInfo.descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
+
+    *pDriverHandle = dxvkDevice->vkd()->vkGetImageViewHandleNVX(vkDevice, &imageViewHandleInfo);
+
+    if (!*pDriverHandle) {
+      Logger::warn("CreateUnorderedAccessViewAndGetDriverHandleNVX() handle==0 - failure");
+      pUAV->Release();
+      return false;
+    }
+
+    return true; // success
+  }
+
+
+  bool STDMETHODCALLTYPE D3D11DeviceExt::CreateShaderResourceViewAndGetDriverHandleNVX(ID3D11Resource* pResource, const D3D11_SHADER_RESOURCE_VIEW_DESC*  pDesc, ID3D11ShaderResourceView** ppSRV, uint32_t* pDriverHandle) {
+    D3D11_COMMON_RESOURCE_DESC resourceDesc;
+    if (!SUCCEEDED(GetCommonResourceDesc(pResource, &resourceDesc))) {
+      Logger::warn("CreateShaderResourceViewAndGetDriverHandleNVX() - GetCommonResourceDesc() failed");
+      return false;
+    }
+    if (resourceDesc.Dim != D3D11_RESOURCE_DIMENSION_TEXTURE2D) {
+      Logger::warn(str::format("CreateShaderResourceViewAndGetDriverHandleNVX() - failure - unsupported dimension: ", resourceDesc.Dim));
+      return false;
+    }
+
+    auto texture = GetCommonTexture(pResource);
+    Rc<DxvkImage> dxvkImage = texture->GetImage();
+    if (0 == (dxvkImage->info().usage & (VK_IMAGE_USAGE_STORAGE_BIT | VK_IMAGE_USAGE_SAMPLED_BIT))) {
+      Logger::warn(str::format("CreateShaderResourceViewAndGetDriverHandleNVX(res=", pResource, ") image info missing required usage bit(s); can't be used for vkGetImageViewHandleNVX - failure"));
+      return false;
+    }
+
+    if (!SUCCEEDED(m_device->CreateShaderResourceView(pResource, pDesc, ppSRV))) {
+      return false;
+    }
+
+    D3D11ShaderResourceView* pSRV = static_cast<D3D11ShaderResourceView*>(*ppSRV);
+    Rc<DxvkDevice> dxvkDevice = m_device->GetDXVKDevice();
+    VkDevice vkDevice = dxvkDevice->handle();
+
+    VkImageViewHandleInfoNVX imageViewHandleInfo = {VK_STRUCTURE_TYPE_IMAGE_VIEW_HANDLE_INFO_NVX};
+    Rc<DxvkImageView> dxvkImageView = pSRV->GetImageView();
+    VkImageView vkImageView = dxvkImageView->handle();
+
+    imageViewHandleInfo.imageView = vkImageView;
+    imageViewHandleInfo.descriptorType = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
+
+    *pDriverHandle = dxvkDevice->vkd()->vkGetImageViewHandleNVX(vkDevice, &imageViewHandleInfo);
+
+    if (!*pDriverHandle) {
+      Logger::warn("CreateShaderResourceViewAndGetDriverHandleNVX() handle==0 - failure");
+      pSRV->Release();
+      return false;
+    }
+
+    // will need to look-up resource from uint32 handle later
+    AddSrvAndHandleNVX(*ppSRV, *pDriverHandle);
+
+    return true; // success
+  }
+
+
+  bool STDMETHODCALLTYPE D3D11DeviceExt::CreateSamplerStateAndGetDriverHandleNVX(const D3D11_SAMPLER_DESC* pSamplerDesc, ID3D11SamplerState** ppSamplerState, uint32_t* pDriverHandle) {
+    if (!SUCCEEDED(m_device->CreateSamplerState(pSamplerDesc, ppSamplerState))) {
+      return false;
+    }
+
+    // for our purposes the actual value doesn't matter, only its uniqueness
+    static ULONG seqNum = 1;
+    *pDriverHandle = InterlockedIncrement(&seqNum);
+
+    // will need to look-up sampler from uint32 handle later
+    AddSamplerAndHandleNVX(*ppSamplerState, *pDriverHandle);
+
+    return true;
+  }
+
   
   
   D3D11VideoDevice::D3D11VideoDevice(
@@ -2827,7 +3147,8 @@ namespace dxvk {
       return S_OK;
     }
     
-    if (riid == __uuidof(ID3D11VkExtDevice)) {
+    if (riid == __uuidof(ID3D11VkExtDevice)
+     || riid == __uuidof(ID3D11VkExtDevice1)) {
       *ppvObject = ref(&m_d3d11DeviceExt);
       return S_OK;
     }

--- a/src/d3d11/d3d11_device.h
+++ b/src/d3d11/d3d11_device.h
@@ -555,14 +555,23 @@ namespace dxvk {
     D3D11DXGIDevice* m_container;
     D3D11Device*     m_device;
     
-    void AddSamplerAndHandleNVX(ID3D11SamplerState *sampler, uint32_t handle);
-    ID3D11SamplerState *HandleToSamplerNVX(uint32_t handle);
-    void AddSrvAndHandleNVX(ID3D11ShaderResourceView *srv_imageview, uint32_t handle);
-    ID3D11ShaderResourceView *HandleToSrvNVX(uint32_t handle);
+    void AddSamplerAndHandleNVX(
+            ID3D11SamplerState*       pSampler,
+            uint32_t                  Handle);
+
+    ID3D11SamplerState* HandleToSamplerNVX(
+            uint32_t                  Handle);
+
+    void AddSrvAndHandleNVX(
+            ID3D11ShaderResourceView* pSrv,
+            uint32_t                  Handle);
+
+    ID3D11ShaderResourceView* HandleToSrvNVX(
+            uint32_t                  Handle);
     
-    D3D10Multithread  m_multithreadMapsLock;
-    std::unordered_map<uint32_t, ID3D11SamplerState *> m_SamplerHandleToPtr;
-    std::unordered_map<uint32_t, ID3D11ShaderResourceView *> m_SrvHandleToPtr;
+    dxvk::mutex m_mapLock;
+    std::unordered_map<uint32_t, ID3D11SamplerState*> m_samplerHandleToPtr;
+    std::unordered_map<uint32_t, ID3D11ShaderResourceView*> m_srvHandleToPtr;
   };
 
 

--- a/src/d3d11/d3d11_device.h
+++ b/src/d3d11/d3d11_device.h
@@ -15,6 +15,7 @@
 #include "../util/com/com_private_data.h"
 
 #include "d3d11_cmdlist.h"
+#include "d3d11_cuda.h"
 #include "d3d11_initializer.h"
 #include "d3d11_interfaces.h"
 #include "d3d11_interop.h"
@@ -565,31 +566,6 @@ namespace dxvk {
   };
 
 
-  class CubinShaderWrapper : public IUnknown {
-  public:
-    CubinShaderWrapper(Rc<dxvk::DxvkDevice> in_dxvkDevice)
-    : m_RefCount(0UL), rcDxvkDevice(in_dxvkDevice) { };
-    ~CubinShaderWrapper() {
-      VkDevice vkDevice = rcDxvkDevice->handle();
-      rcDxvkDevice->vkd()->vkDestroyCuFunctionNVX(vkDevice, Function, nullptr);
-      rcDxvkDevice->vkd()->vkDestroyCuModuleNVX(vkDevice, Module, nullptr);
-    };
-    HRESULT STDMETHODCALLTYPE QueryInterface(REFIID, void **) { return E_NOTIMPL; }
-    ULONG STDMETHODCALLTYPE AddRef() { return InterlockedIncrement(&m_RefCount); }
-    ULONG STDMETHODCALLTYPE Release() {
-      ULONG rc = InterlockedDecrement(&m_RefCount);
-      if (rc == 0) delete this;
-      return rc;
-    }
-    VkCuModuleNVX Module;
-    VkCuFunctionNVX Function;
-    uint32_t BlockDimX, BlockDimY, BlockDimZ;
-    Rc<DxvkDevice> rcDxvkDevice;
-  private:
-    ULONG m_RefCount;
-  };
-  
-  
   /**
    * \brief D3D11 video device
    */

--- a/src/d3d11/d3d11_initializer.cpp
+++ b/src/d3d11/d3d11_initializer.cpp
@@ -264,12 +264,7 @@ namespace dxvk {
     // Initialize the image on the GPU
     std::lock_guard<dxvk::mutex> lock(m_mutex);
 
-    VkImageSubresourceRange subresources;
-    subresources.aspectMask     = image->formatInfo()->aspectMask;
-    subresources.baseMipLevel   = 0;
-    subresources.levelCount     = image->info().mipLevels;
-    subresources.baseArrayLayer = 0;
-    subresources.layerCount     = image->info().numLayers;
+    VkImageSubresourceRange subresources = image->getAvailableSubresources();
     
     m_context->initImage(image, subresources, VK_IMAGE_LAYOUT_PREINITIALIZED);
 

--- a/src/d3d11/d3d11_interfaces.h
+++ b/src/d3d11/d3d11_interfaces.h
@@ -14,6 +14,8 @@ enum D3D11_VK_EXTENSION : uint32_t {
   D3D11_VK_EXT_MULTI_DRAW_INDIRECT_COUNT  = 1,
   D3D11_VK_EXT_DEPTH_BOUNDS               = 2,
   D3D11_VK_EXT_BARRIER_CONTROL            = 3,
+  D3D11_VK_NVX_BINARY_IMPORT              = 4,
+  D3D11_VK_NVX_IMAGE_VIEW_HANDLE          = 5,
 };
 
 
@@ -42,6 +44,54 @@ ID3D11VkExtDevice : public IUnknown {
   virtual BOOL STDMETHODCALLTYPE GetExtensionSupport(
           D3D11_VK_EXTENSION      Extension) = 0;
   
+};
+
+
+/**
+ * \brief Extended extended D3D11 device
+ * 
+ * Introduces methods to get virtual addresses and driver
+ * handles for resources, and create and destroy objects
+ * for D3D11-Cuda interop.
+ */
+MIDL_INTERFACE("cfcf64ef-9586-46d0-bca4-97cf2ca61b06")
+ID3D11VkExtDevice1 : public ID3D11VkExtDevice {
+
+  virtual bool STDMETHODCALLTYPE GetResourceHandleGPUVirtualAddressAndSizeNVX(
+          void*                   hObject,
+          uint64_t*               gpuVAStart,
+          uint64_t*               gpuVASize) = 0;
+
+  virtual bool STDMETHODCALLTYPE CreateUnorderedAccessViewAndGetDriverHandleNVX(
+          ID3D11Resource*         pResource,
+          const D3D11_UNORDERED_ACCESS_VIEW_DESC* pDesc,
+          ID3D11UnorderedAccessView** ppUAV,
+          uint32_t*               pDriverHandle) = 0;
+
+  virtual bool STDMETHODCALLTYPE CreateShaderResourceViewAndGetDriverHandleNVX(
+          ID3D11Resource*         pResource,
+          const D3D11_SHADER_RESOURCE_VIEW_DESC* pDesc,
+          ID3D11ShaderResourceView** ppSRV,
+          uint32_t*               pDriverHandle) = 0;
+
+  virtual bool STDMETHODCALLTYPE CreateSamplerStateAndGetDriverHandleNVX(
+          const D3D11_SAMPLER_DESC* pSamplerDesc,
+          ID3D11SamplerState**    ppSamplerState,
+          uint32_t*               pDriverHandle) = 0;
+
+  virtual bool STDMETHODCALLTYPE CreateCubinComputeShaderWithNameNVX(
+          const void*             pCubin,
+          uint32_t                size,
+          uint32_t                blockX,
+          uint32_t                blockY,
+          uint32_t                blockZ,
+          const char*             pShaderName,
+          IUnknown**              phShader) = 0;
+
+  virtual bool STDMETHODCALLTYPE GetCudaTextureObjectNVX(
+          uint32_t                srvDriverHandle,
+          uint32_t                samplerDriverHandle,
+          uint32_t*               pCudaTextureHandle) = 0;
 };
 
 
@@ -88,13 +138,39 @@ ID3D11VkExtContext : public IUnknown {
   
   virtual void STDMETHODCALLTYPE SetBarrierControl(
           UINT                    ControlFlags) = 0;
-  
 };
+
+
+/**
+ * \brief Extended extended D3D11 context
+ * 
+ * Provides functionality to launch a Cuda kernel
+ */
+MIDL_INTERFACE("874b09b2-ae0b-41d8-8476-5f3b7a0e879d")
+ID3D11VkExtContext1 : public ID3D11VkExtContext {
+
+  virtual bool STDMETHODCALLTYPE LaunchCubinShaderNVX(
+          IUnknown*               hShader,
+          uint32_t                gridX,
+          uint32_t                gridY,
+          uint32_t                gridZ,
+          const void*             pParams,
+          uint32_t                paramSize,
+          const void**            pReadResources,
+          uint32_t                numReadResources,
+          const void**            pWriteResources,
+          uint32_t                numWriteResources) = 0;
+};
+
 
 #ifdef _MSC_VER
 struct __declspec(uuid("8a6e3c42-f74c-45b7-8265-a231b677ca17")) ID3D11VkExtDevice;
+struct __declspec(uuid("cfcf64ef-9586-46d0-bca4-97cf2ca61b06")) ID3D11VkExtDevice1;
 struct __declspec(uuid("fd0bca13-5cb6-4c3a-987e-4750de2ca791")) ID3D11VkExtContext;
+struct __declspec(uuid("874b09b2-ae0b-41d8-8476-5f3b7a0e879d")) ID3D11VkExtContext1;
 #else
 __CRT_UUID_DECL(ID3D11VkExtDevice,         0x8a6e3c42,0xf74c,0x45b7,0x82,0x65,0xa2,0x31,0xb6,0x77,0xca,0x17);
+__CRT_UUID_DECL(ID3D11VkExtDevice1,        0xcfcf64ef,0x9586,0x46d0,0xbc,0xa4,0x97,0xcf,0x2c,0xa6,0x1b,0x06);
 __CRT_UUID_DECL(ID3D11VkExtContext,        0xfd0bca13,0x5cb6,0x4c3a,0x98,0x7e,0x47,0x50,0xde,0x2c,0xa7,0x91);
+__CRT_UUID_DECL(ID3D11VkExtContext1,       0x874b09b2,0xae0b,0x41d8,0x84,0x76,0x5f,0x3b,0x7a,0x0e,0x87,0x9d);
 #endif

--- a/src/d3d11/d3d11_interfaces.h
+++ b/src/d3d11/d3d11_interfaces.h
@@ -156,9 +156,9 @@ ID3D11VkExtContext1 : public ID3D11VkExtContext {
           uint32_t                gridZ,
           const void*             pParams,
           uint32_t                paramSize,
-          const void**            pReadResources,
+          void* const*            pReadResources,
           uint32_t                numReadResources,
-          const void**            pWriteResources,
+          void* const*            pWriteResources,
           uint32_t                numWriteResources) = 0;
 };
 

--- a/src/d3d11/meson.build
+++ b/src/d3d11/meson.build
@@ -33,6 +33,7 @@ d3d11_src = [
   'd3d11_context_def.cpp',
   'd3d11_context_ext.cpp',
   'd3d11_context_imm.cpp',
+  'd3d11_cuda.cpp',
   'd3d11_depth_stencil.cpp',
   'd3d11_device.cpp',
   'd3d11_enums.cpp',

--- a/src/dxvk/dxvk_adapter.cpp
+++ b/src/dxvk/dxvk_adapter.cpp
@@ -263,7 +263,7 @@ namespace dxvk {
           DxvkDeviceFeatures  enabledFeatures) {
     DxvkDeviceExtensions devExtensions;
 
-    std::array<DxvkExt*, 25> devExtensionList = {{
+    std::array<DxvkExt*, 28> devExtensionList = {{
       &devExtensions.amdMemoryOverallocationBehaviour,
       &devExtensions.amdShaderFragmentMask,
       &devExtensions.ext4444Formats,
@@ -289,7 +289,16 @@ namespace dxvk {
       &devExtensions.khrSamplerMirrorClampToEdge,
       &devExtensions.khrShaderFloatControls,
       &devExtensions.khrSwapchain,
+      &devExtensions.nvxBinaryImport,
+      &devExtensions.nvxImageViewHandle,
+      &devExtensions.khrBufferDeviceAddress,
     }};
+
+    // VK_KHR_buffer_device_address can be expensive to enable on
+    // some drivers; only enable selectively for Cuda interop
+    if (m_deviceExtensions.supports(devExtensions.nvxBinaryImport.name()) &&
+        m_deviceExtensions.supports(devExtensions.nvxImageViewHandle.name()))
+      devExtensions.khrBufferDeviceAddress.setMode(DxvkExtMode::Optional);
 
     DxvkNameSet extensionsEnabled;
 

--- a/src/dxvk/dxvk_barrier.cpp
+++ b/src/dxvk/dxvk_barrier.cpp
@@ -13,6 +13,19 @@ namespace dxvk {
   }
 
   
+  void DxvkBarrierSet::accessMemory(
+          VkPipelineStageFlags      srcStages,
+          VkAccessFlags             srcAccess,
+          VkPipelineStageFlags      dstStages,
+          VkAccessFlags             dstAccess) {
+    m_srcStages |= srcStages;
+    m_dstStages |= dstStages;
+    
+    m_srcAccess |= srcAccess;
+    m_dstAccess |= dstAccess;
+  }
+
+
   void DxvkBarrierSet::accessBuffer(
     const DxvkBufferSliceHandle&    bufSlice,
           VkPipelineStageFlags      srcStages,

--- a/src/dxvk/dxvk_barrier.h
+++ b/src/dxvk/dxvk_barrier.h
@@ -19,7 +19,13 @@ namespace dxvk {
     
     DxvkBarrierSet(DxvkCmdBuffer cmdBuffer);
     ~DxvkBarrierSet();
-        
+
+    void accessMemory(
+            VkPipelineStageFlags      srcStages,
+            VkAccessFlags             srcAccess,
+            VkPipelineStageFlags      dstStages,
+            VkAccessFlags             dstAccess);
+
     void accessBuffer(
       const DxvkBufferSliceHandle&    bufSlice,
             VkPipelineStageFlags      srcStages,

--- a/src/dxvk/dxvk_cmdlist.h
+++ b/src/dxvk/dxvk_cmdlist.h
@@ -340,6 +340,9 @@ namespace dxvk {
         pSizes, pStrides);
     }
     
+    void cmdLaunchCuKernel(VkCuLaunchInfoNVX launchInfo) {
+      m_vkd->vkCmdCuLaunchKernelNVX(m_execBuffer, &launchInfo);
+    }
     
     void cmdBlitImage(
             VkImage                 srcImage,

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -1,4 +1,6 @@
 #include <cstring>
+#include <vector>
+#include <utility>
 
 #include "dxvk_device.h"
 #include "dxvk_context.h"
@@ -302,12 +304,7 @@ namespace dxvk {
     if (image->info().layout != layout) {
       this->spillRenderPass(true);
 
-      VkImageSubresourceRange subresources;
-      subresources.aspectMask     = image->formatInfo()->aspectMask;
-      subresources.baseArrayLayer = 0;
-      subresources.baseMipLevel   = 0;
-      subresources.layerCount     = image->info().numLayers;
-      subresources.levelCount     = image->info().mipLevels;
+      VkImageSubresourceRange subresources = image->getAvailableSubresources();
 
       this->prepareImage(m_execBarriers, image, subresources);
 
@@ -2607,6 +2604,134 @@ namespace dxvk {
 
     m_cmd->trackGpuEvent(event->reset(handle));
     m_cmd->trackResource<DxvkAccess::None>(event);
+  }
+  
+
+  void DxvkContext::launchCuKernelNVX(
+         VkCuLaunchInfoNVX& nvxLaunchInfo,
+         std::vector<std::pair<Rc<DxvkBuffer>, DxvkAccessFlags>>& buffers,
+         std::vector<std::pair<Rc<DxvkImage>, DxvkAccessFlags>>& images)
+  {
+    // the resources in the std::vectors above are called-out
+    // explicitly in the API for barrier and tracking purposes
+    // since they're being used bindlessly.
+
+    // resources may appear multiple times as both read and write,
+    // so start by merging the duplicates.  note: in practice
+    // there are typically just a handful of resources.
+    auto MergeAccessFlagsForDuplicates = [](auto& vec) {
+      for (int i = 0; i < vec.size(); i++) {
+        for (int j = i+1; j < vec.size(); j++) {
+          if (vec[i].first == vec[j].first) {
+            // merge dupe into earlier entry
+            vec[i].second.set(vec[j].second);
+            // remove dupe by swapping-to-back then shrinking vector
+            std::swap(vec[j], vec.back());
+            vec.pop_back();
+          }
+        }
+      }
+    };
+    MergeAccessFlagsForDuplicates(images);
+    MergeAccessFlagsForDuplicates(buffers);
+
+    this->spillRenderPass(true);
+
+    for (auto& r : images) {
+      auto& img = r.first;
+      this->prepareImage(m_execBarriers, img, img->getAvailableSubresources());
+    }
+
+    bool needExecBarrierFlush = false;
+    for (auto& r : buffers) {
+      if (m_execBarriers.isBufferDirty(r.first->getSliceHandle(), r.second)) {
+        needExecBarrierFlush = true;
+        break;
+      }
+    }
+    if (!needExecBarrierFlush) {
+      for (auto& r : images) {
+        auto& img = r.first;
+        if (m_execBarriers.isImageDirty(img, img->getAvailableSubresources(), r.second)) {
+          needExecBarrierFlush = true;
+          break;
+        }
+      }
+    }
+
+    // flush any outstanding barriers for dirty inputs/outputs
+    if (needExecBarrierFlush)
+      m_execBarriers.recordCommands(m_cmd);
+
+    // create acquisition barriers
+    for (auto& r : buffers) {
+      auto& buf = r.first;
+      VkAccessFlags accessFlags = (r.second.test(DxvkAccess::Read) * VK_ACCESS_SHADER_READ_BIT) | (r.second.test(DxvkAccess::Write) * VK_ACCESS_SHADER_WRITE_BIT);
+      DxvkBufferSliceHandle bufferSlice = buf->getSliceHandle();
+      m_execAcquires.accessBuffer(
+        bufferSlice,
+        buf->info().stages,
+        buf->info().access,
+        VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
+        accessFlags);
+    }
+    for (auto& r : images) {
+      auto& img = r.first;
+      VkAccessFlags accessFlags = (r.second.test(DxvkAccess::Read) * VK_ACCESS_SHADER_READ_BIT) | (r.second.test(DxvkAccess::Write) * VK_ACCESS_SHADER_WRITE_BIT);
+      m_execAcquires.accessImage(
+        img,
+        img->getAvailableSubresources(),
+        img->info().layout,
+        img->info().stages,
+        img->info().access,
+        img->info().layout,
+        VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
+        accessFlags
+        );
+    }
+
+    // flush acquisition barriers
+    m_execAcquires.recordCommands(m_cmd);
+
+    // now actually run the cuda kernel
+    m_cmd->cmdLaunchCuKernel(nvxLaunchInfo);
+
+    // transition resources back to expected state
+    for (auto& r : buffers) {
+      auto& buf = r.first;
+      VkAccessFlags accessFlags = (r.second.test(DxvkAccess::Read) * VK_ACCESS_SHADER_READ_BIT) | (r.second.test(DxvkAccess::Write) * VK_ACCESS_SHADER_WRITE_BIT);
+      DxvkBufferSliceHandle bufferSlice = buf->getSliceHandle();
+      m_execBarriers.accessBuffer(
+        bufferSlice,
+        VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
+        accessFlags,
+        buf->info().stages,
+        buf->info().access);
+    }
+    for (auto& r : images) {
+      auto& img = r.first;
+      VkAccessFlags accessFlags = (r.second.test(DxvkAccess::Read) * VK_ACCESS_SHADER_READ_BIT) | (r.second.test(DxvkAccess::Write) * VK_ACCESS_SHADER_WRITE_BIT);
+      m_execBarriers.accessImage(
+        img,
+        img->getAvailableSubresources(),
+        img->info().layout,
+        VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
+        accessFlags,
+        img->info().layout,
+        img->info().stages,
+        img->info().access
+        );
+    }
+
+    // add keepalive refs for resources until cmdlist is done
+    for (auto& r : images) {
+      if (r.second.test(DxvkAccess::Read)) m_cmd->trackResource<DxvkAccess::Read>(r.first);
+      if (r.second.test(DxvkAccess::Write)) m_cmd->trackResource<DxvkAccess::Write>(r.first);
+    }
+    for (auto& r : buffers) {
+      if (r.second.test(DxvkAccess::Read)) m_cmd->trackResource<DxvkAccess::Read>(r.first);
+      if (r.second.test(DxvkAccess::Write)) m_cmd->trackResource<DxvkAccess::Write>(r.first);
+    }
   }
   
   

--- a/src/dxvk/dxvk_context.h
+++ b/src/dxvk/dxvk_context.h
@@ -1002,9 +1002,9 @@ namespace dxvk {
      * \param [in] images List of {image,read,write} used by kernel
      */
     void launchCuKernelNVX(
-            VkCuLaunchInfoNVX& nvxLaunchInfo,
-            std::vector<std::pair<Rc<DxvkBuffer>, DxvkAccessFlags>>& buffers,
-            std::vector<std::pair<Rc<DxvkImage>, DxvkAccessFlags>>& images);
+      const VkCuLaunchInfoNVX& nvxLaunchInfo,
+      const std::vector<std::pair<Rc<DxvkBuffer>, DxvkAccessFlags>>& buffers,
+      const std::vector<std::pair<Rc<DxvkImage>, DxvkAccessFlags>>& images);
     
     /**
      * \brief Signals a GPU event

--- a/src/dxvk/dxvk_context.h
+++ b/src/dxvk/dxvk_context.h
@@ -6,6 +6,7 @@
 #include "dxvk_context_state.h"
 #include "dxvk_data.h"
 #include "dxvk_objects.h"
+#include "dxvk_resource.h"
 #include "dxvk_util.h"
 
 namespace dxvk {
@@ -987,6 +988,23 @@ namespace dxvk {
      */
     void setBarrierControl(
             DxvkBarrierControlFlags control);
+    
+    /**
+     * \brief Launches a Cuda kernel
+     *
+     * Since the kernel is launched with an opaque set of
+     * kernel-specific parameters which may reference
+     * resources bindlessly, such resources must be listed by
+     * the caller in the 'buffers' and 'images' parameters so
+     * that their access may be tracked appropriately.
+     * \param [in] nvxLaunchInfo Kernel launch parameter struct
+     * \param [in] buffers List of {buffer,read,write} used by kernel
+     * \param [in] images List of {image,read,write} used by kernel
+     */
+    void launchCuKernelNVX(
+            VkCuLaunchInfoNVX& nvxLaunchInfo,
+            std::vector<std::pair<Rc<DxvkBuffer>, DxvkAccessFlags>>& buffers,
+            std::vector<std::pair<Rc<DxvkImage>, DxvkAccessFlags>>& images);
     
     /**
      * \brief Signals a GPU event

--- a/src/dxvk/dxvk_extensions.h
+++ b/src/dxvk/dxvk_extensions.h
@@ -283,6 +283,9 @@ namespace dxvk {
     DxvkExt khrSamplerMirrorClampToEdge       = { VK_KHR_SAMPLER_MIRROR_CLAMP_TO_EDGE_EXTENSION_NAME,       DxvkExtMode::Optional };
     DxvkExt khrShaderFloatControls            = { VK_KHR_SHADER_FLOAT_CONTROLS_EXTENSION_NAME,              DxvkExtMode::Optional };
     DxvkExt khrSwapchain                      = { VK_KHR_SWAPCHAIN_EXTENSION_NAME,                          DxvkExtMode::Required };
+    DxvkExt nvxBinaryImport                   = { VK_NVX_BINARY_IMPORT_EXTENSION_NAME,                      DxvkExtMode::Optional };
+    DxvkExt nvxImageViewHandle                = { VK_NVX_IMAGE_VIEW_HANDLE_EXTENSION_NAME,                  DxvkExtMode::Optional };
+    DxvkExt khrBufferDeviceAddress            = { VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME,              DxvkExtMode::Disabled };
   };
   
   /**

--- a/src/dxvk/dxvk_image.h
+++ b/src/dxvk/dxvk_image.h
@@ -298,6 +298,21 @@ namespace dxvk {
     VkDeviceSize memSize() const {
       return m_image.memory.length();
     }
+
+    /**
+     * \brief Get full subresource range of the image
+     * 
+     * \returns Resource range of the whole image
+     */
+    VkImageSubresourceRange getAvailableSubresources() const {
+      VkImageSubresourceRange result;
+      result.aspectMask     = formatInfo()->aspectMask;
+      result.baseMipLevel   = 0;
+      result.levelCount     = info().mipLevels;
+      result.baseArrayLayer = 0;
+      result.layerCount     = info().numLayers;
+      return result;
+    }
     
   private:
     

--- a/src/vulkan/vulkan_loader.h
+++ b/src/vulkan/vulkan_loader.h
@@ -347,6 +347,23 @@ namespace dxvk::vk {
     VULKAN_FN(vkCmdBeginQueryIndexedEXT);
     VULKAN_FN(vkCmdEndQueryIndexedEXT);
     #endif
+
+    #ifdef VK_NVX_image_view_handle
+    VULKAN_FN(vkGetImageViewHandleNVX);
+    VULKAN_FN(vkGetImageViewAddressNVX);
+    #endif
+
+    #ifdef VK_NVX_binary_import
+    VULKAN_FN(vkCreateCuModuleNVX);
+    VULKAN_FN(vkCreateCuFunctionNVX);
+    VULKAN_FN(vkDestroyCuModuleNVX);
+    VULKAN_FN(vkDestroyCuFunctionNVX);
+    VULKAN_FN(vkCmdCuLaunchKernelNVX);
+    #endif
+
+    #ifdef VK_KHR_buffer_device_address
+    VULKAN_FN(vkGetBufferDeviceAddressKHR);
+    #endif
   };
   
 }


### PR DESCRIPTION
Notably, fairly generic functions to create/launch/destroy Cuda kernels,
and methods to fetch GPU virtual addresses and handles for DX11 resources.

Depends upon https://github.com/doitsujin/dxvk/pull/2287

Note: Also requires some corresponding dxvk-nvapi [changes](https://github.com/jp7677/dxvk-nvapi/pull/33) for [DLSS](https://developer.nvidia.com/dlss) to
be initialized successfully.
