### PR TITLE
Reduce the amount of CS thread sync points using CS thread sequence number

### DIFF
--- a/src/d3d9/d3d9_common_buffer.h
+++ b/src/d3d9/d3d9_common_buffer.h
@@ -187,6 +187,28 @@ namespace dxvk {
 
     void PreLoad();
 
+     /**
+     * \brief Tracks sequence number
+     *
+     * Stores which CS chunk the resource was last used on.
+     * \param [in] Seq Sequence number
+     */
+    void TrackMappingBufferSequenceNumber(uint64_t Seq) {
+      m_seq = Seq;
+    }
+
+
+    /**
+     * \brief Queries sequence number for a given subresource
+     *
+     * Returns which CS chunk the resource was last used on.
+     * \param [in] Subresource Subresource index
+     * \returns Sequence number for the given subresource
+     */
+    uint64_t GetMappingBufferSequenceNumber() const {
+      return m_seq;
+    }
+
   private:
 
     Rc<DxvkBuffer> CreateBuffer() const;
@@ -219,6 +241,8 @@ namespace dxvk {
     D3D9Range                   m_gpuReadingRange;
 
     uint32_t                    m_lockCount = 0;
+
+    uint64_t                    m_seq = 0ull;
 
   };
 

--- a/src/d3d9/d3d9_common_texture.h
+++ b/src/d3d9/d3d9_common_texture.h
@@ -435,6 +435,31 @@ namespace dxvk {
     static VkImageType GetImageTypeFromResourceType(
             D3DRESOURCETYPE  Dimension);
 
+     /**
+     * \brief Tracks sequence number for a given subresource
+     *
+     * Stores which CS chunk the resource was last used on.
+     * \param [in] Subresource Subresource index
+     * \param [in] Seq Sequence number
+     */
+    void TrackMappingBufferSequenceNumber(UINT Subresource, uint64_t Seq) {
+      if (Subresource < m_seqs.size())
+        m_seqs[Subresource] = Seq;
+    }
+
+    /**
+     * \brief Queries sequence number for a given subresource
+     *
+     * Returns which CS chunk the resource was last used on.
+     * \param [in] Subresource Subresource index
+     * \returns Sequence number for the given subresource
+     */
+    uint64_t GetMappingBufferSequenceNumber(UINT Subresource) {
+      return Subresource < m_seqs.size()
+        ? m_seqs[Subresource]
+        : 0ull;
+    }
+
   private:
 
     D3D9DeviceEx*                 m_device;
@@ -448,6 +473,8 @@ namespace dxvk {
       Rc<DxvkBuffer>>             m_buffers;
     D3D9SubresourceArray<
       DxvkBufferSliceHandle>      m_mappedSlices;
+    D3D9SubresourceArray<
+      uint64_t>                   m_seqs = { };
 
     D3D9_VK_FORMAT_MAPPING        m_mapping;
 

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -112,7 +112,7 @@ namespace dxvk {
 
   D3D9DeviceEx::~D3D9DeviceEx() {
     Flush();
-    SynchronizeCsThread();
+    SynchronizeCsThread(DxvkCsThread::SynchronizeAll);
 
     delete m_initializer;
     delete m_converter;
@@ -328,7 +328,7 @@ namespace dxvk {
       return hr;
 
     Flush();
-    SynchronizeCsThread();
+    SynchronizeCsThread(DxvkCsThread::SynchronizeAll);
 
     return D3D_OK;
   }
@@ -4051,6 +4051,7 @@ namespace dxvk {
 
   bool D3D9DeviceEx::WaitForResource(
   const Rc<DxvkResource>&                 Resource,
+        uint64_t                          SequenceNumber,
         DWORD                             MapFlags) {
     // Wait for the any pending D3D9 command to be executed
     // on the CS thread so that we can determine whether the
@@ -4062,7 +4063,7 @@ namespace dxvk {
       : DxvkAccess::Read;
 
     if (!Resource->isInUse(access))
-      SynchronizeCsThread();
+      SynchronizeCsThread(SequenceNumber);
 
     if (Resource->isInUse(access)) {
       if (MapFlags & D3DLOCK_DONOTWAIT) {
@@ -4076,7 +4077,7 @@ namespace dxvk {
         // Make sure pending commands using the resource get
         // executed on the the GPU if we have to wait for it
         Flush();
-        SynchronizeCsThread();
+        SynchronizeCsThread(SequenceNumber);
 
         m_dxvkDevice->waitForResource(Resource, access);
       }
@@ -4229,10 +4230,10 @@ namespace dxvk {
         std::memset(physSlice.mapPtr, 0, physSlice.length);
       }
       else if (!skipWait) {
-        if (!(Flags & D3DLOCK_DONOTWAIT) && !WaitForResource(mappedBuffer, D3DLOCK_DONOTWAIT))
+        if (!(Flags & D3DLOCK_DONOTWAIT) && !WaitForResource(mappedBuffer, pResource->GetMappingBufferSequenceNumber(Subresource), D3DLOCK_DONOTWAIT))
           pResource->EnableStagingBufferUploads(Subresource);
 
-        if (!WaitForResource(mappedBuffer, Flags))
+        if (!WaitForResource(mappedBuffer, pResource->GetMappingBufferSequenceNumber(Subresource), Flags))
           return D3DERR_WASSTILLDRAWING;
       }
     }
@@ -4311,7 +4312,7 @@ namespace dxvk {
           });
         }
 
-        if (!WaitForResource(mappedBuffer, Flags))
+        if (!WaitForResource(mappedBuffer, DxvkCsThread::SynchronizeAll, Flags))
           return D3DERR_WASSTILLDRAWING;
       } else {
         // If we are a new alloc, and we weren't written by the GPU
@@ -4523,7 +4524,7 @@ namespace dxvk {
         pitch, std::min(convertFormat.PlaneCount, 2u) * pitch * texLevelExtentBlockCount.height);
 
       Flush();
-      SynchronizeCsThread();
+      SynchronizeCsThread(DxvkCsThread::SynchronizeAll);
 
       m_converter->ConvertFormat(
         convertFormat,
@@ -4640,10 +4641,10 @@ namespace dxvk {
       const bool directMapping = pResource->GetMapMode() == D3D9_COMMON_BUFFER_MAP_MODE_DIRECT;
       const bool skipWait = (!wasWrittenByGPU && (usesStagingBuffer || readOnly || (noOverlap && !directMapping))) || noOverwrite;
       if (!skipWait) {
-        if (!(Flags & D3DLOCK_DONOTWAIT) && !WaitForResource(mappingBuffer, D3DLOCK_DONOTWAIT))
+        if (!(Flags & D3DLOCK_DONOTWAIT) && !WaitForResource(mappingBuffer, pResource->GetMappingBufferSequenceNumber(), D3DLOCK_DONOTWAIT))
           pResource->EnableStagingBufferUploads();
 
-        if (!WaitForResource(mappingBuffer, Flags))
+        if (!WaitForResource(mappingBuffer, pResource->GetMappingBufferSequenceNumber(), Flags))
           return D3DERR_WASSTILLDRAWING;
 
         pResource->SetWrittenByGPU(false);
@@ -4759,14 +4760,14 @@ namespace dxvk {
   }
 
 
-  void D3D9DeviceEx::SynchronizeCsThread() {
+  void D3D9DeviceEx::SynchronizeCsThread(uint64_t SequenceNumber) {
     D3D9DeviceLock lock = LockDevice();
 
     // Dispatch current chunk so that all commands
     // recorded prior to this function will be run
     FlushCsChunk();
 
-    m_csThread.synchronize(DxvkCsThread::SynchronizeAll);
+    m_csThread.synchronize(SequenceNumber);
   }
 
 
@@ -7335,7 +7336,7 @@ namespace dxvk {
       return hr;
 
     Flush();
-    SynchronizeCsThread();
+    SynchronizeCsThread(DxvkCsThread::SynchronizeAll);
 
     return D3D_OK;
   }

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -913,6 +913,7 @@ namespace dxvk {
     });
 
     dstTexInfo->SetWrittenByGPU(dst->GetSubresource(), true);
+    TrackTextureMappingBufferSequenceNumber(dstTexInfo, dst->GetSubresource());
 
     return D3D_OK;
   }
@@ -2681,6 +2682,7 @@ namespace dxvk {
     }
 
     dst->SetWrittenByGPU(true);
+    TrackBufferMappingBufferSequenceNumber(dst);
 
     return D3D_OK;
   }
@@ -4532,6 +4534,8 @@ namespace dxvk {
     if (pResource->IsAutomaticMip())
       MarkTextureMipsDirty(pResource);
 
+    TrackTextureMappingBufferSequenceNumber(pResource, Subresource);
+
     return D3D_OK;
   }
 
@@ -4732,7 +4736,7 @@ namespace dxvk {
 
 
   void D3D9DeviceEx::EmitCsChunk(DxvkCsChunkRef&& chunk) {
-    m_csThread.dispatchChunk(std::move(chunk));
+    m_csSeqNum = m_csThread.dispatchChunk(std::move(chunk));
     m_csIsBusy = true;
   }
 
@@ -7334,6 +7338,26 @@ namespace dxvk {
     SynchronizeCsThread();
 
     return D3D_OK;
+  }
+
+  void D3D9DeviceEx::TrackBufferMappingBufferSequenceNumber(
+        D3D9CommonBuffer* pResource) {
+    uint64_t sequenceNumber = GetCurrentSequenceNumber();
+    pResource->TrackMappingBufferSequenceNumber(sequenceNumber);
+  }
+
+  void D3D9DeviceEx::TrackTextureMappingBufferSequenceNumber(
+      D3D9CommonTexture* pResource,
+      UINT Subresource) {
+    uint64_t sequenceNumber = GetCurrentSequenceNumber();
+    pResource->TrackMappingBufferSequenceNumber(Subresource, sequenceNumber);
+  }
+
+  uint64_t D3D9DeviceEx::GetCurrentSequenceNumber() {
+    // We do not flush empty chunks, so if we are tracking a resource
+    // immediately after a flush, we need to use the sequence number
+    // of the previously submitted chunk to prevent deadlocks.
+    return m_csChunk->empty() ? m_csSeqNum : m_csSeqNum + 1;
   }
 
 }

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -1120,6 +1120,15 @@ namespace dxvk {
 
     void UpdateSamplerDepthModeSpecConstant(uint32_t value);
 
+    void TrackBufferMappingBufferSequenceNumber(
+      D3D9CommonBuffer* pResource);
+
+    void TrackTextureMappingBufferSequenceNumber(
+      D3D9CommonTexture* pResource,
+      UINT Subresource);
+
+    uint64_t GetCurrentSequenceNumber();
+
     Com<D3D9InterfaceEx>            m_parent;
     D3DDEVTYPE                      m_deviceType;
     HWND                            m_window;
@@ -1242,6 +1251,7 @@ namespace dxvk {
       = dxvk::high_resolution_clock::now();
     DxvkCsThread                    m_csThread;
     DxvkCsChunkRef                  m_csChunk;
+    uint64_t                        m_csSeqNum = 0ull;
     bool                            m_csIsBusy = false;
 
     std::atomic<int64_t>            m_availableMemory = { 0 };

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -662,6 +662,7 @@ namespace dxvk {
 
     bool WaitForResource(
       const Rc<DxvkResource>&                 Resource,
+            uint64_t                          SequenceNumber,
             DWORD                             MapFlags);
 
     /**
@@ -731,7 +732,7 @@ namespace dxvk {
 
     void CreateConstantBuffers();
 
-    void SynchronizeCsThread();
+    void SynchronizeCsThread(uint64_t SequenceNumber);
 
     void Flush();
 


### PR DESCRIPTION
Port of the recent D3D11 changes.

Works quite nicely in conjunction with the way we handle resource locking.

GTA IV for example was mostly at 0 syncs before. Every couple of seconds there was a frame that had 20-100+ syncs.
With this PR, it's **always** 0.

Yes, I know that the name `TrackBufferMappingBufferSequenceNumber` is really cumbersome but IMO it's really important here to distinguish between the resource itself and the mapping buffer to avoid confusion. Hopefully someone has a suggestion for a better name.

This will have to be rebased against #2157 if that PR is merged first.