### PR TITLE
[util] disable allowDoNotWait for Port Royale 3 attempt 2

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -592,6 +592,11 @@ namespace dxvk {
     { R"(\\bionic_commando\.exe$)", {{
       { "d3d9.maxFrameRate",                "60" },
     }} },
+    /* Port Royale 3                            *
+     * Fixes infinite loading screens           */
+    { R"(\\PortRoyale3\.exe$)", {{
+      { "d3d9.allowDoNotWait",           "False" },
+    }} },
   }};
 
 


### PR DESCRIPTION
See last PR https://github.com/doitsujin/dxvk/pull/2610 for discussion.

Fixes https://github.com/doitsujin/dxvk/issues/2148

I still haven't figured why this issue doesn't happen with the proton dxvk .dll and I'm not sure how to debug it.