### PR TITLE
Fix off by one error in string utility functions

### DIFF
--- a/src/util/util_string.cpp
+++ b/src/util/util_string.cpp
@@ -8,8 +8,6 @@ namespace dxvk::str {
     if (len <= 1)
       return "";
 
-    len -= 1;
-
     std::string result;
     result.resize(len);
     ::WideCharToMultiByte(CP_UTF8, 0, ws, -1,
@@ -30,8 +28,6 @@ namespace dxvk::str {
     
     if (len <= 1)
       return L"";
-
-    len -= 1;
 
     std::wstring result;
     result.resize(len);


### PR DESCRIPTION
Microsoft documentation for WideCharToMultiByte (https://docs.microsoft.com/en-us/windows/win32/api/stringapiset/nf-stringapiset-widechartomultibyte) very clearly states, if cbMultiByte parameter is 0, "the function returns the required buffer size for lpMultiByteStr". The same goes for the cchWideChar parameter to function MultiByteToWideChar.
![image](https://user-images.githubusercontent.com/73044267/147770695-da1ff0e0-f566-4ed6-b267-7d25a1e78c8c.png)

However for some sort of reason, tomb function in dxvk then goes on to subtract 1 from this returned value, before passing it straight back to WideCharToMultibyte parameter cbMultiByte. When executed, this causes an error (OS: Windows 7 x64). I don't know if it causes the same error when run under Wine. Regardless, this usage is clearly nonconformant to the official documentation for this function.
![image](https://user-images.githubusercontent.com/73044267/147770520-9241b7c9-4f9e-4d76-a3e6-9fb9e21ff82e.png)

Please ignore the kernel33.DLL and pretend it is kernel32.DLL.