### PR TITLE
[util] Remove Resident Evil 6 workaround

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -512,7 +512,7 @@ namespace dxvk {
       { "d3d9.floatEmulation",              "Strict" },
     }} },
     /* Resident Evil games                      */
-    { R"(\\(rerev|rerev2|re0hd|bhd|re5dx9|BH6)\.exe$)", {{
+    { R"(\\(rerev|rerev2|re0hd|bhd|re5dx9)\.exe$)", {{
       { "d3d9.allowDirectBufferMapping",                "False" },
     }} },
     /* Limbo                                    */


### PR DESCRIPTION
It's actually making things worse, so better use the default path