### PR TITLE
[util] Add workaround to fix missing sun & light shafts in Beyond Good And Evil

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -570,6 +570,11 @@ namespace dxvk {
     { R"(\\eoa\.exe$)", {{
       { "d3d9.customVendorId",              "10de" },
     }} },
+    /* Beyond Good And Evil                     *
+     * Fixes missing sun and light shafts       */
+    { R"(\\BGE\.exe$)", {{
+      { "d3d9.allowDoNotWait",              "False" },
+    }} },
     /* Supreme Commander & Forged Alliance Forever */
     { R"(\\(SupremeCommander|ForgedAlliance)\.exe$)", {{
       { "d3d9.floatEmulation",            "Strict" },


### PR DESCRIPTION
Fixes a regression introduced by 6fa28bf in Beyond Good And Evil. More details [here](https://github.com/doitsujin/dxvk/issues/1545).