### PR TITLE
make destructor virtual

### DIFF
--- a/src/d3d10/d3d10_reflection.h
+++ b/src/d3d10/d3d10_reflection.h
@@ -17,7 +17,7 @@ namespace dxvk {
     D3D10ShaderReflectionType(
             ID3D11ShaderReflectionType*     d3d11);
     
-    ~D3D10ShaderReflectionType();
+    virtual ~D3D10ShaderReflectionType();
 
     HRESULT STDMETHODCALLTYPE GetDesc(
             D3D10_SHADER_TYPE_DESC*         pDesc);


### PR DESCRIPTION
Fixes usage with std::make_unique.

```
C:/Users/Mangix/scoop/apps/msys2/2022-01-28/clang32/include/c++/v1/__memory/unique_ptr.h:54:5: warning: delete called on non-final 'dxvk::D3D10ShaderReflectionType' that has virtual functions but non-virtual destructor [-Wdelete-non-abstract-non-virtual-dtor]
    delete __ptr;
    ^
C:/Users/Mangix/scoop/apps/msys2/2022-01-28/clang32/include/c++/v1/__memory/unique_ptr.h:315:7: note: in instantiation of member function 'std::default_delete<dxvk::D3D10ShaderReflectionType>::operator()' requested here
      __ptr_.second()(__tmp);
      ^
C:/Users/Mangix/scoop/apps/msys2/2022-01-28/clang32/include/c++/v1/__memory/unique_ptr.h:269:19: note: in instantiation of member function 'std::unique_ptr<dxvk::D3D10ShaderReflectionType>::reset' requested here
  ~unique_ptr() { reset(); }
                  ^
../src/d3d10/d3d10_reflection.cpp:63:9: note: in instantiation of member function 'std::unique_ptr<dxvk::D3D10ShaderReflectionType>::~unique_ptr' requested here
        std::make_unique<D3D10ShaderReflectionType>(pMemberType) }).first;
        ^
1 warning and 1 error generated.
[6/24] Compiling C++ object src/d3d10/d3d10_1.dll.p/d3d10_reflection.cpp.obj
```