### PR TITLE
[d3d9] Defer surface creation if no HWND is given to device

### DIFF
--- a/src/d3d9/d3d9_swapchain.cpp
+++ b/src/d3d9/d3d9_swapchain.cpp
@@ -199,7 +199,7 @@ namespace dxvk {
     m_window = m_presentParams.hDeviceWindow;
 
     UpdatePresentRegion(nullptr, nullptr);
-    if (!pDevice->GetOptions()->deferSurfaceCreation)
+    if (m_window && !pDevice->GetOptions()->deferSurfaceCreation)
       CreatePresenter();
 
     CreateBackBuffers(m_presentParams.BackBufferCount);


### PR DESCRIPTION
Planetary Annihilation: TITANS creates a device with a NULL HWND and requires it to succeed. It doesn't actually do anything with the device, just creates some shaders and then does nothing with them. Maybe checking capabilities? Anyway, this patch lets the game run for me.

I've sent a test to Wine demonstrating this behavior: https://source.winehq.org/git/wine.git/commit/a64ec46e4e33aea801cfbe033e68591abdddfb14

Prior to this patch, DXVK fails the test. After, it succeeds.