### PR TITLE
[dxgi] Only enum outputs which belong to an adapter.

### DIFF
--- a/src/dxgi/dxgi_adapter.cpp
+++ b/src/dxgi/dxgi_adapter.cpp
@@ -148,12 +148,15 @@ namespace dxvk {
     
     if (ppOutput == nullptr)
       return E_INVALIDARG;
-    
-    HMONITOR monitor = wsi::enumMonitors(Output);
-    
+
+    const auto deviceId   = m_adapter->devicePropertiesExt().vk11;
+
+    HMONITOR monitor = wsi::enumMonitors(
+      deviceId.deviceLUIDValid ? reinterpret_cast<const LUID *>(deviceId.deviceLUID) : nullptr, Output);
+
     if (monitor == nullptr)
       return DXGI_ERROR_NOT_FOUND;
-    
+
     *ppOutput = ref(new DxgiOutput(m_factory, this, monitor));
     return S_OK;
   }

--- a/src/dxvk/dxvk_adapter.h
+++ b/src/dxvk/dxvk_adapter.h
@@ -274,7 +274,23 @@ namespace dxvk {
      * \returns \c true if the system has unified memory.
      */
     bool isUnifiedMemoryArchitecture() const;
-    
+
+    void linkToDGPU(Rc<DxvkAdapter> dpgu_adapter)
+    {
+        dpgu_adapter->m_linkedIGPUAdapter = this;
+        m_linkedToDGPU = true;
+    }
+
+    Rc<DxvkAdapter> linkedIGPUAdapter() const
+    {
+        return m_linkedIGPUAdapter;
+    }
+
+    bool isLinkedToDGPU() const
+    {
+        return m_linkedToDGPU;
+    }
+
   private:
     
     Rc<vk::InstanceFn>  m_vki;
@@ -286,7 +302,10 @@ namespace dxvk {
     DxvkDeviceFeatures  m_deviceFeatures;
 
     bool                m_hasMemoryBudget;
-    
+
+    Rc<DxvkAdapter>     m_linkedIGPUAdapter;
+    bool                m_linkedToDGPU = false;
+
     std::vector<VkQueueFamilyProperties> m_queueFamilies;
 
     std::array<std::atomic<uint64_t>, VK_MAX_MEMORY_HEAPS> m_memoryAllocated = { };

--- a/src/dxvk/dxvk_instance.cpp
+++ b/src/dxvk/dxvk_instance.cpp
@@ -251,10 +251,17 @@ namespace dxvk {
 
     DxvkDeviceFilter filter(filterFlags);
     std::vector<Rc<DxvkAdapter>> result;
+    uint32_t numDGPU = 0, numIGPU = 0;
 
     for (uint32_t i = 0; i < numAdapters; i++) {
       if (filter.testAdapter(deviceProperties[i]))
+      {
         result.push_back(new DxvkAdapter(m_vki, adapters[i]));
+        if (deviceProperties[i].deviceType == VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU)
+          ++numDGPU;
+        else if (deviceProperties[i].deviceType == VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU)
+          ++numIGPU;
+      }
     }
     
     std::stable_sort(result.begin(), result.end(),
@@ -279,6 +286,9 @@ namespace dxvk {
     if (result.size() == 0) {
       Logger::warn("DXVK: No adapters found. Please check your "
                    "device filter settings and Vulkan setup.");
+    }
+    else if (numDGPU == 1 && numIGPU == 1) {
+      result[1]->linkToDGPU(result[0]);
     }
     
     return result;

--- a/src/wsi/glfw/wsi_monitor_glfw.cpp
+++ b/src/wsi/glfw/wsi_monitor_glfw.cpp
@@ -22,7 +22,7 @@ namespace dxvk::wsi {
          : nullptr;
   }
 
-  HMONITOR enumMonitors(const LUID *adapterLUID, uint32_t index) {
+  HMONITOR enumMonitors(const LUID *adapterLUID[], uint32_t numLUIDs, uint32_t index) {
     return enumMonitors(index);
   }
 

--- a/src/wsi/glfw/wsi_monitor_glfw.cpp
+++ b/src/wsi/glfw/wsi_monitor_glfw.cpp
@@ -22,6 +22,10 @@ namespace dxvk::wsi {
          : nullptr;
   }
 
+  HMONITOR enumMonitors(const LUID *adapterLUID, uint32_t index) {
+    return enumMonitors(index);
+  }
+
   bool getDisplayName(
       HMONITOR hMonitor,
       WCHAR            (&Name)[32]) {

--- a/src/wsi/sdl2/wsi_monitor_sdl2.cpp
+++ b/src/wsi/sdl2/wsi_monitor_sdl2.cpp
@@ -23,7 +23,7 @@ namespace dxvk::wsi {
       : nullptr;
   }
 
-  HMONITOR enumMonitors(const LUID *adapterLUID, uint32_t index) {
+  HMONITOR enumMonitors(const LUID *adapterLUID[], uint32_t numLUIDs, uint32_t index) {
     return enumMonitors(index);
   }
 

--- a/src/wsi/sdl2/wsi_monitor_sdl2.cpp
+++ b/src/wsi/sdl2/wsi_monitor_sdl2.cpp
@@ -23,6 +23,10 @@ namespace dxvk::wsi {
       : nullptr;
   }
 
+  HMONITOR enumMonitors(const LUID *adapterLUID, uint32_t index) {
+    return enumMonitors(index);
+  }
+
   bool getDisplayName(
           HMONITOR         hMonitor,
           WCHAR            (&Name)[32]) {

--- a/src/wsi/win32/wsi_monitor_win32.cpp
+++ b/src/wsi/win32/wsi_monitor_win32.cpp
@@ -1,9 +1,11 @@
 #include "../wsi_monitor.h"
 
+#include "../../util/util_string.h"
 #include "../../util/log/log.h"
 #include "../../util/util_string.h"
 
 #include <cstring>
+#include <set>
 
 #include <setupapi.h>
 #include <ntddvdeo.h>
@@ -16,6 +18,7 @@ namespace dxvk::wsi {
   }
 
   struct MonitorEnumInfo {
+    const WCHAR *gdiDeviceName;
     UINT      iMonitorId;
     HMONITOR  oMonitor;
   };
@@ -27,23 +30,99 @@ namespace dxvk::wsi {
           LPARAM                    lp) {
     auto data = reinterpret_cast<MonitorEnumInfo*>(lp);
 
-    if (data->iMonitorId--)
-      return TRUE; /* continue */
+    if (data->gdiDeviceName)
+    {
+      MONITORINFOEXW monitorInfo;
 
+      monitorInfo.cbSize = sizeof(monitorInfo);
+      GetMonitorInfoW(hmon, (MONITORINFO *)&monitorInfo);
+      if (wcscmp(data->gdiDeviceName, monitorInfo.szDevice))
+        return TRUE;
+    }
+    if (data->iMonitorId--)
+      return TRUE;
     data->oMonitor = hmon;
-    return FALSE; /* stop */
+    return FALSE;
   }
 
   HMONITOR enumMonitors(uint32_t index) {
     MonitorEnumInfo info;
     info.iMonitorId = index;
     info.oMonitor   = nullptr;
+    info.gdiDeviceName = nullptr;
 
     ::EnumDisplayMonitors(
       nullptr, nullptr, &MonitorEnumProc,
       reinterpret_cast<LPARAM>(&info));
 
     return info.oMonitor;
+  }
+
+  HMONITOR enumMonitors(const LUID *adapterLUID, uint32_t index) {
+
+    if (!adapterLUID)
+      return enumMonitors(index);
+
+    std::vector<DISPLAYCONFIG_PATH_INFO> paths;
+    std::vector<DISPLAYCONFIG_MODE_INFO> modes;
+    std::set<uint32_t> sources;
+    UINT32 pathCount, modeCount;
+    LONG result;
+
+    do
+    {
+        if ((result = GetDisplayConfigBufferSizes(QDC_ONLY_ACTIVE_PATHS, &pathCount, &modeCount)))
+        {
+          Logger::err(str::format("GetDisplayConfigBufferSizes failed, result ", result));
+          return enumMonitors(index);
+        }
+        paths.resize(pathCount);
+        modes.resize(modeCount);
+        result = QueryDisplayConfig(QDC_ONLY_ACTIVE_PATHS, &pathCount, paths.data(), &modeCount, modes.data(), nullptr);
+    } while (result == ERROR_INSUFFICIENT_BUFFER);
+
+    if (result)
+    {
+      Logger::err(str::format("QueryDisplayConfig failed, result ", result));
+      return enumMonitors(index);
+    }
+    paths.resize(pathCount);
+    modes.resize(modeCount);
+
+    MonitorEnumInfo info;
+    info.iMonitorId = index;
+    info.oMonitor = nullptr;
+
+    for (const auto &path : paths)
+    {
+      if (std::memcmp(&path.sourceInfo.adapterId, adapterLUID, sizeof(path.sourceInfo.adapterId)))
+        continue;
+      /* Mirrored displays appear as multiple paths with the same GDI device name, that comes as single
+       * dxgi output. */
+      if (!sources.insert(path.sourceInfo.id).second)
+        continue;
+
+      DISPLAYCONFIG_SOURCE_DEVICE_NAME deviceName;
+
+      deviceName.header.adapterId = path.sourceInfo.adapterId;
+      deviceName.header.id = path.sourceInfo.id;
+      deviceName.header.type = DISPLAYCONFIG_DEVICE_INFO_GET_SOURCE_NAME;
+      deviceName.header.size = sizeof(deviceName);
+      if ((result = DisplayConfigGetDeviceInfo(&deviceName.header)))
+      {
+        Logger::err(str::format("DisplayConfigGetDeviceInfo failed, result ", result));
+        return enumMonitors(index);
+      }
+      info.gdiDeviceName = deviceName.viewGdiDeviceName;
+
+      ::EnumDisplayMonitors(
+        nullptr, nullptr, &MonitorEnumProc,
+        reinterpret_cast<LPARAM>(&info));
+
+      if (info.oMonitor != nullptr)
+        return info.oMonitor;
+    }
+    return nullptr;
   }
 
 

--- a/src/wsi/wsi_monitor.h
+++ b/src/wsi/wsi_monitor.h
@@ -44,6 +44,15 @@ namespace dxvk::wsi {
   HMONITOR enumMonitors(uint32_t index);
 
   /**
+    * \brief Enumerators monitors on the system
+    * \param [in] adapterLUID LUID of the adapter (nullptr for all monitors)
+    * \param [in] index Monitor index within enumeration
+    *
+    * \returns The monitor of given index
+    */
+  HMONITOR enumMonitors(const LUID *adapterLUID, uint32_t index);
+
+  /**
     * \brief Get the GDI name of a HMONITOR
     *
     * Get the GDI Device Name of a HMONITOR to

--- a/src/wsi/wsi_monitor.h
+++ b/src/wsi/wsi_monitor.h
@@ -45,12 +45,13 @@ namespace dxvk::wsi {
 
   /**
     * \brief Enumerators monitors on the system
-    * \param [in] adapterLUID LUID of the adapter (nullptr for all monitors)
+    * \param [in] adapterLUID array of adapters' LUIDs
+    * \param [in] numLUIDs adapterLUID array size (0 for all monitors)
     * \param [in] index Monitor index within enumeration
     *
     * \returns The monitor of given index
     */
-  HMONITOR enumMonitors(const LUID *adapterLUID, uint32_t index);
+  HMONITOR enumMonitors(const LUID *adapterLUID[], uint32_t numLUIDs, uint32_t index);
 
   /**
     * \brief Get the GDI name of a HMONITOR


### PR DESCRIPTION
That's what I see dxgi doing on Windows, and the method of selecting outputs seems to work both in Wine and Windows.

Fixes Monster Hunter Rise in case of multiple adapters which gets a bit mad when dxgi outputs don't match what it gets from QueryDisplayConfig(). Here on a dual GPU laptop (AMD) it keeps requerying display configs and resizing swapchain each frame which effectively results in not working alttabbing out of the game, unability to change display settings (like resolution, monitor) which gets reset to the previous value immediately and hang on exit. With the patch all that seems to be fixed, switching monitor through menu also works correctly.