### PR TITLE
[util] Limit Bionic Commando to 60fps

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -573,6 +573,11 @@ namespace dxvk {
     { R"(\\swtor\.exe$)", {{
       { "d3d9.forceSamplerTypeSpecConstants", "True" },
     }} },
+    /* Bionic Commando                          
+       Physics break at high fps               */
+    { R"(\\bionic_commando\.exe$)", {{
+      { "d3d9.maxFrameRate",                "60" },
+    }} },
   }};
 
 


### PR DESCRIPTION
Game physics doesn't work properly when the game runs ~above 144fps~  at high fps. So might as well cap it.
See [ProtonDB](https://www.protondb.com/app/21670), [PCGamingWiki](https://www.pcgamingwiki.com/wiki/Bionic_Commando_(2009)#Frame_rate_.28FPS.29) or [steam forums](https://steamcommunity.com/app/21670/discussions/0/3050611812308087545/)

Also seems to help make the stuttering the game can have less noticeable when the gpu would have been maxed. Or what ever is the cause.

Edit: Originally capped to 144, but changed to 60. See comments below