### PR TITLE
[d3d9] Add HUD items for WaitForResource & CS thread syncs

### DIFF
--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -4068,6 +4068,8 @@ namespace dxvk {
         return false;
       }
       else {
+        m_waitForResourceCount++;
+
         // Make sure pending commands using the resource get
         // executed on the the GPU if we have to wait for it
         Flush();
@@ -4754,6 +4756,8 @@ namespace dxvk {
 
   void D3D9DeviceEx::SynchronizeCsThread() {
     D3D9DeviceLock lock = LockDevice();
+
+    m_csSyncCount++;
 
     // Dispatch current chunk so that all commands
     // recorded prior to this function will be run

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -916,6 +916,23 @@ namespace dxvk {
       return m_samplerCount.load();
     }
 
+    void UpdateFrameHudCounters() {
+      uint32_t csSyncs = m_csSyncCount;
+      uint32_t waitForResource = m_waitForResourceCount;
+      m_csSyncCount = 0;
+      m_waitForResourceCount = 0;
+      m_csSyncCountLastFrame.store(csSyncs, std::memory_order_seq_cst);
+      m_waitForResourceCountLastFrame.store(waitForResource, std::memory_order_seq_cst);
+    }
+
+    UINT GetCsSyncCount() const {
+      return m_csSyncCountLastFrame.load();
+    }
+
+    UINT GetWaitForResourceCount() const {
+      return m_waitForResourceCountLastFrame.load();
+    }
+
   private:
 
     DxvkCsChunkRef AllocCsChunk() {
@@ -1246,6 +1263,13 @@ namespace dxvk {
 
     std::atomic<int64_t>            m_availableMemory = { 0 };
     std::atomic<int32_t>            m_samplerCount    = { 0 };
+
+    std::atomic<int32_t>            m_waitForResourceCountLastFrame = { 0 };
+    std::atomic<int32_t>            m_csSyncCountLastFrame          = { 0 };
+
+    uint32_t m_waitForResourceCount = 0;
+    uint32_t m_csSyncCount          = 0;
+
 
     Direct3DState9                  m_state;
 

--- a/src/d3d9/d3d9_hud.cpp
+++ b/src/d3d9/d3d9_hud.cpp
@@ -33,4 +33,70 @@ namespace dxvk::hud {
     return position;
   }
 
+
+
+  HudWaitForResourceCount::HudWaitForResourceCount(D3D9DeviceEx* device)
+    : m_device               (device)
+    , m_waitForResourceCount ("0"){
+
+  }
+
+
+  void HudWaitForResourceCount::update(dxvk::high_resolution_clock::time_point time) {
+    m_waitForResourceCount = str::format(m_device->GetWaitForResourceCount());
+  }
+
+
+  HudPos HudWaitForResourceCount::render(
+          HudRenderer&      renderer,
+          HudPos            position) {
+    position.y += 16.0f;
+
+    renderer.drawText(16.0f,
+      { position.x, position.y },
+      { 0.0f, 1.0f, 0.75f, 1.0f },
+      "WaitForResource calls:");
+
+    renderer.drawText(16.0f,
+      { position.x + 270.0f, position.y },
+      { 1.0f, 1.0f, 1.0f, 1.0f },
+      m_waitForResourceCount);
+
+    position.y += 8.0f;
+    return position;
+  }
+
+
+
+  HudCsSyncCount::HudCsSyncCount(D3D9DeviceEx* device)
+    : m_device       (device)
+    , m_syncCount ("0"){
+
+  }
+
+
+  void HudCsSyncCount::update(dxvk::high_resolution_clock::time_point time) {
+    m_syncCount = str::format(m_device->GetCsSyncCount());
+  }
+
+
+  HudPos HudCsSyncCount::render(
+          HudRenderer&      renderer,
+          HudPos            position) {
+    position.y += 16.0f;
+
+    renderer.drawText(16.0f,
+      { position.x, position.y },
+      { 0.0f, 1.0f, 0.75f, 1.0f },
+      "CS Thread syncs:");
+
+    renderer.drawText(16.0f,
+      { position.x + 200.0f, position.y },
+      { 1.0f, 1.0f, 1.0f, 1.0f },
+      m_syncCount);
+
+    position.y += 8.0f;
+    return position;
+  }
+
 }

--- a/src/d3d9/d3d9_hud.h
+++ b/src/d3d9/d3d9_hud.h
@@ -28,4 +28,46 @@ namespace dxvk::hud {
 
   };
 
+  class HudWaitForResourceCount : public HudItem {
+
+  public:
+
+    HudWaitForResourceCount(D3D9DeviceEx* device);
+
+    void update(dxvk::high_resolution_clock::time_point time);
+
+    HudPos render(
+            HudRenderer&      renderer,
+            HudPos            position);
+
+  private:
+
+    D3D9DeviceEx* m_device;
+
+    std::string m_waitForResourceCount;
+
+  };
+
+
+
+  class HudCsSyncCount : public HudItem {
+
+  public:
+
+    HudCsSyncCount(D3D9DeviceEx* device);
+
+    void update(dxvk::high_resolution_clock::time_point time);
+
+    HudPos render(
+            HudRenderer&      renderer,
+            HudPos            position);
+
+  private:
+
+    D3D9DeviceEx* m_device;
+
+    std::string m_syncCount;
+
+  };
+
 }

--- a/src/d3d9/d3d9_swapchain.cpp
+++ b/src/d3d9/d3d9_swapchain.cpp
@@ -240,6 +240,8 @@ namespace dxvk {
           DWORD    dwFlags) {
     D3D9DeviceLock lock = m_parent->LockDevice();
 
+    m_parent->UpdateFrameHudCounters();
+
     uint32_t presentInterval = m_presentParams.PresentationInterval;
 
     // This is not true directly in d3d9 to to timing differences that don't matter for us.
@@ -1083,6 +1085,8 @@ namespace dxvk {
     if (m_hud != nullptr) {
       m_hud->addItem<hud::HudClientApiItem>("api", 1, GetApiName());
       m_hud->addItem<hud::HudSamplerCount>("samplers", -1, m_parent);
+      m_hud->addItem<hud::HudCsSyncCount>("cs_syncs", -1, m_parent);
+      m_hud->addItem<hud::HudWaitForResourceCount>("wait_for_resource", -1, m_parent);
     }
   }
 


### PR DESCRIPTION
Given that 90% of D3D9 performance problems with DXVK come down to WaitForResource, this is something we should have done a lot earlier.