### PR TITLE
[d3d9] Fix sysmem readback

### DIFF
--- a/src/d3d9/d3d9_common_texture.h
+++ b/src/d3d9/d3d9_common_texture.h
@@ -328,7 +328,7 @@ namespace dxvk {
 
     void SetNeedsReadback(UINT Subresource, bool value) { m_needsReadback.set(Subresource, value); }
 
-    bool NeedsReachback(UINT Subresource) const { return m_needsReadback.get(Subresource) && m_image != nullptr; }
+    bool NeedsReachback(UINT Subresource) const { return m_needsReadback.get(Subresource); }
 
     void MarkAllNeedReadback() { m_needsReadback.setAll(); }
 

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -849,6 +849,7 @@ namespace dxvk {
         cLevelExtent);
     });
 
+    dstTexInfo->SetNeedsReadback(dst->GetSubresource(), true);
     TrackTextureMappingBufferSequenceNumber(dstTexInfo, dst->GetSubresource());
 
     return D3D_OK;
@@ -4159,7 +4160,7 @@ namespace dxvk {
         std::memset(physSlice.mapPtr, 0, physSlice.length);
       }
       else if (!skipWait) {
-        if (unlikely(needsReadback)) {
+        if (unlikely(needsReadback) && pResource->GetImage() != nullptr) {
           Rc<DxvkImage> resourceImage = pResource->GetImage();
 
           Rc<DxvkImage> mappedImage = resourceImage->info().sampleCount != 1

--- a/src/d3d9/d3d9_swapchain.cpp
+++ b/src/d3d9/d3d9_swapchain.cpp
@@ -469,6 +469,9 @@ namespace dxvk {
         cLevelExtent);
     });
 
+    dstTexInfo->SetNeedsReadback(dst->GetSubresource(), true);
+    m_parent->TrackTextureMappingBufferSequenceNumber(dstTexInfo, dst->GetSubresource());
+
     return D3D_OK;
   }
 


### PR DESCRIPTION
Upon further inspection, it turns out that 29d88127090997dcac329d35c45bcacf9ae40d37 is wrong. It prevents DXVK from synchronizing the GPU if the texture that gets locked has been used with GetFrontBufferData or GetRendertargetData.