### PR TITLE
[util] Enforce a maxAvailableMemory limit for Majesty 2

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -541,6 +541,14 @@ namespace dxvk {
     { R"(\\SWTFU2\.exe$)", {{
       { "d3d9.forceSamplerTypeSpecConstants",  "True" },
     }} },
+    /* Majesty 2 (Collection)                   *
+     * Crashes on UMA without a memory limit,   *
+     * since the game(s) will allocate all      *
+     * available VRAM on startup.               */
+    { R"(\\Majesty2\.exe$)", {{
+      { "d3d9.memoryTrackTest",             "True" },
+      { "d3d9.maxAvailableMemory",          "2048" },
+    }} },
   }};
 
 


### PR DESCRIPTION
Fixes #1542

While a larger discussion on UMA may be beneficial, the game's VRAM allocation logic is clearly broken in this case. I've bumped the limit to 2048 just to be a bit less restrictive, since the said game pack is known for its mod support, which might complicate things in terms of actual memory usage.