### PR TITLE
Blend HUD text shadow and center correctly

### DIFF
--- a/src/dxvk/hud/shaders/hud_text_frag.frag
+++ b/src/dxvk/hud/shaders/hud_text_frag.frag
@@ -27,10 +27,11 @@ void main() {
   float r_alpha_center = sampleAlpha(0.0f, 5.0f);
   float r_alpha_shadow = sampleAlpha(0.3f, 5.0f);
   
-  vec4 r_center = vec4(v_color.rgb, v_color.a * r_alpha_center);
-  vec4 r_shadow = vec4(0.0f, 0.0f, 0.0f, r_alpha_shadow);
-  
-  o_color = mix(r_shadow, r_center, r_alpha_center);
+  vec3 r_center = v_color.rgb;
+  vec3 r_shadow = vec3(0.0f, 0.0f, 0.0f);
+
+  o_color.rgb = mix(r_shadow, r_center, r_alpha_center);
+  o_color.a = r_alpha_shadow * v_color.a;
   o_color.rgb *= o_color.a;
 
   if (!srgbSwapchain)


### PR DESCRIPTION
This fixes incorrect blending between HUD text, which would cause a narrow transparent gap between the text center and border/shadow that is visible at large text sizes.

EDIT: forgot to mention that this **will also make it so that the border follows the given color's alpha, instead of always being opaque**.