### PR TITLE
Add option to round depth values when using a depth format fallback

### DIFF
--- a/dxvk.conf
+++ b/dxvk.conf
@@ -557,3 +557,10 @@
 # - True/False
 
 # dxvk.enableDebugUtils = False
+
+# Depth rounding
+#
+# Enables rounding depth values when using a fallback depth format.
+# (D24->D32 or D16->D24/D32)
+
+# d3d9.roundDepth = False

--- a/src/d3d9/d3d9_adapter.h
+++ b/src/d3d9/d3d9_adapter.h
@@ -87,6 +87,14 @@ namespace dxvk {
       return m_d3d9Formats.GetUnsupportedFormatInfo(Format);
     }
 
+    bool SupportsD24S8() const {
+      return m_d3d9Formats.SupportsD24S8();
+    }
+
+    bool SupportsD16S8() const {
+      return m_d3d9Formats.SupportsD16S8();
+    }
+
   private:
 
     HRESULT CheckDeviceVkFormat(

--- a/src/d3d9/d3d9_format.h
+++ b/src/d3d9/d3d9_format.h
@@ -204,6 +204,14 @@ namespace dxvk {
     const DxvkFormatInfo* GetUnsupportedFormatInfo(
       D3D9Format            Format) const;
 
+    bool SupportsD24S8() const {
+      return m_d24s8Support;
+    }
+
+    bool SupportsD16S8() const {
+      return m_d16s8Support;
+    }
+
   private:
 
     bool CheckImageFormatSupport(

--- a/src/d3d9/d3d9_options.cpp
+++ b/src/d3d9/d3d9_options.cpp
@@ -73,6 +73,7 @@ namespace dxvk {
     this->apitraceMode                  = config.getOption<bool>        ("d3d9.apitraceMode",                  false);
     this->deviceLocalConstantBuffers    = config.getOption<bool>        ("d3d9.deviceLocalConstantBuffers",    false);
     this->allowDirectBufferMapping      = config.getOption<bool>        ("d3d9.allowDirectBufferMapping",      true);
+    this->roundDepth                    = config.getOption<bool>        ("d3d9.roundDepth",                    false);
 
     // If we are not Nvidia, enable general hazards.
     this->generalHazards = adapter != nullptr

--- a/src/d3d9/d3d9_options.h
+++ b/src/d3d9/d3d9_options.h
@@ -157,6 +157,9 @@ namespace dxvk {
 
     /// Disable direct buffer mapping
     bool allowDirectBufferMapping;
+
+    /// Should we round depth when using the D24->D32 or D16->D24/D32 workaround
+    bool roundDepth;
   };
 
 }

--- a/src/d3d9/d3d9_spec_constants.h
+++ b/src/d3d9/d3d9_spec_constants.h
@@ -19,6 +19,8 @@ namespace dxvk {
     Fetch4            = 9,
 
     SamplerDepthMode  = 10,
+
+    DepthFormatRounding = 11,
   };
 
 }

--- a/src/dxso/dxso_options.cpp
+++ b/src/dxso/dxso_options.cpp
@@ -45,6 +45,8 @@ namespace dxvk {
     alphaTestWiggleRoom = options.alphaTestWiggleRoom;
 
     robustness2Supported = devFeatures.extRobustness2.robustBufferAccess2;
+
+    roundDepth = options.roundDepth;
   }
 
 }

--- a/src/dxso/dxso_options.h
+++ b/src/dxso/dxso_options.h
@@ -57,6 +57,9 @@ namespace dxvk {
 
     /// Whether or not we can rely on robustness2 to handle oob constant access
     bool robustness2Supported;
+
+    /// Should we round depth when using the D24->D32 or D16->D24/D32 workaround
+    bool roundDepth;
   };
 
 }

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -561,6 +561,19 @@ namespace dxvk {
     { R"(\\eoa\.exe$)", {{
       { "d3d9.customVendorId",              "10de" },
     }} },
+    /* Assassin's Creed Brotherhood has shadow acne issues
+       with the D24->D32 workaround. */
+    { R"(\\(ACBSP|ACBMP)\.exe$)", {{
+      { "d3d9.roundDepth",                  "true" },
+    }} },
+    /* SimCity has shadow issues with the D24->D32 workaround. */
+    { R"(\\SimCity\.exe$)", {{
+      { "d3d9.roundDepth",                  "true" },
+    }} },
+    /* The Saboteur has shadow issues with the D24->D32 workaround. */
+    { R"(\\Saboteur\.exe$)", {{
+      { "d3d9.roundDepth",                  "true" },
+    }} },
   }};
 
 


### PR DESCRIPTION
Fixes #2642
Might help #2361
Does not fix #1560

I'm not sure if this is the correct fix or if the underlying issue is somewhere else.
The shadow map bias in ACB appears to be too small, so it ends up relying on rounding inaccuracies.
It's entirely possible that we have small floating point math inaccuracies somewhere else but I have no clue how we'd debug that.
This should at least fix the issue even though it's pretty awful.