### PR TITLE
[vulkan, dxbc, dxvk] Avoid msvc unsigned negation warning.

### DIFF
--- a/src/dxbc/dxbc_compiler.cpp
+++ b/src/dxbc/dxbc_compiler.cpp
@@ -1109,7 +1109,7 @@ namespace dxvk {
       : 0;
     
     uint32_t resAlign = isStructured
-      ? (resStride & -resStride)
+      ? (resStride & (~resStride + 1))
       : 16;
     
     // Compute the DXVK binding slot index for the resource.

--- a/src/dxvk/dxvk_memory.cpp
+++ b/src/dxvk/dxvk_memory.cpp
@@ -283,7 +283,7 @@ namespace dxvk {
     VkMemoryPropertyFlags remFlags = 0;
     
     while (!result && (flags & optFlags)) {
-      remFlags |= optFlags & -optFlags;
+      remFlags |= optFlags & (~optFlags + 1);
       optFlags &= ~remFlags;
 
       result = this->tryAlloc(req, dedAllocPtr, flags & ~remFlags, hints);

--- a/src/vulkan/vulkan_util.h
+++ b/src/vulkan/vulkan_util.h
@@ -131,7 +131,7 @@ namespace dxvk::vk {
       // Depth-stencil isn't considered multi-planar
       return std::exchange(mask, VkImageAspectFlags(0));
     } else {
-      VkImageAspectFlags result = mask & -mask;
+      VkImageAspectFlags result = mask & (~mask + 1);
       mask &= ~result;
       return result;
     }


### PR DESCRIPTION
warning C4146: unary minus operator applied to unsigned type, result still unsigned