### PR TITLE
RFC: Free unused managed buffers

### DIFF
--- a/src/d3d9/d3d9_common_buffer.cpp
+++ b/src/d3d9/d3d9_common_buffer.cpp
@@ -18,6 +18,10 @@ namespace dxvk {
       m_dirtyRange = D3D9Range(0, m_desc.Size);
   }
 
+  D3D9CommonBuffer::~D3D9CommonBuffer() {
+    m_parent->RemoveManagedBuffer(this);
+  }
+
 
   HRESULT D3D9CommonBuffer::Lock(
           UINT   OffsetToLock,
@@ -51,7 +55,7 @@ namespace dxvk {
       auto lock = m_parent->LockDevice();
 
       if (NeedsUpload())
-        m_parent->FlushBuffer(this);
+        m_parent->FlushBuffer(this, true);
     }
   }
 

--- a/src/d3d9/d3d9_common_buffer.h
+++ b/src/d3d9/d3d9_common_buffer.h
@@ -155,12 +155,12 @@ namespace dxvk {
     /**
     * \brief Whether or not the buffer was written to by the GPU (in IDirect3DDevice9::ProcessVertices)
     */
-    inline bool WasWrittenByGPU() const     { return m_wasWrittenByGPU; }
+    inline bool NeedsReadback() const     { return m_needsReadback; }
 
     /**
     * \brief Sets whether or not the buffer was written to by the GPU
     */
-    inline void SetWrittenByGPU(bool state) { m_wasWrittenByGPU = state; }
+    inline void SetNeedsReadback(bool state) { m_needsReadback = state; }
 
     inline uint32_t IncrementLockCount() { return ++m_lockCount; }
     inline uint32_t DecrementLockCount() {
@@ -207,7 +207,7 @@ namespace dxvk {
     D3D9DeviceEx*               m_parent;
     const D3D9_BUFFER_DESC      m_desc;
     DWORD                       m_mapFlags;
-    bool                        m_wasWrittenByGPU = false;
+    bool                        m_needsReadback = false;
     bool                        m_uploadUsingStaging = false;
 
     Rc<DxvkBuffer>              m_buffer;

--- a/src/d3d9/d3d9_common_buffer.h
+++ b/src/d3d9/d3d9_common_buffer.h
@@ -135,6 +135,16 @@ namespace dxvk {
       return m_sliceHandle;
     }
 
+    /**
+     * \brief Creates the staging buffer if necessary
+     * Creates the mapping and staging buffer
+     * allocates a new buffer if necessary
+     * \returns Whether an allocation happened
+     */
+    bool EnsureStagingBuffer();
+
+    void DestroyStagingBuffer();
+
     inline DWORD GetMapFlags() const      { return m_mapFlags; }
     inline void SetMapFlags(DWORD Flags)  { m_mapFlags = Flags; }
 
@@ -190,7 +200,6 @@ namespace dxvk {
   private:
 
     Rc<DxvkBuffer> CreateBuffer() const;
-    Rc<DxvkBuffer> CreateStagingBuffer() const;
 
     inline const Rc<DxvkBuffer>& GetMapBuffer() const {
       return m_stagingBuffer != nullptr ? m_stagingBuffer : m_buffer;

--- a/src/d3d9/d3d9_common_buffer.h
+++ b/src/d3d9/d3d9_common_buffer.h
@@ -77,6 +77,8 @@ namespace dxvk {
             D3D9DeviceEx*      pDevice,
       const D3D9_BUFFER_DESC*  pDesc);
 
+    ~D3D9CommonBuffer();
+
     HRESULT Lock(
             UINT   OffsetToLock,
             UINT   SizeToLock,

--- a/src/d3d9/d3d9_common_buffer.h
+++ b/src/d3d9/d3d9_common_buffer.h
@@ -199,6 +199,14 @@ namespace dxvk {
 
     void PreLoad();
 
+    inline bool DoesRetainManagedMappingBuffer() {
+      return m_managedReadbackCount > 16;
+    }
+
+    inline void NotifyReadback() {
+      m_managedReadbackCount++;
+    }
+
   private:
 
     Rc<DxvkBuffer> CreateBuffer() const;
@@ -230,6 +238,8 @@ namespace dxvk {
     D3D9Range                   m_gpuReadingRange;
 
     uint32_t                    m_lockCount = 0;
+
+    uint32_t                    m_managedReadbackCount = 0;
 
   };
 

--- a/src/d3d9/d3d9_common_texture.cpp
+++ b/src/d3d9/d3d9_common_texture.cpp
@@ -75,6 +75,8 @@ namespace dxvk {
   D3D9CommonTexture::~D3D9CommonTexture() {
     if (m_size != 0)
       m_device->ChangeReportedMemory(m_size);
+
+    m_device->RemoveManagedTexture(this);
   }
 
 

--- a/src/d3d9/d3d9_common_texture.cpp
+++ b/src/d3d9/d3d9_common_texture.cpp
@@ -500,7 +500,7 @@ namespace dxvk {
       return;
 
     auto lock = m_device->LockDevice();
-    m_device->UploadManagedTexture(this);
+    m_device->UploadManagedTexture(this, true);
     m_device->MarkTextureUploaded(this);
   }
 

--- a/src/d3d9/d3d9_common_texture.h
+++ b/src/d3d9/d3d9_common_texture.h
@@ -379,6 +379,8 @@ namespace dxvk {
     void ClearNeedsUpload() { return m_needsUpload.clearAll();  }
     bool DoesStagingBufferUploads(UINT Subresource) const { return m_uploadUsingStaging.get(Subresource); }
 
+    inline bool AnySubresourceDoesStagingBufferUpload() const { return m_uploadUsingStaging.any(); }
+
     void EnableStagingBufferUploads(UINT Subresource) {
       m_uploadUsingStaging.set(Subresource, true);
     }

--- a/src/d3d9/d3d9_common_texture.h
+++ b/src/d3d9/d3d9_common_texture.h
@@ -437,6 +437,15 @@ namespace dxvk {
     static VkImageType GetImageTypeFromResourceType(
             D3DRESOURCETYPE  Dimension);
 
+    inline bool DoesRetainManagedMappingBuffer() {
+      return m_managedReadbackCount > 16;
+    }
+
+    inline void NotifyReadback() {
+      m_managedReadbackCount++;
+    }
+
+
   private:
 
     D3D9DeviceEx*                 m_device;
@@ -481,6 +490,8 @@ namespace dxvk {
     D3DTEXTUREFILTERTYPE          m_mipFilter = D3DTEXF_LINEAR;
 
     std::array<D3DBOX, 6>         m_dirtyBoxes;
+
+    uint32_t                      m_managedReadbackCount = 0;
 
     /**
      * \brief Mip level

--- a/src/d3d9/d3d9_common_texture.h
+++ b/src/d3d9/d3d9_common_texture.h
@@ -239,7 +239,7 @@ namespace dxvk {
      */
     void DestroyBufferSubresource(UINT Subresource) {
       m_buffers[Subresource] = nullptr;
-      SetWrittenByGPU(Subresource, true);
+      SetNeedsReadback(Subresource, true);
     }
 
     bool IsDynamic() const {
@@ -326,11 +326,11 @@ namespace dxvk {
 
     bool IsAnySubresourceLocked() const { return m_locked.any(); }
 
-    void SetWrittenByGPU(UINT Subresource, bool value) { m_wasWrittenByGPU.set(Subresource, value); }
+    void SetNeedsReadback(UINT Subresource, bool value) { m_needsReadback.set(Subresource, value); }
 
-    bool WasWrittenByGPU(UINT Subresource) const { return m_wasWrittenByGPU.get(Subresource); }
+    bool NeedsReachback(UINT Subresource) const { return m_needsReadback.get(Subresource); }
 
-    void MarkAllWrittenByGPU() { m_wasWrittenByGPU.setAll(); }
+    void MarkAllNeedReadback() { m_needsReadback.setAll(); }
 
     void SetReadOnlyLocked(UINT Subresource, bool readOnly) { return m_readOnly.set(Subresource, readOnly); }
 
@@ -466,7 +466,7 @@ namespace dxvk {
 
     D3D9SubresourceBitset         m_readOnly = { };
 
-    D3D9SubresourceBitset         m_wasWrittenByGPU = { };
+    D3D9SubresourceBitset         m_needsReadback = { };
 
     D3D9SubresourceBitset         m_needsUpload = { };
 

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -4640,6 +4640,15 @@ namespace dxvk {
         if (!(Flags & D3DLOCK_DONOTWAIT) && !WaitForResource(mappingBuffer, D3DLOCK_DONOTWAIT))
           pResource->EnableStagingBufferUploads();
 
+        if (unlikely(needsReadback)) {
+          EmitCs([
+            cMappingBuffer = mappingBuffer,
+            cBuffer = pResource->GetBuffer<D3D9_COMMON_BUFFER_TYPE_REAL>()
+          ] (DxvkContext* ctx) {
+            ctx->copyBuffer(cMappingBuffer, 0, cBuffer, 0, cBuffer->info().size);
+          });
+        }
+
         if (!WaitForResource(mappingBuffer, Flags))
           return D3DERR_WASSTILLDRAWING;
 

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -752,7 +752,7 @@ namespace dxvk {
         cSrcSlice.buffer(), cSrcSlice.offset(), 0, 0);
     });
 
-    dstTextureInfo->SetWrittenByGPU(dst->GetSubresource(), true);
+    dstTextureInfo->SetNeedsReadback(dst->GetSubresource(), true);
 
     if (dstTextureInfo->IsAutomaticMip())
       MarkTextureMipsDirty(dstTextureInfo);
@@ -844,7 +844,7 @@ namespace dxvk {
             cSrcSlice.buffer(), cSrcSlice.offset(), 0, 0);
         });
 
-        dstTexInfo->SetWrittenByGPU(dstTexInfo->CalcSubresource(a, m), true);
+        dstTexInfo->SetNeedsReadback(dstTexInfo->CalcSubresource(a, m), true);
       }
     }
 
@@ -912,7 +912,7 @@ namespace dxvk {
         cLevelExtent);
     });
 
-    dstTexInfo->SetWrittenByGPU(dst->GetSubresource(), true);
+    dstTexInfo->SetNeedsReadback(dst->GetSubresource(), true);
 
     return D3D_OK;
   }
@@ -1125,7 +1125,7 @@ namespace dxvk {
       });
     }
 
-    dstTextureInfo->SetWrittenByGPU(dst->GetSubresource(), true);
+    dstTextureInfo->SetNeedsReadback(dst->GetSubresource(), true);
 
     if (dstTextureInfo->IsAutomaticMip())
       MarkTextureMipsDirty(dstTextureInfo);
@@ -1203,7 +1203,7 @@ namespace dxvk {
       });
     }
 
-    dstTextureInfo->SetWrittenByGPU(dst->GetSubresource(), true);
+    dstTextureInfo->SetNeedsReadback(dst->GetSubresource(), true);
 
     if (dstTextureInfo->IsAutomaticMip())
       MarkTextureMipsDirty(dstTextureInfo);
@@ -1297,7 +1297,7 @@ namespace dxvk {
       if (texInfo->IsAutomaticMip())
         texInfo->SetNeedsMipGen(true);
 
-      texInfo->SetWrittenByGPU(rt->GetSubresource(), true);
+      texInfo->SetNeedsReadback(rt->GetSubresource(), true);
     }
 
     if (originalAlphaSwizzleRTs != m_alphaSwizzleRTs)
@@ -2680,7 +2680,7 @@ namespace dxvk {
       });
     }
 
-    dst->SetWrittenByGPU(true);
+    dst->SetNeedsReadback(true);
 
     return D3D_OK;
   }
@@ -4191,8 +4191,8 @@ namespace dxvk {
     // then we need to copy -> buffer
     // We are also always dirty if we are a render target,
     // a depth stencil, or auto generate mipmaps.
-    bool wasWrittenByGPU = pResource->WasWrittenByGPU(Subresource) || renderable;
-    pResource->SetWrittenByGPU(Subresource, false);
+    bool needsReadback = pResource->NeedsReachback(Subresource) || renderable;
+    pResource->SetNeedsReadback(Subresource, false);
 
     DxvkBufferSliceHandle physSlice;
 
@@ -4220,7 +4220,7 @@ namespace dxvk {
       // or is reading. Remember! This will only trigger for MANAGED resources
       // that cannot get affected by GPU, therefore readonly is A-OK for NOT waiting.
       const bool usesStagingBuffer = pResource->DoesStagingBufferUploads(Subresource);
-      const bool skipWait = (scratch || managed || (systemmem && !wasWrittenByGPU))
+      const bool skipWait = (scratch || managed || (systemmem && !needsReadback))
         && (usesStagingBuffer || readOnly);
 
       if (alloced) {
@@ -4237,8 +4237,8 @@ namespace dxvk {
     else {
       physSlice = pResource->GetMappedSlice(Subresource);
 
-      if (!alloced || wasWrittenByGPU) {
-        if (unlikely(wasWrittenByGPU)) {
+      if (!alloced || needsReadback) {
+        if (unlikely(needsReadback)) {
           Rc<DxvkImage> resourceImage = pResource->GetImage();
 
           Rc<DxvkImage> mappedImage = resourceImage->info().sampleCount != 1
@@ -4417,7 +4417,7 @@ namespace dxvk {
 
     if (shouldToss) {
       pResource->DestroyBufferSubresource(Subresource);
-      pResource->SetWrittenByGPU(Subresource, true);
+      pResource->SetNeedsReadback(Subresource, true);
     }
 
     return D3D_OK;
@@ -4613,7 +4613,7 @@ namespace dxvk {
         ctx->invalidateBuffer(cBuffer, cBufferSlice);
       });
 
-      pResource->SetWrittenByGPU(false);
+      pResource->SetNeedsReadback(false);
       pResource->GPUReadingRange().Clear();
     }
     else {
@@ -4628,13 +4628,13 @@ namespace dxvk {
 
       // If we are respecting the bounds ie. (MANAGED) we can test overlap
       // of our bounds, otherwise we just ignore this and go for it all the time.
-      const bool wasWrittenByGPU = pResource->WasWrittenByGPU();
+      const bool needsReadback = pResource->NeedsReadback();
       const bool readOnly = Flags & D3DLOCK_READONLY;
       const bool noOverlap = !pResource->GPUReadingRange().Overlaps(lockRange);
       const bool noOverwrite = Flags & D3DLOCK_NOOVERWRITE;
       const bool usesStagingBuffer = pResource->DoesStagingBufferUploads();
       const bool directMapping = pResource->GetMapMode() == D3D9_COMMON_BUFFER_MAP_MODE_DIRECT;
-      const bool skipWait = (!wasWrittenByGPU && (usesStagingBuffer || readOnly || (noOverlap && !directMapping))) || noOverwrite;
+      const bool skipWait = (!needsReadback && (usesStagingBuffer || readOnly || (noOverlap && !directMapping))) || noOverwrite;
       if (!skipWait) {
         if (!(Flags & D3DLOCK_DONOTWAIT) && !WaitForResource(mappingBuffer, D3DLOCK_DONOTWAIT))
           pResource->EnableStagingBufferUploads();
@@ -4642,7 +4642,7 @@ namespace dxvk {
         if (!WaitForResource(mappingBuffer, Flags))
           return D3DERR_WASSTILLDRAWING;
 
-        pResource->SetWrittenByGPU(false);
+        pResource->SetNeedsReadback(false);
         pResource->GPUReadingRange().Clear();
       }
     }
@@ -5359,7 +5359,7 @@ namespace dxvk {
 
   void D3D9DeviceEx::MarkTextureMipsDirty(D3D9CommonTexture* pResource) {
     pResource->SetNeedsMipGen(true);
-    pResource->MarkAllWrittenByGPU();
+    pResource->MarkAllNeedReadback();
 
     for (uint32_t i : bit::BitMask(m_activeTextures)) {
       // Guaranteed to not be nullptr...
@@ -6984,7 +6984,7 @@ namespace dxvk {
       });
     }
 
-    dstTextureInfo->MarkAllWrittenByGPU();
+    dstTextureInfo->MarkAllNeedReadback();
   }
 
 

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -916,6 +916,10 @@ namespace dxvk {
       return m_samplerCount.load();
     }
 
+    void BumpFrame() {
+      m_frameCounter++;
+    }
+
   private:
 
     DxvkCsChunkRef AllocCsChunk() {
@@ -1248,6 +1252,8 @@ namespace dxvk {
     std::atomic<int32_t>            m_samplerCount    = { 0 };
 
     Direct3DState9                  m_state;
+
+    uint64_t                        m_frameCounter = 0;
 
   };
 

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -719,7 +719,8 @@ namespace dxvk {
             DWORD                   Flags);
 
     HRESULT FlushBuffer(
-            D3D9CommonBuffer*       pResource);
+            D3D9CommonBuffer*       pResource,
+            bool                    TrackResource);
 
     HRESULT UnlockBuffer(
             D3D9CommonBuffer*       pResource);
@@ -923,11 +924,12 @@ namespace dxvk {
 
     void BumpFrame() {
       m_frameCounter++;
-      ClearUnusedManagedTextures();
+      ClearUnusedManagedResources();
     }
 
     void TrackManagedTexture(D3D9CommonTexture* pResource);
     void RemoveManagedTexture(D3D9CommonTexture* pResource);
+    void RemoveManagedBuffer(D3D9CommonBuffer* pResource);
 
   private:
 
@@ -1133,7 +1135,8 @@ namespace dxvk {
 
     void UpdateSamplerDepthModeSpecConstant(uint32_t value);
 
-    void ClearUnusedManagedTextures();
+    void TrackManagedBuffer(D3D9CommonBuffer* pResource);
+    void ClearUnusedManagedResources();
 
     Com<D3D9InterfaceEx>            m_parent;
     D3DDEVTYPE                      m_deviceType;
@@ -1266,6 +1269,7 @@ namespace dxvk {
 
     uint64_t                                         m_frameCounter = 0;
     std::unordered_map<D3D9CommonTexture*, uint64_t> m_managedTextures;
+    std::unordered_map<D3D9CommonBuffer*, uint64_t>  m_managedBuffers;
 
   };
 

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -924,6 +924,7 @@ namespace dxvk {
 
     void BumpFrame() {
       m_frameCounter++;
+      m_managedCleanupThresholdBumpedInFrame = false;
       ClearUnusedManagedResources();
     }
 
@@ -1266,6 +1267,9 @@ namespace dxvk {
     std::atomic<int32_t>            m_samplerCount    = { 0 };
 
     Direct3DState9                  m_state;
+
+    uint32_t                        m_managedCleanupThreshold = 16;
+    bool                            m_managedCleanupThresholdBumpedInFrame = false;
 
     uint64_t                                         m_frameCounter = 0;
     std::unordered_map<D3D9CommonTexture*, uint64_t> m_managedTextures;

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -87,6 +87,11 @@ namespace dxvk {
     void*           mapPtr = nullptr;
   };
 
+  struct D3D9ManagedTexture {
+    D3D9CommonTexture *pResource;
+    uint64_t           lastUpload;
+  };
+
   class D3D9DeviceEx final : public ComObjectClamp<IDirect3DDevice9Ex> {
     constexpr static uint32_t DefaultFrameLatency = 3;
     constexpr static uint32_t MaxFrameLatency     = 20;
@@ -918,7 +923,11 @@ namespace dxvk {
 
     void BumpFrame() {
       m_frameCounter++;
+      ClearUnusedManagedTextures();
     }
+
+    void RefreshManagedTextureTracking(D3D9CommonTexture* pResource);
+    void RemoveManagedTexture(D3D9CommonTexture* pResource);
 
   private:
 
@@ -1124,6 +1133,9 @@ namespace dxvk {
 
     void UpdateSamplerDepthModeSpecConstant(uint32_t value);
 
+    void TrackManagedTexture(D3D9CommonTexture* pResource);
+    void ClearUnusedManagedTextures();
+
     Com<D3D9InterfaceEx>            m_parent;
     D3DDEVTYPE                      m_deviceType;
     HWND                            m_window;
@@ -1253,7 +1265,8 @@ namespace dxvk {
 
     Direct3DState9                  m_state;
 
-    uint64_t                        m_frameCounter = 0;
+    uint64_t                                         m_frameCounter = 0;
+    std::unordered_map<D3D9CommonTexture*, uint64_t> m_managedTextures;
 
   };
 

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -752,7 +752,7 @@ namespace dxvk {
 
     void MarkRenderHazards();
 
-    void UploadManagedTexture(D3D9CommonTexture* pResource);
+    void UploadManagedTexture(D3D9CommonTexture* pResource, bool trackManaged);
 
     void UploadManagedTextures(uint32_t mask);
 
@@ -926,7 +926,7 @@ namespace dxvk {
       ClearUnusedManagedTextures();
     }
 
-    void RefreshManagedTextureTracking(D3D9CommonTexture* pResource);
+    void TrackManagedTexture(D3D9CommonTexture* pResource);
     void RemoveManagedTexture(D3D9CommonTexture* pResource);
 
   private:
@@ -1133,7 +1133,6 @@ namespace dxvk {
 
     void UpdateSamplerDepthModeSpecConstant(uint32_t value);
 
-    void TrackManagedTexture(D3D9CommonTexture* pResource);
     void ClearUnusedManagedTextures();
 
     Com<D3D9InterfaceEx>            m_parent;

--- a/src/d3d9/d3d9_initializer.cpp
+++ b/src/d3d9/d3d9_initializer.cpp
@@ -32,9 +32,6 @@ namespace dxvk {
     (memFlags & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT)
       ? InitHostVisibleBuffer(pBuffer->GetBufferSlice<D3D9_COMMON_BUFFER_TYPE_REAL>())
       : InitDeviceLocalBuffer(pBuffer->GetBufferSlice<D3D9_COMMON_BUFFER_TYPE_REAL>());
-
-    if (pBuffer->GetMapMode() == D3D9_COMMON_BUFFER_MAP_MODE_BUFFER)
-      InitHostVisibleBuffer(pBuffer->GetBufferSlice<D3D9_COMMON_BUFFER_TYPE_STAGING>());
   }
   
 

--- a/src/d3d9/d3d9_options.cpp
+++ b/src/d3d9/d3d9_options.cpp
@@ -43,7 +43,6 @@ namespace dxvk {
     this->maxFrameRate                  = config.getOption<int32_t>     ("d3d9.maxFrameRate",                  0);
     this->presentInterval               = config.getOption<int32_t>     ("d3d9.presentInterval",               -1);
     this->shaderModel                   = config.getOption<int32_t>     ("d3d9.shaderModel",                   3);
-    this->evictManagedOnUnlock          = config.getOption<bool>        ("d3d9.evictManagedOnUnlock",          false);
     this->dpiAware                      = config.getOption<bool>        ("d3d9.dpiAware",                      true);
     this->strictConstantCopies          = config.getOption<bool>        ("d3d9.strictConstantCopies",          false);
     this->strictPow                     = config.getOption<bool>        ("d3d9.strictPow",                     true);

--- a/src/d3d9/d3d9_options.h
+++ b/src/d3d9/d3d9_options.h
@@ -38,9 +38,6 @@ namespace dxvk {
     /// Set the max shader model the device can support in the caps.
     int32_t shaderModel;
 
-    /// Whether or not managed resources should stay in memory until unlock, or until manually evicted.
-    bool evictManagedOnUnlock;
-
     /// Whether or not to set the process as DPI aware in Windows when the API interface is created.
     bool dpiAware;
 

--- a/src/d3d9/d3d9_swapchain.cpp
+++ b/src/d3d9/d3d9_swapchain.cpp
@@ -468,8 +468,8 @@ namespace dxvk {
         cImage, cSubresources, VkOffset3D { 0, 0, 0 },
         cLevelExtent);
     });
-    
-    dstTexInfo->SetWrittenByGPU(dst->GetSubresource(), true);
+
+    dstTexInfo->SetNeedsReadback(dst->GetSubresource(), true);
 
     return D3D_OK;
   }

--- a/src/d3d9/d3d9_swapchain.cpp
+++ b/src/d3d9/d3d9_swapchain.cpp
@@ -240,6 +240,8 @@ namespace dxvk {
           DWORD    dwFlags) {
     D3D9DeviceLock lock = m_parent->LockDevice();
 
+    m_parent->BumpFrame();
+
     uint32_t presentInterval = m_presentParams.PresentationInterval;
 
     // This is not true directly in d3d9 to to timing differences that don't matter for us.

--- a/src/d3d9/d3d9_texture.cpp
+++ b/src/d3d9/d3d9_texture.cpp
@@ -87,6 +87,7 @@ namespace dxvk {
     // and purely rely on AddDirtyRect to notify D3D9 that contents have changed.
     // We have no way of knowing which mip levels were actually changed.
     m_texture.SetAllNeedUpload();
+    m_texture.Device()->TrackManagedTexture(&m_texture);
     return D3D_OK;
   }
 
@@ -169,6 +170,7 @@ namespace dxvk {
     // and purely rely on AddDirtyBox to notify D3D9 that contents have changed.
     // We have no way of knowing which mip levels were actually changed.
     m_texture.SetAllNeedUpload();
+    m_texture.Device()->TrackManagedTexture(&m_texture);
     return D3D_OK;
   }
 
@@ -259,6 +261,7 @@ namespace dxvk {
     for (uint32_t m = 0; m < m_texture.Desc()->MipLevels; m++) {
       m_texture.SetNeedsUpload(m_texture.CalcSubresource(Face, m), true);
     }
+    m_texture.Device()->TrackManagedTexture(&m_texture);
     return D3D_OK;
   }
 


### PR DESCRIPTION
I'd like to reduce the amount of address space DXVK wastes because of D3DPOOL_MANAGED mapping buffers.

I have two slightly different proposals to do that:

- As soon as we upload a managed resource we start keeping track of the last time it was used. Lock and AddDirtyRect mark it as used.
Once per frame we iterate over the textures and free all managed buffers that haven't been used for 16 (arbitrary) frames. I also remove textures that are marked as needing upload (locked but not yet used) to keep the list short.

- The slightly more aggressive variant (implemented by a7de9d85c33648fe109721a4509496933b2828a9 on top of the above) starts tracking managed resources as soon as they get locked. We also keep textures that haven't been uploaded yet in the list and just upload those after 256 (again arbitrary) frames. This has the advantage that we don't waste memory on textures that got locked but never get used.

The commits after that do the same thing with buffers.

It works very well in Witcher 2 in my very limited testing. 550 -> 54 MB. So less than 10% of what it used before.
![image](https://user-images.githubusercontent.com/1131720/153792207-b4eacba0-c044-47ab-b7cb-6ed346c458e2.png)

I hope that it works with broken games that keep the map pointer around if we make the number of frames it takes before we free the managed buffer large enough. Especially given that I update it in AddDirtyRect & dont free buffers that need to get uploaded.
If it does not, I'd be inclined to add an app option to disable the cleanup.

Also, right now I've disabled all this on 64bit builds. Not sure about that, unnecessarily wasting memory isn't great in 64bit games either even if it shouldnt really be a problem. 


