### PR TITLE
remove DLLEXPORT on redeclaration

### DIFF
--- a/src/dxgi/dxgi_main.cpp
+++ b/src/dxgi/dxgi_main.cpp
@@ -22,20 +22,20 @@ namespace dxvk {
 }
 
 extern "C" {
-  DLLEXPORT HRESULT __stdcall CreateDXGIFactory2(UINT Flags, REFIID riid, void **ppFactory) {
+  HRESULT __stdcall CreateDXGIFactory2(UINT Flags, REFIID riid, void **ppFactory) {
     dxvk::Logger::warn("CreateDXGIFactory2: Ignoring flags");
     return dxvk::createDxgiFactory(Flags, riid, ppFactory);
   }
 
-  DLLEXPORT HRESULT __stdcall CreateDXGIFactory1(REFIID riid, void **ppFactory) {
+  HRESULT __stdcall CreateDXGIFactory1(REFIID riid, void **ppFactory) {
     return dxvk::createDxgiFactory(0, riid, ppFactory);
   }
   
-  DLLEXPORT HRESULT __stdcall CreateDXGIFactory(REFIID riid, void **ppFactory) {
+  HRESULT __stdcall CreateDXGIFactory(REFIID riid, void **ppFactory) {
     return dxvk::createDxgiFactory(0, riid, ppFactory);
   }
 
-  DLLEXPORT HRESULT __stdcall DXGIDeclareAdapterRemovalSupport() {
+  HRESULT __stdcall DXGIDeclareAdapterRemovalSupport() {
     static bool enabled = false;
 
     if (std::exchange(enabled, true))
@@ -45,7 +45,7 @@ extern "C" {
     return S_OK;
   }
 
-  DLLEXPORT HRESULT __stdcall DXGIGetDebugInterface1(UINT Flags, REFIID riid, void **ppDebug) {
+  HRESULT __stdcall DXGIGetDebugInterface1(UINT Flags, REFIID riid, void **ppDebug) {
     static bool errorShown = false;
 
     if (!std::exchange(errorShown, true))


### PR DESCRIPTION
Fixes warning under MinGW.

```
../src/dxgi/dxgi_main.cpp:25:31: warning: redeclaration of 'CreateDXGIFactory2' should not add 'dllexport' attribute [-Wdll-attribute-on-redeclaration]
  DLLEXPORT HRESULT __stdcall CreateDXGIFactory2(UINT Flags, REFIID riid, void **ppFactory) {
                              ^
C:/Users/Mangix/scoop/apps/msys2/2022-01-28/clang32/include/dxgi1_3.h:1941:20: note: previous declaration is here
HRESULT __stdcall  CreateDXGIFactory2(UINT flags,REFIID iid,void **factory);
                   ^
../src/dxgi/dxgi_main.cpp:30:31: warning: redeclaration of 'CreateDXGIFactory1' should not add 'dllexport' attribute [-Wdll-attribute-on-redeclaration]
  DLLEXPORT HRESULT __stdcall CreateDXGIFactory1(REFIID riid, void **ppFactory) {
                              ^
C:/Users/Mangix/scoop/apps/msys2/2022-01-28/clang32/include/dxgi.h:1973:20: note: previous declaration is here
HRESULT __stdcall  CreateDXGIFactory1(REFIID riid,void **factory);
                   ^
../src/dxgi/dxgi_main.cpp:34:31: warning: redeclaration of 'CreateDXGIFactory' should not add 'dllexport' attribute [-Wdll-attribute-on-redeclaration]
  DLLEXPORT HRESULT __stdcall CreateDXGIFactory(REFIID riid, void **ppFactory) {
                              ^
C:/Users/Mangix/scoop/apps/msys2/2022-01-28/clang32/include/dxgi.h:1971:20: note: previous declaration is here
HRESULT __stdcall  CreateDXGIFactory(REFIID riid,void **factory);
                   ^
../src/dxgi/dxgi_main.cpp:48:31: warning: redeclaration of 'DXGIGetDebugInterface1' should not add 'dllexport' attribute [-Wdll-attribute-on-redeclaration]
  DLLEXPORT HRESULT __stdcall DXGIGetDebugInterface1(UINT Flags, REFIID riid, void **ppDebug) {
                              ^
C:/Users/Mangix/scoop/apps/msys2/2022-01-28/clang32/include/dxgi1_3.h:1943:20: note: previous declaration is here
HRESULT __stdcall  DXGIGetDebugInterface1(UINT flags,REFIID iid,void **debug);
                   ^
4 warnings generated.
```