### PR TITLE
add missing vector header

### DIFF
--- a/src/d3d9/d3d9_mem.h
+++ b/src/d3d9/d3d9_mem.h
@@ -12,6 +12,8 @@
   #include <winbase.h>
 #endif
 
+#include <vector>
+
 namespace dxvk {
 
   class D3D9MemoryAllocator;


### PR DESCRIPTION
Fixes compilation under MSYS2's clang backend.

```
$ ninja
[2/3] Compiling C++ object src/d3d9/d3d9.dll.p/d3d9_mem.cpp.obj
FAILED: src/d3d9/d3d9.dll.p/d3d9_mem.cpp.obj
"ccache" "c++" "-Isrc/d3d9/d3d9.dll.p" "-Isrc/d3d9" "-I../src/d3d9" "-I../include" "-fcolor-diagnostics" "-D_FILE_OFFSET_BITS=64" "-Wall" "-Winvalid-pch" "-Wnon-virtual-dtor" "-std=c++17" "-O0" "-g" "-msse" "-msse2" "-msse3" "-mfpmath=sse" "-Wimplicit-fallthrough" "-Wno-unused-private-field" "-Wno-microsoft-exception-spec" "-DNOMINMAX" "-D_WIN32_WINNT=0xa00" "-gstrict-dwarf" "-gdwarf-2" -MD -MQ src/d3d9/d3d9.dll.p/d3d9_mem.cpp.obj -MF "src/d3d9/d3d9.dll.p/d3d9_mem.cpp.obj.d" -o src/d3d9/d3d9.dll.p/d3d9_mem.cpp.obj "-c" ../src/d3d9/d3d9_mem.cpp
In file included from ../src/d3d9/d3d9_mem.cpp:1:
../src/d3d9/d3d9_mem.h:70:36: error: implicit instantiation of undefined template 'std::vector<dxvk::D3D9MemoryRange>'
      std::vector<D3D9MemoryRange> m_freeRanges;
                                   ^
C:/Users/Mangix/scoop/apps/msys2/2022-01-28/clang32/include/c++/v1/iosfwd:260:28: note: template is declared here
class _LIBCPP_TEMPLATE_VIS vector;
                           ^
In file included from ../src/d3d9/d3d9_mem.cpp:1:
../src/d3d9/d3d9_mem.h:71:37: error: implicit instantiation of undefined template 'std::vector<dxvk::D3D9MappingRange>'
      std::vector<D3D9MappingRange> m_mappingRanges;
                                    ^
C:/Users/Mangix/scoop/apps/msys2/2022-01-28/clang32/include/c++/v1/iosfwd:260:28: note: template is declared here
class _LIBCPP_TEMPLATE_VIS vector;
                           ^
In file included from ../src/d3d9/d3d9_mem.cpp:1:
../src/d3d9/d3d9_mem.h:129:53: error: implicit instantiation of undefined template 'std::vector<std::unique_ptr<dxvk::D3D9MemoryChunk>>'
      std::vector<std::unique_ptr<D3D9MemoryChunk>> m_chunks;
                                                    ^
C:/Users/Mangix/scoop/apps/msys2/2022-01-28/clang32/include/c++/v1/iosfwd:260:28: note: template is declared here
class _LIBCPP_TEMPLATE_VIS vector;
                           ^
3 errors generated.
ninja: build stopped: subcommand failed.
```