### PR TITLE
 [util] Enable cached dynamic resources for DayZ

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -597,6 +597,10 @@ namespace dxvk {
     { R"(\\PortRoyale3\.exe$)", {{
       { "d3d9.allowDoNotWait",           "False" },
     }} },
+    /* DayZ */
+    { R"(\\DayZ_x64\.exe$)", {{
+      { "d3d11.cachedDynamicResources",     "cr" },
+    }} },
   }};
 
 

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -301,6 +301,10 @@ namespace dxvk {
     { R"(\\GW2.Main_Win64_Retail\.exe$)", {{
       { "dxgi.customVendorId",           "10de"   },
     }} },
+    /* DayZ */
+    { R"(\\DayZ_x64\.exe$)", {{
+      { "d3d11.cachedDynamicResources",     "cr" },
+    }} },
 
     /**********************************************/
     /* D3D9 GAMES                                 */
@@ -596,10 +600,6 @@ namespace dxvk {
      * Fixes infinite loading screens           */
     { R"(\\PortRoyale3\.exe$)", {{
       { "d3d9.allowDoNotWait",           "False" },
-    }} },
-    /* DayZ */
-    { R"(\\DayZ_x64\.exe$)", {{
-      { "d3d11.cachedDynamicResources",     "cr" },
     }} },
   }};
 


### PR DESCRIPTION
In my testing, constant buffers improve roughly 100% and shader resources add another 25% on top of that.

Note: FPS drops this fixes are only in specific spots and dont seem to happen on native D3D11 Nvidia (but do on AMD)