### PR TITLE
Fix DxvkShaderConstData garbage pointer for default c'tor

### DIFF
--- a/src/dxvk/dxvk_shader.cpp
+++ b/src/dxvk/dxvk_shader.cpp
@@ -6,7 +6,8 @@
 
 namespace dxvk {
   
-  DxvkShaderConstData::DxvkShaderConstData() : m_size(0), m_data(nullptr) {
+  DxvkShaderConstData::DxvkShaderConstData()
+  : m_size(0), m_data(nullptr) {
 
   }
 

--- a/src/dxvk/dxvk_shader.cpp
+++ b/src/dxvk/dxvk_shader.cpp
@@ -6,7 +6,7 @@
 
 namespace dxvk {
   
-  DxvkShaderConstData::DxvkShaderConstData() {
+  DxvkShaderConstData::DxvkShaderConstData() : m_size(0), m_data(nullptr) {
 
   }
 


### PR DESCRIPTION
The current default c'tor DxvkShaderConstData doesn't set the m_data
pointer. The copy c'tor takes over that pointer when assigning, which
results in seg faults if an object is ever assigned. This fixes it by
initializing the correct data.