### PR TITLE
[meta] Move apitrace guide over to dxvk repo

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -11,7 +11,7 @@ Please describe your issue as accurately as possible. If you run into a problem 
 
 **Important:** When reporting an issue with a specific game or application, such as crashes or rendering issues, please include log files and, if possible, a D3D11/D3D9 Apitrace (see https://github.com/apitrace/apitrace) so that the issue can be reproduced.
 In order to create a trace for **D3D11/D3D10**: Run `wine apitrace.exe trace -a dxgi YOURGAME.exe`.
-In order to create a trace for **D3D9**: Follow https://github.com/Joshua-Ashton/d9vk/wiki/Making-a-Trace.
+In order to create a trace for **D3D9**: Follow https://github.com/doitsujin/dxvk/wiki/Making-a-Trace.
 Preferably record the trace on Windows, or wined3d if possible.
 
 **Reports with no log files will be ignored.**


### PR DESCRIPTION
Every single time I ask someone for an apitrace, we run into the problem that the apitrace CI is dead. So I decided to copy the guide over to the DXVK wiki and update the download links.