### PR TITLE
Rework D3D9 float emulation - as an option

### DIFF
--- a/dxvk.conf
+++ b/dxvk.conf
@@ -334,13 +334,16 @@
 
 
 # Force enable/disable floating point quirk emulation
-# 
+#
 # Force toggle anything * 0 emulation
-# Tristate
+# Setting it to True will use a faster but less accurate approach that works for most games.
 # Supported values:
-# - True/False
+# - True: Use a faster but less accurate approach. Good enough for most games
+# - False: Disable float emulation completely
+# - Strict: Use a slower but more correct approach. Necessary for some games
+# - Auto: DXVK will pick automatically
 
-# d3d9.floatEmulation = 
+# d3d9.floatEmulation = True
 
 
 # Enable dialog box mode

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -6455,7 +6455,7 @@ namespace dxvk {
       StartRegister,
       pConstantData,
       Count,
-      m_d3d9Options.d3d9FloatEmulation);
+      m_d3d9Options.d3d9FloatEmulation == D3D9FloatEmulation::Enabled);
 
     return D3D_OK;
   }

--- a/src/d3d9/d3d9_options.cpp
+++ b/src/d3d9/d3d9_options.cpp
@@ -81,8 +81,14 @@ namespace dxvk {
                             0, 0);
     applyTristate(this->generalHazards, config.getOption<Tristate>("d3d9.generalHazards", Tristate::Auto));
 
-    this->d3d9FloatEmulation = true; // <-- Future Extension?
-    applyTristate(this->d3d9FloatEmulation, config.getOption<Tristate>("d3d9.floatEmulation", Tristate::Auto));
+    std::string floatEmulation = Config::toLower(config.getOption<std::string>("d3d9.floatEmulation", "true"));
+    if (floatEmulation == "strict") {
+      d3d9FloatEmulation  = D3D9FloatEmulation::Strict;
+    } else if (floatEmulation == "false") {
+      d3d9FloatEmulation  = D3D9FloatEmulation::Disabled;
+    } else {
+      d3d9FloatEmulation  = D3D9FloatEmulation::Enabled;
+    }
   }
 
 }

--- a/src/d3d9/d3d9_options.h
+++ b/src/d3d9/d3d9_options.h
@@ -7,6 +7,12 @@
 
 namespace dxvk {
 
+  enum class D3D9FloatEmulation {
+    Disabled,
+    Enabled,
+    Strict
+  };
+
   struct D3D9Options {
 
     D3D9Options(const Rc<DxvkDevice>& device, const Config& config);
@@ -83,7 +89,7 @@ namespace dxvk {
     uint32_t maxAvailableMemory;
 
     /// D3D9 Floating Point Emulation (anything * 0 = 0)
-    bool d3d9FloatEmulation;
+    D3D9FloatEmulation d3d9FloatEmulation;
 
     /// Support the DF16 & DF24 texture format
     bool supportDFFormats;

--- a/src/dxso/dxso_compiler.cpp
+++ b/src/dxso/dxso_compiler.cpp
@@ -2359,12 +2359,7 @@ namespace dxvk {
     result.type.ctype  = dst.type.ctype;
     result.type.ccount = componentCount;
 
-    DxsoVectorType scalarType;
-    scalarType.ctype = result.type.ctype;
-    scalarType.ccount = 1;
-
     const uint32_t typeId = getVectorTypeId(result.type);
-    const uint32_t scalarTypeId = getVectorTypeId(scalarType);
 
     DxsoRegMask srcMask(true, true, true, dotCount == 4);
     std::array<uint32_t, 4> indices;
@@ -2373,9 +2368,9 @@ namespace dxvk {
     DxsoRegister src1 = ctx.src[1];
 
     for (uint32_t i = 0; i < componentCount; i++) {
-      indices[i] = m_module.opDot(scalarTypeId,
-        emitRegisterLoad(src0, srcMask).id,
-        emitRegisterLoad(src1, srcMask).id);
+      indices[i] = emitDot(
+        emitRegisterLoad(src0, srcMask),
+        emitRegisterLoad(src1, srcMask)).id;
 
       src1.id.num++;
     }

--- a/src/dxso/dxso_compiler.cpp
+++ b/src/dxso/dxso_compiler.cpp
@@ -1495,6 +1495,36 @@ namespace dxvk {
   }
 
 
+  DxsoRegisterValue DxsoCompiler::emitCross(
+          DxsoRegisterValue       a,
+          DxsoRegisterValue       b) {
+    const std::array<uint32_t, 4> shiftIndices = { 1, 2, 0, 1 };
+
+    DxsoRegisterValue result;
+    result.type = { DxsoScalarType::Float32, 3 };
+
+    uint32_t typeId = getVectorTypeId(result.type);
+    std::array<DxsoRegisterValue, 2> products;
+
+    for (uint32_t i = 0; i < 2; i++) {
+      DxsoRegisterValue ashift;
+      ashift.type = result.type;
+      ashift.id = m_module.opVectorShuffle(typeId,
+        a.id, a.id, 3, &shiftIndices[i]);
+
+      DxsoRegisterValue bshift;
+      bshift.type = result.type;
+      bshift.id = m_module.opVectorShuffle(typeId,
+        b.id, b.id, 3, &shiftIndices[1 - i]);
+
+      products[i] = emitMul(ashift, bshift);
+    }
+
+    result.id = m_module.opFSub(typeId, products[0].id, products[1].id);
+    return result;
+  }
+
+
   DxsoRegisterValue DxsoCompiler::emitRegisterInsert(
             DxsoRegisterValue       dstValue,
             DxsoRegisterValue       srcValue,
@@ -2035,11 +2065,9 @@ namespace dxvk {
       case DxsoOpcode::Crs: {
         DxsoRegMask vec3Mask(true, true, true, false);
         
-        DxsoRegisterValue crossValue;
-        crossValue.type = { DxsoScalarType::Float32, 3 };
-        crossValue.id = m_module.opCross(getVectorTypeId(crossValue.type),
-          emitRegisterLoad(src[0], vec3Mask).id,
-          emitRegisterLoad(src[1], vec3Mask).id);
+        DxsoRegisterValue crossValue = emitCross(
+          emitRegisterLoad(src[0], vec3Mask),
+          emitRegisterLoad(src[1], vec3Mask));
 
         std::array<uint32_t, 3> indices = { 0, 0, 0 };
 

--- a/src/dxso/dxso_compiler.cpp
+++ b/src/dxso/dxso_compiler.cpp
@@ -2163,15 +2163,15 @@ namespace dxvk {
         const uint32_t z = 2;
         const uint32_t w = 3;
 
-        uint32_t src0Y = m_module.opCompositeExtract(scalarTypeId, src0, 1, &y);
-        uint32_t src1Y = m_module.opCompositeExtract(scalarTypeId, src1, 1, &y);
+        DxsoRegisterValue src0Y = { scalarType, m_module.opCompositeExtract(scalarTypeId, src0, 1, &y) };
+        DxsoRegisterValue src1Y = { scalarType, m_module.opCompositeExtract(scalarTypeId, src1, 1, &y) };
 
         uint32_t src0Z = m_module.opCompositeExtract(scalarTypeId, src0, 1, &z);
         uint32_t src1W = m_module.opCompositeExtract(scalarTypeId, src1, 1, &w);
 
         std::array<uint32_t, 4> resultIndices;
         resultIndices[0] = m_module.constf32(1.0f);
-        resultIndices[1] = m_module.opFMul(scalarTypeId, src0Y, src1Y);
+        resultIndices[1] = emitMul(src0Y, src1Y).id;
         resultIndices[2] = src0Z;
         resultIndices[3] = src1W;
 

--- a/src/dxso/dxso_compiler.cpp
+++ b/src/dxso/dxso_compiler.cpp
@@ -2715,7 +2715,7 @@ void DxsoCompiler::emitControlFlowGenericLoop(
         reg.id.num -= (count - 1) - i;
         auto m = emitRegisterLoadTexcoord(reg, vec3Mask);
 
-        indices[i] = m_module.opDot(getScalarTypeId(DxsoScalarType::Float32), m.id, n.id);
+        indices[i] = emitDot(m, n).id;
       }
 
       if (opcode == DxsoOpcode::TexM3x3Spec || opcode == DxsoOpcode::TexM3x3VSpec) {

--- a/src/dxso/dxso_compiler.cpp
+++ b/src/dxso/dxso_compiler.cpp
@@ -3652,26 +3652,27 @@ void DxsoCompiler::emitControlFlowGenericLoop(
     }
 
     // Compute clip distances
-    uint32_t positionId = m_module.opLoad(vec4Type, positionPtr);
+    DxsoRegisterValue position;
+    position.type = { DxsoScalarType::Float32, 4 };
+    position.id = m_module.opLoad(vec4Type, positionPtr);
     
     for (uint32_t i = 0; i < caps::MaxClipPlanes; i++) {
       std::array<uint32_t, 2> blockMembers = {{
         m_module.constu32(0),
         m_module.constu32(i),
       }};
-      
-      uint32_t planeId = m_module.opLoad(vec4Type,
-        m_module.opAccessChain(
-          m_module.defPointerType(vec4Type, spv::StorageClassUniform),
-          clipPlaneBlock, blockMembers.size(), blockMembers.data()));
-      
-      uint32_t distId = m_module.opDot(floatType, positionId, planeId);
-      
-      m_module.opStore(
-        m_module.opAccessChain(
-          m_module.defPointerType(floatType, spv::StorageClassOutput),
-          clipDistArray, 1, &blockMembers[1]),
-        distId);
+
+      DxsoRegisterValue plane;
+      plane.type = { DxsoScalarType::Float32, 4 };
+      plane.id = m_module.opLoad(vec4Type, m_module.opAccessChain(
+        m_module.defPointerType(vec4Type, spv::StorageClassUniform),
+        clipPlaneBlock, blockMembers.size(), blockMembers.data()));
+
+      DxsoRegisterValue dist = emitDot(position, plane);
+
+      m_module.opStore(m_module.opAccessChain(
+        m_module.defPointerType(floatType, spv::StorageClassOutput),
+        clipDistArray, 1, &blockMembers[1]), dist.id);
     }
   }
 

--- a/src/dxso/dxso_compiler.cpp
+++ b/src/dxso/dxso_compiler.cpp
@@ -1439,7 +1439,7 @@ namespace dxvk {
   DxsoRegisterValue DxsoCompiler::emitMulOperand(
           DxsoRegisterValue       operand,
           DxsoRegisterValue       other) {
-    if (!m_moduleInfo.options.d3d9FloatEmulation)
+    if (m_moduleInfo.options.d3d9FloatEmulation != D3D9FloatEmulation::Strict)
       return operand;
 
     uint32_t boolId = getVectorTypeId({ DxsoScalarType::Bool, other.type.ccount });
@@ -1965,7 +1965,7 @@ namespace dxvk {
           m_module.constfReplicant(1.0f, result.type.ccount),
           emitRegisterLoad(src[0], mask).id);
 
-        if (m_moduleInfo.options.d3d9FloatEmulation) {
+        if (m_moduleInfo.options.d3d9FloatEmulation == D3D9FloatEmulation::Enabled) {
           result.id = m_module.opNMin(typeId, result.id,
             m_module.constfReplicant(FLT_MAX, result.type.ccount));
         }
@@ -1977,7 +1977,7 @@ namespace dxvk {
         result.id = m_module.opInverseSqrt(typeId,
           result.id);
 
-        if (m_moduleInfo.options.d3d9FloatEmulation) {
+        if (m_moduleInfo.options.d3d9FloatEmulation == D3D9FloatEmulation::Enabled) {
           result.id = m_module.opNMin(typeId, result.id,
             m_module.constfReplicant(FLT_MAX, result.type.ccount));
         }
@@ -2051,7 +2051,7 @@ namespace dxvk {
 
         result.id = m_module.opPow(typeId, base, exponent);
 
-        if (m_moduleInfo.options.strictPow && m_moduleInfo.options.d3d9FloatEmulation) {
+        if (m_moduleInfo.options.strictPow && m_moduleInfo.options.d3d9FloatEmulation != D3D9FloatEmulation::Disabled) {
           DxsoRegisterValue cmp;
           cmp.type  = { DxsoScalarType::Bool, result.type.ccount };
           cmp.id    = m_module.opFOrdEqual(getVectorTypeId(cmp.type),
@@ -2096,7 +2096,7 @@ namespace dxvk {
 
         DxsoRegisterValue dot = emitDot(vec3, vec3);
         dot.id = m_module.opInverseSqrt (scalarTypeId, dot.id);
-        if (m_moduleInfo.options.d3d9FloatEmulation) {
+        if (m_moduleInfo.options.d3d9FloatEmulation == D3D9FloatEmulation::Enabled) {
           dot.id = m_module.opNMin        (scalarTypeId, dot.id,
             m_module.constf32(FLT_MAX));
         }
@@ -2213,7 +2213,7 @@ namespace dxvk {
       case DxsoOpcode::Log:
         result.id = m_module.opFAbs(typeId, emitRegisterLoad(src[0], mask).id);
         result.id = m_module.opLog2(typeId, result.id);
-        if (m_moduleInfo.options.d3d9FloatEmulation) {
+        if (m_moduleInfo.options.d3d9FloatEmulation == D3D9FloatEmulation::Enabled) {
           result.id = m_module.opNMax(typeId, result.id,
             m_module.constfReplicant(-FLT_MAX, result.type.ccount));
         }

--- a/src/dxso/dxso_compiler.h
+++ b/src/dxso/dxso_compiler.h
@@ -543,6 +543,19 @@ namespace dxvk {
     DxsoRegisterValue emitSaturate(
             DxsoRegisterValue       srcValue);
 
+    DxsoRegisterValue emitMulOperand(
+            DxsoRegisterValue       operand,
+            DxsoRegisterValue       other);
+
+    DxsoRegisterValue emitMul(
+            DxsoRegisterValue       a,
+            DxsoRegisterValue       b);
+
+    DxsoRegisterValue emitFma(
+            DxsoRegisterValue       a,
+            DxsoRegisterValue       b,
+            DxsoRegisterValue       c);
+
     DxsoRegisterValue emitDot(
             DxsoRegisterValue       a,
             DxsoRegisterValue       b);

--- a/src/dxso/dxso_compiler.h
+++ b/src/dxso/dxso_compiler.h
@@ -560,6 +560,10 @@ namespace dxvk {
             DxsoRegisterValue       a,
             DxsoRegisterValue       b);
 
+    DxsoRegisterValue emitCross(
+            DxsoRegisterValue       a,
+            DxsoRegisterValue       b);
+
     DxsoRegisterValue emitRegisterInsert(
             DxsoRegisterValue       dstValue,
             DxsoRegisterValue       srcValue,

--- a/src/dxso/dxso_options.h
+++ b/src/dxso/dxso_options.h
@@ -27,7 +27,7 @@ namespace dxvk {
     /// Whether to emulate d3d9 float behaviour using clampps
     /// True:  Perform emulation to emulate behaviour (ie. anything * 0 = 0)
     /// False: Don't do anything.
-    bool d3d9FloatEmulation;
+    D3D9FloatEmulation d3d9FloatEmulation;
 
     /// Whether or not we should care about pow(0, 0) = 1
     bool strictPow;

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -635,8 +635,7 @@ namespace dxvk {
           I             begin,
           I             end,
           V&            value) {
-    std::transform(str.begin(), str.end(), str.begin(),
-      [] (unsigned char c) { return (c >= 'A' && c <= 'Z') ? (c + 'a' - 'A') : c; });
+    str = Config::toLower(str);
 
     for (auto i = begin; i != end; i++) {
       if (str == i->first) {
@@ -706,6 +705,12 @@ namespace dxvk {
       for (auto& pair : m_options)
         Logger::info(str::format("  ", pair.first, " = ", pair.second));
     }
+  }
+
+  std::string Config::toLower(std::string str) {
+    std::transform(str.begin(), str.end(), str.begin(),
+      [] (unsigned char c) { return (c >= 'A' && c <= 'Z') ? (c + 'a' - 'A') : c; });
+    return str;
   }
 
 }

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -459,6 +459,34 @@ namespace dxvk {
     { R"(\\FantasyGrounds\.exe$)", {{
       { "d3d9.noExplicitFrontBuffer",       "True" },
     }} },
+    /* Red Orchestra 2                           */
+    { R"(\\ROGame\.exe$)", {{
+      { "d3d9.floatEmulation",              "Strict" },
+    }} },
+    /* Dark Souls II                            */
+    { R"(\\DarkSoulsII\.exe$)", {{
+      { "d3d9.floatEmulation",              "Strict" },
+    }} },
+    /* Dogfight 1942                            */
+    { R"(\\Dogfight1942\.exe$)", {{
+      { "d3d9.floatEmulation",              "Strict" },
+    }} },
+    /* Bayonetta                                */
+    { R"(\\Bayonetta\.exe$)", {{
+      { "d3d9.floatEmulation",              "Strict" },
+    }} },
+    /* Rayman Origins                           */
+    { R"(\\Rayman Origins\.exe$)", {{
+      { "d3d9.floatEmulation",              "Strict" },
+    }} },
+    /* Guilty Gear Xrd -Relevator-              */
+    { R"(\\GuiltyGearXrd\.exe$)", {{
+      { "d3d9.floatEmulation",              "Strict" },
+    }} },
+    /* Richard Burns Rally                      */
+    { R"(\\RichardBurnsRally_SSE\.exe$)", {{
+      { "d3d9.floatEmulation",              "Strict" },
+    }} },
   }};
 
 

--- a/src/util/config/config.h
+++ b/src/util/config/config.h
@@ -102,6 +102,8 @@ namespace dxvk {
      */
     static Config getUserConfig();
 
+    static std::string toLower(std::string str);
+
   private:
 
     OptionMap m_options;


### PR DESCRIPTION
Basically #2294 except that it's an option only enabled for specific games. (the ones in #2195)

The option `d3d9.floatEmulation` gets a third option besides `True` and `False` called `Strict` which enables the more accurate implementation. Once Mesa has landed an optimization for this, we can just make it automatically pick `Strict`.