### PR TITLE
[d3d9] Fix Sims 2 corrupted graphics on AMD GPUs

### DIFF
--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -3484,7 +3484,7 @@ namespace dxvk {
     desc.MultiSample        = MultiSample;
     desc.MultisampleQuality = MultisampleQuality;
     desc.IsBackBuffer       = FALSE;
-    desc.IsAttachmentOnly   = TRUE;
+    desc.IsAttachmentOnly   = Usage & D3DUSAGE_RENDERTARGET;
 
     if (FAILED(D3D9CommonTexture::NormalizeTextureProperties(this, &desc)))
       return D3DERR_INVALIDCALL;


### PR DESCRIPTION
Fixes #1957 

I tracked the issue down to this commit using git bisect: dcf4599c98ddcb568ba041dca618db1d53a52dc8

I'm not very familiar with DXVK or DirectX 9, but thanks to a PR review suggestion from @Joshua-Ashton https://github.com/doitsujin/dxvk/pull/1944#discussion_r583384741, albeit slightly modified, I managed to fix.

I haven't tested with any other games except for Sims 2. Let me know if there's anything else I need to do help you review this since I couldn't find any contribution guidelines.