### PR TITLE
[d3d11] Don't perform extraneous queue flushes on NVIDIA

### DIFF
--- a/src/d3d11/d3d11_context_imm.cpp
+++ b/src/d3d11/d3d11_context_imm.cpp
@@ -737,7 +737,12 @@ namespace dxvk {
     uint64_t sequenceNumber = GetCurrentSequenceNumber();
     pResource->TrackSequenceNumber(Subresource, sequenceNumber);
 
-    FlushImplicit(TRUE);
+    // Don't flush early on NV
+    if (!m_device->adapter()->matchesDriver(DxvkGpuVendor::Nvidia,
+                                            VK_DRIVER_ID_NVIDIA_PROPRIETARY,
+                                            0,
+                                            0))
+      FlushImplicit(TRUE);
   }
 
 
@@ -746,7 +751,12 @@ namespace dxvk {
     uint64_t sequenceNumber = GetCurrentSequenceNumber();
     pResource->TrackSequenceNumber(sequenceNumber);
 
-    FlushImplicit(TRUE);
+    // Don't flush early on NV
+    if (!m_device->adapter()->matchesDriver(DxvkGpuVendor::Nvidia,
+                                            VK_DRIVER_ID_NVIDIA_PROPRIETARY,
+                                            0,
+                                            0))
+      FlushImplicit(TRUE);
   }
 
 


### PR DESCRIPTION
An API Capture of Assassins Creed 3 shows a significant performance drop of 34% (averaged across tested GPUs in farm) after commit 34fd16b8f22af023abe23cb68daafc23d6f23bbe

As an alternative to this change (which effectively reverts the aforementioned commit for NVIDIA), I tested the following other changes.

- Tweaking MinFlushIntervalUs to values of 1500us and 3000us
- Tweaking IncFlushIntervalUs to values of 500us and 1000us
- Tweaking MaxPendingSubmits to values of 1, 2, and 4
- Changing the StrongHint argument for these flushes to be FALSE.

The only combination of changes that seemed to produce favorable results were to have these flushes not be strongly hinted, and decrease the maximum number of weak pending submissions to 2 (or less).

Perf testing - RTX 2060 SUPER - Driver 510.54
    Before: 170 FPS
    After:  274 FPS