### PR TITLE
[d3d9] Don't set NeedsReadback for POOL_SYSMEM textures

### DIFF
--- a/src/d3d9/d3d9_common_texture.h
+++ b/src/d3d9/d3d9_common_texture.h
@@ -328,7 +328,7 @@ namespace dxvk {
 
     void SetNeedsReadback(UINT Subresource, bool value) { m_needsReadback.set(Subresource, value); }
 
-    bool NeedsReachback(UINT Subresource) const { return m_needsReadback.get(Subresource); }
+    bool NeedsReachback(UINT Subresource) const { return m_needsReadback.get(Subresource) && m_image != nullptr; }
 
     void MarkAllNeedReadback() { m_needsReadback.setAll(); }
 

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -849,7 +849,6 @@ namespace dxvk {
         cLevelExtent);
     });
 
-    dstTexInfo->SetNeedsReadback(dst->GetSubresource(), true);
     TrackTextureMappingBufferSequenceNumber(dstTexInfo, dst->GetSubresource());
 
     return D3D_OK;
@@ -1234,8 +1233,6 @@ namespace dxvk {
 
       if (texInfo->IsAutomaticMip())
         texInfo->SetNeedsMipGen(true);
-
-      texInfo->SetNeedsReadback(rt->GetSubresource(), true);
     }
 
     if (originalAlphaSwizzleRTs != m_alphaSwizzleRTs)

--- a/src/d3d9/d3d9_swapchain.cpp
+++ b/src/d3d9/d3d9_swapchain.cpp
@@ -469,8 +469,6 @@ namespace dxvk {
         cLevelExtent);
     });
 
-    dstTexInfo->SetNeedsReadback(dst->GetSubresource(), true);
-
     return D3D_OK;
   }
 


### PR DESCRIPTION
GetRenderTargetData & GetFrontbufferData only accept D3DPOOL_SYSMEM textures which never have an image. So we never throw away the mapping buffers and cannot do a readback from the non-existant image either.

Fixes a crash when saving in Witcher 2 found by @doitsujin 