### PR TITLE
Only bind frame buffer attachments that are actually going to get used

### DIFF
--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -1795,8 +1795,9 @@ namespace dxvk {
       return m_recorder->SetRenderState(State, Value);
 
     auto& states = m_state.renderStates;
+    DWORD old = states[State];
 
-    bool changed = states[State] != Value;
+    bool changed = old != Value;
 
     if (likely(changed)) {
       const bool oldClipPlaneEnabled = IsClipPlaneEnabled();
@@ -1880,19 +1881,31 @@ namespace dxvk {
           break;
 
         case D3DRS_COLORWRITEENABLE:
-          UpdateActiveRTs(0);
+          if (likely(!old != !Value)) {
+            m_flags.set(D3D9DeviceFlag::DirtyFramebuffer);
+            UpdateActiveRTs(0);
+          }
           m_flags.set(D3D9DeviceFlag::DirtyBlendState);
           break;
         case D3DRS_COLORWRITEENABLE1:
-          UpdateActiveRTs(1);
+          if (likely(!old != !Value && m_state.renderTargets[1] != nullptr)) {
+            m_flags.set(D3D9DeviceFlag::DirtyFramebuffer);
+            UpdateActiveRTs(1);
+          }
           m_flags.set(D3D9DeviceFlag::DirtyBlendState);
           break;
         case D3DRS_COLORWRITEENABLE2:
-          UpdateActiveRTs(2);
+          if (likely(!old != !Value && m_state.renderTargets[2] != nullptr)) {
+            m_flags.set(D3D9DeviceFlag::DirtyFramebuffer);
+            UpdateActiveRTs(2);
+          }
           m_flags.set(D3D9DeviceFlag::DirtyBlendState);
           break;
         case D3DRS_COLORWRITEENABLE3:
-          UpdateActiveRTs(3);
+          if (likely(!old != !Value && m_state.renderTargets[3] != nullptr)) {
+            m_flags.set(D3D9DeviceFlag::DirtyFramebuffer);
+            UpdateActiveRTs(3);
+          }
           m_flags.set(D3D9DeviceFlag::DirtyBlendState);
           break;
 
@@ -5549,6 +5562,9 @@ namespace dxvk {
       if (likely(sampleCount == VK_SAMPLE_COUNT_FLAG_BITS_MAX_ENUM))
         sampleCount = rtImageInfo.sampleCount;
       else if (unlikely(sampleCount != rtImageInfo.sampleCount))
+        continue;
+
+      if (!m_state.renderStates[ColorWriteIndex(i)])
         continue;
 
       attachments.color[i] = {

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -1922,17 +1922,17 @@ namespace dxvk {
             m_flags.set(D3D9DeviceFlag::DirtyMultiSampleState);
           break;
 
+        case D3DRS_STENCILENABLE:
         case D3DRS_ZWRITEENABLE:
-          if (m_activeHazardsDS != 0)
+        case D3DRS_ZENABLE:
+          if (likely(m_state.depthStencil != nullptr))
             m_flags.set(D3D9DeviceFlag::DirtyFramebuffer);
 
           m_flags.set(D3D9DeviceFlag::DirtyDepthStencilState);
           break;
 
-        case D3DRS_ZENABLE:
         case D3DRS_ZFUNC:
         case D3DRS_TWOSIDEDSTENCILMODE:
-        case D3DRS_STENCILENABLE:
         case D3DRS_STENCILFAIL:
         case D3DRS_STENCILZFAIL:
         case D3DRS_STENCILPASS:
@@ -5556,7 +5556,10 @@ namespace dxvk {
         m_state.renderTargets[i]->GetRenderTargetLayout() };
     }
 
-    if (m_state.depthStencil != nullptr) {
+    if (m_state.depthStencil != nullptr &&
+      (m_state.renderStates[D3DRS_ZENABLE]
+        || m_state.renderStates[D3DRS_ZWRITEENABLE]
+        || m_state.renderStates[D3DRS_STENCILENABLE])) {
       const DxvkImageCreateInfo& dsImageInfo = m_state.depthStencil->GetCommonTexture()->GetImage()->info();
       const bool depthWrite = m_state.renderStates[D3DRS_ZWRITEENABLE];
 


### PR DESCRIPTION
When changing Resolution in Metal Gear Rising Revengeance, I ended up with a 1440p render target (the "implicit" one) and a 1080p depth stencil attachment which it creates itself. DXVK then picks the smallest size of all attachments (which is 1080p) as the render area and we end up with this: 
![image](https://user-images.githubusercontent.com/1131720/160835133-8218cc37-b1b2-4fad-a248-6139beaf914c.png)

This is technically a game bug but it seems to work with WineD3D. To work around this, I unbind the depth buffer if unless either the depth test, stencil test or depth write is enabled.

I also do the same thing for color targets now because Dead Space has a render path that relies on that. When DF texture formats are supported, it decides to not use the NULL hack format as a color RT and instead binds a 1x1 color RT when rendering shadow maps. If we unbind that if the color write mask is 0, it works. Granted, we already fixed shadows in DS1 by forcing it to use the NULL format code path, but there might be other games that rely on this behavior.