### PR TITLE
dxvk.conf cleanup

### DIFF
--- a/dxvk.conf
+++ b/dxvk.conf
@@ -426,16 +426,6 @@
 
 # d3d9.deviceLocalConstantBuffers = False
 
-# Allow Read Only
-#
-# Enables using the D3DLOCK_READONLY flag. Some apps use this
-# incorrectly, and write when they should be reading.
-#
-# Supported values:
-# - True/False
-
-# d3d9.allowLockFlagReadonly = True
-
 # No Explicit Front Buffer
 #
 # Disables the front buffer

--- a/dxvk.conf
+++ b/dxvk.conf
@@ -566,4 +566,4 @@
 # Supported values:
 # - True/False
 
-# dxvk.enableDebugUtils = True
+# dxvk.enableDebugUtils = False


### PR DESCRIPTION
Corrects `enableDebugUtils` default to False and removes `allowLockFlagReadonly` option.


I also noticed these options don't have a description or entry in `dxvk.conf`
```
d3d11.zeroInitWorkgroupMemory
d3d11.enableRtOutputNanFixup
d3d11.forceTgsmBarriers
d3d11.floatControls
```
But i don't know if that is on purpose and i wouldn't be able to describe their functionality anyway.