### PR TITLE
Enable strict float emulation for BlazBlue Centralfiction by default

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -487,6 +487,10 @@ namespace dxvk {
     { R"(\\RichardBurnsRally_SSE\.exe$)", {{
       { "d3d9.floatEmulation",              "Strict" },
     }} },
+    /* BlazBlue Centralfiction                  */
+    { R"(\\BBCF\.exe$)", {{
+      { "d3d9.floatEmulation",              "Strict" },
+    }} },
   }};
 
 


### PR DESCRIPTION
Fixes background flickering.