### PR TITLE
[d3d11] Add D3D11On12CreateDevice stub

### DIFF
--- a/src/d3d11/d3d11.def
+++ b/src/d3d11/d3d11.def
@@ -3,3 +3,4 @@ EXPORTS
     D3D11CoreCreateDevice @18
     D3D11CreateDevice @22
     D3D11CreateDeviceAndSwapChain @23
+    D3D11On12CreateDevice @24

--- a/src/d3d11/d3d11_main.cpp
+++ b/src/d3d11/d3d11_main.cpp
@@ -242,4 +242,24 @@ extern "C" {
       ppDevice, pFeatureLevel, ppImmediateContext);
   }
   
+
+  DLLEXPORT HRESULT __stdcall D3D11On12CreateDevice(
+          IUnknown*             pDevice,
+          UINT                  Flags,
+    const D3D_FEATURE_LEVEL*    pFeatureLevels,
+          UINT                  FeatureLevels,
+          IUnknown* const*      ppCommandQueues,
+          UINT                  NumQueues,
+          UINT                  NodeMask,
+          ID3D11Device**        ppDevice,
+          ID3D11DeviceContext** ppImmediateContext,
+          D3D_FEATURE_LEVEL*    pChosenFeatureLevel) {
+    static bool s_errorShown = false;
+
+    if (!std::exchange(s_errorShown, true))
+      Logger::err("D3D11On12CreateDevice: Not implemented");
+
+    return E_NOTIMPL;
+  }
+
 }


### PR DESCRIPTION
"Solves" issues like https://github.com/cursey/reframework-d2d/issues/5 by allowing callers to gracefully handle the failure instead of crashing outright.