### PR TITLE
Temporarily remove blanket feature check with the DX11 feature levels

### DIFF
--- a/src/d3d11/d3d11_device.h
+++ b/src/d3d11/d3d11_device.h
@@ -664,6 +664,34 @@ namespace dxvk {
     D3D11Device*     m_device;
     
   };
+
+  /**
+ * \brief D2DPrivateInfo
+ */
+  class D2DPrivateInfo : public ID2DPrivateInfo {
+
+  public:
+      D2DPrivateInfo(
+          D3D11DXGIDevice* pContainer,
+          D3D11Device* pDevice);
+
+      ULONG STDMETHODCALLTYPE AddRef();
+
+      ULONG STDMETHODCALLTYPE Release();
+
+      HRESULT STDMETHODCALLTYPE QueryInterface(
+          REFIID                  riid,
+          void** ppvObject);
+
+      UINT ConservativeFlushCount(void) { return 0; }
+
+  private:
+
+      D3D11DXGIDevice* m_container;
+      D3D11Device* m_device;
+
+  };
+
   
 
   /**
@@ -793,6 +821,8 @@ namespace dxvk {
     DXGIDXVKDevice      m_metaDevice;
     
     WineDXGISwapChainFactory m_wineFactory;
+
+    D2DPrivateInfo m_d2dPrivateInfo;
     
     uint32_t m_frameLatency = DefaultFrameLatency;
 

--- a/src/dxgi/dxgi_interfaces.h
+++ b/src/dxgi/dxgi_interfaces.h
@@ -354,6 +354,15 @@ IWineDXGISwapChainFactory : public IUnknown {
             IDXGISwapChain1**       ppSwapChain) = 0;
 };
 
+MIDL_INTERFACE("26c5dc23-e49c-4b0a-8f79-e7b1ac804d32")
+ID3D11PartnerDevice2 : public IUnknown{
+};
+
+MIDL_INTERFACE("b79cc8da-337f-400f-b09d-b2edf8a84e47")
+ID2DPrivateInfo : public IUnknown
+{
+    virtual UINT ConservativeFlushCount(void) = 0;
+};
 
 #ifdef _MSC_VER
 struct __declspec(uuid("907bf281-ea3c-43b4-a8e4-9f231107b4ff")) IDXGIDXVKAdapter;

--- a/src/dxvk/dxvk_adapter.cpp
+++ b/src/dxvk/dxvk_adapter.cpp
@@ -263,7 +263,7 @@ namespace dxvk {
           DxvkDeviceFeatures  enabledFeatures) {
     DxvkDeviceExtensions devExtensions;
 
-    std::array<DxvkExt*, 25> devExtensionList = {{
+    std::vector<DxvkExt*> devExtensionList = {
       &devExtensions.amdMemoryOverallocationBehaviour,
       &devExtensions.amdShaderFragmentMask,
       &devExtensions.ext4444Formats,
@@ -285,11 +285,11 @@ namespace dxvk {
       &devExtensions.khrDepthStencilResolve,
       &devExtensions.khrDrawIndirectCount,
       &devExtensions.khrDriverProperties,
-      &devExtensions.khrImageFormatList,
+      //&devExtensions.khrImageFormatList,
       &devExtensions.khrSamplerMirrorClampToEdge,
       &devExtensions.khrShaderFloatControls,
       &devExtensions.khrSwapchain,
-    }};
+    };
 
     DxvkNameSet extensionsEnabled;
 


### PR DESCRIPTION
These changes are needed to get DX11 compatibility with the Juice icd.