### PR TITLE
[util] Enable cached vertex and index buffers for The Evil Within

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -35,6 +35,7 @@ namespace dxvk {
      * multiple times                             */
     { R"(\\EvilWithin(Demo)?\.exe$)", {{
       { "d3d11.dcSingleUseMode",            "False" },
+      { "d3d11.cachedDynamicResources",     "vi"   },
     }} },
     /* Far Cry 3: Assumes clear(0.5) on an UNORM  *
      * format to result in 128 on AMD and 127 on  *


### PR DESCRIPTION
Large performance win.

Master:
![Screenshot from 2022-03-03 23-26-26](https://user-images.githubusercontent.com/8129300/156666199-17406b7b-f23f-407c-9371-25dbd5675094.png)
  
With d3d11.cachedDynamicResources = "vi":
![Screenshot from 2022-03-03 23-31-06](https://user-images.githubusercontent.com/8129300/156666255-6e09cb6c-77aa-4473-a230-0b229dfcf7a8.png)


