### PR TITLE
[util] Enable strict float emulation for Sonic Adventure 2

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -321,7 +321,7 @@ namespace dxvk {
     }} },
     /* Sonic Adventure 2                          */
     { R"(\\Sonic Adventure 2\\(launcher|sonic2app)\.exe$)", {{
-      { "d3d9.floatEmulation",              "False" },
+      { "d3d9.floatEmulation",              "Strict" },
     }} },
     /* The Sims 2,
        Body Shop,


### PR DESCRIPTION
Fixes #2672