### PR TITLE
[build] Try to not break with -Ofast

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -12,6 +12,7 @@ compiler_args = [
   '-msse2',
   '-msse3',
   '-mfpmath=sse',
+  '-fno-finite-math-only',
   '-Wimplicit-fallthrough',
   # clang
   '-Wno-unused-private-field',


### PR DESCRIPTION
In case someone will use -Ofast or -ffast-math (gcc),
which will enable -ffinite-math-only and likely will break
x != x, std::isfinite, std::isnan etc.