### PR TITLE
[d3d11] Use atomics for NVX handles

### DIFF
--- a/src/d3d11/d3d11_device.cpp
+++ b/src/d3d11/d3d11_device.cpp
@@ -2721,8 +2721,8 @@ namespace dxvk {
     }
 
     // for our purposes the actual value doesn't matter, only its uniqueness
-    static ULONG seqNum = 1;
-    *pDriverHandle = InterlockedIncrement(&seqNum);
+    static std::atomic<ULONG> s_seqNum = 0;
+    *pDriverHandle = ++s_seqNum;
 
     // will need to look-up sampler from uint32 handle later
     AddSamplerAndHandleNVX(*ppSamplerState, *pDriverHandle);


### PR DESCRIPTION
Primarily to make DXVK native happy, but also much cleaner.

Signed-off-by: Joshua Ashton <joshua@froggi.es>