### PR TITLE
[d3d9] Use mapped slice when locking POOL_DEFAULT textures

### DIFF
--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -4187,7 +4187,7 @@ namespace dxvk {
       }
     }
     else {
-      physSlice = mappedBuffer->getSliceHandle();
+      physSlice = pResource->GetMappedSlice(Subresource);
 
       if (!alloced || wasWrittenByGPU) {
         if (unlikely(wasWrittenByGPU)) {


### PR DESCRIPTION
Fixes an issue where the game would end up using the wrong
buffer slice if it previously mapped the same texture with DISCARD.

Fixes #2329