### PR TITLE
[d3d9] Disable fetch4 when binding an incompatible texture

### DIFF
--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -3777,12 +3777,19 @@ namespace dxvk {
         m_dirtySamplerStates |= 1u << StateSampler;
       }
 
-      if (unlikely(m_fetch4Enabled & (1u << StateSampler) && !(m_fetch4 & (1u << StateSampler)))) {
-        bool textureSupportsFetch4 = newTexture->SupportsFetch4();
-        if (textureSupportsFetch4
-          && m_state.samplerStates[StateSampler][D3DSAMP_MAGFILTER] == D3DTEXF_POINT
-          && m_state.samplerStates[StateSampler][D3DSAMP_MINFILTER] == D3DTEXF_POINT) {
+      if (unlikely(m_fetch4Enabled & (1u << StateSampler))) {
+        const bool samplerFetch4 = (m_fetch4 & (1u << StateSampler)) != 0;
+        const bool pointFilter = m_state.samplerStates[StateSampler][D3DSAMP_MAGFILTER] == D3DTEXF_POINT
+                                  && m_state.samplerStates[StateSampler][D3DSAMP_MINFILTER] == D3DTEXF_POINT;
+        const bool textureSupportsFetch4 = newTexture->SupportsFetch4();
+
+        if (unlikely(textureSupportsFetch4 && pointFilter && !samplerFetch4)) {
+          // We're swapping a multi channel texture for a single channel texture => turn on fetch4
           m_fetch4 |= 1u << StateSampler;
+          m_dirtySamplerStates |= 1u << StateSampler;
+        } else if (unlikely(!textureSupportsFetch4 && samplerFetch4)) {
+          // We're swapping a single channel texture for a multi channel one => turn off fetch4
+          m_fetch4 &= ~(1u << StateSampler);
           m_dirtySamplerStates |= 1u << StateSampler;
         }
       }


### PR DESCRIPTION
Fixes #2780

Curiously, this is pretty much the same issue as Black Mesa. The game ended up doing fetch4 with the lighting texture.
With Black Mesa I fixed it by restricting fetch4 to single channel formats, the problem was that I didn't disable fetch4 when binding an incompatible texture.

What a mess.