### PR TITLE
[util] Limit Dead Space to 60fps and fix vsync

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -347,9 +347,13 @@ namespace dxvk {
       { "d3d9.memoryTrackTest",             "True" },
     }} },
     /* Dead Space uses the a NULL render target instead
-       of a 1x1 one if DF24 is NOT supported      */
+       of a 1x1 one if DF24 is NOT supported     
+       Mouse and physics issues above 60 FPS
+       Built-in Vsync Locks the game to 30 FPS    */
     { R"(\\Dead Space\.exe$)", {{
       { "d3d9.supportDFFormats",                 "False" },
+      { "d3d9.maxFrameRate",                     "60" },
+      { "d3d9.presentInterval",                  "1" },
     }} },
     /* Halo CE/HaloPC                             */
     { R"(\\halo(ce)?\.exe$)", {{


### PR DESCRIPTION
https://www.pcgamingwiki.com/wiki/Dead_Space#Issues_fixed

The game has mouse acceleration and physics issues above 60 FPS.

Also the game locks to 30 FPS using the built-in vsync. 
Setting `d3d9.presentInterval` to 1 blocks this and the game continues to run at 60 FPS