### PR TITLE
[d3d9] Don't adjust window position and size in windowed mode.

### DIFF
--- a/src/d3d9/d3d9_swapchain.cpp
+++ b/src/d3d9/d3d9_swapchain.cpp
@@ -631,21 +631,6 @@ namespace dxvk {
     if (pPresentParams->Windowed) {
       if (changeFullscreen)
         this->LeaveFullscreenMode();
-
-      // Adjust window position and size
-      RECT newRect = { 0, 0, 0, 0 };
-      RECT oldRect = { 0, 0, 0, 0 };
-      
-      ::GetWindowRect(m_window, &oldRect);
-      ::MapWindowPoints(HWND_DESKTOP, ::GetParent(m_window), reinterpret_cast<POINT*>(&oldRect), 1);
-      ::SetRect(&newRect, 0, 0, pPresentParams->BackBufferWidth, pPresentParams->BackBufferHeight);
-      ::AdjustWindowRectEx(&newRect,
-        ::GetWindowLongW(m_window, GWL_STYLE), FALSE,
-        ::GetWindowLongW(m_window, GWL_EXSTYLE));
-      ::SetRect(&newRect, 0, 0, newRect.right - newRect.left, newRect.bottom - newRect.top);
-      ::OffsetRect(&newRect, oldRect.left, oldRect.top);    
-      ::MoveWindow(m_window, newRect.left, newRect.top,
-        newRect.right - newRect.left, newRect.bottom - newRect.top, TRUE);
     }
     else {
       if (changeFullscreen) {


### PR DESCRIPTION
Fixes DOUKYUUSEI: Bangin' Summer (1689910) stuck resizing the window on desktop (not reproducible every time for me, the best repro rate was achieved with Gnome).

It looks like the problem is inspired by  MoveWindow in D3D9SwapChainEx::Reset(). The game works in windowed d3d9 mode but makes the window fullscreen by setting its size to fullscreen and clearing the style flags (but possibly after the D3D9SwapChainEx::Reset() is called so it may see the flags assuming decorations).