### PR TITLE
[dxgi] Add DXVK_ENABLE_NVAPI envvar

### DIFF
--- a/src/dxgi/dxgi_options.cpp
+++ b/src/dxgi/dxgi_options.cpp
@@ -40,7 +40,11 @@ namespace dxvk {
     this->maxDeviceMemory = VkDeviceSize(config.getOption<int32_t>("dxgi.maxDeviceMemory", 0)) << 20;
     this->maxSharedMemory = VkDeviceSize(config.getOption<int32_t>("dxgi.maxSharedMemory", 0)) << 20;
 
-    this->nvapiHack   = config.getOption<bool>("dxgi.nvapiHack", true);
+    // Force nvapiHack to be disabled if NvAPI is enabled in environment
+    if (env::getEnvVar("DXVK_ENABLE_NVAPI") == "1")
+      this->nvapiHack = false;
+    else
+      this->nvapiHack = config.getOption<bool>("dxgi.nvapiHack", true);
   }
   
 }


### PR DESCRIPTION
Add a new environment variable DXVK_ENABLE_NVAPI as an environment-level override for 'nvapiHack'. This will allow for DLSS (and other NvAPI-backed features) to be available without the user manually writing a configuration file, allowing for more seamless integration with Proton's launch script.