### PR TITLE
Update dxvk.conf add comment to numCompilerThreads

### DIFF
--- a/dxvk.conf
+++ b/dxvk.conf
@@ -226,9 +226,6 @@
 
 
 # Sets number of pipeline compiler threads.
-# 
-# By default on systems with less than 4 cpu threads uses ~50% of available threads,
-# on systems with more than 4 threads uses ~67% of available threads, capped at 32 by default.
 # Auto values leave some cores to the application to avoid excessive stutter.
 #  
 # Supported values:

--- a/dxvk.conf
+++ b/dxvk.conf
@@ -227,6 +227,10 @@
 
 # Sets number of pipeline compiler threads.
 # 
+# By default on systems with less than 4 cpu threads uses ~50% of available threads,
+# on systems with more than 4 threads uses ~67% of available threads, capped at 32 by default.
+# Auto values leave some cores to the application to avoid excessive stutter.
+#  
 # Supported values:
 # - 0 to automatically determine the number of threads to use
 # - any positive number to enforce the thread count


### PR DESCRIPTION
Thread count estimated by https://github.com/doitsujin/dxvk/blob/ff39819086b616d175a8de179c4e292014975116/src/dxvk/dxvk_pipemanager.cpp#L14
Just adding some details in the conf file for clarity on how many threads it'll use by default.