### PR TITLE
[build] Fix generating version.h

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -22,6 +22,7 @@ jobs:
       uses: Joshua-Ashton/arch-mingw-github-action@v7
       with:
         command: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
           export VERSION_NAME="${GITHUB_REF##*/}-${GITHUB_SHA##*/}"
           ./package-release.sh ${VERSION_NAME} build --no-package
           echo "VERSION_NAME=${VERSION_NAME}" >> $GITHUB_ENV


### PR DESCRIPTION
Workaround for generating version.h inside container jobs due to the new git setting `safe.directory`

Just in same way as it's already fixed for other projects on repository side:
https://github.com/HansKristian-Work/vkd3d-proton/commit/0c4df9b32cfa68ae7a84de412e5968785924d76b
https://github.com/jp7677/dxvk-nvapi/commit/3052a78a4d3e3c798286d759a7f3a8c03b3bd691

There is a problem with `artifacts.yml`:
https://github.com/doitsujin/dxvk/runs/7400427307?check_suite_focus=true#step:5:86
```bash
[1/276] Generating version.h with a custom command
fatal: detected dubious ownership in repository at '/github/workspace'
To add an exception for this directory, call:
	git config --global --add safe.directory /github/workspace
```

This change will return and again allow to see inside the game in `DXVK_HUD` (and logs) the version generated by `git describe` instead of fallback to the regular release tag (e.g. `v1.10.1-322-g330ff8fa` instead of `v1.10.1`).

As I understand it, the problem appeared due to git security update https://github.blog/2022-04-12-git-security-vulnerability-announced/. 
The default behavior of the new `safe.directory` option broke https://github.com/actions/checkout and this has been fixed in recent versions of https://github.com/actions/checkout/pull/762. 
But it doesn't seem to affect containers yet, and the behavior of git `safe.directory` remains the same in them. 
(Fortunately, this does not affect local builds of dxvk in any way.)

I've tested the latest versions but haven't found any other working way yet than using the workaround described here: https://github.com/actions/checkout/issues/766#issue-1204908242
> Simply set the GITHUB_WORKSPACE as a safe directory.
> ```
> git config --global --add safe.directory "$GITHUB_WORKSPACE"
> ```
> If you are failing inside a container action, you will need to run this inside your container action script.

UPD. @Joshua-Ashton I checked. This change inside docker helps as alternative fix on container side: https://github.com/Iglu47/arch-mingw-github-action/commit/cd665ba4766edc59479b7670940a9fbdb095b636
```diff
@@ -6,6 +6,7 @@ RUN echo -e '\n\n[multilib]\nInclude = /etc/pacman.d/mirrorlist\n\n' >> /etc/pac
 RUN pacman-key --init
 RUN pacman -Sy --needed --noconfirm archlinux-keyring
 RUN pacman -Syu --needed --noconfirm clang meson glslang git mingw-w64 wine base base-devel sed git tar curl wget bash gzip sudo file gawk grep bzip2 which pacman systemd findutils diffutils coreutils procps-ng util-linux xcb-util xcb-util-keysyms xcb-util-wm lib32-xcb-util lib32-xcb-util-keysyms
+RUN git config --system --add safe.directory /github/workspace
 
 COPY entrypoint.sh /entrypoint.sh```