### PR TITLE
[d3d9] Fix barriers with staging buffers

### DIFF
--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -4028,8 +4028,8 @@ namespace dxvk {
         info.stages = VK_PIPELINE_STAGE_VERTEX_INPUT_BIT;
       } else {
         info.usage  = VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT;
-        info.stages = VK_PIPELINE_STAGE_TRANSFER_BIT;
-        info.access = VK_ACCESS_TRANSFER_READ_BIT;
+        info.stages = VK_PIPELINE_STAGE_TRANSFER_BIT | VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT;
+        info.access = VK_ACCESS_TRANSFER_READ_BIT | VK_ACCESS_SHADER_READ_BIT;
       }
 
       D3D9BufferSlice result;


### PR DESCRIPTION
I don't think this has caused any problems in practice but we should probably still fix this. The staging buffers can be used as texel buffers with the format conversion compute shaders.