### PR TITLE
Rework D3D9 float emulation

### DIFF
--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -6330,11 +6330,7 @@ namespace dxvk {
     }
 
     UpdateStateConstants<ProgramType, ConstantType, T>(
-      &m_state,
-      StartRegister,
-      pConstantData,
-      Count,
-      m_d3d9Options.d3d9FloatEmulation);
+      &m_state, StartRegister, pConstantData, Count);
 
     return D3D_OK;
   }

--- a/src/d3d9/d3d9_state.h
+++ b/src/d3d9/d3d9_state.h
@@ -241,20 +241,12 @@ namespace dxvk {
           D3D9CapturableState* pState,
           UINT                 StartRegister,
     const T*                   pConstantData,
-          UINT                 Count,
-          bool                 FloatEmu) {
+          UINT                 Count) {
     auto UpdateHelper = [&] (auto& set) {
       if constexpr (ConstantType == D3D9ConstantType::Float) {
+        size_t size = Count * sizeof(Vector4);
 
-        if (!FloatEmu) {
-          size_t size = Count * sizeof(Vector4);
-
-          std::memcpy(set.fConsts[StartRegister].data, pConstantData, size);
-        }
-        else {
-          for (UINT i = 0; i < Count; i++)
-            set.fConsts[StartRegister + i] = replaceNaN(pConstantData + (i * 4));
-        }
+        std::memcpy(set.fConsts[StartRegister].data, pConstantData, size);
       }
       else if constexpr (ConstantType == D3D9ConstantType::Int) {
         size_t size = Count * sizeof(Vector4i);

--- a/src/d3d9/d3d9_stateblock.h
+++ b/src/d3d9/d3d9_stateblock.h
@@ -331,15 +331,8 @@ namespace dxvk {
             setCaptures.bConsts.set(reg, true);
         }
 
-        UpdateStateConstants<
-          ProgramType,
-          ConstantType,
-          T>(
-            &m_state,
-            StartRegister,
-            pConstantData,
-            Count,
-            false);
+        UpdateStateConstants<ProgramType, ConstantType, T>(
+          &m_state, StartRegister, pConstantData, Count);
 
         return D3D_OK;
       };

--- a/src/dxso/dxso_compiler.cpp
+++ b/src/dxso/dxso_compiler.cpp
@@ -2275,12 +2275,7 @@ namespace dxvk {
     result.type.ctype  = dst.type.ctype;
     result.type.ccount = componentCount;
 
-    DxsoVectorType scalarType;
-    scalarType.ctype = result.type.ctype;
-    scalarType.ccount = 1;
-
     const uint32_t typeId = getVectorTypeId(result.type);
-    const uint32_t scalarTypeId = getVectorTypeId(scalarType);
 
     DxsoRegMask srcMask(true, true, true, dotCount == 4);
     std::array<uint32_t, 4> indices;
@@ -2289,9 +2284,9 @@ namespace dxvk {
     DxsoRegister src1 = ctx.src[1];
 
     for (uint32_t i = 0; i < componentCount; i++) {
-      indices[i] = m_module.opDot(scalarTypeId,
-        emitRegisterLoad(src0, srcMask).id,
-        emitRegisterLoad(src1, srcMask).id);
+      indices[i] = emitDot(
+        emitRegisterLoad(src0, srcMask),
+        emitRegisterLoad(src1, srcMask)).id;
 
       src1.id.num++;
     }

--- a/src/dxso/dxso_compiler.cpp
+++ b/src/dxso/dxso_compiler.cpp
@@ -2079,15 +2079,15 @@ namespace dxvk {
         const uint32_t z = 2;
         const uint32_t w = 3;
 
-        uint32_t src0Y = m_module.opCompositeExtract(scalarTypeId, src0, 1, &y);
-        uint32_t src1Y = m_module.opCompositeExtract(scalarTypeId, src1, 1, &y);
+        DxsoRegisterValue src0Y = { scalarType, m_module.opCompositeExtract(scalarTypeId, src0, 1, &y) };
+        DxsoRegisterValue src1Y = { scalarType, m_module.opCompositeExtract(scalarTypeId, src1, 1, &y) };
 
         uint32_t src0Z = m_module.opCompositeExtract(scalarTypeId, src0, 1, &z);
         uint32_t src1W = m_module.opCompositeExtract(scalarTypeId, src1, 1, &w);
 
         std::array<uint32_t, 4> resultIndices;
         resultIndices[0] = m_module.constf32(1.0f);
-        resultIndices[1] = m_module.opFMul(scalarTypeId, src0Y, src1Y);
+        resultIndices[1] = emitMul(src0Y, src1Y).id;
         resultIndices[2] = src0Z;
         resultIndices[3] = src1W;
 

--- a/src/dxso/dxso_compiler.cpp
+++ b/src/dxso/dxso_compiler.cpp
@@ -1880,11 +1880,6 @@ namespace dxvk {
         result.id = m_module.opFDiv(typeId,
           m_module.constfReplicant(1.0f, result.type.ccount),
           emitRegisterLoad(src[0], mask).id);
-
-        if (m_moduleInfo.options.d3d9FloatEmulation) {
-          result.id = m_module.opNMin(typeId, result.id,
-            m_module.constfReplicant(FLT_MAX, result.type.ccount));
-        }
         break;
       case DxsoOpcode::Rsq: 
         result.id = m_module.opFAbs(typeId,
@@ -1892,11 +1887,6 @@ namespace dxvk {
 
         result.id = m_module.opInverseSqrt(typeId,
           result.id);
-
-        if (m_moduleInfo.options.d3d9FloatEmulation) {
-          result.id = m_module.opNMin(typeId, result.id,
-            m_module.constfReplicant(FLT_MAX, result.type.ccount));
-        }
         break;
       case DxsoOpcode::Dp3: {
         DxsoRegMask srcMask(true, true, true, false);
@@ -2012,10 +2002,6 @@ namespace dxvk {
 
         DxsoRegisterValue dot = emitDot(vec3, vec3);
         dot.id = m_module.opInverseSqrt (scalarTypeId, dot.id);
-        if (m_moduleInfo.options.d3d9FloatEmulation) {
-          dot.id = m_module.opNMin        (scalarTypeId, dot.id,
-            m_module.constf32(FLT_MAX));
-        }
 
         // r * rsq(r . r);
         result.id = m_module.opVectorTimesScalar(
@@ -2129,10 +2115,6 @@ namespace dxvk {
       case DxsoOpcode::Log:
         result.id = m_module.opFAbs(typeId, emitRegisterLoad(src[0], mask).id);
         result.id = m_module.opLog2(typeId, result.id);
-        if (m_moduleInfo.options.d3d9FloatEmulation) {
-          result.id = m_module.opNMax(typeId, result.id,
-            m_module.constfReplicant(-FLT_MAX, result.type.ccount));
-        }
         break;
       case DxsoOpcode::Lrp:
         result.id = m_module.opFMix(typeId,

--- a/src/dxso/dxso_compiler.cpp
+++ b/src/dxso/dxso_compiler.cpp
@@ -2631,7 +2631,7 @@ void DxsoCompiler::emitControlFlowGenericLoop(
         reg.id.num -= (count - 1) - i;
         auto m = emitRegisterLoadTexcoord(reg, vec3Mask);
 
-        indices[i] = m_module.opDot(getScalarTypeId(DxsoScalarType::Float32), m.id, n.id);
+        indices[i] = emitDot(m, n).id;
       }
 
       if (opcode == DxsoOpcode::TexM3x3Spec || opcode == DxsoOpcode::TexM3x3VSpec) {

--- a/src/dxso/dxso_compiler.cpp
+++ b/src/dxso/dxso_compiler.cpp
@@ -1352,15 +1352,61 @@ namespace dxvk {
   }
 
 
+  DxsoRegisterValue DxsoCompiler::emitMulOperand(
+          DxsoRegisterValue       operand,
+          DxsoRegisterValue       other) {
+    if (!m_moduleInfo.options.d3d9FloatEmulation)
+      return operand;
+
+    uint32_t boolId = getVectorTypeId({ DxsoScalarType::Bool, other.type.ccount });
+    uint32_t zeroId = m_module.constfReplicant(0.0f, other.type.ccount);
+
+    DxsoRegisterValue result;
+    result.type = operand.type;
+    result.id = m_module.opSelect(getVectorTypeId(result.type),
+      m_module.opFOrdEqual(boolId, other.id, zeroId), zeroId, operand.id);
+    return result;
+  }
+
+
+  DxsoRegisterValue DxsoCompiler::emitMul(
+          DxsoRegisterValue       a,
+          DxsoRegisterValue       b) {
+    auto az = emitMulOperand(a, b);
+    auto bz = emitMulOperand(b, a);
+
+    DxsoRegisterValue result;
+    result.type = a.type;
+    result.id = m_module.opFMul(getVectorTypeId(result.type), az.id, bz.id);
+    return result;
+  }
+
+
+  DxsoRegisterValue DxsoCompiler::emitFma(
+          DxsoRegisterValue       a,
+          DxsoRegisterValue       b,
+          DxsoRegisterValue       c) {
+    auto az = emitMulOperand(a, b);
+    auto bz = emitMulOperand(b, a);
+
+    DxsoRegisterValue result;
+    result.type = a.type;
+    result.id = m_module.opFFma(getVectorTypeId(result.type), az.id, bz.id, c.id);
+    return result;
+  }
+
+
   DxsoRegisterValue DxsoCompiler::emitDot(
             DxsoRegisterValue       a,
             DxsoRegisterValue       b) {
+    auto az = emitMulOperand(a, b);
+    auto bz = emitMulOperand(b, a);
+
     DxsoRegisterValue dot;
     dot.type        = a.type;
     dot.type.ccount = 1;
 
-    dot.id = m_module.opDot(getVectorTypeId(dot.type), a.id, b.id);
-
+    dot.id = m_module.opDot(getVectorTypeId(dot.type), az.id, bz.id);
     return dot;
   }
 
@@ -1780,15 +1826,15 @@ namespace dxvk {
         break;
       case DxsoOpcode::Mad:
         if (!m_moduleInfo.options.longMad) {
-          result.id = m_module.opFFma(typeId,
-            emitRegisterLoad(src[0], mask).id,
-            emitRegisterLoad(src[1], mask).id,
-            emitRegisterLoad(src[2], mask).id);
+          result.id = emitFma(
+            emitRegisterLoad(src[0], mask),
+            emitRegisterLoad(src[1], mask),
+            emitRegisterLoad(src[2], mask)).id;
         }
         else {
-          result.id = m_module.opFMul(typeId,
-            emitRegisterLoad(src[0], mask).id,
-            emitRegisterLoad(src[1], mask).id);
+          result.id = emitMul(
+            emitRegisterLoad(src[0], mask),
+            emitRegisterLoad(src[1], mask)).id;
 
           result.id = m_module.opFAdd(typeId,
             result.id,
@@ -1796,9 +1842,9 @@ namespace dxvk {
         }
         break;
       case DxsoOpcode::Mul:
-        result.id = m_module.opFMul(typeId,
-          emitRegisterLoad(src[0], mask).id,
-          emitRegisterLoad(src[1], mask).id);
+        result.id = emitMul(
+          emitRegisterLoad(src[0], mask),
+          emitRegisterLoad(src[1], mask)).id;
         break;
       case DxsoOpcode::Rcp:
         result.id = m_module.opFDiv(typeId,

--- a/src/dxso/dxso_compiler.h
+++ b/src/dxso/dxso_compiler.h
@@ -553,6 +553,10 @@ namespace dxvk {
             DxsoRegisterValue       a,
             DxsoRegisterValue       b);
 
+    DxsoRegisterValue emitCross(
+            DxsoRegisterValue       a,
+            DxsoRegisterValue       b);
+
     DxsoRegisterValue emitRegisterInsert(
             DxsoRegisterValue       dstValue,
             DxsoRegisterValue       srcValue,

--- a/src/dxso/dxso_compiler.h
+++ b/src/dxso/dxso_compiler.h
@@ -536,6 +536,19 @@ namespace dxvk {
     DxsoRegisterValue emitSaturate(
             DxsoRegisterValue       srcValue);
 
+    DxsoRegisterValue emitMulOperand(
+            DxsoRegisterValue       operand,
+            DxsoRegisterValue       other);
+
+    DxsoRegisterValue emitMul(
+            DxsoRegisterValue       a,
+            DxsoRegisterValue       b);
+
+    DxsoRegisterValue emitFma(
+            DxsoRegisterValue       a,
+            DxsoRegisterValue       b,
+            DxsoRegisterValue       c);
+
     DxsoRegisterValue emitDot(
             DxsoRegisterValue       a,
             DxsoRegisterValue       b);

--- a/src/util/util_vector.h
+++ b/src/util/util_vector.h
@@ -149,13 +149,4 @@ namespace dxvk {
   static_assert(sizeof(Vector4)  == sizeof(float) * 4);
   static_assert(sizeof(Vector4i) == sizeof(int)   * 4);
 
-  inline Vector4 replaceNaN(Vector4 a) {
-    Vector4 result;
-    __m128 value = _mm_load_ps(a.data);
-    __m128 mask  = _mm_cmpeq_ps(value, value);
-           value = _mm_and_ps(value, mask);
-    _mm_store_ps(result.data, value);
-    return result;
-  }
-
 }


### PR DESCRIPTION
Replaces almost every occurence of `a * b` with `(b == 0 ? 0 : a) * (a == 0 ? 0 : b)` if we know that both operands may be zero. I've omitted the TexBem instructions for now since I don't know what those do exactly and if there are any NaNs to filter out there, but everythig else should be handled.

The existing `d3d9.floatEmulation` option still works, and setting it to `false` effectively disables this.

Fixes stuff like #2107, but will obviously need a fair bit of testing.