### PR TITLE
[util] Set m_size in small_vector::resize

### DIFF
--- a/src/util/util_small_vector.h
+++ b/src/util/util_small_vector.h
@@ -57,6 +57,8 @@ namespace dxvk {
       
       for (size_t i = m_size; i < n; i++)
         new (ptr(i)) T();
+
+      m_size = n;
     }
 
     void push_back(const T& object) {


### PR DESCRIPTION
Turns out this has been broken since it was added, meaning
isViewCompatible has always returned false putting us down slow paths
for UAV clears + copies for the past two years.