### PR TITLE
Disable direct buffer mapping mode for Resident Evil games

### DIFF
--- a/src/d3d9/d3d9_common_buffer.cpp
+++ b/src/d3d9/d3d9_common_buffer.cpp
@@ -8,9 +8,9 @@ namespace dxvk {
   D3D9CommonBuffer::D3D9CommonBuffer(
           D3D9DeviceEx*      pDevice,
     const D3D9_BUFFER_DESC*  pDesc) 
-    : m_parent ( pDevice ), m_desc ( *pDesc ) {
+    : m_parent ( pDevice ), m_desc ( *pDesc ), m_mapMode(DetermineMapMode()) {
     m_buffer = CreateBuffer();
-    if (GetMapMode() == D3D9_COMMON_BUFFER_MAP_MODE_BUFFER)
+    if (m_mapMode == D3D9_COMMON_BUFFER_MAP_MODE_BUFFER)
       m_stagingBuffer = CreateStagingBuffer();
 
     m_sliceHandle = GetMapBuffer()->getSliceHandle();
@@ -83,7 +83,7 @@ namespace dxvk {
       info.access |= VK_ACCESS_INDEX_READ_BIT;
     }
 
-    if (GetMapMode() == D3D9_COMMON_BUFFER_MAP_MODE_DIRECT) {
+    if (m_mapMode == D3D9_COMMON_BUFFER_MAP_MODE_DIRECT) {
       info.stages |= VK_PIPELINE_STAGE_HOST_BIT;
       info.access |= VK_ACCESS_HOST_WRITE_BIT;
 

--- a/src/d3d9/d3d9_common_buffer.cpp
+++ b/src/d3d9/d3d9_common_buffer.cpp
@@ -7,8 +7,9 @@ namespace dxvk {
 
   D3D9CommonBuffer::D3D9CommonBuffer(
           D3D9DeviceEx*      pDevice,
-    const D3D9_BUFFER_DESC*  pDesc) 
-    : m_parent ( pDevice ), m_desc ( *pDesc ), m_mapMode(DetermineMapMode()) {
+    const D3D9_BUFFER_DESC*  pDesc)
+    : m_parent ( pDevice ), m_desc ( *pDesc ),
+      m_mapMode(DetermineMapMode(pDevice->GetOptions())) {
     m_buffer = CreateBuffer();
     if (m_mapMode == D3D9_COMMON_BUFFER_MAP_MODE_BUFFER)
       m_stagingBuffer = CreateStagingBuffer();

--- a/src/d3d9/d3d9_common_buffer.h
+++ b/src/d3d9/d3d9_common_buffer.h
@@ -88,8 +88,8 @@ namespace dxvk {
     /**
     * \brief Determine the mapping mode of the buffer, (ie. direct mapping or backed)
     */
-    inline D3D9_COMMON_BUFFER_MAP_MODE DetermineMapMode() const {
-      return (m_desc.Pool == D3DPOOL_DEFAULT && (m_desc.Usage & (D3DUSAGE_DYNAMIC | D3DUSAGE_WRITEONLY)))
+    inline D3D9_COMMON_BUFFER_MAP_MODE DetermineMapMode(const D3D9Options* options) const {
+      return (m_desc.Pool == D3DPOOL_DEFAULT && (m_desc.Usage & (D3DUSAGE_DYNAMIC | D3DUSAGE_WRITEONLY)) && options->allowDirectBufferMapping)
         ? D3D9_COMMON_BUFFER_MAP_MODE_DIRECT
         : D3D9_COMMON_BUFFER_MAP_MODE_BUFFER;
     }

--- a/src/d3d9/d3d9_common_buffer.h
+++ b/src/d3d9/d3d9_common_buffer.h
@@ -88,10 +88,17 @@ namespace dxvk {
     /**
     * \brief Determine the mapping mode of the buffer, (ie. direct mapping or backed)
     */
-    inline D3D9_COMMON_BUFFER_MAP_MODE GetMapMode() const {
+    inline D3D9_COMMON_BUFFER_MAP_MODE DetermineMapMode() const {
       return (m_desc.Pool == D3DPOOL_DEFAULT && (m_desc.Usage & (D3DUSAGE_DYNAMIC | D3DUSAGE_WRITEONLY)))
         ? D3D9_COMMON_BUFFER_MAP_MODE_DIRECT
         : D3D9_COMMON_BUFFER_MAP_MODE_BUFFER;
+    }
+
+    /**
+    * \brief Get the mapping mode of the buffer, (ie. direct mapping or backed)
+    */
+    inline D3D9_COMMON_BUFFER_MAP_MODE GetMapMode() const {
+      return m_mapMode;
     }
 
     /**
@@ -209,6 +216,7 @@ namespace dxvk {
     DWORD                       m_mapFlags;
     bool                        m_wasWrittenByGPU = false;
     bool                        m_uploadUsingStaging = false;
+    D3D9_COMMON_BUFFER_MAP_MODE m_mapMode;
 
     Rc<DxvkBuffer>              m_buffer;
     Rc<DxvkBuffer>              m_stagingBuffer;

--- a/src/d3d9/d3d9_options.cpp
+++ b/src/d3d9/d3d9_options.cpp
@@ -72,6 +72,7 @@ namespace dxvk {
     this->alphaTestWiggleRoom           = config.getOption<bool>        ("d3d9.alphaTestWiggleRoom",           false);
     this->apitraceMode                  = config.getOption<bool>        ("d3d9.apitraceMode",                  false);
     this->deviceLocalConstantBuffers    = config.getOption<bool>        ("d3d9.deviceLocalConstantBuffers",    false);
+    this->allowDirectBufferMapping      = config.getOption<bool>        ("d3d9.allowDirectBufferMapping",      true);
 
     // If we are not Nvidia, enable general hazards.
     this->generalHazards = adapter != nullptr

--- a/src/d3d9/d3d9_options.h
+++ b/src/d3d9/d3d9_options.h
@@ -156,6 +156,9 @@ namespace dxvk {
 
     /// Use device local memory for constant buffers.
     bool deviceLocalConstantBuffers;
+
+    /// Disable direct buffer mapping
+    bool allowDirectBufferMapping;
   };
 
 }

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -494,6 +494,10 @@ namespace dxvk {
     { R"(\\Avatar\.exe$)", {{
       { "d3d9.invariantPosition",              "True" },
     }} },
+    /* Resident Evil games                      */
+    { R"(\\(rerev|rerev2|re0hd|bhd|re5dx9|BH6)\.exe$)", {{
+      { "d3d9.allowDirectBufferMapping",                "False" },
+    }} },
   }};
 
 


### PR DESCRIPTION
Fixes #2453 
Fixes #2084
Fixes #2266

RE games lock the same D3DPOOL_DEFAULT + D3DUSAGE_DYNAMIC buffer every frame. DXVK chooses MAP_MODE_DIRECT for it, so all our measures to prevent stalling in `Lock` don't apply here and the game syncs with the GPU every frame.

I'd personally just get rid of MAP_MODE_DIRECT but @Joshua-Ashton told me on Discord to make this an option instead.

This will have to be rebased against #2157 if that PR is merged first.