### PR TITLE
[d3d9] Change texture before updating fetch4

### DIFF
--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -3760,6 +3760,10 @@ namespace dxvk {
 
     DWORD oldUsage = oldTexture != nullptr ? oldTexture->Desc()->Usage : 0;
     DWORD newUsage = newTexture != nullptr ? newTexture->Desc()->Usage : 0;
+    DWORD combinedUsage = oldUsage | newUsage;
+    TextureChangePrivate(m_state.textures[StateSampler], pTexture);
+    m_dirtyTextures |= 1u << StateSampler;
+    UpdateActiveTextures(StateSampler, combinedUsage);
 
     if (newTexture != nullptr) {
       const bool oldDepth = m_depthTextures & (1u << StateSampler);
@@ -3779,14 +3783,6 @@ namespace dxvk {
       if (unlikely(m_fetch4 & (1u << StateSampler)))
         UpdateActiveFetch4(StateSampler);
     }
-
-    DWORD combinedUsage = oldUsage | newUsage;
-
-    TextureChangePrivate(m_state.textures[StateSampler], pTexture);
-
-    m_dirtyTextures |= 1u << StateSampler;
-
-    UpdateActiveTextures(StateSampler, combinedUsage);
 
     return D3D_OK;
   }


### PR DESCRIPTION
Fixes #2780 again.

`UpdateActiveFetch4()` was called before the texture was actually changed, so it ended up checking the old texture.