### PR TITLE
CrossOver 21.1.0 patches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,3 +52,17 @@ jobs:
           name: dxvk-${{ steps.version_name.outputs.name }}
           path: build/dxvk-${{ steps.version_name.outputs.name }}
           if-no-files-found: error
+      
+      - name: Build Async
+        run: |
+          curl -O https://raw.githubusercontent.com/Sporif/dxvk-async/master/dxvk-async.patch
+          patch -p1 < dxvk-async.patch
+          echo "dxvk.enableAsync = true" >> dxvk.conf
+          ./package-release.sh "${{ steps.version_name.outputs.name }}-async" build --no-package
+
+      - name: Upload Async Artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: dxvk-${{ steps.version_name.outputs.name }}-async
+          path: build/dxvk-${{ steps.version_name.outputs.name }}-async
+          if-no-files-found: warn

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,54 @@
+name: Continuous Integration
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  build:
+    name: "Build"
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      # https://github.com/actions/checkout/issues/290
+      - name: Git Fetch
+        run: git fetch --force --tags
+
+      - name: Get Branch Name
+        id: branch_name
+        uses: tj-actions/branch-names@v5
+      
+      - name: Create Version Name
+        id: version_name
+        run: |
+          export VERSION_NAME="${{ steps.branch_name.outputs.current_branch }}-$(git describe)"
+          echo "::set-output name=name::${VERSION_NAME}"
+
+      - name: Setup Problem Matcher
+        uses: Joshua-Ashton/gcc-problem-matcher@v1
+
+      - name: Install Dependencies
+        run: |
+          export HOMEBREW_NO_AUTO_UPDATE=1
+          export HOMEBREW_NO_INSTALL_CLEANUP=1
+          brew install coreutils
+          brew install meson
+          brew install mingw-w64
+          brew install glslang
+
+      - name: Build
+        run: ./package-release.sh ${{ steps.version_name.outputs.name }} build --no-package
+
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: dxvk-${{ steps.version_name.outputs.name }}
+          path: build/dxvk-${{ steps.version_name.outputs.name }}
+          if-no-files-found: error

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.DS_Store
+/.vscode

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ export WINEPREFIX=/path/to/.wine-prefix
 
 ### Requirements:
 - [wine 3.10](https://www.winehq.org/) or newer
+- [greadlink](https://formulae.brew.sh/formula/coreutils)
 - [Meson](https://mesonbuild.com/) build system (at least version 0.46)
 - [Mingw-w64](https://www.mingw-w64.org) compiler and headers (at least version 8.0)
 - [glslang](https://github.com/KhronosGroup/glslang) compiler

--- a/package-release.sh
+++ b/package-release.sh
@@ -10,7 +10,7 @@ if [ -z "$1" ] || [ -z "$2" ]; then
 fi
 
 DXVK_VERSION="$1"
-DXVK_SRC_DIR=`dirname $(readlink -f $0)`
+DXVK_SRC_DIR=`dirname $(greadlink -f $0)`
 DXVK_BUILD_DIR=$(realpath "$2")"/dxvk-$DXVK_VERSION"
 DXVK_ARCHIVE_PATH=$(realpath "$2")"/dxvk-$DXVK_VERSION.tar.gz"
 

--- a/package-release.sh
+++ b/package-release.sh
@@ -89,8 +89,8 @@ function package {
 }
 
 build_arch 64
-build_arch 32
-build_script
+#build_arch 32 # not applicable to macOS since 10.15 Catalina
+#build_script  # not applicable to macOS
 
 if [ $opt_nopackage -eq 0 ]; then
   package

--- a/src/d3d11/d3d11_device.cpp
+++ b/src/d3d11/d3d11_device.cpp
@@ -799,8 +799,10 @@ namespace dxvk {
     InitReturnPtr(ppGeometryShader);
     D3D11CommonShader module;
 
-    if (!m_dxvkDevice->features().extTransformFeedback.transformFeedback)
-      return DXGI_ERROR_INVALID_CALL;
+    if (!m_dxvkDevice->features().extTransformFeedback.transformFeedback) {
+      Logger::err("D3D11: CreateGeometryShaderWithStreamOutput: Transform feedback not supported");
+      return S_OK;
+    }
 
     // Zero-init some counterss so that we can increment
     // them while walking over the stream output entries
@@ -1973,8 +1975,8 @@ namespace dxvk {
       enabled.core.features.logicOp                               = supported.core.features.logicOp;
       enabled.core.features.shaderImageGatherExtended             = VK_TRUE;
       enabled.core.features.variableMultisampleRate               = supported.core.features.variableMultisampleRate;
-      enabled.extTransformFeedback.transformFeedback              = VK_TRUE;
-      enabled.extTransformFeedback.geometryStreams                = VK_TRUE;
+      enabled.extTransformFeedback.transformFeedback              = supported.extTransformFeedback.transformFeedback;
+      enabled.extTransformFeedback.geometryStreams                = supported.extTransformFeedback.geometryStreams;
     }
     
     if (featureLevel >= D3D_FEATURE_LEVEL_10_1) {

--- a/src/d3d11/d3d11_texture.cpp
+++ b/src/d3d11/d3d11_texture.cpp
@@ -565,9 +565,12 @@ namespace dxvk {
     // order to avoid expensive synchronization with the GPU. This does
     // however require linear tiling, which may not be supported for all
     // combinations of image parameters.
-    return this->CheckImageSupport(pImageInfo, VK_IMAGE_TILING_LINEAR)
-      ? D3D11_COMMON_TEXTURE_MAP_MODE_DIRECT
-      : D3D11_COMMON_TEXTURE_MAP_MODE_BUFFER;
+    // HACK: Never use direct mapping; it doesn't work right with MoltenVK
+    // because we don't unmap memory.
+    //return this->CheckImageSupport(pImageInfo, VK_IMAGE_TILING_LINEAR)
+    //  ? D3D11_COMMON_TEXTURE_MAP_MODE_DIRECT
+    //  : D3D11_COMMON_TEXTURE_MAP_MODE_BUFFER;
+    return D3D11_COMMON_TEXTURE_MAP_MODE_BUFFER;
   }
   
   

--- a/src/d3d11/d3d11_view_uav.cpp
+++ b/src/d3d11/d3d11_view_uav.cpp
@@ -59,7 +59,18 @@ namespace dxvk {
       DxvkImageViewCreateInfo viewInfo;
       viewInfo.format  = formatInfo.Format;
       viewInfo.aspect  = formatInfo.Aspect;
-      viewInfo.swizzle = formatInfo.Swizzle;
+      // CrossOver bug 18050:
+      // Vulkan does not allow swizzled textures to be bound
+      // to VK_DESCRIPTOR_TYPE_STORAGE_IMAGE descriptors.
+      // In the particular case of MoltenVK, MTLPixelFormatA8Unorm
+      // textures (or the swizzled equivalent) are not writeable.
+      if (pDesc->Format != DXGI_FORMAT_A8_UNORM) {
+        if (formatInfo.Swizzle.r || formatInfo.Swizzle.g || formatInfo.Swizzle.b || formatInfo.Swizzle.a)
+          Logger::warn(str::format("Swizzled format in UAV: ", pDesc->Format));
+        viewInfo.swizzle = formatInfo.Swizzle;
+      } else {
+        Logger::info("Skipping DXGI_FORMAT_A8_UNORM swizzle for UAV");
+      }
       viewInfo.usage   = VK_IMAGE_USAGE_STORAGE_BIT;
       
       switch (pDesc->ViewDimension) {

--- a/src/dxbc/dxbc_chunk_isgn.cpp
+++ b/src/dxbc/dxbc_chunk_isgn.cpp
@@ -66,13 +66,22 @@ namespace dxvk {
   DxbcRegMask DxbcIsgn::regMask(
           uint32_t     registerId) const {
     DxbcRegMask mask;
+    DxbcRegMask svMask;
 
     for (auto e = this->begin(); e != this->end(); e++) {
-      if (e->registerId == registerId)
-        mask |= e->componentMask;
+      if (e->registerId == registerId) {
+        if (e->systemValue == DxbcSystemValue::None)
+          mask |= e->componentMask;
+        else
+          svMask |= e->componentMask;
+      }
     }
 
-    return mask;
+    if (mask != DxbcRegMask(0) && svMask != DxbcRegMask(0)) {
+      Logger::info("dxbc system value mask hack fired");
+    }
+
+    return mask != DxbcRegMask(0) ? mask : svMask;
   }
 
 

--- a/src/dxvk/dxvk_image.cpp
+++ b/src/dxvk/dxvk_image.cpp
@@ -174,7 +174,9 @@ namespace dxvk {
       case VK_IMAGE_VIEW_TYPE_3D: {
         this->createView(VK_IMAGE_VIEW_TYPE_3D, 1);
         
-        if (m_image->info().flags & VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT && m_info.numLevels == 1) {
+        if (m_image->info().flags & VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT &&
+              info.usage & (VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT|VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT) &&
+              info.numLevels == 1) {
           this->createView(VK_IMAGE_VIEW_TYPE_2D,       1);
           this->createView(VK_IMAGE_VIEW_TYPE_2D_ARRAY, m_image->mipLevelExtent(m_info.minLevel).depth);
         }
@@ -227,8 +229,9 @@ namespace dxvk {
         "DxvkImageView: Failed to create image view:"
         "\n  View type:       ", viewInfo.viewType,
         "\n  View format:     ", viewInfo.format,
+        "\n  Usage:           ", std::hex, viewUsage.usage,
         "\n  Subresources:    ",
-        "\n    Aspect mask:   ", std::hex, viewInfo.subresourceRange.aspectMask,
+        "\n    Aspect mask:   ", viewInfo.subresourceRange.aspectMask, std::dec,
         "\n    Mip levels:    ", viewInfo.subresourceRange.baseMipLevel, " - ",
                                  viewInfo.subresourceRange.levelCount,
         "\n    Array layers:  ", viewInfo.subresourceRange.baseArrayLayer, " - ",
@@ -242,7 +245,7 @@ namespace dxvk {
         "\n    Mip levels:    ", m_image->info().mipLevels,
         "\n    Array layers:  ", m_image->info().numLayers,
         "\n    Samples:       ", m_image->info().sampleCount,
-        "\n    Usage:         ", std::hex, m_image->info().usage,
+        "\n    Usage:         ", std::hex, m_image->info().usage, std::dec,
         "\n    Tiling:        ", m_image->info().tiling));
     }
   }

--- a/src/vulkan/vulkan_presenter.cpp
+++ b/src/vulkan/vulkan_presenter.cpp
@@ -135,7 +135,15 @@ namespace dxvk::vk {
     // Select actual swap chain properties and create swap chain
     m_info.format       = pickFormat(formats.size(), formats.data(), desc.numFormats, desc.formats);
     m_info.presentMode  = pickPresentMode(modes.size(), modes.data(), desc.numPresentModes, desc.presentModes);
-    m_info.imageExtent  = pickImageExtent(caps, desc.imageExtent);
+    /* HACK: FFXIX wants to make sure that the client size of its window is at least 1024x720 and enforces that
+     * by increasing the size in WM_WINDOWPOSCHANGING. Unfortunately it adds the size of the window decorations
+     * in fullscreen mode even though the window does not have any decorations, causing an incorrect rendering
+     * size and mouse pointer offsets at low fullscreen resolutions.
+     *
+     * The game does the same thing on Windows and the bug can be reproduced in borderless windowed fullscreen
+     * mode if the desktop resolution is set to 1280x720. It seems that native d3d ignores the actual window
+     * size in real fullscreen mode. Try to do the same. */
+    m_info.imageExtent  = desc.imageExtent; //pickImageExtent(caps, desc.imageExtent);
     m_info.imageCount   = pickImageCount(caps, m_info.presentMode, desc.imageCount);
 
     if (!m_info.imageExtent.width || !m_info.imageExtent.height) {


### PR DESCRIPTION
Patches from DXVK 1.7 from CrossOver 21.1.0 rolled on top. [Source](https://media.codeweavers.com/pub/crossover/source/crossover-sources-21.1.0.tar.gz).

Still missing paches for:
* `src/dxvk/dxvk_state_cache.cpp`
* `src/dxvk/dxvk_state_cache.h`