### PR TITLE
Added config for A Way Out

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -292,7 +292,10 @@ namespace dxvk {
     { R"(\\SRBT\.exe$)", {{
       { "d3d9.deferSurfaceCreation",        "True" },
     }} },
-
+    /* A Way Out: fix for stuttering and low fps  */
+    { R"(\\AWayOut(_friend)\.exe$)", {{
+      { "dxgi.maxFrameLatency",                "1" },
+    }} },
     /**********************************************/
     /* D3D9 GAMES                                 */
     /**********************************************/

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -293,9 +293,10 @@ namespace dxvk {
       { "d3d9.deferSurfaceCreation",        "True" },
     }} },
     /* A Way Out: fix for stuttering and low fps  */
-    { R"(\\AWayOut(_friend)\.exe$)", {{
+    { R"(\\AWayOut(_friend)?\.exe$)", {{
       { "dxgi.maxFrameLatency",                "1" },
     }} },
+
     /**********************************************/
     /* D3D9 GAMES                                 */
     /**********************************************/


### PR DESCRIPTION
With a regular build of DXVK, this game has serious microstuttering and framerate issues, setting dxgi.maxFrameLatency to 1 fixes this problem.

The game has 2 executables called AWayOut.exe and AWayOut_friend.exe, the rule I added applies to both, but I had no way to test the second one (it's a "trial" version allows a friend that didn't buy the game to play with you online).

Tested on Manjaro Linux (kernel 5.18), Mesa 22.1.2, wine-ge 7.16, AMD 6900XT