### PR TITLE
Use existing staging buffer implementation in D3D9

### DIFF
--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -46,6 +46,7 @@ namespace dxvk {
     , m_adapter        ( pAdapter )
     , m_dxvkDevice     ( dxvkDevice )
     , m_shaderModules  ( new D3D9ShaderModuleSet )
+    , m_stagingBuffer  ( dxvkDevice, StagingBufferSize )
     , m_d3d9Options    ( dxvkDevice, pParent->GetInstance()->config() )
     , m_multithread    ( BehaviorFlags & D3DCREATE_MULTITHREADED )
     , m_isSWVP         ( (BehaviorFlags & D3DCREATE_SOFTWARE_VERTEXPROCESSING) ? true : false )
@@ -4008,61 +4009,11 @@ namespace dxvk {
   }
 
 
-  D3D9BufferSlice D3D9DeviceEx::AllocTempBuffer(VkDeviceSize size) {
-    constexpr VkDeviceSize DefaultSize = 1 << 20;
-
-    VkMemoryPropertyFlags memoryFlags
-      = VK_MEMORY_PROPERTY_HOST_COHERENT_BIT
-      | VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT;
-
-    D3D9BufferSlice& currentSlice = m_managedUploadBuffer;
-
-    if (size <= DefaultSize) {
-      if (unlikely(!currentSlice.slice.defined())) {
-        DxvkBufferCreateInfo info;
-        info.size   = DefaultSize;
-        info.usage  = VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT;
-        info.stages = VK_PIPELINE_STAGE_TRANSFER_BIT | VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT;
-        info.access = VK_ACCESS_TRANSFER_READ_BIT | VK_ACCESS_SHADER_READ_BIT;
-
-        currentSlice.slice  = DxvkBufferSlice(m_dxvkDevice->createBuffer(info, memoryFlags));
-        currentSlice.mapPtr = currentSlice.slice.mapPtr(0);
-      } else if (unlikely(currentSlice.slice.length() < size)) {
-        auto physSlice = currentSlice.slice.buffer()->allocSlice();
-
-        currentSlice.slice  = DxvkBufferSlice(currentSlice.slice.buffer());
-        currentSlice.mapPtr = physSlice.mapPtr;
-
-        EmitCs([
-          cBuffer = currentSlice.slice.buffer(),
-          cSlice  = physSlice
-        ] (DxvkContext* ctx) {
-          ctx->invalidateBuffer(cBuffer, cSlice);
-        });
-      }
-
-      D3D9BufferSlice result;
-      result.slice  = currentSlice.slice.subSlice(0, size);
-      result.mapPtr = reinterpret_cast<char*>(currentSlice.mapPtr) + currentSlice.slice.offset();
-
-      VkDeviceSize adjust = align(size, CACHE_LINE_SIZE);
-      currentSlice.slice = currentSlice.slice.subSlice(adjust, currentSlice.slice.length() - adjust);
-      return result;
-    } else {
-      // Create a temporary buffer for very large allocations
-      DxvkBufferCreateInfo info;
-      info.size   = size;
-      info.usage  = VK_BUFFER_USAGE_VERTEX_BUFFER_BIT
-                  | VK_BUFFER_USAGE_INDEX_BUFFER_BIT;
-      info.access = VK_ACCESS_VERTEX_ATTRIBUTE_READ_BIT
-                  | VK_ACCESS_INDEX_READ_BIT;
-      info.stages = VK_PIPELINE_STAGE_VERTEX_INPUT_BIT;
-
-      D3D9BufferSlice result;
-      result.slice  = DxvkBufferSlice(m_dxvkDevice->createBuffer(info, memoryFlags));
-      result.mapPtr = result.slice.mapPtr(0);
-      return result;
-    }
+  D3D9BufferSlice D3D9DeviceEx::AllocStagingBuffer(VkDeviceSize size) {
+    D3D9BufferSlice result;
+    result.slice = m_stagingBuffer.alloc(256, size);
+    result.mapPtr = result.slice.mapPtr(0);
+    return result;
   }
 
   bool D3D9DeviceEx::ShouldRecord() {
@@ -4524,7 +4475,7 @@ namespace dxvk {
       DxvkBufferSlice copySrcSlice;
       if (pSrcTexture->DoesStagingBufferUploads(SrcSubresource)) {
         VkDeviceSize dirtySize = extentBlockCount.width * extentBlockCount.height * extentBlockCount.depth * formatInfo->elementSize;
-        D3D9BufferSlice slice = AllocTempBuffer(dirtySize);
+        D3D9BufferSlice slice = AllocStagingBuffer(dirtySize);
         copySrcSlice = slice.slice;
         void* srcData = reinterpret_cast<uint8_t*>(srcSlice.mapPtr) + copySrcOffset;
         util::packImageData(
@@ -4574,7 +4525,7 @@ namespace dxvk {
       }
 
       // the converter can not handle the 4 aligned pitch so we always repack into a staging buffer
-      D3D9BufferSlice slice = AllocTempBuffer(srcSlice.length);
+      D3D9BufferSlice slice = AllocStagingBuffer(srcSlice.length);
       VkDeviceSize pitch = align(srcTexLevelExtentBlockCount.width * formatInfo->elementSize, 4);
 
       util::packImageData(
@@ -4734,7 +4685,7 @@ namespace dxvk {
 
     DxvkBufferSlice copySrcSlice;
     if (pResource->DoesStagingBufferUploads()) {
-      D3D9BufferSlice slice = AllocTempBuffer(range.max - range.min);
+      D3D9BufferSlice slice = AllocStagingBuffer(range.max - range.min);
       copySrcSlice = slice.slice;
       void* srcData = reinterpret_cast<uint8_t*>(srcSlice.mapPtr) + range.min;
       memcpy(slice.mapPtr, srcData, range.max - range.min);

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -969,7 +969,8 @@ namespace dxvk {
 
     void DetermineConstantLayouts(bool canSWVP);
 
-    template<bool UpBuffer>
+    D3D9BufferSlice AllocUPBuffer(VkDeviceSize size);
+
     D3D9BufferSlice AllocTempBuffer(VkDeviceSize size);
 
     bool ShouldRecord();
@@ -1163,7 +1164,10 @@ namespace dxvk {
     D3D9ConstantBuffer              m_psFixedFunction;
     D3D9ConstantBuffer              m_psShared;
 
-    D3D9BufferSlice                 m_upBuffer;
+    Rc<DxvkBuffer>                  m_upBuffer;
+    VkDeviceSize                    m_upBufferOffset  = 0ull;
+    void*                           m_upBufferMapPtr  = nullptr;
+
     D3D9BufferSlice                 m_managedUploadBuffer;
 
     D3D9Cursor                      m_cursor;

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -2,6 +2,7 @@
 
 #include "../dxvk/dxvk_device.h"
 #include "../dxvk/dxvk_cs.h"
+#include "../dxvk/dxvk_staging.h"
 
 #include "d3d9_include.h"
 #include "d3d9_cursor.h"
@@ -98,6 +99,8 @@ namespace dxvk {
     constexpr static uint32_t MaxPendingSubmits = 6;
 
     constexpr static uint32_t NullStreamIdx = caps::MaxStreams;
+
+    constexpr static VkDeviceSize StagingBufferSize = 4ull << 20;
 
     friend class D3D9SwapChainEx;
     friend class D3D9ConstantBuffer;
@@ -971,7 +974,7 @@ namespace dxvk {
 
     D3D9BufferSlice AllocUPBuffer(VkDeviceSize size);
 
-    D3D9BufferSlice AllocTempBuffer(VkDeviceSize size);
+    D3D9BufferSlice AllocStagingBuffer(VkDeviceSize size);
 
     bool ShouldRecord();
 
@@ -1168,7 +1171,7 @@ namespace dxvk {
     VkDeviceSize                    m_upBufferOffset  = 0ull;
     void*                           m_upBufferMapPtr  = nullptr;
 
-    D3D9BufferSlice                 m_managedUploadBuffer;
+    DxvkStagingBuffer               m_stagingBuffer;
 
     D3D9Cursor                      m_cursor;
 


### PR DESCRIPTION
This was introduced a while ago for the D3D11 front-end in order to reduce the memory footprint, so we should do the same here.

The `allocSlice` approach has the problem that a single spike in memory usage (e.g. while loading) will persist throughout the entire lifetime of the application, while `DxvkStagingBuffer` creates temporary buffers so that unused memory actually gets freed. On top of that, buffers with *only* read-only access flags receive special memory allocation treatment since they are expected to be short-lived.