### PR TITLE
[util] Disable unmapping for Saints Row 2

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -599,6 +599,10 @@ namespace dxvk {
     { R"(\\yso_win\.exe$)", {{
       { "d3d9.maxFrameLatency",              "1" },
     }} },
+    /* Saints Row 2 - Prevents unmap crash      */
+    { R"(\\SR2_pc\.exe$)", {{
+      { "d3d9.textureMemory",                "0" },
+    }} },
   }};
 
 


### PR DESCRIPTION
Game doesn't like the unmapping changes. Might as well keep it semi broken (the native version that is) instead of fully broken.