### PR TITLE
Revert "[d3d9] Avoid depth degenerate viewports"

### DIFF
--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -5442,16 +5442,12 @@ namespace dxvk {
     // Originally we did this only for powers of two
     // resolutions but since NEAREST filtering fixed to
     // truncate, we need to do this all the time now.
-    constexpr float cf = 0.5f - (1.0f / 128.0f);
-
-    // How much to bias MinZ by to avoid a depth
-    // degenerate viewport.
-    constexpr float zBias = 0.001f;
+    float cf = 0.5f - (1.0f / 128.0f);
 
     viewport = VkViewport{
       float(vp.X)     + cf,    float(vp.Height + vp.Y) + cf,
       float(vp.Width),        -float(vp.Height),
-      vp.MinZ,                 std::max(vp.MaxZ, vp.MinZ + zBias),
+      vp.MinZ,                 vp.MaxZ,
     };
 
     // Scissor rectangles. Vulkan does not provide an easy way


### PR DESCRIPTION
This reverts commit 78d22cc7a5e03817ed06002f50120bfe77efcdd3.

I think this just fixed a Wine test and no actual games. Meanwhile it seems to break Stalker and apparently other games.
Feel free to come up with a better solution. :)

Fixes #2300