### PR TITLE
Added config for James Cameron's Avatar (DX9)

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -491,6 +491,10 @@ namespace dxvk {
     { R"(\\BBCF\.exe$)", {{
       { "d3d9.floatEmulation",              "Strict" },
     }} },
+    /* James Cameron's Avatar needs invariantPosition to fix black flickering vegetation */
+    { R"(\\Avatar\.exe$)", {{
+      { "d3d9.invariantPosition",              "True" },
+    }} },
   }};
 
 


### PR DESCRIPTION
Fixes flickering black vegetation in Avatar.

Does NOT fix the game not detecting DX10, but it's not a big deal since it doesn't add anything.