### PR TITLE
[build] Bump required meson version to >=0.49

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,4 @@
-project('dxvk', ['c', 'cpp'], version : 'v1.10.1', meson_version : '>= 0.47', default_options : [ 'cpp_std=c++17' ])
+project('dxvk', ['c', 'cpp'], version : 'v1.10.1', meson_version : '>= 0.49', default_options : [ 'cpp_std=c++17' ])
 
 cpu_family = target_machine.cpu_family()
 


### PR DESCRIPTION
This might help better organize some platform/arch/compiler specific stuff.
https://mesonbuild.com/Release-notes-for-0-48-0.html
https://mesonbuild.com/Release-notes-for-0-49-0.html

Notably:
##### Projects args can be set separately for cross and native builds (potentially breaking change)
```meson
# Added only to native compilations, not used in cross compilations.
add_project_arguments(..., native : true)
# Added only to cross compilations, not used in native compilations.
add_project_arguments(..., native : false)
```
##### Dictionary addition
```meson
d1 = {'a' : 'b'}
d3 = d1 + {'a' : 'c'}
d3 += {'d' : 'e'}
```
##### Can specify keyword arguments with a dictionary
```meson
options = {'include_directories': include_directories('inc')}
executable(...
  kwargs: options)
```