### PR TITLE
[util] Use raw tzcnt for BitMask iterator

### DIFF
--- a/src/util/util_bit.h
+++ b/src/util/util_bit.h
@@ -336,7 +336,16 @@ namespace dxvk::bit {
       }
 
       uint32_t operator * () const {
+#if (defined(__GNUC__) || defined(__clang__)) && !defined(__BMI__)
+        uint32_t res;
+        asm ("tzcnt %1,%0"
+        : "=r" (res)
+        : "r" (m_mask)
+        : "cc");
+        return res;
+#else
         return tzcnt(m_mask);
+#endif
       }
 
       bool operator == (iterator other) const { return m_mask == other.m_mask; }


### PR DESCRIPTION
Dereferencing an end iterator is UB, so we don't have to care about the 0 case.