### PR TITLE
[util] Report Nvidia VendorId for Myst V

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -554,6 +554,13 @@ namespace dxvk {
       { "d3d9.memoryTrackTest",             "True" },
       { "d3d9.maxAvailableMemory",          "2048" },
     }} },
+    /* Myst V End of Ages                             
+       Game has white textures on amd radv.
+       Expects Nvidia, Intel or ATI VendorId.
+       "Radeon" in gpu description also works   */
+    { R"(\\eoa\.exe$)", {{
+      { "d3d9.customVendorId",              "10de" },
+    }} },
   }};
 
 


### PR DESCRIPTION
Game was made before ATI Technologies was bought by AMD and so doesn't recognize AMD as a GPU vendor, which for some reason makes it bug out.
Setting Nvidia "10de", Intel "8086" or ATI Technologies "0528" makes it work.
It also works when it sees the word "Radeon" in the device description, which is why this issue doesn't show on amdvlk or wined3d.

Closes #1836
The Original game of the issue have had it's engine updated since so it isn't a problem there anymore. This fixes the remaining Myst V part of the issue.

Edit: I should give main credit to @niobium93 for originally discovering that changing the device description fixed the issue.