### PR TITLE
[util] Enable sampler type spec constants for SWTOR

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -565,6 +565,10 @@ namespace dxvk {
     { R"(\\SupremeCommander\.exe$)", {{
       { "d3d9.floatEmulation",        "Strict" },
     }} },
+    /* Star Wars The Old Republic */
+    { R"(\\swtor\.exe$)", {{
+      { "d3d9.forceSamplerTypeSpecConstants", "True" },
+    }} },
   }};
 
 


### PR DESCRIPTION
Fixes #2676

All credit goes to @Blisto91, I just added the config.