### PR TITLE
Add dxgi.customSubSysId and dxgi.customRevision configs

### DIFF
--- a/dxvk.conf
+++ b/dxvk.conf
@@ -48,6 +48,18 @@
 # d3d9.customDeviceDesc = ""
 
 
+# Override the PCI subsystem ID and revision reported to the application.
+# You may need to manually edit these to match your physical GPU for some
+# benchmarking tools to report accurate details about your card.
+#
+# Supported values:
+# - Subsystem ID: Any 8-digit hex number
+# - Revision: Any 2-digit hex number
+
+# dxgi.customSubSysId = 00000000
+# dxgi.customRevision = 00
+
+
 # Report Nvidia GPUs as AMD GPUs by default. This is enabled by default
 # to work around issues with NVAPI, but may cause issues in some games.
 #

--- a/src/dxgi/dxgi_adapter.cpp
+++ b/src/dxgi/dxgi_adapter.cpp
@@ -245,14 +245,22 @@ namespace dxvk {
     auto deviceProp = m_adapter->deviceProperties();
     auto memoryProp = m_adapter->memoryProperties();
     auto deviceId   = m_adapter->devicePropertiesExt().coreDeviceId;
+    auto subSysId   = options->customSubSysId;
+    auto revision   = options->customRevision;
     
-    // Custom Vendor / Device ID
+    // Custom Vendor / Device / Subsystem ID, Revision
     if (options->customVendorId >= 0)
       deviceProp.vendorID = options->customVendorId;
     
     if (options->customDeviceId >= 0)
       deviceProp.deviceID = options->customDeviceId;
     
+    if (subSysId < 0 || subSysId > 0xffffffff)
+      subSysId = 0;
+
+    if (revision < 0 || revision > 0xff)
+      revision = 0;
+
     const char* description = deviceProp.deviceName;
     // Custom device description
     if (!options->customDeviceDesc.empty())
@@ -312,8 +320,8 @@ namespace dxvk {
     
     pDesc->VendorId                       = deviceProp.vendorID;
     pDesc->DeviceId                       = deviceProp.deviceID;
-    pDesc->SubSysId                       = 0;
-    pDesc->Revision                       = 0;
+    pDesc->SubSysId                       = subSysId;
+    pDesc->Revision                       = revision;
     pDesc->DedicatedVideoMemory           = deviceMemory;
     pDesc->DedicatedSystemMemory          = 0;
     pDesc->SharedSystemMemory             = sharedMemory;

--- a/src/dxgi/dxgi_options.cpp
+++ b/src/dxgi/dxgi_options.cpp
@@ -4,13 +4,13 @@
 
 namespace dxvk {
 
-  static int32_t parsePciId(const std::string& str) {
-    if (str.size() != 4)
+  static int64_t parsePciId(const std::string& str, const size_t size = 4) {
+    if (str.size() != size)
       return -1;
     
-    int32_t id = 0;
+    int64_t id = 0;
 
-    for (size_t i = 0; i < str.size(); i++) {
+    for (size_t i = 0; i < size; i++) {
       id *= 16;
 
       if (str[i] >= '0' && str[i] <= '9')
@@ -39,6 +39,9 @@ namespace dxvk {
     // Interpret the memory limits as Megabytes
     this->maxDeviceMemory = VkDeviceSize(config.getOption<int32_t>("dxgi.maxDeviceMemory", 0)) << 20;
     this->maxSharedMemory = VkDeviceSize(config.getOption<int32_t>("dxgi.maxSharedMemory", 0)) << 20;
+
+    this->customSubSysId = parsePciId(config.getOption<std::string>("dxgi.customSubSysId"), 8);
+    this->customRevision = parsePciId(config.getOption<std::string>("dxgi.customRevision"), 2);
 
     this->nvapiHack   = config.getOption<bool>("dxgi.nvapiHack", true);
   }

--- a/src/dxgi/dxgi_options.h
+++ b/src/dxgi/dxgi_options.h
@@ -30,6 +30,9 @@ namespace dxvk {
     VkDeviceSize maxDeviceMemory;
     VkDeviceSize maxSharedMemory;
 
+    int64_t customSubSysId;
+    int16_t customRevision;
+
     /// Emulate UMA
     bool emulateUMA;
 


### PR DESCRIPTION
Admittedly a hack, but a relatively noninvasive one. This makes it possible to inform apps about the GPU's exact board partner vendor and model. The use case I encountered was Superposition not including details about the card in its results when run in Proton. And I couldn't find a proper way to add these automatically in `dxvk::Dxgi::GetDesc3()` either, since it looks like libvulkan simply has no API to query for these.