### PR TITLE
Enable deferSurfaceCreation for Fallout: New Vegas

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -579,6 +579,11 @@ namespace dxvk {
     { R"(\\PortRoyale3\.exe$)", {{
       { "d3d9.allowDoNotWait",           "False" },
     }} },
+    /* Fallout: New Vegas                       
+     * Prevents black screen on startup         */
+    { R"(\\FalloutNV\.exe$)", {{
+      { "d3d9.deferSurfaceCreation",      "True" },
+    }} },
   }};
 
 


### PR DESCRIPTION
Prevents occasional black screen on startup