### PR TITLE
[build] Fix dllexport warnings for llvm-mingw

### DIFF
--- a/src/dxgi/dxgi_include.h
+++ b/src/dxgi/dxgi_include.h
@@ -3,7 +3,7 @@
 //for some reason we need to specify __declspec(dllexport) for MinGW
 #if defined(__WINE__)
   #define DLLEXPORT __attribute__((visibility("default")))
-#elif defined(_MSC_VER)
+#elif defined(_MSC_VER) || defined(__clang__)
   #define DLLEXPORT
 #else
   #define DLLEXPORT __declspec(dllexport)


### PR DESCRIPTION
e.g. `../src/dxgi/dxgi_main.cpp:34:31: warning: redeclaration of 'CreateDXGIFactory' should not add 'dllexport' attribute [-Wdll-attribute-on-redeclaration]`