### PR TITLE
remove dllexport on redeclaration and use WINAPI

### DIFF
--- a/src/d3d11/d3d11_main.cpp
+++ b/src/d3d11/d3d11_main.cpp
@@ -203,7 +203,7 @@ extern "C" {
   }
   
 
-  DLLEXPORT HRESULT __stdcall D3D11CreateDevice(
+  HRESULT WINAPI D3D11CreateDevice(
           IDXGIAdapter*         pAdapter,
           D3D_DRIVER_TYPE       DriverType,
           HMODULE               Software,
@@ -222,7 +222,7 @@ extern "C" {
   }
   
   
-  DLLEXPORT HRESULT __stdcall D3D11CreateDeviceAndSwapChain(
+  HRESULT WINAPI D3D11CreateDeviceAndSwapChain(
           IDXGIAdapter*         pAdapter,
           D3D_DRIVER_TYPE       DriverType,
           HMODULE               Software,
@@ -243,7 +243,7 @@ extern "C" {
   }
   
 
-  DLLEXPORT HRESULT __stdcall D3D11On12CreateDevice(
+  HRESULT WINAPI D3D11On12CreateDevice(
           IUnknown*             pDevice,
           UINT                  Flags,
     const D3D_FEATURE_LEVEL*    pFeatureLevels,


### PR DESCRIPTION
Fixes MinGW warning.

```
[172/277] Compiling C++ object src/d3d11/d3d11.dll.p/d3d11_main.cpp.obj
../src/d3d11/d3d11_main.cpp:206:31: warning: redeclaration of 'D3D11CreateDevice' should not add 'dllexport' attribute [-Wdll-attribute-on-redeclaration]
  DLLEXPORT HRESULT __stdcall D3D11CreateDevice(
                              ^
C:/Users/Mangix/scoop/apps/msys2/2022-01-28/clang32/include/d3d11.h:10976:16: note: previous declaration is here
HRESULT WINAPI D3D11CreateDevice(IDXGIAdapter*,D3D_DRIVER_TYPE,HMODULE,UINT,const D3D_FEATURE_LEVEL*,
               ^
../src/d3d11/d3d11_main.cpp:225:31: warning: redeclaration of 'D3D11CreateDeviceAndSwapChain' should not add 'dllexport' attribute [-Wdll-attribute-on-redeclaration]
  DLLEXPORT HRESULT __stdcall D3D11CreateDeviceAndSwapChain(
                              ^
C:/Users/Mangix/scoop/apps/msys2/2022-01-28/clang32/include/d3d11.h:10981:20: note: previous declaration is here
HRESULT __stdcall  D3D11CreateDeviceAndSwapChain(IDXGIAdapter *adapter,D3D_DRIVER_TYPE driver_type,HMODULE swrast,UINT flags,const D3D_FEATURE_LEVEL *feature_levels,UINT levels,UINT sdk_version,const DXGI_SWAP_CHAIN_DESC *swapchain_desc,IDXGISwapChain **swapchain,ID3D11Device **device,D3D_FEATURE_LEVEL *obtained_feature_level,ID3D11DeviceContext **immediate_context);
                   ^
2 warnings generated.
```