### PR TITLE
[dxgi] Return DXGI_ERROR_INVALID_CALL for invalid IDXGIAdapter3::RegisterVideoMemoryBudgetChangeNotificationEvent() parameters

### DIFF
--- a/src/dxgi/dxgi_adapter.cpp
+++ b/src/dxgi/dxgi_adapter.cpp
@@ -404,7 +404,7 @@ namespace dxvk {
           HANDLE                        hEvent,
           DWORD*                        pdwCookie) {
     if (!hEvent || !pdwCookie)
-      return E_INVALIDARG;
+      return DXGI_ERROR_INVALID_CALL;
 
     std::unique_lock<dxvk::mutex> lock(m_mutex);
     DWORD cookie = ++m_eventCookie;


### PR DESCRIPTION
According to wine tests https://source.winehq.org/git/wine.git/commitdiff/14237e321b30bd3f9eaa441586f82c44c15bc5cf

Signed-off-by: Zhiyi Zhang <zzhang@codeweavers.com>