### PR TITLE
[d3d9] Do not allow _D32 format for surfaces in D3D9Adapter::CheckDeviceFormat().

### DIFF
--- a/src/d3d9/d3d9_adapter.cpp
+++ b/src/d3d9/d3d9_adapter.cpp
@@ -126,6 +126,9 @@ namespace dxvk {
 
     const bool srgb = (Usage & (D3DUSAGE_QUERY_SRGBREAD | D3DUSAGE_QUERY_SRGBWRITE)) != 0;
 
+    if (surface && CheckFormat == D3D9Format::D32)
+      return D3DERR_NOTAVAILABLE;
+
     if (CheckFormat == D3D9Format::INST)
       return D3D_OK;
 


### PR DESCRIPTION
Fixes Metal Slug 2 (266260) which otherwise displays assert error on launch.