### PR TITLE
[util] Enable apitrace mode for Crysis 3 Remastered

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -154,6 +154,12 @@ namespace dxvk {
       { "dxgi.customVendorId",              "10de" },
       { "d3d11.apitraceMode",               "True" },
     }} },
+    /* Crysis 3 Remastered                          *
+     * Apitrace mode helps massively in cpu bound   *
+     * game parts                                   */
+    { R"(\\Crysis3Remastered\.exe$)", {{
+      { "d3d11.apitraceMode",               "True" },
+    }} },
     /* Atelier series - games try to render video *
      * with a D3D9 swap chain over the DXGI swap  *
      * chain, which breaks D3D11 presentation     */


### PR DESCRIPTION
Helps a lot with CPU performance in the grass level

I can't reuse the Crysis 3 entry for that because Remastered also slows to a crawl if I disable the NVAPI hack.