### PR TITLE
Fix raw() accessor on the Flags class

### DIFF
--- a/src/util/util_flags.h
+++ b/src/util/util_flags.h
@@ -64,7 +64,7 @@ namespace dxvk {
       m_bits = 0;
     }
     
-    uint32_t raw() const {
+    IntType raw() const {
       return m_bits;
     }
     


### PR DESCRIPTION
The current implementation has a bug where it casts the underlying
int type to a uint32_t. The is incorrect for enums like DxvkShaderFlag
which are based on uint64_t.