### PR TITLE
Use memory mapped files for managed textures

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ The `DXVK_HUD` environment variable controls a HUD which can display the framera
 - `cs`: Shows worker thread statistics.
 - `compiler`: Shows shader compiler activity
 - `samplers`: Shows the current number of sampler pairs used *[D3D9 Only]*
+- `managed_mem`: Shows the amount of memory used for D3DPOOL_MANAGED data *[D3D9 Only]*
 - `scale=x`: Scales the HUD by a factor of `x` (e.g. `1.5`)
 
 Additionally, `DXVK_HUD=1` has the same effect as `DXVK_HUD=devinfo,fps`, and `DXVK_HUD=full` enables all available HUD elements.

--- a/dxvk.conf
+++ b/dxvk.conf
@@ -294,17 +294,6 @@
 # d3d9.shaderModel = 3
 
 
-# Evict Managed on Unlock
-# 
-# Decides whether we should evict managed resources from
-# system memory when they are unlocked entirely.
-#
-# Supported values:
-# - True, False: Always enable / disable
-
-# d3d9.evictManagedOnUnlock = False
-
-
 # DPI Awareness
 # 
 # Decides whether we should call SetProcessDPIAware on device

--- a/dxvk.conf
+++ b/dxvk.conf
@@ -546,3 +546,10 @@
 # - True/False
 
 # dxvk.enableDebugUtils = False
+
+# Unmapping delay
+#
+# DXVK will unmap D3D9 managed data after a certain number of frames.
+# 0 to disable unmapping.
+
+# d3d9.unmapDelay = 16

--- a/src/d3d9/d3d9_common_texture.cpp
+++ b/src/d3d9/d3d9_common_texture.cpp
@@ -501,6 +501,21 @@ namespace dxvk {
     return VK_IMAGE_LAYOUT_GENERAL;
   }
 
+  D3D9_COMMON_TEXTURE_MAP_MODE D3D9CommonTexture::DetermineMapMode() const {
+    if (m_desc.Format == D3D9Format::NULL_FORMAT)
+    return D3D9_COMMON_TEXTURE_MAP_MODE_NONE;
+
+    if (m_desc.Pool == D3DPOOL_SYSTEMMEM || m_desc.Pool == D3DPOOL_SCRATCH)
+    return D3D9_COMMON_TEXTURE_MAP_MODE_SYSTEMMEM;
+
+#ifdef D3D9_ALLOW_UNMAPPING
+    if (IsManaged() && m_device->GetOptions()->unmapDelay != 0)
+        return D3D9_COMMON_TEXTURE_MAP_MODE_UNMAPPABLE;
+#endif
+
+    return D3D9_COMMON_TEXTURE_MAP_MODE_BACKED;
+}
+
 
   void D3D9CommonTexture::ExportImageInfo() {
     /* From MSDN:

--- a/src/d3d9/d3d9_common_texture.cpp
+++ b/src/d3d9/d3d9_common_texture.cpp
@@ -86,6 +86,8 @@ namespace dxvk {
   D3D9CommonTexture::~D3D9CommonTexture() {
     if (m_size != 0)
       m_device->ChangeReportedMemory(m_size);
+
+    m_device->RemoveMappedTexture(this);
   }
 
 

--- a/src/d3d9/d3d9_common_texture.h
+++ b/src/d3d9/d3d9_common_texture.h
@@ -255,6 +255,13 @@ namespace dxvk {
      */
     bool CreateBufferSubresource(UINT Subresource);
 
+    void UnmapLockingData() {
+      const uint32_t subresources = CountSubresources();
+      for (uint32_t i = 0; i < subresources; i++) {
+        m_lockingData[i].Unmap();
+      }
+    }
+
     /**
      * \brief Destroys a buffer
      * Destroys mapping and staging buffers for a given subresource
@@ -488,6 +495,14 @@ namespace dxvk {
      */
     VkDeviceSize GetMipSize(UINT Subresource) const;
 
+    void SetMappingFrame(uint64_t Frame) {
+      m_mappingFrame = Frame;
+    }
+
+    uint64_t GetMappingFrame() const {
+      return m_mappingFrame;
+    }
+
   private:
 
     D3D9DeviceEx*                 m_device;
@@ -536,6 +551,8 @@ namespace dxvk {
     D3DTEXTUREFILTERTYPE          m_mipFilter = D3DTEXF_LINEAR;
 
     std::array<D3DBOX, 6>         m_dirtyBoxes;
+
+    uint64_t                      m_mappingFrame;
 
     Rc<DxvkImage> CreatePrimaryImage(D3DRESOURCETYPE ResourceType, bool TryOffscreenRT, HANDLE* pSharedHandle) const;
 

--- a/src/d3d9/d3d9_common_texture.h
+++ b/src/d3d9/d3d9_common_texture.h
@@ -3,6 +3,7 @@
 #include "d3d9_format.h"
 #include "d3d9_util.h"
 #include "d3d9_caps.h"
+#include "d3d9_mem.h"
 
 #include "../dxvk/dxvk_device.h"
 
@@ -22,6 +23,7 @@ namespace dxvk {
     D3D9_COMMON_TEXTURE_MAP_MODE_NONE,      ///< No mapping available
     D3D9_COMMON_TEXTURE_MAP_MODE_BACKED,    ///< Mapped image through buffer
     D3D9_COMMON_TEXTURE_MAP_MODE_SYSTEMMEM, ///< Only a buffer - no image
+    D3D9_COMMON_TEXTURE_MAP_MODE_UNMAPPABLE,   ///< Non-Vulkan memory that can be unmapped
   };
   
   /**
@@ -140,6 +142,25 @@ namespace dxvk {
 
       return m_resolveImage;
     }
+
+    /**
+     * \brief Allocates the internal data used for LockRect/LockBox
+     *
+     * This works regardless of the map mode of this texture if necessary
+     * \param [in] Subresource Subresource index
+     * @return Whether it had to be allocated.
+     */
+    bool AllocLockingData(UINT Subresource);
+
+    /**
+     * \brief Returns a pointer to the internal data used for LockRect/LockBox
+     *
+     * This works regardless of the map mode used by this texture
+     * and will map the memory if necessary.
+     * \param [in] Subresource Subresource index
+     * @return Pointer to locking data
+     */
+    void* GetLockingData(UINT Subresource);
 
     const Rc<DxvkBuffer>& GetBuffer(UINT Subresource) {
       return m_buffers[Subresource];
@@ -378,7 +399,7 @@ namespace dxvk {
     bool NeedsUpload(UINT Subresource) const { return m_needsUpload.get(Subresource); }
     bool NeedsAnyUpload() { return m_needsUpload.any(); }
     void ClearNeedsUpload() { return m_needsUpload.clearAll();  }
-    bool DoesStagingBufferUploads(UINT Subresource) const { return m_uploadUsingStaging.get(Subresource); }
+    bool DoesStagingBufferUploads(UINT Subresource) const { return m_mapMode == D3D9_COMMON_TEXTURE_MAP_MODE_UNMAPPABLE || m_uploadUsingStaging.get(Subresource); }
 
     void EnableStagingBufferUploads(UINT Subresource) {
       m_uploadUsingStaging.set(Subresource, true);
@@ -461,6 +482,12 @@ namespace dxvk {
         : 0ull;
     }
 
+    /**
+     * \brief Mip level
+     * \returns Size of packed mip level in bytes
+     */
+    VkDeviceSize GetMipSize(UINT Subresource) const;
+
   private:
 
     D3D9DeviceEx*                 m_device;
@@ -473,7 +500,9 @@ namespace dxvk {
     D3D9SubresourceArray<
       Rc<DxvkBuffer>>             m_buffers;
     D3D9SubresourceArray<
-      DxvkBufferSliceHandle>      m_mappedSlices;
+      DxvkBufferSliceHandle>      m_mappedSlices = { };
+    D3D9SubresourceArray<
+      D3D9Memory>                 m_lockingData = { };
     D3D9SubresourceArray<
       uint64_t>                   m_seqs = { };
 
@@ -508,12 +537,6 @@ namespace dxvk {
 
     std::array<D3DBOX, 6>         m_dirtyBoxes;
 
-    /**
-     * \brief Mip level
-     * \returns Size of packed mip level in bytes
-     */
-    VkDeviceSize GetMipSize(UINT Subresource) const;
-
     Rc<DxvkImage> CreatePrimaryImage(D3DRESOURCETYPE ResourceType, bool TryOffscreenRT, HANDLE* pSharedHandle) const;
 
     Rc<DxvkImage> CreateResolveImage() const;
@@ -536,6 +559,9 @@ namespace dxvk {
 
       if (m_desc.Pool == D3DPOOL_SYSTEMMEM || m_desc.Pool == D3DPOOL_SCRATCH)
         return D3D9_COMMON_TEXTURE_MAP_MODE_SYSTEMMEM;
+
+      if (IsManaged())
+        return D3D9_COMMON_TEXTURE_MAP_MODE_UNMAPPABLE;
 
       return D3D9_COMMON_TEXTURE_MAP_MODE_BACKED;
     }

--- a/src/d3d9/d3d9_common_texture.h
+++ b/src/d3d9/d3d9_common_texture.h
@@ -570,20 +570,7 @@ namespace dxvk {
             VkFormat              Format,
             VkImageTiling         Tiling) const;
 
-    D3D9_COMMON_TEXTURE_MAP_MODE DetermineMapMode() const {
-      if (m_desc.Format == D3D9Format::NULL_FORMAT)
-        return D3D9_COMMON_TEXTURE_MAP_MODE_NONE;
-
-      if (m_desc.Pool == D3DPOOL_SYSTEMMEM || m_desc.Pool == D3DPOOL_SCRATCH)
-        return D3D9_COMMON_TEXTURE_MAP_MODE_SYSTEMMEM;
-
-#ifdef D3D9_ALLOW_UNMAPPING
-      if (IsManaged())
-        return D3D9_COMMON_TEXTURE_MAP_MODE_UNMAPPABLE;
-#endif
-
-      return D3D9_COMMON_TEXTURE_MAP_MODE_BACKED;
-    }
+    D3D9_COMMON_TEXTURE_MAP_MODE DetermineMapMode() const;
 
     VkImageLayout OptimizeLayout(
             VkImageUsageFlags         Usage) const;

--- a/src/d3d9/d3d9_common_texture.h
+++ b/src/d3d9/d3d9_common_texture.h
@@ -560,8 +560,10 @@ namespace dxvk {
       if (m_desc.Pool == D3DPOOL_SYSTEMMEM || m_desc.Pool == D3DPOOL_SCRATCH)
         return D3D9_COMMON_TEXTURE_MAP_MODE_SYSTEMMEM;
 
+#ifdef D3D9_ALLOW_UNMAPPING
       if (IsManaged())
         return D3D9_COMMON_TEXTURE_MAP_MODE_UNMAPPABLE;
+#endif
 
       return D3D9_COMMON_TEXTURE_MAP_MODE_BACKED;
     }

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -7434,9 +7434,12 @@ namespace dxvk {
   void D3D9DeviceEx::UnmapTextures() {
     // Will only be called inside the device lock
 #ifdef D3D9_USE_MEM_FILE_FOR_MANAGED
+    if (m_d3d9Options.unmapDelay == 0)
+      return;
+
     const bool force = m_memoryAllocator.MappedMemory() > 512 << 20;
     for (auto iter = m_mappedTextures.begin(); iter != m_mappedTextures.end();) {
-      const bool mappingBufferUnused = (m_frameCounter - (*iter)->GetMappingFrame() > 16 || force) && !(*iter)->IsAnySubresourceLocked();
+      const bool mappingBufferUnused = (m_frameCounter - (*iter)->GetMappingFrame() > uint32_t(m_d3d9Options.unmapDelay) || force) && !(*iter)->IsAnySubresourceLocked();
       if (!mappingBufferUnused) {
          iter++;
         continue;

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -4324,8 +4324,7 @@ namespace dxvk {
     pResource->SetLocked(Subresource, true);
 
     const bool noDirtyUpdate = Flags & D3DLOCK_NO_DIRTY_UPDATE;
-    if (likely((pResource->IsManaged() && m_d3d9Options.evictManagedOnUnlock)
-      || ((desc.Pool == D3DPOOL_DEFAULT || !noDirtyUpdate) && !readOnly))) {
+    if ((desc.Pool == D3DPOOL_DEFAULT || !noDirtyUpdate) && !readOnly) {
       if (pBox && MipLevel != 0) {
         D3DBOX scaledBox = *pBox;
         scaledBox.Left   <<= MipLevel;
@@ -4340,7 +4339,7 @@ namespace dxvk {
       }
     }
 
-    if (managed && !m_d3d9Options.evictManagedOnUnlock && !readOnly) {
+    if (managed && !readOnly) {
       pResource->SetNeedsUpload(Subresource, true);
 
       for (uint32_t i : bit::BitMask(m_activeTextures)) {
@@ -4388,7 +4387,7 @@ namespace dxvk {
     const D3DBOX& box = pResource->GetDirtyBox(Face);
     bool shouldFlush  = pResource->GetMapMode() == D3D9_COMMON_TEXTURE_MAP_MODE_BACKED;
          shouldFlush &= box.Left < box.Right && box.Top < box.Bottom && box.Front < box.Back;
-         shouldFlush &= !pResource->IsManaged() || m_d3d9Options.evictManagedOnUnlock;
+         shouldFlush &= !pResource->IsManaged();
 
     if (shouldFlush) {
         this->FlushImage(pResource, Subresource);
@@ -4400,7 +4399,7 @@ namespace dxvk {
     // and we aren't managed (for sysmem copy.)
     bool shouldToss  = pResource->GetMapMode() == D3D9_COMMON_TEXTURE_MAP_MODE_BACKED;
          shouldToss &= !pResource->IsDynamic();
-         shouldToss &= !pResource->IsManaged() || m_d3d9Options.evictManagedOnUnlock;
+         shouldToss &= !pResource->IsManaged();
 
     if (shouldToss) {
       pResource->DestroyBufferSubresource(Subresource);

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -4495,11 +4495,11 @@ namespace dxvk {
       VkDeviceSize rowAlignment = 1;
       DxvkBufferSlice copySrcSlice;
       if (pSrcTexture->DoesStagingBufferUploads(SrcSubresource)) {
-        void* mapPtr = pSrcTexture->GetLockingData(SrcSubresource);
+        const void* mapPtr = pSrcTexture->GetLockingData(SrcSubresource);
         VkDeviceSize dirtySize = extentBlockCount.width * extentBlockCount.height * extentBlockCount.depth * formatInfo->elementSize;
         D3D9BufferSlice slice = AllocTempBuffer<false>(dirtySize);
         copySrcSlice = slice.slice;
-        void* srcData = reinterpret_cast<uint8_t*>(mapPtr) + copySrcOffset;
+        const void* srcData = reinterpret_cast<const uint8_t*>(mapPtr) + copySrcOffset;
         util::packImageData(
           slice.mapPtr, srcData, extentBlockCount, formatInfo->elementSize,
           pitch, pitch * srcTexLevelExtentBlockCount.height);

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -9,6 +9,7 @@
 #include "d3d9_multithread.h"
 #include "d3d9_adapter.h"
 #include "d3d9_constant_set.h"
+#include "d3d9_mem.h"
 
 #include "d3d9_state.h"
 
@@ -928,6 +929,10 @@ namespace dxvk {
       return m_samplerCount.load();
     }
 
+    D3D9MemoryAllocator* GetAllocator() {
+      return &m_memoryAllocator;
+    }
+
   private:
 
     DxvkCsChunkRef AllocCsChunk() {
@@ -1149,6 +1154,8 @@ namespace dxvk {
 
     D3D9Adapter*                    m_adapter;
     Rc<DxvkDevice>                  m_dxvkDevice;
+
+    D3D9MemoryAllocator             m_memoryAllocator;
 
     uint32_t                        m_frameLatency = DefaultFrameLatency;
 

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -26,6 +26,7 @@
 
 #include "d3d9_shader_permutations.h"
 
+#include <unordered_set>
 #include <vector>
 #include <type_traits>
 #include <unordered_map>
@@ -935,7 +936,12 @@ namespace dxvk {
 
     void BumpFrame() {
       m_frameCounter++;
+      UnmapTextures();
     }
+
+    void* MapTexture(D3D9CommonTexture* pTexture, UINT Subresource);
+    void TouchMappedTexture(D3D9CommonTexture* pTexture);
+    void RemoveMappedTexture(D3D9CommonTexture* pTexture);
 
   private:
 
@@ -1148,6 +1154,8 @@ namespace dxvk {
       D3D9CommonTexture* pResource,
       UINT Subresource);
 
+    void UnmapTextures();
+
     uint64_t GetCurrentSequenceNumber();
 
     Com<D3D9InterfaceEx>            m_parent;
@@ -1285,6 +1293,10 @@ namespace dxvk {
     Direct3DState9                  m_state;
 
     uint64_t                        m_frameCounter = 0;
+
+#ifdef D3D9_ALLOW_UNMAPPING
+    std::unordered_set<D3D9CommonTexture*> m_mappedTextures;
+#endif
 
   };
 

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -933,6 +933,10 @@ namespace dxvk {
       return &m_memoryAllocator;
     }
 
+    void BumpFrame() {
+      m_frameCounter++;
+    }
+
   private:
 
     DxvkCsChunkRef AllocCsChunk() {
@@ -1279,6 +1283,8 @@ namespace dxvk {
     std::atomic<int32_t>            m_samplerCount    = { 0 };
 
     Direct3DState9                  m_state;
+
+    uint64_t                        m_frameCounter = 0;
 
   };
 

--- a/src/d3d9/d3d9_hud.cpp
+++ b/src/d3d9/d3d9_hud.cpp
@@ -33,4 +33,34 @@ namespace dxvk::hud {
     return position;
   }
 
+  HudManagedMemory::HudManagedMemory(D3D9DeviceEx* device)
+          : m_device       (device)
+          , m_memoryText ("") {}
+
+
+  void HudManagedMemory::update(dxvk::high_resolution_clock::time_point time) {
+    D3D9MemoryAllocator* allocator = m_device->GetAllocator();
+    m_memoryText = str::format(allocator->AllocatedMemory() >> 20, " MiB, Used: ", allocator->UsedMemory() >> 20, " MiB, Mapped: ", allocator->MappedMemory() >> 20, " MiB");
+  }
+
+
+  HudPos HudManagedMemory::render(
+          HudRenderer&      renderer,
+          HudPos            position) {
+    position.y += 16.0f;
+
+    renderer.drawText(16.0f,
+                      { position.x, position.y },
+                      { 0.0f, 1.0f, 0.75f, 1.0f },
+                      "Managed memory:");
+
+    renderer.drawText(16.0f,
+                      { position.x + 200.0f, position.y },
+                      { 1.0f, 1.0f, 1.0f, 1.0f },
+                      m_memoryText);
+
+    position.y += 8.0f;
+    return position;
+  }
+
 }

--- a/src/d3d9/d3d9_hud.h
+++ b/src/d3d9/d3d9_hud.h
@@ -6,7 +6,7 @@
 namespace dxvk::hud {
 
   /**
-   * \brief HUD item to display DXVK version
+   * \brief HUD item to display sampler count
    */
   class HudSamplerCount : public HudItem {
 
@@ -27,5 +27,28 @@ namespace dxvk::hud {
     std::string m_samplerCount;
 
   };
+
+    /**
+     * \brief HUD item to display managed texture memory
+     */
+    class HudManagedMemory : public HudItem {
+
+    public:
+
+        HudManagedMemory(D3D9DeviceEx* device);
+
+        void update(dxvk::high_resolution_clock::time_point time);
+
+        HudPos render(
+                HudRenderer&      renderer,
+                HudPos            position);
+
+    private:
+
+        D3D9DeviceEx* m_device;
+
+        std::string m_memoryText;
+
+    };
 
 }

--- a/src/d3d9/d3d9_initializer.cpp
+++ b/src/d3d9/d3d9_initializer.cpp
@@ -44,7 +44,8 @@ namespace dxvk {
     if (pTexture->GetMapMode() == D3D9_COMMON_TEXTURE_MAP_MODE_NONE)
       return;
 
-    (pTexture->GetMapMode() == D3D9_COMMON_TEXTURE_MAP_MODE_BACKED)
+    (pTexture->GetMapMode() == D3D9_COMMON_TEXTURE_MAP_MODE_BACKED
+      || pTexture->GetMapMode() == D3D9_COMMON_TEXTURE_MAP_MODE_UNMAPPABLE)
       ? InitDeviceLocalTexture(pTexture)
       : InitHostVisibleTexture(pTexture, pInitialData);
   }

--- a/src/d3d9/d3d9_mem.cpp
+++ b/src/d3d9/d3d9_mem.cpp
@@ -1,12 +1,255 @@
 #include "d3d9_mem.h"
 #include "../util/util_string.h"
-#include "../util/log/log.h"
 #include "../util/util_math.h"
-#include "../util/util_env.h"
-#include "d3d9_include.h"
+#include "../util/log/log.h"
+#include "../util/util_likely.h"
 #include <utility>
 
 namespace dxvk {
+
+#ifdef D3D9_ALLOW_UNMAPPING
+  D3D9Memory D3D9MemoryAllocator::Alloc(uint32_t Size) {
+    std::lock_guard<dxvk::mutex> lock(m_mutex);
+
+    uint32_t alignedSize = align(Size, 16);
+    for (auto& chunk : m_chunks) {
+      D3D9Memory memory = chunk->Alloc(alignedSize);
+      if (memory) {
+        m_usedMemory += memory.GetSize();
+        return memory;
+      }
+    }
+
+    alignedSize = align(Size, 4 << 10);
+    uint32_t chunkSize = std::max(D3D9ChunkSize, alignedSize);
+    m_allocatedMemory += chunkSize;
+
+    D3D9MemoryChunk* chunk = new D3D9MemoryChunk(this, chunkSize);
+    std::unique_ptr<D3D9MemoryChunk> uniqueChunk(chunk);
+    D3D9Memory memory = uniqueChunk->Alloc(alignedSize);
+    m_usedMemory += memory.GetSize();
+
+    m_chunks.push_back(std::move(uniqueChunk));
+    return memory;
+  }
+
+  void D3D9MemoryAllocator::FreeChunk(D3D9MemoryChunk *Chunk) {
+    std::lock_guard<dxvk::mutex> lock(m_mutex);
+
+    m_allocatedMemory -= Chunk->Size();
+
+    m_chunks.erase(std::remove_if(m_chunks.begin(), m_chunks.end(), [&](auto& item) {
+        return item.get() == Chunk;
+    }), m_chunks.end());
+  }
+
+  void D3D9MemoryAllocator::NotifyMapped(uint32_t Size) {
+    std::lock_guard<dxvk::mutex> lock(m_mutex);
+
+    m_mappedMemory += Size;
+  }
+
+  void D3D9MemoryAllocator::NotifyUnmapped(uint32_t Size) {
+    std::lock_guard<dxvk::mutex> lock(m_mutex);
+
+    m_mappedMemory -= Size;
+  }
+
+  void D3D9MemoryAllocator::NotifyFreed(uint32_t Size) {
+    std::lock_guard<dxvk::mutex> lock(m_mutex);
+
+    m_usedMemory -= Size;
+  }
+
+  uint32_t D3D9MemoryAllocator::MappedMemory() {
+    std::lock_guard<dxvk::mutex> lock(m_mutex);
+
+    return m_mappedMemory;
+  }
+
+  uint32_t D3D9MemoryAllocator::UsedMemory() {
+    std::lock_guard<dxvk::mutex> lock(m_mutex);
+
+    return m_usedMemory;
+  }
+
+  uint32_t D3D9MemoryAllocator::AllocatedMemory() {
+    std::lock_guard<dxvk::mutex> lock(m_mutex);
+
+    return m_allocatedMemory;
+  }
+
+
+  D3D9MemoryChunk::D3D9MemoryChunk(D3D9MemoryAllocator* Allocator, uint32_t Size)
+    : m_allocator(Allocator), m_size(Size) {
+    m_mapping = CreateFileMappingA(INVALID_HANDLE_VALUE, nullptr, PAGE_READWRITE | SEC_COMMIT, 0, Size, nullptr);
+    m_freeRanges.push_back({ 0, Size });
+  }
+
+  D3D9MemoryChunk::~D3D9MemoryChunk() {
+    std::lock_guard<dxvk::mutex> lock(m_mutex);
+
+    if (m_ptr != nullptr) {
+      UnmapViewOfFile(m_ptr);
+    }
+    CloseHandle(m_mapping);
+  }
+
+  void D3D9MemoryChunk::IncMapCounter() {
+    std::lock_guard<dxvk::mutex> lock(m_mutex);
+    m_mapCounter++;
+
+    if (m_mapCounter == 1) {
+      m_allocator->NotifyMapped(m_size);
+      m_ptr = MapViewOfFile(m_mapping, FILE_MAP_ALL_ACCESS, 0, 0, m_size);
+    }
+  }
+
+  void D3D9MemoryChunk::DecMapCounter() {
+    std::lock_guard<dxvk::mutex> lock(m_mutex);
+    m_mapCounter--;
+
+    if (m_mapCounter == 0) {
+      m_allocator->NotifyUnmapped(m_size);
+      UnmapViewOfFile(m_ptr);
+      m_ptr = nullptr;
+    }
+  }
+
+  D3D9Memory D3D9MemoryChunk::Alloc(uint32_t Size) {
+    std::lock_guard<dxvk::mutex> lock(m_mutex);
+
+    uint32_t offset = 0;
+    uint32_t size = 0;
+
+    for (auto range = m_freeRanges.begin(); range != m_freeRanges.end(); range++) {
+      if (range->length >= Size) {
+        offset = range->offset;
+        size = Size;
+        range->offset += Size;
+        range->length -= Size;
+        if (range->length < (4 << 10)) {
+          size += range->length;
+          m_freeRanges.erase(range);
+        }
+        break;
+      }
+    }
+
+    if (size != 0)
+      return D3D9Memory(this, offset, size);
+
+    return {};
+  }
+
+  void D3D9MemoryChunk::Free(D3D9Memory *Memory) {
+    std::lock_guard<dxvk::mutex> lock(m_mutex);
+
+    uint32_t offset = Memory->GetOffset();
+    uint32_t length = Memory->GetSize();
+
+    auto curr = m_freeRanges.begin();
+
+    // shamelessly stolen from dxvk_memory.cpp
+    while (curr != m_freeRanges.end()) {
+      if (curr->offset == offset + length) {
+        length += curr->length;
+        curr = m_freeRanges.erase(curr);
+      } else if (curr->offset + curr->length == offset) {
+        offset -= curr->length;
+        length += curr->length;
+        curr = m_freeRanges.erase(curr);
+      } else {
+        curr++;
+      }
+    }
+
+    m_freeRanges.push_back({ offset, length });
+    m_allocator->NotifyFreed(Memory->GetSize());
+  }
+
+  bool D3D9MemoryChunk::IsEmpty() {
+    std::lock_guard<dxvk::mutex> lock(m_mutex);
+
+    return m_freeRanges.size() == 1
+        && m_freeRanges[0].length == m_size;
+  }
+
+  D3D9MemoryAllocator* D3D9MemoryChunk::Allocator() const {
+    return m_allocator;
+  }
+
+
+  D3D9Memory::D3D9Memory(D3D9MemoryChunk* Chunk, size_t Offset, size_t Size)
+    : m_chunk(Chunk), m_offset(Offset), m_size(Size) {}
+
+  D3D9Memory::D3D9Memory(D3D9Memory&& other)
+    : m_chunk(std::exchange(other.m_chunk, nullptr)),
+      m_ptr(std::exchange(other.m_ptr, nullptr)),
+      m_offset(std::exchange(other.m_offset, 0)),
+      m_size(std::exchange(other.m_size, 0)) {}
+
+  D3D9Memory::~D3D9Memory() {
+    this->Free();
+  }
+
+  D3D9Memory& D3D9Memory::operator = (D3D9Memory&& other) {
+    this->Free();
+
+    m_chunk = std::exchange(other.m_chunk, nullptr);
+    m_ptr = std::exchange(other.m_ptr, nullptr);
+    m_offset = std::exchange(other.m_offset, 0);
+    m_size = std::exchange(other.m_size, 0);
+    return *this;
+  }
+
+  void D3D9Memory::Free() {
+    if (unlikely(m_chunk == nullptr))
+      return;
+
+    if (m_ptr != nullptr)
+      m_chunk->DecMapCounter();
+
+    m_chunk->Free(this);
+    if (m_chunk->IsEmpty()) {
+      D3D9MemoryAllocator* allocator = m_chunk->Allocator();
+      allocator->FreeChunk(m_chunk);
+    }
+    m_chunk = nullptr;
+  }
+
+  void D3D9Memory::Map() {
+    if (unlikely(m_ptr != nullptr))
+      return;
+
+    if (unlikely(m_chunk == nullptr)) {
+      Logger::err("Tried to map dead memory");
+      return;
+    }
+
+    m_chunk->IncMapCounter();
+    uint8_t* ptr = reinterpret_cast<uint8_t*>(m_chunk->Ptr());
+    m_ptr = ptr + m_offset;
+  }
+
+  void D3D9Memory::Unmap() {
+    if (unlikely(m_ptr == nullptr))
+      return;
+
+    m_ptr = nullptr;
+    m_chunk->DecMapCounter();
+  }
+
+  void* D3D9Memory::Ptr() {
+    if (unlikely(m_ptr == nullptr)) {
+      Logger::err("Tried accessing unmapped memory.");
+      return nullptr;
+    }
+
+    return m_ptr;
+  }
+
+#else
 
     D3D9Memory D3D9MemoryAllocator::Alloc(uint32_t Size) {
       std::lock_guard<dxvk::mutex> lock(m_mutex);
@@ -69,5 +312,7 @@ namespace dxvk {
 
       std::free(m_ptr);
     }
+
+#endif
 
 }

--- a/src/d3d9/d3d9_mem.cpp
+++ b/src/d3d9/d3d9_mem.cpp
@@ -1,0 +1,73 @@
+#include "d3d9_mem.h"
+#include "../util/util_string.h"
+#include "../util/log/log.h"
+#include "../util/util_math.h"
+#include "../util/util_env.h"
+#include "d3d9_include.h"
+#include <utility>
+
+namespace dxvk {
+
+    D3D9Memory D3D9MemoryAllocator::Alloc(uint32_t Size) {
+      std::lock_guard<dxvk::mutex> lock(m_mutex);
+
+      m_usedMemory += Size;
+
+      return D3D9Memory(this, Size);
+    }
+
+    void D3D9MemoryAllocator::NotifyFreed(uint32_t Size) {
+      std::lock_guard<dxvk::mutex> lock(m_mutex);
+
+      m_usedMemory -= Size;
+    }
+
+    uint32_t D3D9MemoryAllocator::MappedMemory() {
+      std::lock_guard<dxvk::mutex> lock(m_mutex);
+
+      return m_usedMemory;
+    }
+
+    uint32_t D3D9MemoryAllocator::UsedMemory() {
+      std::lock_guard<dxvk::mutex> lock(m_mutex);
+
+      return m_usedMemory;
+    }
+
+    uint32_t D3D9MemoryAllocator::AllocatedMemory() {
+      std::lock_guard<dxvk::mutex> lock(m_mutex);
+
+      return m_usedMemory;
+    }
+
+    D3D9Memory::D3D9Memory(D3D9MemoryAllocator* Allocator, size_t Size)
+      : m_allocator(Allocator), m_ptr(std::malloc(Size)), m_size(Size) { }
+
+    D3D9Memory::D3D9Memory(D3D9Memory&& other)
+      : m_allocator(std::exchange(other.m_allocator, nullptr)),
+        m_ptr(std::exchange(other.m_ptr, nullptr)),
+        m_size(std::exchange(other.m_size, 0)) {}
+
+    D3D9Memory::~D3D9Memory() {
+      this->Free();
+    }
+
+    D3D9Memory& D3D9Memory::operator = (D3D9Memory&& other) {
+      this->Free();
+
+      m_allocator = std::exchange(other.m_allocator, nullptr);
+      m_ptr = std::exchange(other.m_ptr, nullptr);
+      m_size = std::exchange(other.m_size, 0);
+      return *this;
+    }
+
+    void D3D9Memory::Free() {
+      if (!m_ptr)
+        return;
+
+      m_allocator->NotifyFreed(m_size);
+
+      std::free(m_ptr);
+    }
+
+}

--- a/src/d3d9/d3d9_mem.h
+++ b/src/d3d9/d3d9_mem.h
@@ -3,10 +3,120 @@
 
 #include "../util/thread.h"
 
+#if defined(_WIN32) && !defined(_WIN64)
+  #define D3D9_ALLOW_UNMAPPING
+#endif
+
+#ifdef D3D9_ALLOW_UNMAPPING
+  #define WIN32_LEAN_AND_MEAN
+  #include <winbase.h>
+#endif
+
 namespace dxvk {
 
   class D3D9MemoryAllocator;
   class D3D9Memory;
+
+#ifdef D3D9_ALLOW_UNMAPPING
+
+  class D3D9MemoryChunk;
+
+  constexpr uint32_t D3D9ChunkSize = 16 << 20;
+
+  struct D3D9MemoryRange {
+    uint32_t offset;
+    uint32_t length;
+  };
+
+  class D3D9MemoryChunk {
+    friend D3D9MemoryAllocator;
+
+    public:
+      ~D3D9MemoryChunk();
+
+      D3D9MemoryChunk             (const D3D9MemoryChunk&) = delete;
+      D3D9MemoryChunk& operator = (const D3D9MemoryChunk&) = delete;
+
+      D3D9MemoryChunk             (D3D9MemoryChunk&& other) = delete;
+      D3D9MemoryChunk& operator = (D3D9MemoryChunk&& other) = delete;
+
+      void IncMapCounter();
+      void DecMapCounter();
+      void* Ptr() const { return m_ptr; }
+      D3D9Memory Alloc(uint32_t Size);
+      void Free(D3D9Memory* Memory);
+      bool IsEmpty();
+      uint32_t Size() const { return m_size; }
+      D3D9MemoryAllocator* Allocator() const;
+
+    private:
+      D3D9MemoryChunk(D3D9MemoryAllocator* Allocator, uint32_t Size);
+
+      dxvk::mutex m_mutex;
+      D3D9MemoryAllocator* m_allocator;
+      uint32_t m_mapCounter = 0;
+      HANDLE m_mapping;
+      void* m_ptr;
+      uint32_t m_size;
+      std::vector<D3D9MemoryRange> m_freeRanges;
+  };
+
+  class D3D9Memory {
+    friend D3D9MemoryChunk;
+
+    public:
+      D3D9Memory() {}
+      ~D3D9Memory();
+
+      D3D9Memory             (const D3D9Memory&) = delete;
+      D3D9Memory& operator = (const D3D9Memory&) = delete;
+
+      D3D9Memory             (D3D9Memory&& other);
+      D3D9Memory& operator = (D3D9Memory&& other);
+
+      operator bool() const { return m_chunk != nullptr; }
+
+      void Map();
+      void Unmap();
+      void* Ptr();
+      D3D9MemoryChunk* GetChunk() const { return m_chunk; }
+      size_t GetOffset() const { return m_offset; }
+      size_t GetSize() const { return m_size; }
+
+    private:
+      D3D9Memory(D3D9MemoryChunk* Chunk, size_t Offset, size_t Size);
+      void Free();
+
+      D3D9MemoryChunk* m_chunk = nullptr;
+      void* m_ptr              = nullptr;
+      size_t m_offset          = 0;
+      size_t m_size            = 0;
+  };
+
+  class D3D9MemoryAllocator {
+    friend D3D9MemoryChunk;
+
+    public:
+      D3D9MemoryAllocator() = default;
+      ~D3D9MemoryAllocator() = default;
+      D3D9Memory Alloc(uint32_t Size);
+      void FreeChunk(D3D9MemoryChunk* Chunk);
+      void NotifyMapped(uint32_t Size);
+      void NotifyUnmapped(uint32_t Size);
+      void NotifyFreed(uint32_t Size);
+      uint32_t MappedMemory();
+      uint32_t UsedMemory();
+      uint32_t AllocatedMemory();
+
+    private:
+      dxvk::mutex m_mutex;
+      std::vector<std::unique_ptr<D3D9MemoryChunk>> m_chunks;
+      size_t m_mappedMemory = 0;
+      size_t m_allocatedMemory = 0;
+      size_t m_usedMemory = 0;
+  };
+
+#else
     class D3D9Memory {
     public:
       D3D9Memory() = default;
@@ -49,5 +159,7 @@ namespace dxvk {
       dxvk::mutex m_mutex;
       size_t m_usedMemory = 0;
     };
+
+#endif
 
 }

--- a/src/d3d9/d3d9_mem.h
+++ b/src/d3d9/d3d9_mem.h
@@ -1,0 +1,53 @@
+
+#pragma once
+
+#include "../util/thread.h"
+
+namespace dxvk {
+
+  class D3D9MemoryAllocator;
+  class D3D9Memory;
+    class D3D9Memory {
+    public:
+      D3D9Memory() = default;
+      D3D9Memory(D3D9MemoryAllocator* Allocator, size_t Size);
+      ~D3D9Memory();
+
+      D3D9Memory             (const D3D9Memory&) = delete;
+      D3D9Memory& operator = (const D3D9Memory&) = delete;
+
+      D3D9Memory             (D3D9Memory&& other);
+      D3D9Memory& operator = (D3D9Memory&& other);
+
+      operator bool() const { return m_ptr != nullptr; }
+
+      void Map(){}
+      void Unmap(){}
+      void* Ptr() { return m_ptr; }
+
+    private:
+      void Free();
+
+      D3D9MemoryAllocator* m_allocator = nullptr;
+      void* m_ptr              = nullptr;
+      size_t m_offset          = 0;
+      size_t m_size            = 0;
+    };
+
+    class D3D9MemoryAllocator {
+
+    public:
+      D3D9MemoryAllocator() = default;
+      ~D3D9MemoryAllocator() = default;
+      D3D9Memory Alloc(uint32_t Size);
+      void NotifyFreed(uint32_t Size);
+      uint32_t MappedMemory();
+      uint32_t UsedMemory();
+      uint32_t AllocatedMemory();
+
+    private:
+      dxvk::mutex m_mutex;
+      size_t m_usedMemory = 0;
+    };
+
+}

--- a/src/d3d9/d3d9_options.cpp
+++ b/src/d3d9/d3d9_options.cpp
@@ -43,7 +43,6 @@ namespace dxvk {
     this->maxFrameRate                  = config.getOption<int32_t>     ("d3d9.maxFrameRate",                  0);
     this->presentInterval               = config.getOption<int32_t>     ("d3d9.presentInterval",               -1);
     this->shaderModel                   = config.getOption<int32_t>     ("d3d9.shaderModel",                   3);
-    this->evictManagedOnUnlock          = config.getOption<bool>        ("d3d9.evictManagedOnUnlock",          false);
     this->dpiAware                      = config.getOption<bool>        ("d3d9.dpiAware",                      true);
     this->strictConstantCopies          = config.getOption<bool>        ("d3d9.strictConstantCopies",          false);
     this->strictPow                     = config.getOption<bool>        ("d3d9.strictPow",                     true);

--- a/src/d3d9/d3d9_options.cpp
+++ b/src/d3d9/d3d9_options.cpp
@@ -72,6 +72,7 @@ namespace dxvk {
     this->apitraceMode                  = config.getOption<bool>        ("d3d9.apitraceMode",                  false);
     this->deviceLocalConstantBuffers    = config.getOption<bool>        ("d3d9.deviceLocalConstantBuffers",    false);
     this->allowDirectBufferMapping      = config.getOption<bool>        ("d3d9.allowDirectBufferMapping",      true);
+    this->unmapDelay                    = config.getOption<int32_t>     ("d3d9.unmapDelay", 16);
 
     // If we are not Nvidia, enable general hazards.
     this->generalHazards = adapter != nullptr

--- a/src/d3d9/d3d9_options.h
+++ b/src/d3d9/d3d9_options.h
@@ -36,9 +36,6 @@ namespace dxvk {
     /// Set the max shader model the device can support in the caps.
     int32_t shaderModel;
 
-    /// Whether or not managed resources should stay in memory until unlock, or until manually evicted.
-    bool evictManagedOnUnlock;
-
     /// Whether or not to set the process as DPI aware in Windows when the API interface is created.
     bool dpiAware;
 

--- a/src/d3d9/d3d9_options.h
+++ b/src/d3d9/d3d9_options.h
@@ -154,6 +154,9 @@ namespace dxvk {
 
     /// Disable direct buffer mapping
     bool allowDirectBufferMapping;
+
+    /// How many frames need to pass before managed data gets unmapped
+    int32_t unmapDelay;
   };
 
 }

--- a/src/d3d9/d3d9_swapchain.cpp
+++ b/src/d3d9/d3d9_swapchain.cpp
@@ -252,6 +252,8 @@ namespace dxvk {
           DWORD    dwFlags) {
     D3D9DeviceLock lock = m_parent->LockDevice();
 
+    m_parent->BumpFrame();
+
     uint32_t presentInterval = m_presentParams.PresentationInterval;
 
     // This is not true directly in d3d9 to to timing differences that don't matter for us.

--- a/src/d3d9/d3d9_swapchain.cpp
+++ b/src/d3d9/d3d9_swapchain.cpp
@@ -1092,6 +1092,7 @@ namespace dxvk {
     if (m_hud != nullptr) {
       m_hud->addItem<hud::HudClientApiItem>("api", 1, GetApiName());
       m_hud->addItem<hud::HudSamplerCount>("samplers", -1, m_parent);
+      m_hud->addItem<hud::HudManagedMemory>("managed_mem", -1, m_parent);
     }
   }
 

--- a/src/d3d9/d3d9_texture.cpp
+++ b/src/d3d9/d3d9_texture.cpp
@@ -88,6 +88,7 @@ namespace dxvk {
     // and purely rely on AddDirtyRect to notify D3D9 that contents have changed.
     // We have no way of knowing which mip levels were actually changed.
     m_texture.SetAllNeedUpload();
+    m_parent->TouchMappedTexture(&m_texture);
     return D3D_OK;
   }
 
@@ -170,6 +171,7 @@ namespace dxvk {
     // and purely rely on AddDirtyBox to notify D3D9 that contents have changed.
     // We have no way of knowing which mip levels were actually changed.
     m_texture.SetAllNeedUpload();
+    m_parent->TouchMappedTexture(&m_texture);
     return D3D_OK;
   }
 
@@ -260,6 +262,7 @@ namespace dxvk {
     for (uint32_t m = 0; m < m_texture.Desc()->MipLevels; m++) {
       m_texture.SetNeedsUpload(m_texture.CalcSubresource(Face, m), true);
     }
+    m_parent->TouchMappedTexture(&m_texture);
     return D3D_OK;
   }
 

--- a/src/d3d9/meson.build
+++ b/src/d3d9/meson.build
@@ -39,7 +39,8 @@ d3d9_src = [
   'd3d9_swvp_emu.cpp',
   'd3d9_format_helpers.cpp',
   'd3d9_hud.cpp',
-  'd3d9_annotation.cpp'
+  'd3d9_annotation.cpp',
+  'd3d9_mem.cpp',
 ]
 
 d3d9_dll = shared_library('d3d9'+dll_ext, d3d9_src, glsl_generator.process(d3d9_shaders), d3d9_res,

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -306,10 +306,12 @@ namespace dxvk {
     { R"(\\Borderlands(2|PreSequel)\.exe$)", {{
       { "d3d9.lenientClear",                "True" },
       { "d3d9.supportDFFormats",            "False" },
+      { "d3d9.unmapDelay",                  "4" },
     }} },
     /* Borderlands                                */
     { R"(\\Borderlands\.exe$)", {{
       { "d3d9.lenientClear",                "True" },
+      { "d3d9.unmapDelay",                  "4" },
     }} },
     /* Gothic 3                                   */
     { R"(\\Gothic(3|3Final| III Forsaken Gods)\.exe$)", {{


### PR DESCRIPTION
In order to finally fix some of our address space problems, I took a page out of Gallium Nines book.

Managed textures now use memory mapped files to store the internal data. The data is suballocated from 4MB (totally arbitrary) memory mapped files. This allows us to map and unmap that memory as we see fit. This only impacts managed textures, systemmem textures still use the DXVKBuffer to store their data because they can be used with `GetRenderTargetData` to read back data from the GPU. I don't think those are a problem anyway. Buffers are also unchanged. It's possible to extend this to buffers but I'd like to get some feedback first.

Unmapping follows a simple heuristic: We track the frame in which a texture was last used with `LockRect`, `AddDirtyRect` or when it was actually uploaded. If that was more than 16 frames ago or we've crossed the threshold of 512MB for mapped textures, we unmap. I hope that's good enough for games that keep the pointer around after calling Unlock. If it's not we can either try to tweak the heuristic, come up with something smarter or just disable it using a config option. I'd rather not punish decent D3D9 games that just happen to use too many high res managed textures because some do stupid things that aren't supposed to be allowed.

All of this is disabled in 64 bit builds of course.

The branch is basically a prototype. It works pretty well with Borderlands 2 and Witcher 2, both of which use a ton of managed textures. I'd like to get some feedback on this. Should we also extend this to buffers? Do you have any other ideas for the unmap heuristic?


