### PR TITLE
[dxvk] Disable graphics pipeline libraries on 32-bit builds

### DIFF
--- a/src/dxvk/dxvk_options.cpp
+++ b/src/dxvk/dxvk_options.cpp
@@ -1,12 +1,15 @@
 #include "dxvk_options.h"
 
+#include "../util/util_env.h"
+
 namespace dxvk {
 
   DxvkOptions::DxvkOptions(const Config& config) {
     enableDebugUtils      = config.getOption<bool>    ("dxvk.enableDebugUtils",       false);
     enableStateCache      = config.getOption<bool>    ("dxvk.enableStateCache",       true);
     numCompilerThreads    = config.getOption<int32_t> ("dxvk.numCompilerThreads",     0);
-    enableGraphicsPipelineLibrary = config.getOption<Tristate>("dxvk.enableGraphicsPipelineLibrary", Tristate::Auto);
+    enableGraphicsPipelineLibrary = config.getOption<Tristate>("dxvk.enableGraphicsPipelineLibrary",
+      env::is32BitHostPlatform() ? Tristate::False : Tristate::Auto);
     useRawSsbo            = config.getOption<Tristate>("dxvk.useRawSsbo",             Tristate::Auto);
     shrinkNvidiaHvvHeap   = config.getOption<bool>    ("dxvk.shrinkNvidiaHvvHeap",    false);
     hud                   = config.getOption<std::string>("dxvk.hud", "");


### PR DESCRIPTION
Can't say I'm overly happy with this but unless we find a way to make all D3D9 games work reliably with the feature enabled we don't really have much of a choice.