### PR TITLE
[d3d9] window messages hook improvements

### DIFF
--- a/src/d3d9/d3d9_swapchain.cpp
+++ b/src/d3d9/d3d9_swapchain.cpp
@@ -128,6 +128,7 @@ namespace dxvk {
       windowData.swapchain->GetDevice()->GetCreationParameters(&create_parms);
 
       if (!(create_parms.BehaviorFlags & D3DCREATE_NOWINDOWCHANGES)) {
+        D3D9WindowMessageFilter filter(window);
         if (wparam) {
           // Heroes of Might and Magic V needs this to resume drawing after a focus loss
           D3DPRESENT_PARAMETERS params;

--- a/src/d3d9/d3d9_swapchain.cpp
+++ b/src/d3d9/d3d9_swapchain.cpp
@@ -10,6 +10,7 @@ namespace dxvk {
   struct D3D9WindowData {
     bool unicode;
     bool filter;
+    bool activateProcessed;
     WNDPROC proc;
     D3D9SwapChainEx* swapchain;
   };
@@ -18,6 +19,13 @@ namespace dxvk {
   static dxvk::recursive_mutex g_windowProcMapMutex;
   static std::unordered_map<HWND, D3D9WindowData> g_windowProcMap;
 
+  static void SetActivateProcessed(HWND window, bool processed)
+  {
+      std::lock_guard lock(g_windowProcMapMutex);
+      auto it = g_windowProcMap.find(window);
+      if (it != g_windowProcMap.end())
+        it->second.activateProcessed = processed;
+  }
 
   template <typename T, typename J, typename ... Args>
   auto CallCharsetFunction(T unicode, J ascii, bool isUnicode, Args... args) {
@@ -88,6 +96,7 @@ namespace dxvk {
     D3D9WindowData windowData;
     windowData.unicode = IsWindowUnicode(window);
     windowData.filter  = false;
+    windowData.activateProcessed = false;
     windowData.proc = reinterpret_cast<WNDPROC>(
       CallCharsetFunction(
       SetWindowLongPtrW, SetWindowLongPtrA, windowData.unicode,
@@ -129,7 +138,7 @@ namespace dxvk {
 
       if (!(create_parms.BehaviorFlags & D3DCREATE_NOWINDOWCHANGES)) {
         D3D9WindowMessageFilter filter(window);
-        if (wparam) {
+        if (wparam && !windowData.activateProcessed) {
           // Heroes of Might and Magic V needs this to resume drawing after a focus loss
           D3DPRESENT_PARAMETERS params;
           RECT rect;
@@ -138,10 +147,12 @@ namespace dxvk {
           windowData.swapchain->GetPresentParameters(&params);
           SetWindowPos(window, nullptr, rect.left, rect.top, params.BackBufferWidth, params.BackBufferHeight,
                        SWP_NOACTIVATE | SWP_NOZORDER);
+          SetActivateProcessed(window, true);
         }
-        else {
+        else if (!wparam) {
           if (IsWindowVisible(window))
             ShowWindow(window, SW_MINIMIZE);
+          SetActivateProcessed(window, false);
         }
       }
     }


### PR DESCRIPTION
Supposed to fix #2569 (the part which locks the game during fullscreen state change). I could not reproduce exactly the lock but I observed endlessly bouncing window messages between dxvk resetting window size and the game setting it back which are likely the cause of hangs under other WMs / conditions, and this bouncing should be fixed by the PR.

Here is the squeeze of some testing I did (an addition to existing Wine d3d9 test): https://gist.github.com/gofman/b89c0f2154f6d87123f038941641df51

The testing I did here involved studying message sequences which are never the same between native and dxvk d3d9 on Windows, primarily because of the window style changes. Also, part of the sequence depends on asynchronous messages triggered by display mode change, thus some added waits without which the test may fail on native as well.

The absence of activate_processed check for deactivation event processing is not a typo, that's how I read those observed message sequences.