### PR TITLE
Fix link with dxgi

### DIFF
--- a/src/d3d10/meson.build
+++ b/src/d3d10/meson.build
@@ -28,7 +28,7 @@ d3d10_deps = [ lib_d3dcompiler_43, lib_dxgi, dxbc_dep, dxvk_dep, d3d10_core_dep 
 
 d3d10_dll = shared_library('d3d10'+dll_ext, d3d10_main_src, d3d10_res,
   name_prefix         : '',
-  dependencies        : [ d3d10_deps ],
+  dependencies        : [ d3d10_deps, dxgi_dep ],
   include_directories : dxvk_include_path,
   install             : true,
   vs_module_defs      : 'd3d10'+def_spec_ext,
@@ -36,7 +36,7 @@ d3d10_dll = shared_library('d3d10'+dll_ext, d3d10_main_src, d3d10_res,
 
 d3d10_1_dll = shared_library('d3d10_1'+dll_ext, d3d10_main_src, d3d10_1_res,
   name_prefix         : '',
-  dependencies        : [ d3d10_deps ],
+  dependencies        : [ d3d10_deps, dxgi_dep ],
   include_directories : dxvk_include_path,
   install             : true,
   vs_module_defs      : 'd3d10_1'+def_spec_ext,

--- a/src/d3d11/meson.build
+++ b/src/d3d11/meson.build
@@ -68,7 +68,7 @@ d3d11_shaders = files([
 d3d11_dll = shared_library('d3d11'+dll_ext, dxgi_common_src + d3d11_src + d3d10_src,
     glsl_generator.process(d3d11_shaders), d3d11_res,
   name_prefix         : '',
-  dependencies        : [ lib_dxgi, dxbc_dep, dxvk_dep ],
+  dependencies        : [ lib_dxgi, dxbc_dep, dxvk_dep, dxgi_dep ],
   include_directories : dxvk_include_path,
   install             : true,
   vs_module_defs      : 'd3d11'+def_spec_ext,


### PR DESCRIPTION
When building 1.10 with mingw 2.37 it fails with:
  /usr/bin/x86_64-w64-mingw32-ld: src/d3d11/d3d11.dll.p/d3d11_main.cpp.obj:./build-win64/../src/d3d11/d3d11_main.cpp:137: u    ndefined reference to `CreateDXGIFactory1'
Same with d3d10 and d3d10_1.