### PR TITLE
[d3d9] Calculate slice alignment when uploading straight from the mapping buffer

### DIFF
--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -4478,6 +4478,7 @@ namespace dxvk {
           + srcOffsetBlockCount.y * pitch
           + srcOffsetBlockCount.x * formatInfo->elementSize;
 
+      VkDeviceSize sliceAlignment = 1;
       VkDeviceSize rowAlignment = 1;
       DxvkBufferSlice copySrcSlice;
       if (pSrcTexture->DoesStagingBufferUploads(SrcSubresource)) {
@@ -4490,7 +4491,9 @@ namespace dxvk {
           pitch, pitch * srcTexLevelExtentBlockCount.height);
       } else {
         copySrcSlice = DxvkBufferSlice(pSrcTexture->GetBuffer(SrcSubresource), copySrcOffset, srcSlice.length);
-        rowAlignment = pitch; // row alignment can act as the pitch parameter
+        // row/slice alignment can act as the pitch parameter
+        rowAlignment = pitch;
+        sliceAlignment = srcTexLevelExtentBlockCount.height * pitch;
       }
 
       EmitCs([
@@ -4499,13 +4502,14 @@ namespace dxvk {
         cDstLayers      = dstLayers,
         cDstLevelExtent = alignedExtent,
         cOffset         = alignedDestOffset,
-        cRowAlignment   = rowAlignment
+        cRowAlignment   = rowAlignment,
+        cSliceAlignment = sliceAlignment
       ] (DxvkContext* ctx) {
         ctx->copyBufferToImage(
           cDstImage,  cDstLayers,
           cOffset, cDstLevelExtent,
           cSrcSlice.buffer(), cSrcSlice.offset(),
-          cRowAlignment, 0);
+          cRowAlignment, cSliceAlignment);
       });
 
       TrackTextureMappingBufferSequenceNumber(pSrcTexture, SrcSubresource);


### PR DESCRIPTION
Fixes #2586

The upload path for "uncontested" resources uses the mapping buffer directly instead of doing another copy to a temporary staging buffer. Before 40444c1f5075756593d7e5f6673f25851c23efcb this was only done when uploading textures after Lock/Unlock but now it all uses the same code so we ran into a bug here.

If possible, we only copy a part of the texture based on the dirty box set either directly with `AddDirtyBox`/`AddDirtyRect` or using `Lock`. In that case the data is not tightly packed but we didn't calculate the slice pitch correctly.