### PR TITLE
[util] Add workarounds for Garden Warfare 2

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -296,6 +296,11 @@ namespace dxvk {
     { R"(\\AWayOut(_friend)?\.exe$)", {{
       { "dxgi.maxFrameLatency",                "1" },
     }} },
+    /* Garden Warfare 2
+       Won't start on amd Id without atiadlxx     */
+    { R"(\\GW2.Main_Win64_Retail\.exe$)", {{
+      { "dxgi.customVendorId",           "10de"   },
+    }} },
 
     /**********************************************/
     /* D3D9 GAMES                                 */


### PR DESCRIPTION
Game won't launch with amd vendorId but works with `10de`. Everyone on ProtonDB sets it to `1c06` instead which also works, but i couldn't find whose vendorId that was so just went with 10de. Didn't find it to cause any issues from some short testing.