### PR TITLE
call wineboot as a script,

### DIFF
--- a/setup_dxvk.sh
+++ b/setup_dxvk.sh
@@ -80,7 +80,7 @@ fi
 
 # ensure wine placeholder dlls are recreated
 # if they are missing
-$wineboot -u
+bash $wineboot -u
 
 win64_sys_path=$($wine64 winepath -u 'C:\windows\system32' 2> /dev/null)
 win64_sys_path="${win64_sys_path/$'\r'/}"


### PR DESCRIPTION
wineboot is a script, and in tkg when you call it directly from this setup script, I get
```
environment: : command not found
```
Therefore, to call a script from within a script let's use bash because...
```
$ file /opt/wine-staging/bin/wineboot
/opt/wine-staging/bin/wineboot: POSIX shell script, ASCII text executable
```