### PR TITLE
[util] Enable d3d9.deferSurfaceCreation for Small Radios Big Televisions

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -287,6 +287,10 @@ namespace dxvk {
     /* Stranger of Paradise - FF Origin           */
     { R"(\\SOPFFO\.exe$)", {{
       { "d3d9.deferSurfaceCreation",        "True" },
+    /* Small Radios Big Televisions               */
+    }} },
+    { R"(\\SRBT\.exe$)", {{
+      { "d3d9.deferSurfaceCreation",        "True" },
     }} },
 
     /**********************************************/


### PR DESCRIPTION
SRBT doesn't actually use d3d at all, it is OpenGL game. But just in case it creates d3d9 device after it has setup GL context. d3d9 swapchain creation leads to the new "client window" creation in winex11, the old one (which is actually used for rendering) gets reparented to hidden window and nothing is displayed.

This is not impossible but rather involved to fix in winex11.drv, so since the config option is already there for a bunch of games maybe we can add another one.