### PR TITLE
[d3d11] Only use cube arrays for regular cubemap views on FL10_1 or h…

### DIFF
--- a/src/d3d11/d3d11_view_srv.cpp
+++ b/src/d3d11/d3d11_view_srv.cpp
@@ -144,13 +144,14 @@ namespace dxvk {
           viewInfo.numLayers = 1;
           break;
           
-        case D3D11_SRV_DIMENSION_TEXTURECUBE:
-          viewInfo.type      = VK_IMAGE_VIEW_TYPE_CUBE_ARRAY;
+        case D3D11_SRV_DIMENSION_TEXTURECUBE: {
+          const bool cubeArraysEnabled = pDevice->GetDXVKDevice()->features().core.features.imageCubeArray;
+          viewInfo.type      = cubeArraysEnabled ? VK_IMAGE_VIEW_TYPE_CUBE_ARRAY : VK_IMAGE_VIEW_TYPE_CUBE;
           viewInfo.minLevel  = pDesc->TextureCube.MostDetailedMip;
           viewInfo.numLevels = pDesc->TextureCube.MipLevels;
           viewInfo.minLayer  = 0;
           viewInfo.numLayers = 6;
-          break;
+        } break;
           
         case D3D11_SRV_DIMENSION_TEXTURECUBEARRAY:
           viewInfo.type      = VK_IMAGE_VIEW_TYPE_CUBE_ARRAY;


### PR DESCRIPTION
Should fix
```
VUID-VkImageViewCreateInfo-viewType-01004(ERROR / SPEC): msgNum: 1838557948 - Validation Error: [ VUID-VkImageViewCreateInfo-viewType-01004 ] Object 0: handle = 0xead9370000000008, type = VK_OBJECT_TYPE_IMAGE; | MessageID = 0x6d962afc | vkCreateImageView(): pCreateInfo->viewType can't be VK_IMAGE_VIEW_TYPE_CUBE_ARRAY without enabling the imageCubeArray feature. The Vulkan spec states: If the image cubemap arrays feature is not enabled, viewType must not be VK_IMAGE_VIEW_TYPE_CUBE_ARRAY (https://www.khronos.org/registry/vulkan/specs/1.2-extensions/html/vkspec.html#VUID-VkImageViewCreateInfo-viewType-01004)
    Objects: 1
        [0] 0xead9370000000008, type: 10, name: NULL
```
reported by Cherser on Discord with EA Origin. I dont see how else, this validation error could come up. We always enable the feature for higher feature levels.