### PR TITLE
D3D9 shader bytecode cleanup

### DIFF
--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -47,6 +47,7 @@ namespace dxvk {
     , m_adapter         ( pAdapter )
     , m_dxvkDevice      ( dxvkDevice )
     , m_memoryAllocator ( )
+    , m_shaderAllocator ( )
     , m_shaderModules   ( new D3D9ShaderModuleSet )
     , m_stagingBuffer   ( dxvkDevice, StagingBufferSize )
     , m_d3d9Options     ( dxvkDevice, pParent->GetInstance()->config() )
@@ -2836,7 +2837,11 @@ namespace dxvk {
       &moduleInfo)))
       return D3DERR_INVALIDCALL;
 
-    *ppShader = ref(new D3D9VertexShader(this, module, pFunction, bytecodeLength));
+    *ppShader = ref(new D3D9VertexShader(this,
+      &m_shaderAllocator,
+      module,
+      pFunction,
+      bytecodeLength));
 
     return D3D_OK;
   }
@@ -3170,7 +3175,11 @@ namespace dxvk {
       &moduleInfo)))
       return D3DERR_INVALIDCALL;
 
-    *ppShader = ref(new D3D9PixelShader(this, module, pFunction, bytecodeLength));
+    *ppShader = ref(new D3D9PixelShader(this,
+      &m_shaderAllocator,
+      module,
+      pFunction,
+      bytecodeLength));
 
     return D3D_OK;
   }

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -2827,14 +2827,16 @@ namespace dxvk {
     moduleInfo.options = m_dxsoOptions;
 
     D3D9CommonShader module;
+    uint32_t bytecodeLength;
 
     if (FAILED(this->CreateShaderModule(&module,
+      &bytecodeLength,
       VK_SHADER_STAGE_VERTEX_BIT,
       pFunction,
       &moduleInfo)))
       return D3DERR_INVALIDCALL;
 
-    *ppShader = ref(new D3D9VertexShader(this, module));
+    *ppShader = ref(new D3D9VertexShader(this, module, pFunction, bytecodeLength));
 
     return D3D_OK;
   }
@@ -3159,14 +3161,16 @@ namespace dxvk {
     moduleInfo.options = m_dxsoOptions;
 
     D3D9CommonShader module;
+    uint32_t bytecodeLength;
 
     if (FAILED(this->CreateShaderModule(&module,
+      &bytecodeLength,
       VK_SHADER_STAGE_FRAGMENT_BIT,
       pFunction,
       &moduleInfo)))
       return D3DERR_INVALIDCALL;
 
-    *ppShader = ref(new D3D9PixelShader(this, module));
+    *ppShader = ref(new D3D9PixelShader(this, module, pFunction, bytecodeLength));
 
     return D3D_OK;
   }
@@ -6322,12 +6326,13 @@ namespace dxvk {
 
   HRESULT D3D9DeviceEx::CreateShaderModule(
         D3D9CommonShader*     pShaderModule,
+        uint32_t*             pLength,
         VkShaderStageFlagBits ShaderStage,
   const DWORD*                pShaderBytecode,
   const DxsoModuleInfo*       pModuleInfo) {
     try {
       m_shaderModules->GetShaderModule(this, pShaderModule,
-        ShaderStage, pModuleInfo, pShaderBytecode);
+        pLength, ShaderStage, pModuleInfo, pShaderBytecode);
 
       return D3D_OK;
     }

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -1171,6 +1171,11 @@ namespace dxvk {
 
     D3D9MemoryAllocator             m_memoryAllocator;
 
+    // Second memory allocator used for D3D9 shader bytecode.
+    // Most games never access the stored bytecode, so putting that
+    // into the same chunks as texture memory would waste address space.
+    D3D9MemoryAllocator             m_shaderAllocator;
+
     uint32_t                        m_frameLatency = DefaultFrameLatency;
 
     D3D9Initializer*                m_initializer = nullptr;

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -994,6 +994,7 @@ namespace dxvk {
 
     HRESULT               CreateShaderModule(
             D3D9CommonShader*     pShaderModule,
+            uint32_t*             pLength,
             VkShaderStageFlagBits ShaderStage,
       const DWORD*                pShaderBytecode,
       const DxsoModuleInfo*       pModuleInfo);

--- a/src/d3d9/d3d9_mem.h
+++ b/src/d3d9/d3d9_mem.h
@@ -126,25 +126,49 @@ namespace dxvk {
   };
 
 #else
-    class D3D9Memory {
+  class D3D9Memory {
+    friend D3D9MemoryAllocator;
+
     public:
-      operator bool() const { return false; }
+      D3D9Memory() {}
+      ~D3D9Memory();
+
+      D3D9Memory             (const D3D9Memory&) = delete;
+      D3D9Memory& operator = (const D3D9Memory&) = delete;
+
+      D3D9Memory             (D3D9Memory&& other);
+      D3D9Memory& operator = (D3D9Memory&& other);
+
+      operator bool() const { return m_ptr != nullptr; }
 
       void Map() {}
       void Unmap() {}
-      void* Ptr() { return nullptr; }
+      void* Ptr() { return m_ptr; }
+      size_t GetSize() const { return m_size; }
 
     private:
+      D3D9Memory(D3D9MemoryAllocator* pAllocator, size_t Size);
       void Free();
+
+      D3D9MemoryAllocator* m_allocator = nullptr;
+      void* m_ptr                      = nullptr;
+      size_t m_size                    = 0;
     };
 
     class D3D9MemoryAllocator {
 
     public:
-      D3D9Memory Alloc(uint32_t Size) { return { }; }
-      uint32_t MappedMemory() { return 0; }
-      uint32_t UsedMemory() { return 0; }
-      uint32_t AllocatedMemory() { return 0; }
+      D3D9Memory Alloc(uint32_t Size);
+      uint32_t MappedMemory();
+      uint32_t UsedMemory();
+      uint32_t AllocatedMemory();
+      void NotifyFreed(uint32_t Size) {
+        m_allocatedMemory -= Size;
+      }
+
+    private:
+      std::atomic<size_t> m_allocatedMemory = 0;
+
     };
 
 #endif

--- a/src/d3d9/d3d9_mem.h
+++ b/src/d3d9/d3d9_mem.h
@@ -47,11 +47,6 @@ namespace dxvk {
       D3D9MemoryChunk             (D3D9MemoryChunk&& other) = delete;
       D3D9MemoryChunk& operator = (D3D9MemoryChunk&& other) = delete;
 
-#ifdef D3D9_MEM_MAP_CHUNKS
-      void IncMapCounter();
-      void DecMapCounter();
-      void* Ptr() const { return m_ptr; }
-#endif
       D3D9Memory Alloc(uint32_t Size);
       void Free(D3D9Memory* Memory);
       bool IsEmpty();
@@ -71,11 +66,6 @@ namespace dxvk {
       uint32_t m_mappingGranularity;
       std::vector<D3D9MemoryRange> m_freeRanges;
       std::vector<D3D9MappingRange> m_mappingRanges;
-
-#ifdef D3D9_MEM_MAP_CHUNKS
-      uint32_t m_mapCounter = 0;
-      void* m_ptr;
-#endif
   };
 
   class D3D9Memory {

--- a/src/d3d9/d3d9_shader.cpp
+++ b/src/d3d9/d3d9_shader.cpp
@@ -17,8 +17,6 @@ namespace dxvk {
       const DxsoAnalysisInfo&     AnalysisInfo,
             DxsoModule*           pModule) {
     const uint32_t bytecodeLength = AnalysisInfo.bytecodeByteLength;
-    m_bytecode.resize(bytecodeLength);
-    std::memcpy(m_bytecode.data(), pShaderBytecode, bytecodeLength);
 
     const std::string name = Key.toString();
     Logger::debug(str::format("Compiling shader ", name));
@@ -98,6 +96,7 @@ namespace dxvk {
   void D3D9ShaderModuleSet::GetShaderModule(
             D3D9DeviceEx*         pDevice,
             D3D9CommonShader*     pShaderModule,
+            uint32_t*             pLength,
             VkShaderStageFlagBits ShaderStage,
       const DxsoModuleInfo*       pDxbcModuleInfo,
       const void*                 pShaderBytecode) {
@@ -113,6 +112,7 @@ namespace dxvk {
       throw DxvkError("GetShaderModule: Bytecode does not match shader stage");
 
     DxsoAnalysisInfo info = module.analyze();
+    *pLength = info.bytecodeByteLength;
 
     DxvkShaderKey lookupKey = DxvkShaderKey(
       ShaderStage,

--- a/src/d3d9/d3d9_shader.h
+++ b/src/d3d9/d3d9_shader.h
@@ -41,10 +41,6 @@ namespace dxvk {
       return m_shaders[D3D9ShaderPermutations::None]->debugName();
     }
 
-    const std::vector<uint8_t>& GetBytecode() const {
-      return m_bytecode;
-    }
-
     const DxsoIsgn& GetIsgn() const {
       return m_isgn;
     }
@@ -71,8 +67,6 @@ namespace dxvk {
 
     DxsoPermutations      m_shaders;
 
-    std::vector<uint8_t>  m_bytecode;
-
   };
 
   /**
@@ -89,9 +83,15 @@ namespace dxvk {
 
     D3D9Shader(
             D3D9DeviceEx*      pDevice,
-      const D3D9CommonShader&  CommonShader)
+      const D3D9CommonShader&  CommonShader,
+      const void*              pShaderBytecode,
+            uint32_t           BytecodeLength)
       : D3D9DeviceChild<Base>( pDevice )
-      , m_shader             ( CommonShader ) { }
+      , m_shader             ( CommonShader ) {
+
+      m_bytecode.resize(BytecodeLength);
+      std::memcpy(m_bytecode.data(), pShaderBytecode, BytecodeLength);
+    }
 
     HRESULT STDMETHODCALLTYPE QueryInterface(REFIID riid, void** ppvObject) {
       if (ppvObject == nullptr)
@@ -114,15 +114,13 @@ namespace dxvk {
       if (pSizeOfData == nullptr)
         return D3DERR_INVALIDCALL;
 
-      const auto& bytecode = m_shader.GetBytecode();
-
       if (pOut == nullptr) {
-        *pSizeOfData = bytecode.size();
+        *pSizeOfData = m_bytecode.size();
         return D3D_OK;
       }
 
-      size_t copyAmount = std::min(size_t(*pSizeOfData), bytecode.size());
-      std::memcpy(pOut, bytecode.data(), copyAmount);
+      size_t copyAmount = std::min(size_t(*pSizeOfData), m_bytecode.size());
+      std::memcpy(pOut, m_bytecode.data(), copyAmount);
 
       return D3D_OK;
     }
@@ -135,6 +133,8 @@ namespace dxvk {
 
     D3D9CommonShader m_shader;
 
+    std::vector<uint8_t>  m_bytecode;
+
   };
 
   // Needs their own classes and not usings for forward decl.
@@ -145,8 +145,10 @@ namespace dxvk {
 
     D3D9VertexShader(
             D3D9DeviceEx*      pDevice,
-      const D3D9CommonShader&  CommonShader)
-      : D3D9Shader<IDirect3DVertexShader9>( pDevice, CommonShader ) { }
+      const D3D9CommonShader&  CommonShader,
+      const void*              pShaderBytecode,
+            uint32_t           BytecodeLength)
+      : D3D9Shader<IDirect3DVertexShader9>( pDevice, CommonShader, pShaderBytecode, BytecodeLength ) { }
 
   };
 
@@ -156,8 +158,10 @@ namespace dxvk {
 
     D3D9PixelShader(
             D3D9DeviceEx*      pDevice,
-      const D3D9CommonShader&  CommonShader)
-      : D3D9Shader<IDirect3DPixelShader9>( pDevice, CommonShader ) { }
+      const D3D9CommonShader&  CommonShader,
+      const void*              pShaderBytecode,
+            uint32_t           BytecodeLength)
+      : D3D9Shader<IDirect3DPixelShader9>( pDevice, CommonShader, pShaderBytecode, BytecodeLength ) { }
 
   };
 
@@ -176,6 +180,7 @@ namespace dxvk {
     void GetShaderModule(
             D3D9DeviceEx*         pDevice,
             D3D9CommonShader*     pShaderModule,
+            uint32_t*             pLength,
             VkShaderStageFlagBits ShaderStage,
       const DxsoModuleInfo*       pDxbcModuleInfo,
       const void*                 pShaderBytecode);

--- a/src/d3d9/d3d9_shader.h
+++ b/src/d3d9/d3d9_shader.h
@@ -4,6 +4,7 @@
 #include "../dxso/dxso_module.h"
 #include "d3d9_shader_permutations.h"
 #include "d3d9_util.h"
+#include "d3d9_mem.h"
 
 #include <array>
 
@@ -82,15 +83,19 @@ namespace dxvk {
   public:
 
     D3D9Shader(
-            D3D9DeviceEx*      pDevice,
-      const D3D9CommonShader&  CommonShader,
-      const void*              pShaderBytecode,
-            uint32_t           BytecodeLength)
+            D3D9DeviceEx*        pDevice,
+            D3D9MemoryAllocator* pAllocator,
+      const D3D9CommonShader&    CommonShader,
+      const void*                pShaderBytecode,
+            uint32_t             BytecodeLength)
       : D3D9DeviceChild<Base>( pDevice )
-      , m_shader             ( CommonShader ) {
+      , m_shader             ( CommonShader )
+      , m_bytecodeLength     ( BytecodeLength ) {
 
-      m_bytecode.resize(BytecodeLength);
-      std::memcpy(m_bytecode.data(), pShaderBytecode, BytecodeLength);
+      m_bytecode = pAllocator->Alloc(BytecodeLength);
+      m_bytecode.Map();
+      std::memcpy(m_bytecode.Ptr(), pShaderBytecode, BytecodeLength);
+      m_bytecode.Unmap();
     }
 
     HRESULT STDMETHODCALLTYPE QueryInterface(REFIID riid, void** ppvObject) {
@@ -115,12 +120,14 @@ namespace dxvk {
         return D3DERR_INVALIDCALL;
 
       if (pOut == nullptr) {
-        *pSizeOfData = m_bytecode.size();
+        *pSizeOfData = m_bytecodeLength;
         return D3D_OK;
       }
 
-      size_t copyAmount = std::min(size_t(*pSizeOfData), m_bytecode.size());
-      std::memcpy(pOut, m_bytecode.data(), copyAmount);
+      m_bytecode.Map();
+      uint32_t copyAmount = std::min(*pSizeOfData, m_bytecodeLength);
+      std::memcpy(pOut, m_bytecode.Ptr(), copyAmount);
+      m_bytecode.Unmap();
 
       return D3D_OK;
     }
@@ -133,7 +140,8 @@ namespace dxvk {
 
     D3D9CommonShader m_shader;
 
-    std::vector<uint8_t>  m_bytecode;
+    D3D9Memory       m_bytecode;
+    uint32_t         m_bytecodeLength;
 
   };
 
@@ -144,11 +152,12 @@ namespace dxvk {
   public:
 
     D3D9VertexShader(
-            D3D9DeviceEx*      pDevice,
-      const D3D9CommonShader&  CommonShader,
-      const void*              pShaderBytecode,
-            uint32_t           BytecodeLength)
-      : D3D9Shader<IDirect3DVertexShader9>( pDevice, CommonShader, pShaderBytecode, BytecodeLength ) { }
+            D3D9DeviceEx*        pDevice,
+            D3D9MemoryAllocator* pAllocator,
+      const D3D9CommonShader&    CommonShader,
+      const void*                pShaderBytecode,
+            uint32_t             BytecodeLength)
+      : D3D9Shader<IDirect3DVertexShader9>( pDevice, pAllocator, CommonShader, pShaderBytecode, BytecodeLength ) { }
 
   };
 
@@ -157,11 +166,12 @@ namespace dxvk {
   public:
 
     D3D9PixelShader(
-            D3D9DeviceEx*      pDevice,
-      const D3D9CommonShader&  CommonShader,
-      const void*              pShaderBytecode,
-            uint32_t           BytecodeLength)
-      : D3D9Shader<IDirect3DPixelShader9>( pDevice, CommonShader, pShaderBytecode, BytecodeLength ) { }
+            D3D9DeviceEx*        pDevice,
+            D3D9MemoryAllocator* pAllocator,
+      const D3D9CommonShader&    CommonShader,
+      const void*                pShaderBytecode,
+            uint32_t             BytecodeLength)
+      : D3D9Shader<IDirect3DPixelShader9>( pDevice, pAllocator, CommonShader, pShaderBytecode, BytecodeLength ) { }
 
   };
 


### PR DESCRIPTION
- Reduces the amount of times we copy the d3d9 shader bytecode
- Unmaps the stored shader bytecode on 32bit systems.

Saves ~40MB of address space in RE6.