### PR TITLE
[util] Use cached constant buffers for Armored Warfare

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -230,6 +230,10 @@ namespace dxvk {
     { R"(\\SGWContracts\.exe$)", {{
       { "d3d11.cachedDynamicResources",     "a"    },
     }} },
+    /* Armored Warfare             */
+    { R"(\\armoredwarfare\.exe$)", {{
+      { "d3d11.cachedDynamicResources",     "c"    },
+    }} },
     /* Shadow of the Tomb Raider - invariant      *
      * position breaks character rendering on NV  */
     { R"(\\SOTTR\.exe$)", {{


### PR DESCRIPTION
Improves performance in Armored Warfare when not GPU bound.
`"c"` was the only one i found to improve performance in my limited testing.

closes #2306 

<details>
  <summary>Low settings without conf</summary>
  
![Screenshot_20220408_214655](https://user-images.githubusercontent.com/47954800/162517474-d0adbd15-90e3-48ac-a6a3-3dae139b05f3.png)
</details>

<details>
  <summary>Low settings with conf</summary>
  
![Screenshot_20220408_214405](https://user-images.githubusercontent.com/47954800/162517580-6cd98c01-f584-4e14-b505-ad6e02967606.png)
</details>

I did not find that  `dxgi.customVendorId = 10de` improved performance when either cpu or gpu bound in this game. So didn't add that one. (Testing was done on my AMD setup)