### PR TITLE
Tweak the issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,10 +6,10 @@ labels: ''
 assignees: ''
 
 ---
-
+<!--
 Please describe your issue as accurately as possible. If you run into a problem with a binary release, make sure to test with latest `master` as well.
 
-**Important:** When reporting an issue with a specific game or application, such as crashes or rendering issues, please include log files and, if possible, a D3D11/D3D9 Apitrace (see https://github.com/apitrace/apitrace) so that the issue can be reproduced.
+IMPORTANT: When reporting an issue with a specific game or application, such as crashes or rendering issues, please include log files and, if possible, a D3D11/D3D9 Apitrace (see https://github.com/apitrace/apitrace) so that the issue can be reproduced.
 In order to create a trace for **D3D11/D3D10**: Run `wine apitrace.exe trace -a dxgi YOURGAME.exe`.
 In order to create a trace for **D3D9**: Follow https://github.com/doitsujin/dxvk/wiki/Making-a-Trace.
 Preferably record the trace on Windows, or wined3d if possible.
@@ -17,6 +17,7 @@ Preferably record the trace on Windows, or wined3d if possible.
 Log files should appear in the same folder as the game or application `.exe`. 
 Note that Proton and the Lutris Wine runner disables dxvk logging by default and can be enabled by setting `DXVK_LOG_LEVEL=info`. Alternatively you can enable logging in either Proton or the Lutris Wine runner itself.
 
+-->
 **Reports with no log files will be ignored.**
 
 ### Software information

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -10,9 +10,8 @@ assignees: ''
 Please describe your issue as accurately as possible. If you run into a problem with a binary release, make sure to test with latest `master` as well.
 
 IMPORTANT: When reporting an issue with a specific game or application, such as crashes or rendering issues, please include log files and, if possible, a D3D11/D3D9 Apitrace (see https://github.com/apitrace/apitrace) so that the issue can be reproduced.
-In order to create a trace for **D3D11/D3D10**: Run `wine apitrace.exe trace -a dxgi YOURGAME.exe`.
-In order to create a trace for **D3D9**: Follow https://github.com/doitsujin/dxvk/wiki/Making-a-Trace.
 Preferably record the trace on Windows, or wined3d if possible.
+In order to create a trace follow https://github.com/doitsujin/dxvk/wiki/Making-a-Trace.
 
 Log files should appear in the same folder as the game or application `.exe`. 
 Note that Proton and the Lutris Wine runner disables dxvk logging by default and can be enabled by setting `DXVK_LOG_LEVEL=info`. Alternatively you can enable logging in either Proton or the Lutris Wine runner itself.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -20,6 +20,9 @@ Note that Proton and the Lutris Wine runner disables dxvk logging by default and
 -->
 **Reports with no log files will be ignored.**
 
+### Issue description
+Describe what is wrong. Include screenshots or videos if relevant.
+
 ### Software information
 Name of the game, settings used etc.
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -14,6 +14,9 @@ In order to create a trace for **D3D11/D3D10**: Run `wine apitrace.exe trace -a 
 In order to create a trace for **D3D9**: Follow https://github.com/doitsujin/dxvk/wiki/Making-a-Trace.
 Preferably record the trace on Windows, or wined3d if possible.
 
+Log files should appear in the same folder as the game or application `.exe`. 
+Note that Proton and the Lutris Wine runner disables dxvk logging by default and can be enabled by setting `DXVK_LOG_LEVEL=info`. Alternatively you can enable logging in either Proton or the Lutris Wine runner itself.
+
 **Reports with no log files will be ignored.**
 
 ### Software information


### PR DESCRIPTION
Added info about logs to instructions.
Hidden instructions in final issue in case the user doesn't delete them so they don't make noise.
Added a issue description heading with a note about adding screenshots or videos if relevant.

Let me know if any of the changes doesn't suit you.

See updated template at: https://github.com/Blisto91/dxvk/issues/new/choose