### PR TITLE
[util] Force sampler type spec const for Star Wars TFU2

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -530,6 +530,13 @@ namespace dxvk {
     { R"(\\limbo\.exe$)", {{
       { "d3d9.maxFrameRate",                "60" },
     }} },
+    /* Star Wars The Force Unleashed 2          *
+     * Black particles because it tries to bind *
+     * a 2D texture for a shader that           *
+     * declares a 3d texture.                   */
+    { R"(\\SWTFU2\.exe$)", {{
+      { "d3d9.forceSamplerTypeSpecConstants",  "True" },
+    }} },
   }};
 
 


### PR DESCRIPTION
Fixes this: 
![image](https://user-images.githubusercontent.com/1131720/161858089-7b5affc0-2abf-420f-8dfe-408055bd6766.png)

![image](https://user-images.githubusercontent.com/1131720/161858461-6d668eeb-27fd-475d-bfbd-5264f64ffdf8.png)
