### PR TITLE
[d3d9] Dirty FF vertex shader if any  D3D9VertexDeclFlags change.

### DIFF
--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -2722,11 +2722,8 @@ namespace dxvk {
 
     bool dirtyFFShader = decl == nullptr || m_state.vertexDecl == nullptr;
     if (!dirtyFFShader)
-      dirtyFFShader |= decl->TestFlag(D3D9VertexDeclFlag::HasPositionT)  != m_state.vertexDecl->TestFlag(D3D9VertexDeclFlag::HasPositionT)
-                    || decl->TestFlag(D3D9VertexDeclFlag::HasColor0)     != m_state.vertexDecl->TestFlag(D3D9VertexDeclFlag::HasColor0)
-                    || decl->TestFlag(D3D9VertexDeclFlag::HasColor1)     != m_state.vertexDecl->TestFlag(D3D9VertexDeclFlag::HasColor1)
-                    || decl->TestFlag(D3D9VertexDeclFlag::HasPointSize)  != m_state.vertexDecl->TestFlag(D3D9VertexDeclFlag::HasPointSize)
-                    || decl->GetTexcoordMask()                           != m_state.vertexDecl->GetTexcoordMask();
+      dirtyFFShader |= decl->GetFlags()        != m_state.vertexDecl->GetFlags()
+                    || decl->GetTexcoordMask() != m_state.vertexDecl->GetTexcoordMask();
 
     if (dirtyFFShader)
       m_flags.set(D3D9DeviceFlag::DirtyFFVertexShader);

--- a/src/d3d9/d3d9_vertex_declaration.h
+++ b/src/d3d9/d3d9_vertex_declaration.h
@@ -7,7 +7,7 @@
 
 namespace dxvk {
 
-  enum D3D9VertexDeclFlag {
+  enum class D3D9VertexDeclFlag {
     HasColor0,
     HasColor1,
     HasPositionT,
@@ -56,6 +56,10 @@ namespace dxvk {
 
     bool TestFlag(D3D9VertexDeclFlag flag) const {
       return m_flags.test(flag);
+    }
+
+    D3D9VertexDeclFlags GetFlags() const {
+      return m_flags;
     }
 
     uint32_t GetTexcoordMask() const {


### PR DESCRIPTION
The vertex shader depends on all of these in some way.