### PR TITLE
[d3d9] Add Direct3D9ForceHybridEnumeration empty export function.

### DIFF
--- a/src/d3d9/d3d9.def
+++ b/src/d3d9/d3d9.def
@@ -23,3 +23,5 @@ EXPORTS
 
   DXVK_RegisterAnnotation @ 28257 NONAME
   DXVK_UnRegisterAnnotation @ 28258 NONAME
+
+  Direct3D9ForceHybridEnumeration @16 NONAME PRIVATE

--- a/src/d3d9/d3d9_main.cpp
+++ b/src/d3d9/d3d9_main.cpp
@@ -98,4 +98,7 @@ extern "C" {
     dxvk::D3D9GlobalAnnotationList::Instance().UnregisterAnnotator(annotation);
   }
 
+  DLLEXPORT void __stdcall Direct3D9ForceHybridEnumeration(UINT uHybrid) {
+  }
+
 }


### PR DESCRIPTION
The WLK tests for d3d9 call Direct3D9ForceHybridEnumeration function. When it is missing the exception is thrown and the application is terminated.
With empty stub is added the test starts the operation.
