### PR TITLE
[d3d9] add D3DFMT_UNKNOWN to windowed BackBufferFormat

### DIFF
--- a/src/d3d9/d3d9_monitor.cpp
+++ b/src/d3d9/d3d9_monitor.cpp
@@ -57,7 +57,8 @@ namespace dxvk {
         || BackBufferFormat == D3D9Format::X8R8G8B8
         || BackBufferFormat == D3D9Format::A1R5G5B5
         || BackBufferFormat == D3D9Format::X1R5G5B5
-        || BackBufferFormat == D3D9Format::R5G6B5;
+        || BackBufferFormat == D3D9Format::R5G6B5
+        || BackBufferFormat == D3D9Format::Unknown;
   }
 
 }


### PR DESCRIPTION
All credit goes to `tfo#2734` from discord. They haven't replied back so don't have their github name.

Fixes #2363


![Screenshot_20220708_204616](https://user-images.githubusercontent.com/47954800/178055101-2e4a94c6-900c-4118-aeb1-6c84dcda48ea.png)
