### PR TITLE
Limit D3D9 staging memory

### DIFF
--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -4596,7 +4596,8 @@ namespace dxvk {
 
     DxvkBufferSliceHandle physSlice;
 
-    if ((Flags & D3DLOCK_DISCARD) && (directMapping || needsReadback)) {
+    bool smallEnoughForDiscard = !env::is32BitHostPlatform() || desc.Size < 2 << 20;
+    if ((Flags & D3DLOCK_DISCARD) && (directMapping || needsReadback) && smallEnoughForDiscard) {
       // Allocate a new backing slice for the buffer and set
       // it as the 'new' mapped slice. This assumes that the
       // only way to invalidate a buffer is by mapping it.

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -4527,6 +4527,7 @@ namespace dxvk {
         slice.slice);
     }
     UnmapTextures();
+    FlushImplicit(false);
   }
 
   void D3D9DeviceEx::EmitGenerateMips(
@@ -4683,6 +4684,7 @@ namespace dxvk {
     TrackBufferMappingBufferSequenceNumber(pResource);
 
     UnmapTextures();
+    FlushImplicit(false);
     return D3D_OK;
   }
 
@@ -4704,8 +4706,6 @@ namespace dxvk {
 
     if (pResource->Desc()->Pool != D3DPOOL_DEFAULT)
       return D3D_OK;
-
-    FlushImplicit(FALSE);
 
     FlushBuffer(pResource);
 

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -12,6 +12,7 @@
 #include "d3d9_constant_buffer.h"
 #include "d3d9_constant_set.h"
 #include "d3d9_mem.h"
+#include "d3d9_staging.h"
 
 #include "d3d9_state.h"
 
@@ -107,11 +108,11 @@ namespace dxvk {
 
     constexpr static uint32_t NullStreamIdx = caps::MaxStreams;
 
-    constexpr static VkDeviceSize StagingBufferSize = 4ull << 20;
-
     friend class D3D9SwapChainEx;
     friend class D3D9ConstantBuffer;
     friend class D3D9UserDefinedAnnotation;
+    friend class D3D9StagingBuffer;
+
   public:
 
     D3D9DeviceEx(
@@ -1194,7 +1195,7 @@ namespace dxvk {
     VkDeviceSize                    m_upBufferOffset  = 0ull;
     void*                           m_upBufferMapPtr  = nullptr;
 
-    DxvkStagingBuffer               m_stagingBuffer;
+    D3D9StagingBuffer               m_stagingBuffer;
 
     D3D9Cursor                      m_cursor;
 

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -944,6 +944,10 @@ namespace dxvk {
     void TouchMappedTexture(D3D9CommonTexture* pTexture);
     void RemoveMappedTexture(D3D9CommonTexture* pTexture);
 
+    uint32_t StagingMemory() {
+      return m_stagingBuffer.StagingMemory();
+    }
+
   private:
 
     DxvkCsChunkRef AllocCsChunk() {

--- a/src/d3d9/d3d9_hud.cpp
+++ b/src/d3d9/d3d9_hud.cpp
@@ -45,6 +45,7 @@ namespace dxvk::hud {
     m_maxAllocated = std::max(m_maxAllocated, allocator->AllocatedMemory());
     m_maxUsed = std::max(m_maxUsed, allocator->UsedMemory());
     m_maxMapped = std::max(m_maxMapped, allocator->MappedMemory());
+    m_maxStaging = std::max(m_maxStaging, m_device->StagingMemory());
 
     auto elapsed = std::chrono::duration_cast<std::chrono::microseconds>(time - m_lastUpdate);
 
@@ -53,9 +54,11 @@ namespace dxvk::hud {
 
     m_allocatedString = str::format(m_maxAllocated >> 20, " MB (Used: ", m_maxUsed >> 20, " MB)");
     m_mappedString = str::format(m_maxMapped >> 20, " MB");
+    m_stagingString = str::format(m_maxStaging >> 20, " MB");
     m_maxAllocated = 0;
     m_maxUsed = 0;
     m_maxMapped = 0;
+    m_maxStaging = 0;
     m_lastUpdate = time;
   }
 
@@ -86,6 +89,20 @@ namespace dxvk::hud {
                       { position.x + 120.0f, position.y },
                       { 1.0f, 1.0f, 1.0f, 1.0f },
                       m_mappedString);
+
+    if (env::is32BitHostPlatform() && m_device->GetOptions()->stagingMemory != 0) {
+      position.y += 24.0f;
+
+      renderer.drawText(16.0f,
+                        { position.x, position.y },
+                        { 0.0f, 1.0f, 0.75f, 1.0f },
+                        "Staging:");
+
+      renderer.drawText(16.0f,
+                        { position.x + 120.0f, position.y },
+                        { 1.0f, 1.0f, 1.0f, 1.0f },
+                        m_stagingString);
+    }
 
     position.y += 8.0f;
 

--- a/src/d3d9/d3d9_hud.h
+++ b/src/d3d9/d3d9_hud.h
@@ -51,12 +51,14 @@ namespace dxvk::hud {
         uint32_t m_maxAllocated = 0;
         uint32_t m_maxUsed      = 0;
         uint32_t m_maxMapped    = 0;
+        uint32_t m_maxStaging   = 0;
 
         dxvk::high_resolution_clock::time_point m_lastUpdate
           = dxvk::high_resolution_clock::now();
 
         std::string m_allocatedString;
         std::string m_mappedString;
+        std::string m_stagingString;
 
     };
 

--- a/src/d3d9/d3d9_options.cpp
+++ b/src/d3d9/d3d9_options.cpp
@@ -74,6 +74,7 @@ namespace dxvk {
     this->allowDirectBufferMapping      = config.getOption<bool>        ("d3d9.allowDirectBufferMapping",      true);
     this->seamlessCubes                 = config.getOption<bool>        ("d3d9.seamlessCubes",                 false);
     this->textureMemory                 = config.getOption<int32_t>     ("d3d9.textureMemory",                100) << 20;
+    this->stagingMemory                 = config.getOption<int32_t>     ("d3d9.stagingMemory",                16) << 20;
 
     std::string floatEmulation = Config::toLower(config.getOption<std::string>("d3d9.floatEmulation", "auto"));
     if (floatEmulation == "strict") {

--- a/src/d3d9/d3d9_options.h
+++ b/src/d3d9/d3d9_options.h
@@ -156,6 +156,9 @@ namespace dxvk {
 
     /// How much virtual memory will be used for textures (in MB).
     int32_t textureMemory;
+
+    /// How much virtual memory will be used for staging buffers (in MB).
+    int32_t stagingMemory;
   };
 
 }

--- a/src/d3d9/d3d9_staging.cpp
+++ b/src/d3d9/d3d9_staging.cpp
@@ -11,13 +11,14 @@ namespace dxvk {
   DxvkBufferSlice D3D9StagingBuffer::Alloc(uint32_t Size) {
     const uint32_t limit = m_device->GetOptions()->stagingMemory;
     if (env::is32BitHostPlatform() && limit != 0) {
+      uint32_t stagingMem = m_stagingMem;
       uint64_t sequenceNumber = m_device->GetCurrentSequenceNumber();
       D3D9StagingAlloc last;
       bool pastFinishedAllocations = false;
       for (auto iter = m_stagingAllocs.cbegin(); iter != m_stagingAllocs.cend();) {
         if (!pastFinishedAllocations && sequenceNumber > iter->sequenceNumber && !iter->marker->isInUse(DxvkAccess::Write)) {
           // The memory used for this allocation has already been reclaimed.
-          m_stagingMem -= iter->size;
+          stagingMem -= iter->size;
           iter = m_stagingAllocs.erase(iter);
           continue;
         }
@@ -26,9 +27,9 @@ namespace dxvk {
         // we don't have to check the entries that come afterwards.
         pastFinishedAllocations = true;
 
-        if (m_stagingMem >= uint32_t(limit)) {
+        if (stagingMem >= uint32_t(limit)) {
           // We're past the limit, find the newest entry we need to wait for to get under the limit again.
-          m_stagingMem -= iter->size;
+          stagingMem -= iter->size;
           last = *iter;
           iter = m_stagingAllocs.erase(iter);
           continue;
@@ -43,6 +44,7 @@ namespace dxvk {
         Logger::warn("Staging memory exhausted. Stalling");
         m_device->WaitForResource(last.marker, last.sequenceNumber, 0);
       }
+      m_stagingMem = stagingMem;
 
       uint32_t alignedSize = dxvk::align(Size, 256);
       m_stagingMem += alignedSize;

--- a/src/d3d9/d3d9_staging.cpp
+++ b/src/d3d9/d3d9_staging.cpp
@@ -1,0 +1,65 @@
+#include "d3d9_staging.h"
+#include "d3d9_device.h"
+
+namespace dxvk {
+
+  D3D9StagingBuffer::D3D9StagingBuffer(D3D9DeviceEx* pDevice)
+  : m_device        (pDevice),
+    m_stagingBuffer ( pDevice->GetDXVKDevice(), StagingBufferSize ) {
+  }
+
+  DxvkBufferSlice D3D9StagingBuffer::Alloc(uint32_t Size) {
+    const uint32_t limit = m_device->GetOptions()->stagingMemory;
+    if (env::is32BitHostPlatform() && limit != 0) {
+      uint64_t sequenceNumber = m_device->GetCurrentSequenceNumber();
+      D3D9StagingAlloc last;
+      bool pastFinishedAllocations = false;
+      for (auto iter = m_stagingAllocs.cbegin(); iter != m_stagingAllocs.cend();) {
+        if (!pastFinishedAllocations && sequenceNumber > iter->sequenceNumber && !iter->marker->isInUse(DxvkAccess::Write)) {
+          // The memory used for this allocation has already been reclaimed.
+          m_stagingMem -= iter->size;
+          iter = m_stagingAllocs.erase(iter);
+          continue;
+        }
+
+        // The list is ordered, so once we've reached the first entry that is still in use,
+        // we don't have to check the entries that come afterwards.
+        pastFinishedAllocations = true;
+
+        if (m_stagingMem >= uint32_t(limit)) {
+          // We're past the limit, find the newest entry we need to wait for to get under the limit again.
+          m_stagingMem -= iter->size;
+          last = *iter;
+          iter = m_stagingAllocs.erase(iter);
+          continue;
+        }
+
+        break;
+      }
+
+      if (last.marker != nullptr) {
+        // This should hopefully only happen on loading screens.
+        // Either way, stalling is preferable to crashing.
+        Logger::warn("Staging memory exhausted. Stalling");
+        m_device->WaitForResource(last.marker, last.sequenceNumber, 0);
+      }
+
+      uint32_t alignedSize = dxvk::align(Size, 256);
+      m_stagingMem += alignedSize;
+      if (!m_stagingAllocs.empty() && m_stagingAllocs.back().sequenceNumber == sequenceNumber) {
+        m_stagingAllocs.back().size += alignedSize;
+      } else {
+        Rc<DxvkMarker> marker = m_device->GetDXVKDevice()->createMarker();
+        m_stagingAllocs.push_back(D3D9StagingAlloc(marker, sequenceNumber, alignedSize));
+
+        m_device->EmitCs([
+          cMarker = std::move(marker)
+        ] (DxvkContext* ctx) {
+          ctx->insertMarker(cMarker);
+        });
+      }
+    }
+
+    return m_stagingBuffer.alloc(256, Size);
+  }
+}

--- a/src/d3d9/d3d9_staging.h
+++ b/src/d3d9/d3d9_staging.h
@@ -36,7 +36,7 @@ namespace dxvk {
     DxvkBufferSlice Alloc(uint32_t Size);
 
     uint32_t StagingMemory() const {
-      return m_stagingMem;
+      return m_stagingMem.load();
     }
 
   private:
@@ -45,7 +45,7 @@ namespace dxvk {
 
     DxvkStagingBuffer m_stagingBuffer;
 
-    uint32_t                        m_stagingMem = 0;
+    std::atomic<uint32_t>           m_stagingMem = 0;
     std::list<D3D9StagingAlloc>     m_stagingAllocs;
   };
 

--- a/src/d3d9/d3d9_staging.h
+++ b/src/d3d9/d3d9_staging.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include "../dxvk/dxvk_staging.h"
+#include "../dxvk/dxvk_marker.h"
+
+#include "d3d9_include.h"
+
+namespace dxvk {
+
+  class D3D9DeviceEx;
+
+  struct D3D9StagingAlloc {
+    Rc<DxvkMarker> marker;
+    uint64_t sequenceNumber;
+    uint32_t size;
+
+    D3D9StagingAlloc()
+      : marker(nullptr),
+        sequenceNumber(0),
+        size(0) {}
+
+    D3D9StagingAlloc(Rc<DxvkMarker> Marker, uint64_t SequenceNumber, uint32_t Size)
+      : marker(Marker),
+        sequenceNumber(SequenceNumber),
+        size(Size) {}
+  };
+
+  class D3D9StagingBuffer {
+
+    constexpr static VkDeviceSize StagingBufferSize = 4ull << 20;
+
+  public:
+
+    D3D9StagingBuffer(D3D9DeviceEx* pDevice);
+
+    DxvkBufferSlice Alloc(uint32_t Size);
+
+    uint32_t StagingMemory() const {
+      return m_stagingMem;
+    }
+
+  private:
+
+    D3D9DeviceEx* m_device;
+
+    DxvkStagingBuffer m_stagingBuffer;
+
+    uint32_t                        m_stagingMem = 0;
+    std::list<D3D9StagingAlloc>     m_stagingAllocs;
+  };
+
+}

--- a/src/d3d9/meson.build
+++ b/src/d3d9/meson.build
@@ -41,7 +41,8 @@ d3d9_src = [
   'd3d9_format_helpers.cpp',
   'd3d9_hud.cpp',
   'd3d9_annotation.cpp',
-  'd3d9_mem.cpp'
+  'd3d9_mem.cpp',
+  'd3d9_staging.cpp',
 ]
 
 d3d9_dll = shared_library('d3d9'+dll_ext, d3d9_src, glsl_generator.process(d3d9_shaders), d3d9_res,

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -5855,4 +5855,9 @@ namespace dxvk {
     }
   }
 
+
+  void DxvkContext::insertMarker(const Rc<DxvkMarker>& marker) {
+    m_cmd->trackResource<DxvkAccess::Write>(marker);
+  }
+
 }

--- a/src/dxvk/dxvk_context.h
+++ b/src/dxvk/dxvk_context.h
@@ -8,6 +8,7 @@
 #include "dxvk_objects.h"
 #include "dxvk_resource.h"
 #include "dxvk_util.h"
+#include "dxvk_marker.h"
 
 namespace dxvk {
   
@@ -1251,6 +1252,8 @@ namespace dxvk {
      * tools to mark different workloads within a frame.
      */
     void insertDebugLabel(VkDebugUtilsLabelEXT *label);
+
+    void insertMarker(const Rc<DxvkMarker>& marker);
 
     /**
      * \brief Increments a given stat counter

--- a/src/dxvk/dxvk_device.h
+++ b/src/dxvk/dxvk_device.h
@@ -22,6 +22,7 @@
 #include "dxvk_shader.h"
 #include "dxvk_stats.h"
 #include "dxvk_unbound.h"
+#include "dxvk_marker.h"
 
 #include "../vulkan/vulkan_presenter.h"
 
@@ -342,6 +343,10 @@ namespace dxvk {
      */
     Rc<DxvkSampler> createSampler(
       const DxvkSamplerCreateInfo&  createInfo);
+
+    Rc<DxvkMarker> createMarker() {
+      return new DxvkMarker();
+    }
     
     /**
      * \brief Retrieves stat counters

--- a/src/dxvk/dxvk_marker.h
+++ b/src/dxvk/dxvk_marker.h
@@ -1,0 +1,8 @@
+#pragma once
+
+
+#include "dxvk_resource.h"
+
+namespace dxvk {
+  class DxvkMarker : public DxvkResource {};
+}

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -607,6 +607,11 @@ namespace dxvk {
     { R"(\\witcher\.exe$)", {{
       { "d3d9.apitraceMode",              "True" },
     }} },
+    /* Guitar Hero World Tour                   *
+     * Very prone to address space crashes      */
+    { R"(\\(GHWT|GHWT_Definitive)\.exe$)", {{
+      { "d3d9.textureMemory",               "16" },
+    }} },
   }};
 
 


### PR DESCRIPTION
Games like Witcher 2 and modded Mass Effect 2 peak at 190MB and 170MB of memory used for staging buffers during loading screens. In the case of UE3 games, that happens at the same time as a very high peak for mapped resource memory, so this could be potentially problematic. Those games don't crash for me but I'd still prefer to get this under control.

The idea of this PR is to add a limit to how much staging memory an application is allowed to use and stall once we've exceeded that. I've settled on 16MB which was never an issue during gameplay in my testing.

Ideally we'd just unmap the memory and just not care but that doesn't work on Nvidia.

To track how much memory we're using for staging buffers, I add a new blank class that inherits from DxvkResource.
That allows us to check whether it's still in use (ie the command list has not been reset by the fence thread).
It's preferable to keep those objects around compared to keeping references to the actual staging buffers and checking those.
A prettier version of this would somehow inform DxvkCsThread of the last sequence number completed by the GPU. That's tricky to implement however, especially with DeferredContexts.
