### PR TITLE
Use memory mapped files for D3D9 texture mapping data

### DIFF
--- a/dxvk.conf
+++ b/dxvk.conf
@@ -298,17 +298,6 @@
 # d3d9.shaderModel = 3
 
 
-# Evict Managed on Unlock
-# 
-# Decides whether we should evict managed resources from
-# system memory when they are unlocked entirely.
-#
-# Supported values:
-# - True, False: Always enable / disable
-
-# d3d9.evictManagedOnUnlock = False
-
-
 # DPI Awareness
 # 
 # Decides whether we should call SetProcessDPIAware on device

--- a/dxvk.conf
+++ b/dxvk.conf
@@ -560,3 +560,12 @@
 # - True/False
 
 # dxvk.enableDebugUtils = False
+
+# Memory limit for locked D3D9 textures
+#
+# How much virtual memory will be used for textures (in MB).
+# 0 to disable the limit.
+# THIS DOES NOT IMPACT ACTUAL MEMORY CONSUMPTION OR TEXTURE QUALITY.
+# DO NOT CHANGE THIS UNLESS YOU HAVE A VERY GOOD REASON.
+
+# d3d9.textureMemory = 100

--- a/src/d3d9/d3d9_common_buffer.h
+++ b/src/d3d9/d3d9_common_buffer.h
@@ -156,11 +156,6 @@ namespace dxvk {
     inline D3D9Range& DirtyRange()  { return m_dirtyRange; }
 
     /**
-     * \brief The range of the buffer that might currently be read by the GPU
-     */
-    inline D3D9Range& GPUReadingRange() { return m_gpuReadingRange; }
-
-    /**
     * \brief Whether or not the buffer was written to by the GPU (in IDirect3DDevice9::ProcessVertices)
     */
     inline bool NeedsReadback() const     { return m_needsReadback; }
@@ -183,15 +178,6 @@ namespace dxvk {
      * \brief Whether or not the staging buffer needs to be copied to the actual buffer
      */
     inline bool NeedsUpload() { return m_desc.Pool != D3DPOOL_DEFAULT && !m_dirtyRange.IsDegenerate(); }
-
-    inline bool DoesStagingBufferUploads() const { return m_uploadUsingStaging; }
-
-    inline void EnableStagingBufferUploads() {
-      if (GetMapMode() != D3D9_COMMON_BUFFER_MAP_MODE_BUFFER)
-        return;
-
-      m_uploadUsingStaging = true;
-    }
 
     void PreLoad();
 
@@ -252,7 +238,6 @@ namespace dxvk {
     DxvkBufferSliceHandle       m_sliceHandle;
 
     D3D9Range                   m_dirtyRange;
-    D3D9Range                   m_gpuReadingRange;
 
     uint32_t                    m_lockCount = 0;
 

--- a/src/d3d9/d3d9_common_texture.cpp
+++ b/src/d3d9/d3d9_common_texture.cpp
@@ -89,6 +89,8 @@ namespace dxvk {
   D3D9CommonTexture::~D3D9CommonTexture() {
     if (m_size != 0)
       m_device->ChangeReportedMemory(m_size);
+
+    m_device->RemoveMappedTexture(this);
   }
 
 
@@ -488,7 +490,7 @@ namespace dxvk {
       return D3D9_COMMON_TEXTURE_MAP_MODE_NONE;
 
 #ifdef D3D9_ALLOW_UNMAPPING
-    if (m_desc.Pool != D3DPOOL_DEFAULT)
+    if (m_device->GetOptions()->textureMemory != 0 && m_desc.Pool != D3DPOOL_DEFAULT)
       return D3D9_COMMON_TEXTURE_MAP_MODE_UNMAPPABLE;
 #endif
 

--- a/src/d3d9/d3d9_common_texture.h
+++ b/src/d3d9/d3d9_common_texture.h
@@ -378,11 +378,6 @@ namespace dxvk {
     bool NeedsUpload(UINT Subresource) const { return m_needsUpload.get(Subresource); }
     bool NeedsAnyUpload() { return m_needsUpload.any(); }
     void ClearNeedsUpload() { return m_needsUpload.clearAll();  }
-    bool DoesStagingBufferUploads(UINT Subresource) const { return m_uploadUsingStaging.get(Subresource); }
-
-    void EnableStagingBufferUploads(UINT Subresource) {
-      m_uploadUsingStaging.set(Subresource, true);
-    }
 
     void SetNeedsMipGen(bool value) { m_needsMipGen = value; }
     bool NeedsMipGen() const { return m_needsMipGen; }

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -39,19 +39,20 @@ namespace dxvk {
           HWND                   hFocusWindow,
           DWORD                  BehaviorFlags,
           Rc<DxvkDevice>         dxvkDevice)
-    : m_parent         ( pParent )
-    , m_deviceType     ( DeviceType )
-    , m_window         ( hFocusWindow )
-    , m_behaviorFlags  ( BehaviorFlags )
-    , m_adapter        ( pAdapter )
-    , m_dxvkDevice     ( dxvkDevice )
-    , m_shaderModules  ( new D3D9ShaderModuleSet )
-    , m_stagingBuffer  ( dxvkDevice, StagingBufferSize )
-    , m_d3d9Options    ( dxvkDevice, pParent->GetInstance()->config() )
-    , m_multithread    ( BehaviorFlags & D3DCREATE_MULTITHREADED )
-    , m_isSWVP         ( (BehaviorFlags & D3DCREATE_SOFTWARE_VERTEXPROCESSING) ? true : false )
-    , m_csThread       ( dxvkDevice, dxvkDevice->createContext(DxvkContextType::Primary) )
-    , m_csChunk        ( AllocCsChunk() ) {
+    : m_parent          ( pParent )
+    , m_deviceType      ( DeviceType )
+    , m_window          ( hFocusWindow )
+    , m_behaviorFlags   ( BehaviorFlags )
+    , m_adapter         ( pAdapter )
+    , m_dxvkDevice      ( dxvkDevice )
+    , m_memoryAllocator ( )
+    , m_shaderModules   ( new D3D9ShaderModuleSet )
+    , m_stagingBuffer   ( dxvkDevice, StagingBufferSize )
+    , m_d3d9Options     ( dxvkDevice, pParent->GetInstance()->config() )
+    , m_multithread     ( BehaviorFlags & D3DCREATE_MULTITHREADED )
+    , m_isSWVP          ( (BehaviorFlags & D3DCREATE_SOFTWARE_VERTEXPROCESSING) ? true : false )
+    , m_csThread        ( dxvkDevice, dxvkDevice->createContext(DxvkContextType::Primary) )
+    , m_csChunk         ( AllocCsChunk() ) {
     // If we can SWVP, then we use an extended constant set
     // as SWVP has many more slots available than HWVP.
     bool canSWVP = CanSWVP();

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -4309,8 +4309,7 @@ namespace dxvk {
     pResource->SetLocked(Subresource, true);
 
     const bool noDirtyUpdate = Flags & D3DLOCK_NO_DIRTY_UPDATE;
-    if (likely((pResource->IsManaged() && m_d3d9Options.evictManagedOnUnlock)
-      || ((desc.Pool == D3DPOOL_DEFAULT || !noDirtyUpdate) && !readOnly))) {
+    if ((desc.Pool == D3DPOOL_DEFAULT || !noDirtyUpdate) && !readOnly) {
       if (pBox && MipLevel != 0) {
         D3DBOX scaledBox = *pBox;
         scaledBox.Left   <<= MipLevel;
@@ -4325,7 +4324,7 @@ namespace dxvk {
       }
     }
 
-    if (managed && !m_d3d9Options.evictManagedOnUnlock && !readOnly) {
+    if (managed && !readOnly) {
       pResource->SetNeedsUpload(Subresource, true);
 
       for (uint32_t i : bit::BitMask(m_activeTextures)) {
@@ -4373,7 +4372,7 @@ namespace dxvk {
     const D3DBOX& box = pResource->GetDirtyBox(Face);
     bool shouldFlush  = pResource->GetMapMode() == D3D9_COMMON_TEXTURE_MAP_MODE_BACKED;
          shouldFlush &= box.Left < box.Right && box.Top < box.Bottom && box.Front < box.Back;
-         shouldFlush &= !pResource->IsManaged() || m_d3d9Options.evictManagedOnUnlock;
+         shouldFlush &= !pResource->IsManaged();
 
     if (shouldFlush) {
         this->FlushImage(pResource, Subresource);
@@ -4385,7 +4384,7 @@ namespace dxvk {
     // and we aren't managed (for sysmem copy.)
     bool shouldToss  = pResource->GetMapMode() == D3D9_COMMON_TEXTURE_MAP_MODE_BACKED;
          shouldToss &= !pResource->IsDynamic();
-         shouldToss &= !pResource->IsManaged() || m_d3d9Options.evictManagedOnUnlock;
+         shouldToss &= !pResource->IsManaged();
 
     if (shouldToss) {
       pResource->DestroyBufferSubresource(Subresource);

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -11,6 +11,7 @@
 #include "d3d9_adapter.h"
 #include "d3d9_constant_buffer.h"
 #include "d3d9_constant_set.h"
+#include "d3d9_mem.h"
 
 #include "d3d9_state.h"
 
@@ -929,6 +930,10 @@ namespace dxvk {
       return m_samplerCount.load();
     }
 
+    D3D9MemoryAllocator* GetAllocator() {
+      return &m_memoryAllocator;
+    }
+
   private:
 
     DxvkCsChunkRef AllocCsChunk() {
@@ -1147,6 +1152,8 @@ namespace dxvk {
 
     D3D9Adapter*                    m_adapter;
     Rc<DxvkDevice>                  m_dxvkDevice;
+
+    D3D9MemoryAllocator             m_memoryAllocator;
 
     uint32_t                        m_frameLatency = DefaultFrameLatency;
 

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -28,9 +28,12 @@
 
 #include "d3d9_shader_permutations.h"
 
+#include <unordered_set>
 #include <vector>
 #include <type_traits>
 #include <unordered_map>
+
+#include "../util/util_lru.h"
 
 namespace dxvk {
 
@@ -934,6 +937,10 @@ namespace dxvk {
       return &m_memoryAllocator;
     }
 
+    void* MapTexture(D3D9CommonTexture* pTexture, UINT Subresource);
+    void TouchMappedTexture(D3D9CommonTexture* pTexture);
+    void RemoveMappedTexture(D3D9CommonTexture* pTexture);
+
   private:
 
     DxvkCsChunkRef AllocCsChunk() {
@@ -1142,6 +1149,8 @@ namespace dxvk {
       D3D9CommonTexture* pResource,
       UINT Subresource);
 
+    void UnmapTextures();
+
     uint64_t GetCurrentSequenceNumber();
 
     Com<D3D9InterfaceEx>            m_parent;
@@ -1282,6 +1291,9 @@ namespace dxvk {
 
     Direct3DState9                  m_state;
 
+#ifdef D3D9_ALLOW_UNMAPPING
+    lru_list<D3D9CommonTexture*>    m_mappedTextures;
+#endif
   };
 
 }

--- a/src/d3d9/d3d9_hud.cpp
+++ b/src/d3d9/d3d9_hud.cpp
@@ -33,4 +33,63 @@ namespace dxvk::hud {
     return position;
   }
 
+  HudTextureMemory::HudTextureMemory(D3D9DeviceEx* device)
+          : m_device          (device)
+          , m_allocatedString ("")
+          , m_mappedString    ("") {}
+
+
+  void HudTextureMemory::update(dxvk::high_resolution_clock::time_point time) {
+    D3D9MemoryAllocator* allocator = m_device->GetAllocator();
+
+    m_maxAllocated = std::max(m_maxAllocated, allocator->AllocatedMemory());
+    m_maxUsed = std::max(m_maxUsed, allocator->UsedMemory());
+    m_maxMapped = std::max(m_maxMapped, allocator->MappedMemory());
+
+    auto elapsed = std::chrono::duration_cast<std::chrono::microseconds>(time - m_lastUpdate);
+
+    if (elapsed.count() < UpdateInterval)
+      return;
+
+    m_allocatedString = str::format(m_maxAllocated >> 20, " MB (Used: ", m_maxUsed >> 20, " MB)");
+    m_mappedString = str::format(m_maxMapped >> 20, " MB");
+    m_maxAllocated = 0;
+    m_maxUsed = 0;
+    m_maxMapped = 0;
+    m_lastUpdate = time;
+  }
+
+
+  HudPos HudTextureMemory::render(
+          HudRenderer&      renderer,
+          HudPos            position) {
+    position.y += 16.0f;
+
+    renderer.drawText(16.0f,
+                      { position.x, position.y },
+                      { 0.0f, 1.0f, 0.75f, 1.0f },
+                      "Mappable:");
+
+    renderer.drawText(16.0f,
+                      { position.x + 120.0f, position.y },
+                      { 1.0f, 1.0f, 1.0f, 1.0f },
+                      m_allocatedString);
+
+    position.y += 24.0f;
+
+    renderer.drawText(16.0f,
+                      { position.x, position.y },
+                      { 0.0f, 1.0f, 0.75f, 1.0f },
+                      "Mapped:");
+
+    renderer.drawText(16.0f,
+                      { position.x + 120.0f, position.y },
+                      { 1.0f, 1.0f, 1.0f, 1.0f },
+                      m_mappedString);
+
+    position.y += 8.0f;
+
+    return position;
+  }
+
 }

--- a/src/d3d9/d3d9_hud.h
+++ b/src/d3d9/d3d9_hud.h
@@ -6,7 +6,7 @@
 namespace dxvk::hud {
 
   /**
-   * \brief HUD item to display DXVK version
+   * \brief HUD item to display sampler count
    */
   class HudSamplerCount : public HudItem {
 
@@ -27,5 +27,37 @@ namespace dxvk::hud {
     std::string m_samplerCount;
 
   };
+
+    /**
+     * \brief HUD item to display unmappable memory
+     */
+    class HudTextureMemory : public HudItem {
+      constexpr static int64_t UpdateInterval = 500'000;
+
+    public:
+
+        HudTextureMemory(D3D9DeviceEx* device);
+
+        void update(dxvk::high_resolution_clock::time_point time);
+
+        HudPos render(
+                HudRenderer&      renderer,
+                HudPos            position);
+
+    private:
+
+        D3D9DeviceEx* m_device;
+
+        uint32_t m_maxAllocated = 0;
+        uint32_t m_maxUsed      = 0;
+        uint32_t m_maxMapped    = 0;
+
+        dxvk::high_resolution_clock::time_point m_lastUpdate
+          = dxvk::high_resolution_clock::now();
+
+        std::string m_allocatedString;
+        std::string m_mappedString;
+
+    };
 
 }

--- a/src/d3d9/d3d9_mem.cpp
+++ b/src/d3d9/d3d9_mem.cpp
@@ -1,0 +1,292 @@
+#include "d3d9_mem.h"
+#include "../util/util_string.h"
+#include "../util/util_math.h"
+#include "../util/log/log.h"
+#include "../util/util_likely.h"
+#include <utility>
+
+#ifdef D3D9_ALLOW_UNMAPPING
+#include <sysinfoapi.h>
+#endif
+
+namespace dxvk {
+
+#ifdef D3D9_ALLOW_UNMAPPING
+  D3D9MemoryAllocator::D3D9MemoryAllocator() {
+    SYSTEM_INFO sysInfo;
+    GetSystemInfo(&sysInfo);
+    m_allocationGranularity = sysInfo.dwAllocationGranularity;
+  }
+
+  D3D9Memory D3D9MemoryAllocator::Alloc(uint32_t Size) {
+    std::lock_guard<dxvk::mutex> lock(m_mutex);
+
+    uint32_t alignedSize = align(Size, CACHE_LINE_SIZE);
+    for (auto& chunk : m_chunks) {
+      D3D9Memory memory = chunk->Alloc(alignedSize);
+      if (memory) {
+        m_usedMemory += memory.GetSize();
+        return memory;
+      }
+    }
+
+    uint32_t chunkSize = std::max(D3D9ChunkSize, alignedSize);
+    m_allocatedMemory += chunkSize;
+
+    D3D9MemoryChunk* chunk = new D3D9MemoryChunk(this, chunkSize);
+    std::unique_ptr<D3D9MemoryChunk> uniqueChunk(chunk);
+    D3D9Memory memory = uniqueChunk->Alloc(alignedSize);
+    m_usedMemory += memory.GetSize();
+
+    m_chunks.push_back(std::move(uniqueChunk));
+    return memory;
+  }
+
+  void D3D9MemoryAllocator::FreeChunk(D3D9MemoryChunk *Chunk) {
+    std::lock_guard<dxvk::mutex> lock(m_mutex);
+
+    m_allocatedMemory -= Chunk->Size();
+
+    m_chunks.erase(std::remove_if(m_chunks.begin(), m_chunks.end(), [&](auto& item) {
+        return item.get() == Chunk;
+    }), m_chunks.end());
+  }
+
+  void D3D9MemoryAllocator::NotifyMapped(uint32_t Size) {
+    m_mappedMemory += Size;
+  }
+
+  void D3D9MemoryAllocator::NotifyUnmapped(uint32_t Size) {
+    m_mappedMemory -= Size;
+  }
+
+  void D3D9MemoryAllocator::NotifyFreed(uint32_t Size) {
+    m_usedMemory -= Size;
+  }
+
+  uint32_t D3D9MemoryAllocator::MappedMemory() {
+    return m_mappedMemory.load();
+  }
+
+  uint32_t D3D9MemoryAllocator::UsedMemory() {
+    return m_usedMemory.load();
+  }
+
+  uint32_t D3D9MemoryAllocator::AllocatedMemory() {
+    return m_allocatedMemory.load();
+  }
+
+  D3D9MemoryChunk::D3D9MemoryChunk(D3D9MemoryAllocator* Allocator, uint32_t Size)
+    : m_allocator(Allocator), m_size(Size), m_mappingGranularity(m_allocator->MemoryGranularity() * 16) {
+    m_mapping = CreateFileMappingA(INVALID_HANDLE_VALUE, nullptr, PAGE_READWRITE | SEC_COMMIT, 0, Size, nullptr);
+    m_freeRanges.push_back({ 0, Size });
+    m_mappingRanges.resize(((Size + m_mappingGranularity - 1) / m_mappingGranularity));
+  }
+
+  D3D9MemoryChunk::~D3D9MemoryChunk() {
+    std::lock_guard<dxvk::mutex> lock(m_mutex);
+
+    CloseHandle(m_mapping);
+  }
+
+  void* D3D9MemoryChunk::Map(D3D9Memory* memory) {
+    std::lock_guard<dxvk::mutex> lock(m_mutex);
+
+    uint32_t alignedOffset = alignDown(memory->GetOffset(), m_mappingGranularity);
+    uint32_t alignmentDelta = memory->GetOffset() - alignedOffset;
+    uint32_t alignedSize = memory->GetSize() + alignmentDelta;
+    if (alignedSize > m_mappingGranularity) {
+      // The allocation crosses the boundary of the internal mapping page it's a part of
+      // so we map it on it's own.
+      alignedOffset = alignDown(memory->GetOffset(), m_allocator->MemoryGranularity());
+      alignmentDelta = memory->GetOffset() - alignedOffset;
+      alignedSize = memory->GetSize() + alignmentDelta;
+
+      m_allocator->NotifyMapped(alignedSize);
+      uint8_t* basePtr = static_cast<uint8_t*>(MapViewOfFile(m_mapping, FILE_MAP_ALL_ACCESS, 0, alignedOffset, alignedSize));
+      if (unlikely(basePtr == nullptr)) {
+        DWORD error = GetLastError();
+        Logger::err(str::format("Mapping non-persisted file failed: ", error, ", Mapped memory: ", m_allocator->MappedMemory()));
+        return nullptr;
+      }
+      return basePtr + alignmentDelta;
+    }
+
+    // For small allocations we map the entire mapping page to minimize the overhead from having the align the offset to 65k bytes.
+    // This should hopefully also reduce the amount of MapViewOfFile calls we do for tiny allocations.
+    auto& mappingRange = m_mappingRanges[memory->GetOffset() /  m_mappingGranularity];
+    if (unlikely(mappingRange.refCount == 0)) {
+      m_allocator->NotifyMapped(m_mappingGranularity);
+      mappingRange.ptr = static_cast<uint8_t*>(MapViewOfFile(m_mapping, FILE_MAP_ALL_ACCESS, 0, alignedOffset, m_mappingGranularity));
+      if (unlikely(mappingRange.ptr == nullptr)) {
+        DWORD error = GetLastError();
+        LPTSTR buffer = nullptr;
+        FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM, nullptr, error, MAKELANGID(LANG_NEUTRAL, SUBLANG_NEUTRAL), (LPTSTR)&buffer, 0, nullptr);
+        Logger::err(str::format("Mapping non-persisted file failed: ", error, ", Mapped memory: ", m_allocator->MappedMemory(), ", Msg: ", buffer));
+        if (buffer) {
+          LocalFree(buffer);
+        }
+      }
+    }
+    mappingRange.refCount++;
+    uint8_t* basePtr = static_cast<uint8_t*>(mappingRange.ptr);
+    return basePtr + alignmentDelta;
+  }
+
+  void D3D9MemoryChunk::Unmap(D3D9Memory* memory) {
+    std::lock_guard<dxvk::mutex> lock(m_mutex);
+
+    uint32_t alignedOffset = alignDown(memory->GetOffset(), m_mappingGranularity);
+    uint32_t alignmentDelta = memory->GetOffset() - alignedOffset;
+    uint32_t alignedSize = memory->GetSize() + alignmentDelta;
+    if (alignedSize > m_mappingGranularity) {
+      // Single use mapping
+      alignedOffset = alignDown(memory->GetOffset(), m_allocator->MemoryGranularity());
+      alignmentDelta = memory->GetOffset() - alignedOffset;
+      alignedSize = memory->GetSize() + alignmentDelta;
+
+      uint8_t* basePtr = static_cast<uint8_t*>(memory->Ptr()) - alignmentDelta;
+      UnmapViewOfFile(basePtr);
+      m_allocator->NotifyUnmapped(alignedSize);
+      return;
+    }
+    auto& mappingRange = m_mappingRanges[memory->GetOffset() /  m_mappingGranularity];
+    mappingRange.refCount--;
+    if (unlikely(mappingRange.refCount == 0)) {
+      UnmapViewOfFile(mappingRange.ptr);
+      mappingRange.ptr = nullptr;
+      m_allocator->NotifyUnmapped(m_mappingGranularity);
+    }
+  }
+
+  D3D9Memory D3D9MemoryChunk::Alloc(uint32_t Size) {
+    std::lock_guard<dxvk::mutex> lock(m_mutex);
+
+    uint32_t offset = 0;
+    uint32_t size = 0;
+
+    for (auto range = m_freeRanges.begin(); range != m_freeRanges.end(); range++) {
+      if (range->length >= Size) {
+        offset = range->offset;
+        size = Size;
+        range->offset += Size;
+        range->length -= Size;
+        if (range->length < (4 << 10)) {
+          size += range->length;
+          m_freeRanges.erase(range);
+        }
+        break;
+      }
+    }
+
+    if (size != 0)
+      return D3D9Memory(this, offset, Size);
+
+    return {};
+  }
+
+  void D3D9MemoryChunk::Free(D3D9Memory *Memory) {
+    std::lock_guard<dxvk::mutex> lock(m_mutex);
+
+    uint32_t offset = Memory->GetOffset();
+    uint32_t size = Memory->GetSize();
+
+    auto curr = m_freeRanges.begin();
+
+    // shamelessly stolen from dxvk_memory.cpp
+    while (curr != m_freeRanges.end()) {
+      if (curr->offset == offset + size) {
+        size += curr->length;
+        curr = m_freeRanges.erase(curr);
+      } else if (curr->offset + curr->length == offset) {
+        offset -= curr->length;
+        size += curr->length;
+        curr = m_freeRanges.erase(curr);
+      } else {
+        curr++;
+      }
+    }
+
+    m_freeRanges.push_back({ offset, size });
+    m_allocator->NotifyFreed(Memory->GetSize());
+  }
+
+  bool D3D9MemoryChunk::IsEmpty() {
+    std::lock_guard<dxvk::mutex> lock(m_mutex);
+
+    return m_freeRanges.size() == 1
+        && m_freeRanges[0].length == m_size;
+  }
+
+  D3D9MemoryAllocator* D3D9MemoryChunk::Allocator() const {
+    return m_allocator;
+  }
+
+  HANDLE D3D9MemoryChunk::FileHandle() const {
+    return m_mapping;
+  }
+
+
+  D3D9Memory::D3D9Memory(D3D9MemoryChunk* Chunk, size_t Offset, size_t Size)
+    : m_chunk(Chunk), m_offset(Offset), m_size(Size) {}
+
+  D3D9Memory::D3D9Memory(D3D9Memory&& other)
+    : m_chunk(std::exchange(other.m_chunk, nullptr)),
+      m_ptr(std::exchange(other.m_ptr, nullptr)),
+      m_offset(std::exchange(other.m_offset, 0)),
+      m_size(std::exchange(other.m_size, 0)) {}
+
+  D3D9Memory::~D3D9Memory() {
+    this->Free();
+  }
+
+  D3D9Memory& D3D9Memory::operator = (D3D9Memory&& other) {
+    this->Free();
+
+    m_chunk = std::exchange(other.m_chunk, nullptr);
+    m_ptr = std::exchange(other.m_ptr, nullptr);
+    m_offset = std::exchange(other.m_offset, 0);
+    m_size = std::exchange(other.m_size, 0);
+    return *this;
+  }
+
+  void D3D9Memory::Free() {
+    if (unlikely(m_chunk == nullptr))
+      return;
+
+    if (m_ptr != nullptr)
+      Unmap();
+
+    m_chunk->Free(this);
+    if (m_chunk->IsEmpty()) {
+      D3D9MemoryAllocator* allocator = m_chunk->Allocator();
+      allocator->FreeChunk(m_chunk);
+    }
+    m_chunk = nullptr;
+  }
+
+  void D3D9Memory::Map() {
+    if (unlikely(m_ptr != nullptr))
+      return;
+
+    if (unlikely(m_chunk == nullptr))
+      return;
+
+    m_ptr = m_chunk->Map(this);
+  }
+
+  void D3D9Memory::Unmap() {
+    if (unlikely(m_ptr == nullptr))
+      return;
+
+    m_chunk->Unmap(this);
+    m_ptr = nullptr;
+  }
+
+  void* D3D9Memory::Ptr() {
+    return m_ptr;
+  }
+
+#endif
+
+}

--- a/src/d3d9/d3d9_mem.h
+++ b/src/d3d9/d3d9_mem.h
@@ -1,0 +1,160 @@
+
+#pragma once
+
+#include "../util/thread.h"
+
+#if defined(_WIN32) && !defined(_WIN64)
+  #define D3D9_ALLOW_UNMAPPING
+#endif
+
+#ifdef D3D9_ALLOW_UNMAPPING
+  #define WIN32_LEAN_AND_MEAN
+  #include <winbase.h>
+#endif
+
+namespace dxvk {
+
+  class D3D9MemoryAllocator;
+  class D3D9Memory;
+
+#ifdef D3D9_ALLOW_UNMAPPING
+
+  class D3D9MemoryChunk;
+
+  constexpr uint32_t D3D9ChunkSize = 64 << 20;
+
+  struct D3D9MemoryRange {
+    uint32_t offset;
+    uint32_t length;
+  };
+
+  struct D3D9MappingRange {
+    uint32_t refCount = 0;
+    void* ptr = nullptr;
+  };
+
+  class D3D9MemoryChunk {
+    friend D3D9MemoryAllocator;
+
+    public:
+      ~D3D9MemoryChunk();
+
+      D3D9MemoryChunk             (const D3D9MemoryChunk&) = delete;
+      D3D9MemoryChunk& operator = (const D3D9MemoryChunk&) = delete;
+
+      D3D9MemoryChunk             (D3D9MemoryChunk&& other) = delete;
+      D3D9MemoryChunk& operator = (D3D9MemoryChunk&& other) = delete;
+
+#ifdef D3D9_MEM_MAP_CHUNKS
+      void IncMapCounter();
+      void DecMapCounter();
+      void* Ptr() const { return m_ptr; }
+#endif
+      D3D9Memory Alloc(uint32_t Size);
+      void Free(D3D9Memory* Memory);
+      bool IsEmpty();
+      uint32_t Size() const { return m_size; }
+      D3D9MemoryAllocator* Allocator() const;
+      HANDLE FileHandle() const;
+      void* Map(D3D9Memory* memory);
+      void Unmap(D3D9Memory* memory);
+
+    private:
+      D3D9MemoryChunk(D3D9MemoryAllocator* Allocator, uint32_t Size);
+
+      dxvk::mutex m_mutex;
+      D3D9MemoryAllocator* m_allocator;
+      HANDLE m_mapping;
+      uint32_t m_size;
+      uint32_t m_mappingGranularity;
+      std::vector<D3D9MemoryRange> m_freeRanges;
+      std::vector<D3D9MappingRange> m_mappingRanges;
+
+#ifdef D3D9_MEM_MAP_CHUNKS
+      uint32_t m_mapCounter = 0;
+      void* m_ptr;
+#endif
+  };
+
+  class D3D9Memory {
+    friend D3D9MemoryChunk;
+
+    public:
+      D3D9Memory() {}
+      ~D3D9Memory();
+
+      D3D9Memory             (const D3D9Memory&) = delete;
+      D3D9Memory& operator = (const D3D9Memory&) = delete;
+
+      D3D9Memory             (D3D9Memory&& other);
+      D3D9Memory& operator = (D3D9Memory&& other);
+
+      operator bool() const { return m_chunk != nullptr; }
+
+      void Map();
+      void Unmap();
+      void* Ptr();
+      D3D9MemoryChunk* GetChunk() const { return m_chunk; }
+      size_t GetOffset() const { return m_offset; }
+      size_t GetSize() const { return m_size; }
+
+    private:
+      D3D9Memory(D3D9MemoryChunk* Chunk, size_t Offset, size_t Size);
+      void Free();
+
+      D3D9MemoryChunk* m_chunk = nullptr;
+      void* m_ptr              = nullptr;
+      size_t m_offset          = 0;
+      size_t m_size            = 0;
+  };
+
+  class D3D9MemoryAllocator {
+    friend D3D9MemoryChunk;
+
+    public:
+      D3D9MemoryAllocator();
+      ~D3D9MemoryAllocator() = default;
+      D3D9Memory Alloc(uint32_t Size);
+      void FreeChunk(D3D9MemoryChunk* Chunk);
+      void NotifyMapped(uint32_t Size);
+      void NotifyUnmapped(uint32_t Size);
+      void NotifyFreed(uint32_t Size);
+      uint32_t MappedMemory();
+      uint32_t UsedMemory();
+      uint32_t AllocatedMemory();
+      uint32_t MemoryGranularity() { return m_allocationGranularity; }
+
+    private:
+      dxvk::mutex m_mutex;
+      std::vector<std::unique_ptr<D3D9MemoryChunk>> m_chunks;
+      std::atomic<size_t> m_mappedMemory = 0;
+      std::atomic<size_t> m_allocatedMemory = 0;
+      std::atomic<size_t> m_usedMemory = 0;
+      uint32_t m_allocationGranularity;
+  };
+
+#else
+    class D3D9Memory {
+    public:
+      operator bool() const { return false; }
+
+      void Map() {}
+      void Unmap() {}
+      void* Ptr() { return nullptr; }
+
+    private:
+      void Free();
+    };
+
+    class D3D9MemoryAllocator {
+
+    public:
+      D3D9Memory Alloc(uint32_t Size) { return { }; }
+      uint32_t MappedMemory() { return 0; }
+      uint32_t UsedMemory() { return 0; }
+      uint32_t AllocatedMemory() { return 0; }
+    };
+
+#endif
+
+}

--- a/src/d3d9/d3d9_options.cpp
+++ b/src/d3d9/d3d9_options.cpp
@@ -43,7 +43,6 @@ namespace dxvk {
     this->maxFrameRate                  = config.getOption<int32_t>     ("d3d9.maxFrameRate",                  0);
     this->presentInterval               = config.getOption<int32_t>     ("d3d9.presentInterval",               -1);
     this->shaderModel                   = config.getOption<int32_t>     ("d3d9.shaderModel",                   3);
-    this->evictManagedOnUnlock          = config.getOption<bool>        ("d3d9.evictManagedOnUnlock",          false);
     this->dpiAware                      = config.getOption<bool>        ("d3d9.dpiAware",                      true);
     this->strictConstantCopies          = config.getOption<bool>        ("d3d9.strictConstantCopies",          false);
     this->strictPow                     = config.getOption<bool>        ("d3d9.strictPow",                     true);

--- a/src/d3d9/d3d9_options.cpp
+++ b/src/d3d9/d3d9_options.cpp
@@ -73,6 +73,7 @@ namespace dxvk {
     this->deviceLocalConstantBuffers    = config.getOption<bool>        ("d3d9.deviceLocalConstantBuffers",    false);
     this->allowDirectBufferMapping      = config.getOption<bool>        ("d3d9.allowDirectBufferMapping",      true);
     this->seamlessCubes                 = config.getOption<bool>        ("d3d9.seamlessCubes",                 false);
+    this->textureMemory                 = config.getOption<int32_t>     ("d3d9.textureMemory",                100) << 20;
 
     // If we are not Nvidia, enable general hazards.
     this->generalHazards = adapter != nullptr

--- a/src/d3d9/d3d9_options.h
+++ b/src/d3d9/d3d9_options.h
@@ -36,9 +36,6 @@ namespace dxvk {
     /// Set the max shader model the device can support in the caps.
     int32_t shaderModel;
 
-    /// Whether or not managed resources should stay in memory until unlock, or until manually evicted.
-    bool evictManagedOnUnlock;
-
     /// Whether or not to set the process as DPI aware in Windows when the API interface is created.
     bool dpiAware;
 

--- a/src/d3d9/d3d9_options.h
+++ b/src/d3d9/d3d9_options.h
@@ -157,6 +157,9 @@ namespace dxvk {
 
     /// Don't use non seamless cube maps
     bool seamlessCubes;
+
+    /// How much virtual memory will be used for textures (in MB).
+    int32_t textureMemory;
   };
 
 }

--- a/src/d3d9/d3d9_swapchain.cpp
+++ b/src/d3d9/d3d9_swapchain.cpp
@@ -1081,6 +1081,10 @@ namespace dxvk {
     if (m_hud != nullptr) {
       m_hud->addItem<hud::HudClientApiItem>("api", 1, GetApiName());
       m_hud->addItem<hud::HudSamplerCount>("samplers", -1, m_parent);
+
+#ifdef D3D9_ALLOW_UNMAPPING
+      m_hud->addItem<hud::HudTextureMemory>("memory", -1, m_parent);
+#endif
     }
   }
 

--- a/src/d3d9/d3d9_swapchain.cpp
+++ b/src/d3d9/d3d9_swapchain.cpp
@@ -341,7 +341,10 @@ namespace dxvk {
     if (unlikely(dstTexInfo->Desc()->Pool != D3DPOOL_SYSTEMMEM && dstTexInfo->Desc()->Pool != D3DPOOL_SCRATCH))
       return D3DERR_INVALIDCALL;
 
-    Rc<DxvkBuffer> dstBuffer = dstTexInfo->GetBuffer(dst->GetSubresource());
+    VkExtent3D dstTexExtent = dstTexInfo->GetExtentMip(dst->GetMipLevel());
+    VkExtent3D srcTexExtent = srcTexInfo->GetExtentMip(0);
+
+    Rc<DxvkBuffer> dstBuffer = dstTexInfo->GetBuffer(dst->GetSubresource(), dstTexExtent.width > srcTexExtent.width || dstTexExtent.height > srcTexExtent.height);
     Rc<DxvkImage>  srcImage  = srcTexInfo->GetImage();
 
     if (srcImage->info().sampleCount != VK_SAMPLE_COUNT_1_BIT) {

--- a/src/d3d9/d3d9_texture.cpp
+++ b/src/d3d9/d3d9_texture.cpp
@@ -87,7 +87,9 @@ namespace dxvk {
     // Some games keep using the pointer returned in LockRect() after calling Unlock()
     // and purely rely on AddDirtyRect to notify D3D9 that contents have changed.
     // We have no way of knowing which mip levels were actually changed.
-    m_texture.SetAllNeedUpload();
+    if (m_texture.IsManaged())
+      m_texture.SetAllNeedUpload();
+
     return D3D_OK;
   }
 
@@ -169,7 +171,9 @@ namespace dxvk {
     // Some games keep using the pointer returned in LockBox() after calling Unlock()
     // and purely rely on AddDirtyBox to notify D3D9 that contents have changed.
     // We have no way of knowing which mip levels were actually changed.
-    m_texture.SetAllNeedUpload();
+    if (m_texture.IsManaged())
+      m_texture.SetAllNeedUpload();
+
     return D3D_OK;
   }
 
@@ -257,9 +261,12 @@ namespace dxvk {
     // Some games keep using the pointer returned in LockRect() after calling Unlock()
     // and purely rely on AddDirtyRect to notify D3D9 that contents have changed.
     // We have no way of knowing which mip levels were actually changed.
-    for (uint32_t m = 0; m < m_texture.Desc()->MipLevels; m++) {
-      m_texture.SetNeedsUpload(m_texture.CalcSubresource(Face, m), true);
+    if (m_texture.IsManaged()) {
+      for (uint32_t m = 0; m < m_texture.Desc()->MipLevels; m++) {
+        m_texture.SetNeedsUpload(m_texture.CalcSubresource(Face, m), true);
+      }
     }
+
     return D3D_OK;
   }
 

--- a/src/d3d9/d3d9_texture.cpp
+++ b/src/d3d9/d3d9_texture.cpp
@@ -90,6 +90,7 @@ namespace dxvk {
     if (m_texture.IsManaged())
       m_texture.SetAllNeedUpload();
 
+    m_parent->TouchMappedTexture(&m_texture);
     return D3D_OK;
   }
 
@@ -174,6 +175,7 @@ namespace dxvk {
     if (m_texture.IsManaged())
       m_texture.SetAllNeedUpload();
 
+    m_parent->TouchMappedTexture(&m_texture);
     return D3D_OK;
   }
 
@@ -267,6 +269,7 @@ namespace dxvk {
       }
     }
 
+    m_parent->TouchMappedTexture(&m_texture);
     return D3D_OK;
   }
 

--- a/src/d3d9/meson.build
+++ b/src/d3d9/meson.build
@@ -40,7 +40,8 @@ d3d9_src = [
   'd3d9_swvp_emu.cpp',
   'd3d9_format_helpers.cpp',
   'd3d9_hud.cpp',
-  'd3d9_annotation.cpp'
+  'd3d9_annotation.cpp',
+  'd3d9_mem.cpp'
 ]
 
 d3d9_dll = shared_library('d3d9'+dll_ext, d3d9_src, glsl_generator.process(d3d9_shaders), d3d9_res,

--- a/src/util/util_lru.h
+++ b/src/util/util_lru.h
@@ -1,0 +1,69 @@
+#include <cstdint>
+#include <list>
+#include <unordered_map>
+
+namespace dxvk {
+
+  template<typename T>
+  class lru_list {
+
+  public:
+    typedef typename std::list<T>::const_iterator const_iterator;
+
+    void insert(T value) {
+      auto cacheIter = m_cache.find(value);
+      if (cacheIter != m_cache.end())
+        m_list.erase(cacheIter->second);
+
+      m_list.push_back(value);
+      auto iter = m_list.cend();
+      iter--;
+      m_cache[value] = iter;
+    }
+
+    void remove(const T& value) {
+      auto cacheIter = m_cache.find(value);
+      if (cacheIter == m_cache.end())
+        return;
+
+      m_list.erase(cacheIter->second);
+      m_cache.erase(cacheIter);
+    }
+
+    const_iterator remove(const_iterator iter) {
+      auto cacheIter = m_cache.find(*iter);
+      m_cache.erase(cacheIter);
+      return m_list.erase(iter);
+    }
+
+    void touch(const T& value) {
+      auto cacheIter = m_cache.find(value);
+      if (cacheIter == m_cache.end())
+        return;
+
+      m_list.erase(cacheIter->second);
+      m_list.push_back(value);
+      auto iter = m_list.cend();
+      --iter;
+      m_cache[value] = iter;
+    }
+
+    const_iterator leastRecentlyUsedIter() const {
+      return m_list.cbegin();
+    }
+
+    const_iterator leastRecentlyUsedEndIter() const {
+      return m_list.cend();
+    }
+
+    uint32_t size() const noexcept {
+      return m_list.size();
+    }
+
+  private:
+    std::list<T> m_list;
+    std::unordered_map<T, const_iterator> m_cache;
+
+  };
+
+}


### PR DESCRIPTION
In order to finally fix some of our address space problems, I took a page out of Gallium Nine's book.

Most resources require a copy in system memory that we have to keep around in order to avoid stalling in Lock* calls. Those take up a lot of address space leading to crashes when we exhaust the 2 or respectively 3GB (with LAA) of address space. 

To avoid that, we need to unmap resources once the application is done with them on the CPU. In theory that is possible with Vulkan memory, there is however two problems with doing it with Vulkan memory directly: 
- The DXVK memory allocator and buffer system is not designed with this in mind.
- Nvidia seems to map host visible Vulkan memory when it is allocated. (@DadSchoorse tested that.)

To work around those limitations, we use Win32 memory mapped files. Those can be mapped and unmapped as we please.

## Allocation & Mapping

We suballocate from 64MB memory mapped files to avoid overhead of allocating those. 64MB is quite a lot so we try to lock at the level of a suballocation. There is however a problem with that: MapViewOfFile requires the offset to be aligned to the memory allocation granularity which is 65k. To avoid a lot of wasted memory and address space and lots of MapViewOfFile calls for tiny resources, there are two strategies. We try to allocate tightly packed, so we cannot guarantee the alignment. Every mem file is split up into "mapping pages" that are 1MB (+- alignment to 65k) each. When a resource gets mapped, we either map the entire page or reuse the existing pointer. If a resource is either larger than such a page or crosses from one page to another, it gets a separate mapping. We round down the offset to 65k and increase the size accordingly.

## D3D resources

We use memory mapped files for all texture types, except ones placed in D3DPOOL_DEFAULT. I originally used it for buffers too but dropped that because Crysis apparently reads or writes from/to a locking pointer outside of the correct scope. That's not super rare either according to Joshua.

## GPU Readback

D3DPOOL_SYSTEMMEM textures can be written by the GPU with functions like GetRenderTargetData. When that happens, we lazily create a DXVK buffer and use that instead of the memory mapped file allocation for all future locking calls. That works well because GetRendertargetData and GetFrontbufferData usually overwrite the entire image. We compare the texture sizes and when the destination texture is smaller, we copy over the data from the memory mapped file. After that, we free that and use the buffer for everything else.

## Unmapping

Unmapping is done using a least recently used list. There is a configurable virtual memory budget which is set to 100MB by default. Once we cross that, we start unmapping old resources all the way until we are only using 3/4th of the budget.
We can only unmap resources that aren't currently locked, otherwise we could be potentially invalidating a pointer that the application is still going to use.

## 64 bit builds & DXVK Native

All of this is only enabled for 32bit Win32 builds. It gets removed by the preprocessor otherwise.

## Cleanup

I removed the direct upload path and because we pretty much always use the staging buffer upload path now anyway. It's necessary for the memory mapped files to work and the direct path was only implemented because I was worried about raised address space usage. We now have a better solution for that. Along with that, there's some nice cleanup in the LockImage/LockBuffer functions.

I also removed evictManagedOnUnlock. This PR basically solves the same problem without the downsides. The option has never really been useful as pretty much all games that tended to crash also relied on the system memory copies to avoid terrible hitches.