### PR TITLE
[dxgi] Return success from DxgiSwapChain::Present1() if window is destroyed

### DIFF
--- a/src/dxgi/dxgi_swapchain.cpp
+++ b/src/dxgi/dxgi_swapchain.cpp
@@ -255,8 +255,9 @@ namespace dxvk {
           UINT                      SyncInterval,
           UINT                      PresentFlags,
     const DXGI_PRESENT_PARAMETERS*  pPresentParameters) {
+
     if (!IsWindow(m_window))
-      return DXGI_ERROR_INVALID_CALL;
+      return S_OK;
     
     if (SyncInterval > 4)
       return DXGI_ERROR_INVALID_CALL;


### PR DESCRIPTION
That is what wined3d does. I could not find an existing test for _Present on already destroyed window but I tested that (for d3d10 and d3d11) and _Present still returns success.

Fixes one of the possible CoD: Infinite Warfare hang on exit scenarious (there are few of them, other are related to user32 / winex11.drv / winevulkan interaction for a specific case). What happens is:
 - On exit the window gets destroyed first (not related here, but there is specifics causing the mentioned issues not related to dxvk: main threads sends WM_QUIT to the message queue and GUI thread just exits with the game window being auto killed due to the owning thread exit);
 - Main thread still waits for the last Present and to do that it signals the event for presentation thread and waits for another event to be signaled back;
 - Presentation thread calls _Present and gets DXGI_INVALID_CALL because the window is already destroyed which is not expected; the thread unwinds forgetting to signal the event and it hangs forever.