### PR TITLE
Add support for shared ID3D11Fence object

### DIFF
--- a/src/d3d11/d3d11_device.cpp
+++ b/src/d3d11/d3d11_device.cpp
@@ -1353,7 +1353,7 @@ namespace dxvk {
     InitReturnPtr(ppFence);
 
     try {
-      Com<D3D11Fence> fence = new D3D11Fence(this, InitialValue, Flags);
+      Com<D3D11Fence> fence = new D3D11Fence(this, InitialValue, Flags, INVALID_HANDLE_VALUE);
       return fence->QueryInterface(riid, ppFence);
     } catch (const DxvkError& e) {
       Logger::err(e.message());
@@ -1424,8 +1424,16 @@ namespace dxvk {
           void**      ppFence) {
     InitReturnPtr(ppFence);
 
-    Logger::err("D3D11Device::OpenSharedFence: Not implemented");
-    return E_NOTIMPL;
+    if (ppFence == nullptr)
+      return S_FALSE;
+
+    try {
+      Com<D3D11Fence> fence = new D3D11Fence(this, 0, D3D11_FENCE_FLAG_SHARED, hFence);
+      return fence->QueryInterface(ReturnedInterface, ppFence);
+    } catch (const DxvkError& e) {
+      Logger::err(e.message());
+      return E_FAIL;
+    }
   }
 
 

--- a/src/d3d11/d3d11_fence.cpp
+++ b/src/d3d11/d3d11_fence.cpp
@@ -6,12 +6,21 @@ namespace dxvk {
   D3D11Fence::D3D11Fence(
           D3D11Device*        pDevice,
           UINT64              InitialValue,
-          D3D11_FENCE_FLAG    Flags)
+          D3D11_FENCE_FLAG    Flags,
+          HANDLE              hFence)
   : D3D11DeviceChild<ID3D11Fence>(pDevice) {
     DxvkFenceCreateInfo fenceInfo;
     fenceInfo.initialValue = InitialValue;
+    m_flags = Flags;
 
-    if (Flags)
+    if (Flags & D3D11_FENCE_FLAG_SHARED) {
+      fenceInfo.sharedType = VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D11_FENCE_BIT;
+      if (hFence == nullptr)
+        hFence = INVALID_HANDLE_VALUE;
+      fenceInfo.sharedHandle = hFence;
+    }
+
+    if (Flags & ~D3D11_FENCE_FLAG_SHARED)
       Logger::err(str::format("Fence flags 0x", std::hex, Flags, " not supported"));
 
     m_fence = pDevice->GetDXVKDevice()->createFence(fenceInfo);
@@ -49,14 +58,31 @@ namespace dxvk {
           DWORD               dwAccess,
           LPCWSTR             lpName,
           HANDLE*             pHandle) {
-    Logger::err("D3D11Fence::CreateSharedHandle: Not implemented");
-    return E_NOTIMPL;
+    if (!(m_flags & D3D11_FENCE_FLAG_SHARED))
+      return E_INVALIDARG;
+
+    if (pAttributes)
+      Logger::warn(str::format("CreateSharedHandle: attributes ", pAttributes, " not handled"));
+    if (dwAccess)
+      Logger::warn(str::format("CreateSharedHandle: access ", dwAccess, " not handled"));
+    if (lpName)
+      Logger::warn(str::format("CreateSharedHandle: name ", dxvk::str::fromws(lpName), " not handled"));
+
+    HANDLE sharedHandle = m_fence->sharedHandle();
+    if (sharedHandle == INVALID_HANDLE_VALUE)
+      return E_INVALIDARG;
+
+    *pHandle = sharedHandle;
+    return S_OK;
   }
 
 
   HRESULT STDMETHODCALLTYPE D3D11Fence::SetEventOnCompletion(
           UINT64              Value,
           HANDLE              hEvent) {
+    // TODO in case of rewinds, the stored value may be higher.
+    // For shared fences, calling vkWaitSemaphores here could alleviate the issue.
+
     m_fence->enqueueWait(Value, [hEvent] {
       SetEvent(hEvent);
     });
@@ -66,6 +92,9 @@ namespace dxvk {
 
 
   UINT64 STDMETHODCALLTYPE D3D11Fence::GetCompletedValue() {
+    // TODO in the case of rewinds, the stored value may be higher.
+    // For shared fences, calling vkGetSemaphoreCounterValue here could alleviate the issue.
+
     return m_fence->getValue();
   }
   

--- a/src/d3d11/d3d11_fence.h
+++ b/src/d3d11/d3d11_fence.h
@@ -14,7 +14,8 @@ namespace dxvk {
     D3D11Fence(
             D3D11Device*        pDevice,
             UINT64              InitialValue,
-            D3D11_FENCE_FLAG    Flags);
+            D3D11_FENCE_FLAG    Flags,
+            HANDLE              hFence);
 
     ~D3D11Fence();
     
@@ -41,6 +42,7 @@ namespace dxvk {
   private:
     
     Rc<DxvkFence> m_fence;
+    D3D11_FENCE_FLAG m_flags;
 
   };
   

--- a/src/dxvk/dxvk_adapter.cpp
+++ b/src/dxvk/dxvk_adapter.cpp
@@ -283,7 +283,7 @@ namespace dxvk {
           DxvkDeviceFeatures  enabledFeatures) {
     DxvkDeviceExtensions devExtensions;
 
-    std::array<DxvkExt*, 20> devExtensionList = {{
+    std::array<DxvkExt*, 21> devExtensionList = {{
       &devExtensions.amdMemoryOverallocationBehaviour,
       &devExtensions.amdShaderFragmentMask,
       &devExtensions.extConservativeRasterization,
@@ -300,6 +300,7 @@ namespace dxvk {
       &devExtensions.extTransformFeedback,
       &devExtensions.extVertexAttributeDivisor,
       &devExtensions.khrExternalMemoryWin32,
+      &devExtensions.khrExternalSemaphoreWin32,
       &devExtensions.khrPipelineLibrary,
       &devExtensions.khrSwapchain,
       &devExtensions.nvxBinaryImport,

--- a/src/dxvk/dxvk_extensions.h
+++ b/src/dxvk/dxvk_extensions.h
@@ -292,6 +292,7 @@ namespace dxvk {
     DxvkExt extTransformFeedback              = { VK_EXT_TRANSFORM_FEEDBACK_EXTENSION_NAME,                 DxvkExtMode::Optional };
     DxvkExt extVertexAttributeDivisor         = { VK_EXT_VERTEX_ATTRIBUTE_DIVISOR_EXTENSION_NAME,           DxvkExtMode::Optional };
     DxvkExt khrExternalMemoryWin32            = { VK_KHR_EXTERNAL_MEMORY_WIN32_EXTENSION_NAME,              DxvkExtMode::Optional };
+    DxvkExt khrExternalSemaphoreWin32         = { VK_KHR_EXTERNAL_SEMAPHORE_WIN32_EXTENSION_NAME,           DxvkExtMode::Optional };
     DxvkExt khrPipelineLibrary                = { VK_KHR_PIPELINE_LIBRARY_EXTENSION_NAME,                   DxvkExtMode::Optional };
     DxvkExt khrSwapchain                      = { VK_KHR_SWAPCHAIN_EXTENSION_NAME,                          DxvkExtMode::Required };
     DxvkExt nvxBinaryImport                   = { VK_NVX_BINARY_IMPORT_EXTENSION_NAME,                      DxvkExtMode::Disabled };

--- a/src/dxvk/dxvk_fence.h
+++ b/src/dxvk/dxvk_fence.h
@@ -21,6 +21,15 @@ namespace dxvk {
    */
   struct DxvkFenceCreateInfo {
     uint64_t        initialValue;
+    VkExternalSemaphoreHandleTypeFlagBits sharedType = VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_FLAG_BITS_MAX_ENUM;
+    union {
+#ifdef _WIN32
+      HANDLE          sharedHandle = INVALID_HANDLE_VALUE;
+#else
+      // Placeholder for other handle types, such as FD
+      void *dummy;
+#endif
+    };
   };
 
   /**
@@ -77,6 +86,12 @@ namespace dxvk {
      * \param [in] event Callback
      */
     void enqueueWait(uint64_t value, DxvkFenceEvent&& event);
+
+    /**
+     * \brief Create a new shared handle to timeline semaphore backing the fence
+     * \returns The shared handle with the type given by DxvkFenceCreateInfo::sharedType
+     */
+    HANDLE sharedHandle() const;
 
   private:
 

--- a/src/vulkan/vulkan_loader.h
+++ b/src/vulkan/vulkan_loader.h
@@ -379,6 +379,11 @@ namespace dxvk::vk {
     VULKAN_FN(vkGetMemoryWin32HandleKHR);
     VULKAN_FN(vkGetMemoryWin32HandlePropertiesKHR);
     #endif
+
+    #ifdef VK_KHR_external_semaphore_win32
+    VULKAN_FN(vkGetSemaphoreWin32HandleKHR);
+    VULKAN_FN(vkImportSemaphoreWin32HandleKHR);
+    #endif
   };
   
 }


### PR DESCRIPTION
Implements shared fences on top of D3D11_FENCE shareable Vulkan timeline semaphores, with the rewind support done in winevulkan.

Corresponding VKD3D-Proton PR: https://github.com/HansKristian-Work/vkd3d-proton/pull/1175