### PR TITLE
[build] Use MSBuild backend on Windows CI

### DIFF
--- a/.github/workflows/test-build-windows.yml
+++ b/.github/workflows/test-build-windows.yml
@@ -19,9 +19,10 @@ jobs:
         choco install vulkan-sdk -y
         Write-Output "$([System.Environment]::GetEnvironmentVariable('VULKAN_SDK', 'Machine'))\Bin" `
           | Out-File -FilePath "${Env:GITHUB_PATH}" -Append
-    - name: Setup Meson and Ninja
+
+    - name: Setup Meson
       shell: pwsh
-      run: pip install meson ninja
+      run: pip install meson
 
     - name: Find Visual Studio
       shell: pwsh
@@ -31,23 +32,21 @@ jobs:
           | Select-Object -ExpandProperty InstallationPath
         Write-Output "VSDEVCMD=${installationPath}\Common7\Tools\VsDevCmd.bat" `
           | Out-File -FilePath "${Env:GITHUB_ENV}" -Append
-    - name: Prepare MSVC x86
-      shell: pwsh
-      run: |
-        & "${Env:COMSPEC}" /s /c "`"${Env:VSDEVCMD}`" -arch=x86 -host_arch=x64 -no_logo && set" `
-          | Out-File -FilePath "${Env:GITHUB_ENV}" -Append
+
     - name: Build MSVC x86
       shell: pwsh
       run: |
-        meson --buildtype release build-msvc-x86
-        ninja -C build-msvc-x86
-    - name: Prepare MSVC x64
-      shell: pwsh
-      run: |
-        & "${Env:COMSPEC}" /s /c "`"${Env:VSDEVCMD}`" -arch=x64 -host_arch=x64 -no_logo && set" `
-          | Out-File -FilePath "${Env:GITHUB_ENV}" -Append
+        & "${Env:COMSPEC}" /s /c "`"${Env:VSDEVCMD}`" -arch=x86 -host_arch=x64 -no_logo && set" `
+          | % { , ($_ -Split '=', 2) } `
+          | % { [System.Environment]::SetEnvironmentVariable($_[0], $_[1]) }
+        meson --buildtype release --backend vs2022 build-msvc-x86
+        msbuild -m build-msvc-x86/dxvk.sln
+
     - name: Build MSVC x64
       shell: pwsh
       run: |
-        meson --buildtype release build-msvc-x64
-        ninja -C build-msvc-x64 
+        & "${Env:COMSPEC}" /s /c "`"${Env:VSDEVCMD}`" -arch=x64 -host_arch=x64 -no_logo && set" `
+          | % { , ($_ -Split '=', 2) } `
+          | % { [System.Environment]::SetEnvironmentVariable($_[0], $_[1]) }
+        meson --buildtype release --backend vs2022 build-msvc-x64
+        msbuild -m build-msvc-x64/dxvk.sln


### PR DESCRIPTION
Also merge Prepare and Build steps to prevent environment variable leaks and apply some minor formatting changes.

Same thing as https://github.com/HansKristian-Work/vkd3d-proton/pull/988 but adapted for DXVK.