### PR TITLE
Proton Shared Texture Resources Implementation

### DIFF
--- a/src/d3d11/d3d11_device.cpp
+++ b/src/d3d11/d3d11_device.cpp
@@ -23,6 +23,8 @@
 #include "d3d11_texture.h"
 #include "d3d11_video.h"
 
+#include "../util/util_shared_res.h"
+
 namespace dxvk {
   
   constexpr uint32_t D3D11DXGIDevice::DefaultFrameLatency;
@@ -207,7 +209,7 @@ namespace dxvk {
       return S_FALSE;
     
     try {
-      Com<D3D11Texture2D> texture = new D3D11Texture2D(this, &desc);
+      Com<D3D11Texture2D> texture = new D3D11Texture2D(this, &desc, nullptr);
       m_initializer->InitTexture(texture->GetCommonTexture(), pInitialData);
       *ppTexture2D = texture.ref();
       return S_OK;
@@ -1388,10 +1390,7 @@ namespace dxvk {
           HANDLE      hResource,
           REFIID      ReturnedInterface,
           void**      ppResource) {
-    InitReturnPtr(ppResource);
-    
-    Logger::err("D3D11Device::OpenSharedResource: Not implemented");
-    return E_NOTIMPL;
+    return OpenSharedResourceGeneric(true, hResource, ReturnedInterface, ppResource);
   }
   
   
@@ -1399,10 +1398,7 @@ namespace dxvk {
           HANDLE      hResource,
           REFIID      ReturnedInterface,
           void**      ppResource) {
-    InitReturnPtr(ppResource);
-    
-    Logger::err("D3D11Device::OpenSharedResource1: Not implemented");
-    return E_NOTIMPL;
+    return OpenSharedResourceGeneric(false, hResource, ReturnedInterface, ppResource);
   }
 
   
@@ -2257,6 +2253,62 @@ namespace dxvk {
     }
 
     return ~0u;
+  }
+
+
+  HRESULT D3D11Device::OpenSharedResourceGeneric(
+          BOOL        isKmtResource,
+          HANDLE      hResource,
+          REFIID      ReturnedInterface,
+          void**      ppResource) {
+    InitReturnPtr(ppResource);
+
+    if (ppResource == nullptr)
+      return S_FALSE;
+
+    HANDLE ntHandle = isKmtResource ? openKmtHandle(hResource) : hResource;
+
+    if (ntHandle == INVALID_HANDLE_VALUE) {
+      Logger::warn(str::format("D3D11Device::OpenSharedResourceGeneric: Handle not found: ", hResource));
+      return E_INVALIDARG;
+    }
+
+    DxvkSharedTextureMetadata metadata;
+    bool ret = getSharedMetadata(ntHandle, &metadata, sizeof(metadata), NULL);
+
+    if (isKmtResource)
+      ::CloseHandle(ntHandle);
+
+    if (!ret) {
+      Logger::warn("D3D11Device::OpenSharedResourceGeneric: Failed to get shared resource info for a texture");
+      return E_INVALIDARG;
+    }
+
+    D3D11_COMMON_TEXTURE_DESC d3d11Desc;
+
+    d3d11Desc.Width          = metadata.Width;
+    d3d11Desc.Height         = metadata.Height;
+    d3d11Desc.Depth          = 1,
+    d3d11Desc.MipLevels      = metadata.MipLevels;
+    d3d11Desc.ArraySize      = metadata.ArraySize;
+    d3d11Desc.Format         = metadata.Format;
+    d3d11Desc.SampleDesc     = metadata.SampleDesc;
+    d3d11Desc.Usage          = metadata.Usage;
+    d3d11Desc.BindFlags      = metadata.BindFlags;
+    d3d11Desc.CPUAccessFlags = metadata.CPUAccessFlags;
+    d3d11Desc.MiscFlags      = metadata.MiscFlags;
+    d3d11Desc.TextureLayout  = metadata.TextureLayout;
+
+    // Only 2D textures may be shared
+    try {
+      const Com<D3D11Texture2D> texture = new D3D11Texture2D(this, &d3d11Desc, hResource);
+      texture->QueryInterface(ReturnedInterface, ppResource);
+      return S_OK;
+    }
+    catch (const DxvkError& e) {
+      Logger::err(e.message());
+      return E_INVALIDARG;
+    }
   }
 
 

--- a/src/d3d11/d3d11_device.h
+++ b/src/d3d11/d3d11_device.h
@@ -473,6 +473,12 @@ namespace dxvk {
             VkFormat    Format,
             VkImageType Type) const;
 
+    HRESULT OpenSharedResourceGeneric(
+            BOOL        NTHandle,
+            HANDLE      hResource,
+            REFIID      ReturnedInterface,
+            void**      ppResource);
+
     uint32_t GetViewPlaneIndex(
             ID3D11Resource*         pResource,
             DXGI_FORMAT             ViewFormat);

--- a/src/d3d11/d3d11_resource.cpp
+++ b/src/d3d11/d3d11_resource.cpp
@@ -81,9 +81,17 @@ namespace dxvk {
 
   HRESULT STDMETHODCALLTYPE D3D11DXGIResource::GetSharedHandle(
           HANDLE*                 pSharedHandle) {
-    InitReturnPtr(pSharedHandle);
-    Logger::err("D3D11DXGIResource::GetSharedHandle: Stub");
-    return E_NOTIMPL;
+    auto texture = GetCommonTexture(m_resource);
+    if (texture == nullptr || pSharedHandle == nullptr)
+      return E_INVALIDARG;
+
+    HANDLE kmtHandle = texture->GetImage()->sharedHandle();
+
+    if (kmtHandle == INVALID_HANDLE_VALUE)
+      return E_INVALIDARG;
+
+    *pSharedHandle = kmtHandle;
+    return S_OK;
   }
 
 
@@ -132,9 +140,20 @@ namespace dxvk {
           DWORD                   dwAccess,
           LPCWSTR                 lpName,
           HANDLE*                 pHandle) {
-    InitReturnPtr(pHandle);
-    Logger::err("D3D11DXGIResource::CreateSharedHandle: Stub");
-    return E_NOTIMPL;
+    auto texture = GetCommonTexture(m_resource);
+    if (texture == nullptr || pHandle == nullptr)
+      return E_INVALIDARG;
+
+    if (lpName)
+      Logger::warn("Naming shared resources not supported");
+
+    HANDLE handle = texture->GetImage()->sharedHandle();
+
+    if (handle == INVALID_HANDLE_VALUE)
+      return E_INVALIDARG;
+
+    *pHandle = handle;
+    return S_OK;
   }
 
 

--- a/src/d3d11/d3d11_swapchain.cpp
+++ b/src/d3d11/d3d11_swapchain.cpp
@@ -445,7 +445,7 @@ namespace dxvk {
       VkImage imageHandle = m_presenter->getImage(i).image;
       
       Rc<DxvkImage> image = new DxvkImage(
-        m_device->vkd(), imageInfo, imageHandle);
+        m_device.ptr(), imageInfo, imageHandle);
 
       m_imageViews[i] = new DxvkImageView(
         m_device->vkd(), image, viewInfo);

--- a/src/d3d11/d3d11_texture.h
+++ b/src/d3d11/d3d11_texture.h
@@ -78,7 +78,8 @@ namespace dxvk {
       const D3D11_COMMON_TEXTURE_DESC*  pDesc,
             D3D11_RESOURCE_DIMENSION    Dimension,
             DXGI_USAGE                  DxgiUsage,
-            VkImage                     vkImage);
+            VkImage                     vkImage,
+            HANDLE                      hSharedHandle);
     
     ~D3D11CommonTexture();
     
@@ -418,13 +419,14 @@ namespace dxvk {
     
     D3D11_COMMON_TEXTURE_MAP_MODE DetermineMapMode(
       const DxvkImageCreateInfo*  pImageInfo) const;
+
+    void ExportImageInfo();
     
     static VkImageType GetImageTypeFromResourceDim(
             D3D11_RESOURCE_DIMENSION  Dimension);
     
     static VkImageLayout OptimizeLayout(
             VkImageUsageFlags         Usage);
-    
   };
 
 
@@ -599,7 +601,8 @@ namespace dxvk {
     
     D3D11Texture2D(
             D3D11Device*                pDevice,
-      const D3D11_COMMON_TEXTURE_DESC*  pDesc);
+      const D3D11_COMMON_TEXTURE_DESC*  pDesc,
+            HANDLE                      hSharedHandle);
 
     D3D11Texture2D(
             D3D11Device*                pDevice,

--- a/src/d3d9/d3d9_common_texture.cpp
+++ b/src/d3d9/d3d9_common_texture.cpp
@@ -3,6 +3,8 @@
 #include "d3d9_util.h"
 #include "d3d9_device.h"
 
+#include "../util/util_shared_res.h"
+
 #include <algorithm>
 
 namespace dxvk {
@@ -10,7 +12,8 @@ namespace dxvk {
   D3D9CommonTexture::D3D9CommonTexture(
           D3D9DeviceEx*             pDevice,
     const D3D9_COMMON_TEXTURE_DESC* pDesc,
-          D3DRESOURCETYPE           ResourceType)
+          D3DRESOURCETYPE           ResourceType,
+          HANDLE*                   pSharedHandle)
     : m_device(pDevice), m_desc(*pDesc), m_type(ResourceType) {
     if (m_desc.Format == D3D9Format::Unknown)
       m_desc.Format = (m_desc.Usage & D3DUSAGE_DEPTHSTENCIL)
@@ -26,6 +29,9 @@ namespace dxvk {
       for (uint32_t i = 0; i < subresources; i++) {
         SetNeedsUpload(i, true);
       }
+      if (pSharedHandle) {
+        throw DxvkError("D3D9: Incompatible pool type for texture sharing.");
+      }
     }
 
     m_mapping = pDevice->LookupFormat(m_desc.Format);
@@ -39,7 +45,7 @@ namespace dxvk {
                           !(m_desc.Usage & (D3DUSAGE_RENDERTARGET | D3DUSAGE_DEPTHSTENCIL));
 
       try {
-        m_image = CreatePrimaryImage(ResourceType, plainSurface);
+        m_image = CreatePrimaryImage(ResourceType, plainSurface, pSharedHandle);
       }
       catch (const DxvkError& e) {
         // D3DUSAGE_AUTOGENMIPMAP and offscreen plain is mutually exclusive
@@ -47,10 +53,15 @@ namespace dxvk {
         if (m_desc.Usage & D3DUSAGE_AUTOGENMIPMAP || plainSurface) {
           m_desc.Usage &= ~D3DUSAGE_AUTOGENMIPMAP;
           m_desc.MipLevels = 1;
-          m_image = CreatePrimaryImage(ResourceType, false);
+          m_image = CreatePrimaryImage(ResourceType, false, pSharedHandle);
         }
         else
           throw e;
+      }
+
+      if (pSharedHandle && *pSharedHandle == nullptr) {
+        *pSharedHandle = m_image->sharedHandle();
+        ExportImageInfo();
       }
 
       CreateSampleView(0);
@@ -206,7 +217,7 @@ namespace dxvk {
   }
 
 
-  Rc<DxvkImage> D3D9CommonTexture::CreatePrimaryImage(D3DRESOURCETYPE ResourceType, bool TryOffscreenRT) const {
+  Rc<DxvkImage> D3D9CommonTexture::CreatePrimaryImage(D3DRESOURCETYPE ResourceType, bool TryOffscreenRT, HANDLE* pSharedHandle) const {
     DxvkImageCreateInfo imageInfo;
     imageInfo.type            = GetImageTypeFromResourceType(ResourceType);
     imageInfo.format          = m_mapping.ConversionFormatInfo.FormatColor != VK_FORMAT_UNDEFINED
@@ -230,6 +241,13 @@ namespace dxvk {
     imageInfo.tiling          = VK_IMAGE_TILING_OPTIMAL;
     imageInfo.layout          = VK_IMAGE_LAYOUT_GENERAL;
     imageInfo.shared          = m_desc.IsBackBuffer;
+    if (pSharedHandle) {
+      imageInfo.shared = true;
+      imageInfo.sharing.mode = (*pSharedHandle == INVALID_HANDLE_VALUE || *pSharedHandle == nullptr) ? DxvkSharedHandleMode::Export : DxvkSharedHandleMode::Import;
+      imageInfo.sharing.type = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_KMT_BIT;
+      imageInfo.sharing.handle = *pSharedHandle;
+      // TODO: validate metadata?
+    }
 
     if (m_mapping.ConversionFormatInfo.FormatType != D3D9ConversionFormat_None) {
       imageInfo.usage  |= VK_IMAGE_USAGE_STORAGE_BIT;
@@ -280,7 +298,7 @@ namespace dxvk {
     // We must keep LINEAR images in GENERAL layout, but we
     // can choose a better layout for the image based on how
     // it is going to be used by the game.
-    if (imageInfo.tiling == VK_IMAGE_TILING_OPTIMAL)
+    if (imageInfo.tiling == VK_IMAGE_TILING_OPTIMAL && imageInfo.sharing.mode == DxvkSharedHandleMode::None)
       imageInfo.layout = OptimizeLayout(imageInfo.usage);
 
     // For some formats, we need to enable render target
@@ -453,6 +471,56 @@ namespace dxvk {
     
     // Otherwise, we have to stick with the default layout
     return VK_IMAGE_LAYOUT_GENERAL;
+  }
+
+
+  void D3D9CommonTexture::ExportImageInfo() {
+    /* From MSDN:
+      Textures being shared from D3D9 to D3D11 have the following restrictions.
+
+      - Textures must be 2D
+      - Only 1 mip level is allowed
+      - Texture must have default usage
+      - Texture must be write only
+      - MSAA textures are not allowed
+      - Bind flags must have SHADER_RESOURCE and RENDER_TARGET set
+      - Only R10G10B10A2_UNORM, R16G16B16A16_FLOAT and R8G8B8A8_UNORM formats are allowed
+    */
+    DXGI_FORMAT dxgiFormat = DXGI_FORMAT_UNKNOWN;
+
+    switch (m_desc.Format) {
+      case D3D9Format::A2B10G10R10: dxgiFormat = DXGI_FORMAT_R10G10B10A2_UNORM; break;
+      case D3D9Format::A16B16G16R16F: dxgiFormat = DXGI_FORMAT_R16G16B16A16_FLOAT; break;
+      case D3D9Format::A8B8G8R8: dxgiFormat = DXGI_FORMAT_B8G8R8A8_UNORM; break;
+      case D3D9Format::X8R8G8B8: dxgiFormat = DXGI_FORMAT_B8G8R8X8_UNORM; break;
+    }
+
+    if (m_desc.Depth == 1 && m_desc.MipLevels == 1 && m_desc.MultiSample == D3DMULTISAMPLE_NONE &&
+        m_desc.Usage & D3DUSAGE_RENDERTARGET && dxgiFormat != DXGI_FORMAT_UNKNOWN) {
+      HANDLE ntHandle = openKmtHandle(m_image->sharedHandle());
+
+      DxvkSharedTextureMetadata metadata;
+
+      metadata.Width              = m_desc.Width;
+      metadata.Height             = m_desc.Height;
+      metadata.MipLevels          = m_desc.MipLevels;
+      metadata.ArraySize          = m_desc.ArraySize;
+      metadata.Format             = dxgiFormat;
+      metadata.SampleDesc.Count   = 1;
+      metadata.SampleDesc.Quality = 0;
+      metadata.Usage              = D3D11_USAGE_DEFAULT;
+      metadata.BindFlags          = D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_RENDER_TARGET;
+      metadata.CPUAccessFlags     = 0;
+      metadata.MiscFlags          = D3D11_RESOURCE_MISC_SHARED;
+      metadata.TextureLayout      = D3D11_TEXTURE_LAYOUT_UNDEFINED;
+
+      if (ntHandle == INVALID_HANDLE_VALUE || !setSharedMetadata(ntHandle, &metadata, sizeof(metadata))) {
+        Logger::warn("D3D9: Failed to write shared resource info for a texture");
+      }
+
+      if (ntHandle != INVALID_HANDLE_VALUE)
+        ::CloseHandle(ntHandle);
+    }
   }
 
 

--- a/src/d3d9/d3d9_common_texture.h
+++ b/src/d3d9/d3d9_common_texture.h
@@ -71,7 +71,8 @@ namespace dxvk {
     D3D9CommonTexture(
             D3D9DeviceEx*             pDevice,
       const D3D9_COMMON_TEXTURE_DESC* pDesc,
-            D3DRESOURCETYPE           ResourceType);
+            D3DRESOURCETYPE           ResourceType,
+            HANDLE*                   pSharedHandle);
 
     ~D3D9CommonTexture();
 
@@ -513,7 +514,7 @@ namespace dxvk {
      */
     VkDeviceSize GetMipSize(UINT Subresource) const;
 
-    Rc<DxvkImage> CreatePrimaryImage(D3DRESOURCETYPE ResourceType, bool TryOffscreenRT) const;
+    Rc<DxvkImage> CreatePrimaryImage(D3DRESOURCETYPE ResourceType, bool TryOffscreenRT, HANDLE* pSharedHandle) const;
 
     Rc<DxvkImage> CreateResolveImage() const;
 
@@ -541,6 +542,8 @@ namespace dxvk {
 
     VkImageLayout OptimizeLayout(
             VkImageUsageFlags         Usage) const;
+
+    void ExportImageInfo();
 
     static VkImageViewType GetImageViewTypeFromResourceType(
             D3DRESOURCETYPE  Dimension,

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -427,12 +427,17 @@ namespace dxvk {
       return D3DERR_INVALIDCALL;
 
     try {
-      const Com<D3D9Texture2D> texture = new D3D9Texture2D(this, &desc);
-
       void* initialData = nullptr;
 
-      if (Pool == D3DPOOL_SYSTEMMEM && Levels == 1 && pSharedHandle != nullptr)
+      if (Pool == D3DPOOL_SYSTEMMEM && Levels == 1 && pSharedHandle != nullptr) {
         initialData = *(reinterpret_cast<void**>(pSharedHandle));
+        pSharedHandle = nullptr;
+      }
+
+      if (pSharedHandle != nullptr && Pool != D3DPOOL_DEFAULT)
+        return D3DERR_INVALIDCALL;
+
+      const Com<D3D9Texture2D> texture = new D3D9Texture2D(this, &desc, pSharedHandle);
 
       m_initializer->InitTexture(texture->GetCommonTexture(), initialData);
       *ppTexture = texture.ref();
@@ -460,6 +465,9 @@ namespace dxvk {
 
     if (unlikely(ppVolumeTexture == nullptr))
       return D3DERR_INVALIDCALL;
+
+    if (pSharedHandle)
+        Logger::err("CreateVolumeTexture: Shared volume textures not supported");
 
     D3D9_COMMON_TEXTURE_DESC desc;
     desc.Width              = Width;
@@ -506,6 +514,9 @@ namespace dxvk {
     if (unlikely(ppCubeTexture == nullptr))
       return D3DERR_INVALIDCALL;
 
+    if (pSharedHandle)
+        Logger::err("CreateCubeTexture: Shared cube textures not supported");
+
     D3D9_COMMON_TEXTURE_DESC desc;
     desc.Width              = EdgeLength;
     desc.Height             = EdgeLength;
@@ -550,6 +561,9 @@ namespace dxvk {
     if (unlikely(ppVertexBuffer == nullptr))
       return D3DERR_INVALIDCALL;
 
+    if (pSharedHandle)
+        Logger::err("CreateVertexBuffer: Shared vertex buffers not supported");
+
     D3D9_BUFFER_DESC desc;
     desc.Format = D3D9Format::VERTEXDATA;
     desc.FVF    = FVF;
@@ -585,6 +599,9 @@ namespace dxvk {
 
     if (unlikely(ppIndexBuffer == nullptr))
       return D3DERR_INVALIDCALL;
+
+    if (pSharedHandle)
+        Logger::err("CreateIndexBuffer: Shared index buffers not supported");
 
     D3D9_BUFFER_DESC desc;
     desc.Format = EnumerateFormat(Format);
@@ -3427,7 +3444,7 @@ namespace dxvk {
       return D3DERR_INVALIDCALL;
 
     try {
-      const Com<D3D9Surface> surface = new D3D9Surface(this, &desc, nullptr);
+      const Com<D3D9Surface> surface = new D3D9Surface(this, &desc, nullptr, pSharedHandle);
       m_initializer->InitTexture(surface->GetCommonTexture());
       *ppSurface = surface.ref();
       return D3D_OK;
@@ -3470,8 +3487,11 @@ namespace dxvk {
     if (FAILED(D3D9CommonTexture::NormalizeTextureProperties(this, &desc)))
       return D3DERR_INVALIDCALL;
 
+    if (pSharedHandle != nullptr && Pool != D3DPOOL_DEFAULT)
+      return D3DERR_INVALIDCALL;
+
     try {
-      const Com<D3D9Surface> surface = new D3D9Surface(this, &desc, nullptr);
+      const Com<D3D9Surface> surface = new D3D9Surface(this, &desc, nullptr, pSharedHandle);
       m_initializer->InitTexture(surface->GetCommonTexture());
       *ppSurface = surface.ref();
       return D3D_OK;
@@ -3517,7 +3537,7 @@ namespace dxvk {
       return D3DERR_INVALIDCALL;
 
     try {
-      const Com<D3D9Surface> surface = new D3D9Surface(this, &desc, nullptr);
+      const Com<D3D9Surface> surface = new D3D9Surface(this, &desc, nullptr, pSharedHandle);
       m_initializer->InitTexture(surface->GetCommonTexture());
       *ppSurface = surface.ref();
       return D3D_OK;
@@ -7264,7 +7284,7 @@ namespace dxvk {
       if (FAILED(D3D9CommonTexture::NormalizeTextureProperties(this, &desc)))
         return D3DERR_NOTAVAILABLE;
 
-      m_autoDepthStencil = new D3D9Surface(this, &desc, nullptr);
+      m_autoDepthStencil = new D3D9Surface(this, &desc, nullptr, nullptr);
       m_initializer->InitTexture(m_autoDepthStencil->GetCommonTexture());
       SetDepthStencilSurface(m_autoDepthStencil.ptr());
     }

--- a/src/d3d9/d3d9_format.h
+++ b/src/d3d9/d3d9_format.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "d3d9_include.h"
+#include <d3d9.h>
 #include "d3d9_options.h"
 
 #include "../dxvk/dxvk_adapter.h"

--- a/src/d3d9/d3d9_options.h
+++ b/src/d3d9/d3d9_options.h
@@ -3,8 +3,6 @@
 #include "../util/config/config.h"
 #include "../dxvk/dxvk_device.h"
 
-#include "d3d9_include.h"
-
 namespace dxvk {
 
   enum class D3D9FloatEmulation {

--- a/src/d3d9/d3d9_surface.cpp
+++ b/src/d3d9/d3d9_surface.cpp
@@ -9,10 +9,11 @@ namespace dxvk {
   D3D9Surface::D3D9Surface(
           D3D9DeviceEx*             pDevice,
     const D3D9_COMMON_TEXTURE_DESC* pDesc,
-          IUnknown*                 pContainer)
+          IUnknown*                 pContainer,
+          HANDLE*                   pSharedHandle)
     : D3D9SurfaceBase(
         pDevice,
-        new D3D9CommonTexture( pDevice, pDesc, D3DRTYPE_SURFACE),
+        new D3D9CommonTexture( pDevice, pDesc, D3DRTYPE_SURFACE, pSharedHandle),
         0, 0,
         nullptr,
         pContainer) { }

--- a/src/d3d9/d3d9_surface.h
+++ b/src/d3d9/d3d9_surface.h
@@ -20,7 +20,8 @@ namespace dxvk {
     D3D9Surface(
             D3D9DeviceEx*             pDevice,
       const D3D9_COMMON_TEXTURE_DESC* pDesc,
-            IUnknown*                 pContainer);
+            IUnknown*                 pContainer,
+            HANDLE*                   pSharedHandle);
 
     D3D9Surface(
             D3D9DeviceEx*             pDevice,

--- a/src/d3d9/d3d9_swapchain.cpp
+++ b/src/d3d9/d3d9_swapchain.cpp
@@ -994,7 +994,7 @@ namespace dxvk {
       VkImage imageHandle = m_presenter->getImage(i).image;
       
       Rc<DxvkImage> image = new DxvkImage(
-        m_device->vkd(), imageInfo, imageHandle);
+        m_device.ptr(), imageInfo, imageHandle);
 
       m_imageViews[i] = new DxvkImageView(
         m_device->vkd(), image, viewInfo);

--- a/src/d3d9/d3d9_swapchain.cpp
+++ b/src/d3d9/d3d9_swapchain.cpp
@@ -1035,7 +1035,7 @@ namespace dxvk {
     desc.IsAttachmentOnly   = FALSE;
 
     for (uint32_t i = 0; i < m_backBuffers.size(); i++)
-      m_backBuffers[i] = new D3D9Surface(m_parent, &desc, this);
+      m_backBuffers[i] = new D3D9Surface(m_parent, &desc, this, nullptr);
 
     auto swapImage = m_backBuffers[0]->GetCommonTexture()->GetImage();
 

--- a/src/d3d9/d3d9_texture.cpp
+++ b/src/d3d9/d3d9_texture.cpp
@@ -8,8 +8,9 @@ namespace dxvk {
 
   D3D9Texture2D::D3D9Texture2D(
           D3D9DeviceEx*             pDevice,
-    const D3D9_COMMON_TEXTURE_DESC* pDesc)
-    : D3D9Texture2DBase( pDevice, pDesc, D3DRTYPE_TEXTURE ) { }
+    const D3D9_COMMON_TEXTURE_DESC* pDesc,
+          HANDLE*                   pSharedHandle)
+    : D3D9Texture2DBase( pDevice, pDesc, D3DRTYPE_TEXTURE, pSharedHandle ) { }
 
 
   HRESULT STDMETHODCALLTYPE D3D9Texture2D::QueryInterface(REFIID riid, void** ppvObject) {
@@ -97,7 +98,7 @@ namespace dxvk {
   D3D9Texture3D::D3D9Texture3D(
           D3D9DeviceEx*             pDevice,
     const D3D9_COMMON_TEXTURE_DESC* pDesc)
-    : D3D9Texture3DBase( pDevice, pDesc, D3DRTYPE_VOLUMETEXTURE ) { }
+    : D3D9Texture3DBase( pDevice, pDesc, D3DRTYPE_VOLUMETEXTURE, nullptr ) { }
 
 
   HRESULT STDMETHODCALLTYPE D3D9Texture3D::QueryInterface(REFIID riid, void** ppvObject) {
@@ -179,7 +180,7 @@ namespace dxvk {
   D3D9TextureCube::D3D9TextureCube(
           D3D9DeviceEx*             pDevice,
     const D3D9_COMMON_TEXTURE_DESC* pDesc)
-    : D3D9TextureCubeBase( pDevice, pDesc, D3DRTYPE_CUBETEXTURE ) { }
+    : D3D9TextureCubeBase( pDevice, pDesc, D3DRTYPE_CUBETEXTURE, nullptr ) { }
 
 
   HRESULT STDMETHODCALLTYPE D3D9TextureCube::QueryInterface(REFIID riid, void** ppvObject) {

--- a/src/d3d9/d3d9_texture.h
+++ b/src/d3d9/d3d9_texture.h
@@ -23,9 +23,10 @@ namespace dxvk {
     D3D9BaseTexture(
             D3D9DeviceEx*             pDevice,
       const D3D9_COMMON_TEXTURE_DESC* pDesc,
-            D3DRESOURCETYPE           ResourceType)
+            D3DRESOURCETYPE           ResourceType,
+            HANDLE*                   pSharedHandle)
       : D3D9Resource<Base...> ( pDevice )
-      , m_texture             ( pDevice, pDesc, ResourceType )
+      , m_texture             ( pDevice, pDesc, ResourceType, pSharedHandle )
       , m_lod                 ( 0 ) {
       const uint32_t arraySlices = m_texture.Desc()->ArraySize;
       const uint32_t mipLevels   = m_texture.Desc()->MipLevels;
@@ -130,7 +131,8 @@ namespace dxvk {
 
     D3D9Texture2D(
             D3D9DeviceEx*             pDevice,
-      const D3D9_COMMON_TEXTURE_DESC* pDesc);
+      const D3D9_COMMON_TEXTURE_DESC* pDesc,
+            HANDLE*                   pSharedHandle);
 
     HRESULT STDMETHODCALLTYPE QueryInterface(REFIID riid, void** ppvObject);
 

--- a/src/d3d9/d3d9_volume.cpp
+++ b/src/d3d9/d3d9_volume.cpp
@@ -10,7 +10,7 @@ namespace dxvk {
     const D3D9_COMMON_TEXTURE_DESC* pDesc)
     : D3D9VolumeBase(
         pDevice,
-        new D3D9CommonTexture( pDevice, pDesc, D3DRTYPE_VOLUMETEXTURE ),
+        new D3D9CommonTexture( pDevice, pDesc, D3DRTYPE_VOLUMETEXTURE, nullptr ),
         0, 0,
         nullptr,
         nullptr) { }

--- a/src/dxvk/dxvk_adapter.cpp
+++ b/src/dxvk/dxvk_adapter.cpp
@@ -263,7 +263,7 @@ namespace dxvk {
           DxvkDeviceFeatures  enabledFeatures) {
     DxvkDeviceExtensions devExtensions;
 
-    std::array<DxvkExt*, 28> devExtensionList = {{
+    std::array<DxvkExt*, 29> devExtensionList = {{
       &devExtensions.amdMemoryOverallocationBehaviour,
       &devExtensions.amdShaderFragmentMask,
       &devExtensions.ext4444Formats,
@@ -286,6 +286,7 @@ namespace dxvk {
       &devExtensions.khrDepthStencilResolve,
       &devExtensions.khrDrawIndirectCount,
       &devExtensions.khrDriverProperties,
+      &devExtensions.khrExternalMemoryWin32,
       &devExtensions.khrImageFormatList,
       &devExtensions.khrSamplerMirrorClampToEdge,
       &devExtensions.khrShaderFloatControls,

--- a/src/dxvk/dxvk_device.cpp
+++ b/src/dxvk/dxvk_device.cpp
@@ -135,14 +135,14 @@ namespace dxvk {
   Rc<DxvkImage> DxvkDevice::createImage(
     const DxvkImageCreateInfo&  createInfo,
           VkMemoryPropertyFlags memoryType) {
-    return new DxvkImage(m_vkd, createInfo, m_objects.memoryManager(), memoryType);
+    return new DxvkImage(this, createInfo, m_objects.memoryManager(), memoryType);
   }
   
   
   Rc<DxvkImage> DxvkDevice::createImageFromVkImage(
     const DxvkImageCreateInfo&  createInfo,
           VkImage               image) {
-    return new DxvkImage(m_vkd, createInfo, image);
+    return new DxvkImage(this, createInfo, image);
   }
   
   Rc<DxvkImageView> DxvkDevice::createImageView(

--- a/src/dxvk/dxvk_extensions.h
+++ b/src/dxvk/dxvk_extensions.h
@@ -298,6 +298,7 @@ namespace dxvk {
     DxvkExt khrDepthStencilResolve            = { VK_KHR_DEPTH_STENCIL_RESOLVE_EXTENSION_NAME,              DxvkExtMode::Optional };
     DxvkExt khrDrawIndirectCount              = { VK_KHR_DRAW_INDIRECT_COUNT_EXTENSION_NAME,                DxvkExtMode::Optional };
     DxvkExt khrDriverProperties               = { VK_KHR_DRIVER_PROPERTIES_EXTENSION_NAME,                  DxvkExtMode::Optional };
+    DxvkExt khrExternalMemoryWin32            = { VK_KHR_EXTERNAL_MEMORY_WIN32_EXTENSION_NAME,              DxvkExtMode::Optional };
     DxvkExt khrImageFormatList                = { VK_KHR_IMAGE_FORMAT_LIST_EXTENSION_NAME,                  DxvkExtMode::Required };
     DxvkExt khrSamplerMirrorClampToEdge       = { VK_KHR_SAMPLER_MIRROR_CLAMP_TO_EDGE_EXTENSION_NAME,       DxvkExtMode::Optional };
     DxvkExt khrShaderFloatControls            = { VK_KHR_SHADER_FLOAT_CONTROLS_EXTENSION_NAME,              DxvkExtMode::Optional };

--- a/src/dxvk/dxvk_image.cpp
+++ b/src/dxvk/dxvk_image.cpp
@@ -1,16 +1,18 @@
 #include "dxvk_image.h"
 
+#include "dxvk_device.h"
+
 namespace dxvk {
   
   std::atomic<uint64_t> DxvkImageView::s_cookie = { 0ull };
 
 
   DxvkImage::DxvkImage(
-    const Rc<vk::DeviceFn>&     vkd,
+    const DxvkDevice*           device,
     const DxvkImageCreateInfo&  createInfo,
           DxvkMemoryAllocator&  memAlloc,
           VkMemoryPropertyFlags memFlags)
-  : m_vkd(vkd), m_info(createInfo), m_memFlags(memFlags) {
+  : m_vkd(device->vkd()), m_device(device), m_info(createInfo), m_memFlags(memFlags) {
 
     // Copy the compatible view formats to a persistent array
     m_viewFormats.resize(createInfo.viewFormatCount);
@@ -42,6 +44,17 @@ namespace dxvk {
     info.queueFamilyIndexCount = 0;
     info.pQueueFamilyIndices   = nullptr;
     info.initialLayout         = createInfo.initialLayout;
+
+    m_shared = canShareImage(info, createInfo.sharing);
+
+    VkExternalMemoryImageCreateInfo externalInfo;
+    if (m_shared) {
+      externalInfo.sType = VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_IMAGE_CREATE_INFO;
+      externalInfo.pNext = nullptr;
+      externalInfo.handleTypes = createInfo.sharing.type;
+
+      formatList.pNext = &externalInfo;
+    }
     
     if (m_vkd->vkCreateImage(m_vkd->device(),
           &info, nullptr, &m_image.image) != VK_SUCCESS) {
@@ -83,7 +96,29 @@ namespace dxvk {
     dedMemoryAllocInfo.pNext  = VK_NULL_HANDLE;
     dedMemoryAllocInfo.buffer = VK_NULL_HANDLE;
     dedMemoryAllocInfo.image  = m_image.image;
-    
+
+    VkExportMemoryAllocateInfo exportInfo;
+    if (m_shared && createInfo.sharing.mode == DxvkSharedHandleMode::Export) {
+      exportInfo.sType = VK_STRUCTURE_TYPE_EXPORT_MEMORY_ALLOCATE_INFO;
+      exportInfo.pNext = nullptr;
+      exportInfo.handleTypes = createInfo.sharing.type;
+
+      dedMemoryAllocInfo.pNext = &exportInfo;
+    }
+
+#ifdef _WIN32
+    VkImportMemoryWin32HandleInfoKHR importInfo;
+    if (m_shared && createInfo.sharing.mode == DxvkSharedHandleMode::Import) {
+      importInfo.sType = VK_STRUCTURE_TYPE_IMPORT_MEMORY_WIN32_HANDLE_INFO_KHR;
+      importInfo.pNext = nullptr;
+      importInfo.handleType = createInfo.sharing.type;
+      importInfo.handle = createInfo.sharing.handle;
+      importInfo.name = nullptr;
+
+      dedMemoryAllocInfo.pNext = &importInfo;
+    }
+#endif
+
     m_vkd->vkGetImageMemoryRequirements2(
       m_vkd->device(), &memReqInfo, &memReq);
 
@@ -117,10 +152,10 @@ namespace dxvk {
   
   
   DxvkImage::DxvkImage(
-    const Rc<vk::DeviceFn>&     vkd,
+    const DxvkDevice*           device,
     const DxvkImageCreateInfo&  info,
           VkImage               image)
-  : m_vkd(vkd), m_info(info), m_image({ image }) {
+  : m_vkd(device->vkd()), m_device(device), m_info(info), m_image({ image }) {
     
     m_viewFormats.resize(info.viewFormatCount);
     for (uint32_t i = 0; i < info.viewFormatCount; i++)
@@ -135,8 +170,85 @@ namespace dxvk {
     if (m_image.memory.memory() != VK_NULL_HANDLE)
       m_vkd->vkDestroyImage(m_vkd->device(), m_image.image, nullptr);
   }
-  
-  
+
+
+  bool DxvkImage::canShareImage(const VkImageCreateInfo&  createInfo, const DxvkSharedHandleInfo& sharingInfo) const {
+    if (sharingInfo.mode == DxvkSharedHandleMode::None)
+      return false;
+
+    if (!m_device->extensions().khrExternalMemoryWin32) {
+      Logger::err("Failed to create shared resource: VK_KHR_EXTERNAL_MEMORY_WIN32 not supported");
+      return false;
+    }
+
+    VkPhysicalDeviceExternalImageFormatInfo externalImageFormatInfo;
+    externalImageFormatInfo.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_IMAGE_FORMAT_INFO;
+    externalImageFormatInfo.pNext = VK_NULL_HANDLE;
+    externalImageFormatInfo.handleType = sharingInfo.type;
+
+    VkPhysicalDeviceImageFormatInfo2 imageFormatInfo;
+    imageFormatInfo.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_FORMAT_INFO_2;
+    imageFormatInfo.pNext = &externalImageFormatInfo;
+    imageFormatInfo.format = createInfo.format;
+    imageFormatInfo.type = createInfo.imageType;
+    imageFormatInfo.tiling = createInfo.tiling;
+    imageFormatInfo.usage = createInfo.usage;
+    imageFormatInfo.flags = createInfo.flags;
+
+    VkExternalImageFormatProperties externalImageFormatProperties;
+    externalImageFormatProperties.sType = VK_STRUCTURE_TYPE_EXTERNAL_IMAGE_FORMAT_PROPERTIES;
+    externalImageFormatProperties.pNext = nullptr;
+    externalImageFormatProperties.externalMemoryProperties = {};
+
+    VkImageFormatProperties2 imageFormatProperties;
+    imageFormatProperties.sType = VK_STRUCTURE_TYPE_IMAGE_FORMAT_PROPERTIES_2;
+    imageFormatProperties.pNext = &externalImageFormatProperties;
+    imageFormatProperties.imageFormatProperties = {};
+
+    VkResult vr = m_device->adapter()->vki()->vkGetPhysicalDeviceImageFormatProperties2(m_device->adapter()->handle(), &imageFormatInfo, &imageFormatProperties);
+    if (vr != VK_SUCCESS) {
+      Logger::err(str::format("Failed to create shared resource: getImageProperties failed:", vr));
+      return false;
+    }
+
+    if (sharingInfo.mode == DxvkSharedHandleMode::Export) {
+      bool ret = externalImageFormatProperties.externalMemoryProperties.externalMemoryFeatures & VK_EXTERNAL_MEMORY_FEATURE_EXPORTABLE_BIT;
+      if (!ret)
+        Logger::err("Failed to create shared resource: image cannot be exported");
+      return ret;
+    }
+
+    if (sharingInfo.mode == DxvkSharedHandleMode::Import) {
+      bool ret = externalImageFormatProperties.externalMemoryProperties.externalMemoryFeatures & VK_EXTERNAL_MEMORY_FEATURE_IMPORTABLE_BIT;
+      if (!ret)
+        Logger::err("Failed to create shared resource: image cannot be imported");
+      return ret;
+    }
+
+    return false;
+  }
+
+
+  HANDLE DxvkImage::sharedHandle() const {
+    HANDLE handle = INVALID_HANDLE_VALUE;
+
+    if (!m_shared)
+      return INVALID_HANDLE_VALUE;
+
+#ifdef _WIN32
+    VkMemoryGetWin32HandleInfoKHR handleInfo;
+    handleInfo.sType = VK_STRUCTURE_TYPE_MEMORY_GET_WIN32_HANDLE_INFO_KHR;
+    handleInfo.pNext = nullptr;
+    handleInfo.handleType = m_info.sharing.type;
+    handleInfo.memory = m_image.memory.memory();
+    if (m_vkd->vkGetMemoryWin32HandleKHR(m_vkd->device(), &handleInfo, &handle) != VK_SUCCESS)
+      Logger::warn("DxvkImage::DxvkImage: Failed to get shared handle for image");
+#endif
+
+    return handle;
+  }
+
+
   DxvkImageView::DxvkImageView(
     const Rc<vk::DeviceFn>&         vkd,
     const Rc<DxvkImage>&            image,

--- a/src/dxvk/dxvk_image.h
+++ b/src/dxvk/dxvk_image.h
@@ -65,6 +65,9 @@ namespace dxvk {
     // be used with this image
     uint32_t        viewFormatCount = 0;
     const VkFormat* viewFormats     = nullptr;
+
+    // Shared handle info
+    DxvkSharedHandleInfo sharing;
   };
   
   
@@ -124,7 +127,7 @@ namespace dxvk {
   public:
     
     DxvkImage(
-      const Rc<vk::DeviceFn>&     vkd,
+      const DxvkDevice*           device,
       const DxvkImageCreateInfo&  createInfo,
             DxvkMemoryAllocator&  memAlloc,
             VkMemoryPropertyFlags memFlags);
@@ -138,7 +141,7 @@ namespace dxvk {
      * otherwise some image operations may fail.
      */
     DxvkImage(
-      const Rc<vk::DeviceFn>&     vkd,
+      const DxvkDevice*           device,
       const DxvkImageCreateInfo&  info,
             VkImage               image);
     
@@ -313,16 +316,27 @@ namespace dxvk {
       result.layerCount     = info().numLayers;
       return result;
     }
+
+    /**
+     * \brief Create a new shared handle to dedicated memory backing the image
+     * 
+     * \returns The shared handle with the type given by DxvkSharedHandleInfo::type
+     */
+    HANDLE sharedHandle() const;
     
   private:
     
     Rc<vk::DeviceFn>      m_vkd;
+    const DxvkDevice*     m_device;
     DxvkImageCreateInfo   m_info;
     VkMemoryPropertyFlags m_memFlags;
     DxvkPhysicalImage     m_image;
+    bool m_shared = false;
 
     small_vector<VkFormat, 4> m_viewFormats;
     
+    bool canShareImage(const VkImageCreateInfo&  createInfo, const DxvkSharedHandleInfo& sharingInfo) const;
+
   };
   
   

--- a/src/dxvk/dxvk_memory.h
+++ b/src/dxvk/dxvk_memory.h
@@ -17,8 +17,33 @@ namespace dxvk {
     VkDeviceSize memoryAllocated = 0;
     VkDeviceSize memoryUsed      = 0;
   };
-  
-  
+
+
+  enum class DxvkSharedHandleMode {
+      None,
+      Import,
+      Export,
+  };
+
+  /**
+   * \brief Shared handle info
+   *
+   * The shared resource information for a given resource.
+   */
+  struct DxvkSharedHandleInfo {
+    DxvkSharedHandleMode mode = DxvkSharedHandleMode::None;
+    VkExternalMemoryHandleTypeFlagBits type   = VK_EXTERNAL_MEMORY_HANDLE_TYPE_FLAG_BITS_MAX_ENUM;
+    union {
+#ifdef _WIN32
+      HANDLE                             handle = INVALID_HANDLE_VALUE;
+#else
+      // Placeholder for other handle types, such as FD
+      void *dummy;
+#endif
+    };
+  };
+
+
   /**
    * \brief Device memory object
    * 

--- a/src/util/meson.build
+++ b/src/util/meson.build
@@ -6,6 +6,7 @@ util_src = files([
   'util_luid.cpp',
   'util_matrix.cpp',
   'util_monitor.cpp',
+  'util_shared_res.cpp',
   
   'com/com_guid.cpp',
   'com/com_private_data.cpp',

--- a/src/util/util_shared_res.cpp
+++ b/src/util/util_shared_res.cpp
@@ -1,0 +1,46 @@
+#include "util_shared_res.h"
+
+#include "winioctl.h"
+
+namespace dxvk {
+
+  #define IOCTL_SHARED_GPU_RESOURCE_OPEN             CTL_CODE(FILE_DEVICE_VIDEO, 1, METHOD_BUFFERED, FILE_WRITE_ACCESS)
+
+  HANDLE openKmtHandle(HANDLE kmt_handle) {
+    HANDLE handle = ::CreateFileA("\\\\.\\SharedGpuResource", GENERIC_READ | GENERIC_WRITE, 0, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+    if (handle == INVALID_HANDLE_VALUE)
+      return handle;
+
+    struct
+    {
+        unsigned int kmt_handle;
+        WCHAR name[1];
+    } shared_resource_open = {0};
+    shared_resource_open.kmt_handle = reinterpret_cast<uintptr_t>(kmt_handle);
+
+    bool succeed = ::DeviceIoControl(handle, IOCTL_SHARED_GPU_RESOURCE_OPEN, &shared_resource_open, sizeof(shared_resource_open), NULL, 0, NULL, NULL);
+    if (!succeed) {
+      ::CloseHandle(handle);
+      return INVALID_HANDLE_VALUE;
+    }
+    return handle; 
+  }
+
+  #define IOCTL_SHARED_GPU_RESOURCE_SET_METADATA           CTL_CODE(FILE_DEVICE_VIDEO, 4, METHOD_BUFFERED, FILE_WRITE_ACCESS)
+
+  bool setSharedMetadata(HANDLE handle, void *buf, uint32_t bufSize) {
+    DWORD retSize;
+    return ::DeviceIoControl(handle, IOCTL_SHARED_GPU_RESOURCE_SET_METADATA, buf, bufSize, NULL, 0, &retSize, NULL);
+  }
+
+  #define IOCTL_SHARED_GPU_RESOURCE_GET_METADATA           CTL_CODE(FILE_DEVICE_VIDEO, 5, METHOD_BUFFERED, FILE_READ_ACCESS)
+
+  bool getSharedMetadata(HANDLE handle, void *buf, uint32_t bufSize, uint32_t *metadataSize) {
+    DWORD retSize;
+    bool ret = ::DeviceIoControl(handle, IOCTL_SHARED_GPU_RESOURCE_GET_METADATA, NULL, 0, buf, bufSize, &retSize, NULL);
+    if (metadataSize)
+      *metadataSize = retSize;
+    return ret;
+  }
+
+}

--- a/src/util/util_shared_res.h
+++ b/src/util/util_shared_res.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <cstdint>
+
+#include "./com/com_include.h"
+
+#include <d3d11_4.h>
+
+namespace dxvk {
+
+    HANDLE openKmtHandle(HANDLE kmt_handle);
+
+    bool setSharedMetadata(HANDLE handle, void *buf, uint32_t bufSize);
+    bool getSharedMetadata(HANDLE handle, void *buf, uint32_t bufSize, uint32_t *metadataSize);
+
+    struct DxvkSharedTextureMetadata {
+      UINT             Width;
+      UINT             Height;
+      UINT             MipLevels;
+      UINT             ArraySize;
+      DXGI_FORMAT      Format;
+      DXGI_SAMPLE_DESC SampleDesc;
+      D3D11_USAGE      Usage;
+      UINT             BindFlags;
+      UINT             CPUAccessFlags;
+      UINT             MiscFlags;
+      D3D11_TEXTURE_LAYOUT TextureLayout;
+    };
+
+}

--- a/src/vulkan/vulkan_loader.h
+++ b/src/vulkan/vulkan_loader.h
@@ -364,6 +364,11 @@ namespace dxvk::vk {
     #ifdef VK_KHR_buffer_device_address
     VULKAN_FN(vkGetBufferDeviceAddressKHR);
     #endif
+
+    #ifdef VK_KHR_external_memory_win32
+    VULKAN_FN(vkGetMemoryWin32HandleKHR);
+    VULKAN_FN(vkGetMemoryWin32HandlePropertiesKHR);
+    #endif
   };
   
 }


### PR DESCRIPTION
This Pull Request implements shared texture resources for d3d9 and d3d11, using some Proton-Specific extensions to store texture metadata alongside the shared memory handles that back them.  The goal here is just to get the code reviewed if needed, not to get it upstream.

The first commit is a bit of a megacommit, so if it proves a pain to review I'll split it up.

Link to Wine branch for Proton: https://github.com/Guy1524/wine/commits/shared-resources