### PR TITLE
Pipeline lifetime tracking on 32-bit

### DIFF
--- a/dxvk.conf
+++ b/dxvk.conf
@@ -286,6 +286,20 @@
 # dxvk.enableGraphicsPipelineLibrary = Auto
 
 
+# Controls pipeline lifetime tracking
+#
+# If enabled, pipeline libraries will be freed aggressively in order
+# save memory and address space. Has no effect if graphics pipeline
+# libraries are not supported or disabled.
+#
+# Supported values:
+# - Auto: Enable tracking for 32-bit applications only
+# - True: Always enable tracking
+# - False: Always disable tracking
+
+# dxvk.trackPipelineLifetime = Auto
+
+
 # Sets enabled HUD elements
 # 
 # Behaves like the DXVK_HUD environment variable if the

--- a/src/dxvk/dxvk_cmdlist.cpp
+++ b/src/dxvk/dxvk_cmdlist.cpp
@@ -219,10 +219,17 @@ namespace dxvk {
     m_signalTracker.reset();
     m_statCounters.reset();
 
+    // Recycle descriptor pools
     for (const auto& descriptorPools : m_descriptorPools)
       descriptorPools.second->recycleDescriptorPool(descriptorPools.first);
 
     m_descriptorPools.clear();
+
+    // Release pipelines
+    for (auto pipeline : m_pipelines)
+      pipeline->releasePipeline();
+
+    m_pipelines.clear();
 
     m_waitSemaphores.clear();
     m_signalSemaphores.clear();

--- a/src/dxvk/dxvk_cmdlist.h
+++ b/src/dxvk/dxvk_cmdlist.h
@@ -8,6 +8,7 @@
 #include "dxvk_fence.h"
 #include "dxvk_gpu_event.h"
 #include "dxvk_gpu_query.h"
+#include "dxvk_graphics.h"
 #include "dxvk_lifetime.h"
 #include "dxvk_limits.h"
 #include "dxvk_pipelayout.h"
@@ -30,7 +31,7 @@ namespace dxvk {
   };
   
   using DxvkCmdBufferFlags = Flags<DxvkCmdBuffer>;
-  
+
   /**
    * \brief Queue submission info
    *
@@ -176,6 +177,15 @@ namespace dxvk {
       m_gpuQueryTracker.trackQuery(handle);
     }
     
+    /**
+     * \brief Tracks a graphics pipeline
+     * \param [in] pipeline Pipeline
+     */
+    void trackGraphicsPipeline(DxvkGraphicsPipeline* pipeline) {
+      pipeline->acquirePipeline();
+      m_pipelines.push_back(pipeline);
+    }
+
     /**
      * \brief Queues signal
      * 
@@ -821,6 +831,8 @@ namespace dxvk {
     std::vector<std::pair<
       Rc<DxvkDescriptorPool>,
       Rc<DxvkDescriptorManager>>> m_descriptorPools;
+
+    std::vector<DxvkGraphicsPipeline*> m_pipelines;
 
     VkCommandBuffer getCmdBuffer(DxvkCmdBuffer cmdBuffer) const {
       if (cmdBuffer == DxvkCmdBuffer::ExecBuffer) return m_execBuffer;

--- a/src/dxvk/dxvk_compute.cpp
+++ b/src/dxvk/dxvk_compute.cpp
@@ -30,6 +30,9 @@ namespace dxvk {
   
   
   DxvkComputePipeline::~DxvkComputePipeline() {
+    if (m_libraryHandle)
+      m_library->releasePipelineHandle();
+
     for (const auto& instance : m_pipelines)
       this->destroyPipeline(instance.handle);
   }
@@ -45,7 +48,7 @@ namespace dxvk {
       // Retrieve actual pipeline handle on first use. This
       // may wait for an ongoing compile job to finish, or
       // compile the pipeline immediately on the calling thread.
-      m_libraryHandle = m_library->getPipelineHandle(
+      m_libraryHandle = m_library->acquirePipelineHandle(
         DxvkShaderPipelineLibraryCompileArgs());
 
       return m_libraryHandle;

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -49,6 +49,11 @@ namespace dxvk {
 
     if (m_device->features().extTransformFeedback.transformFeedback)
       m_globalRwGraphicsBarrier.access |= VK_ACCESS_TRANSFORM_FEEDBACK_COUNTER_READ_BIT_EXT;
+
+    // Store the lifetime tracking bit as a context feature so
+    // that we don't have to scan device features at draw time
+    if (m_device->mustTrackPipelineLifetime())
+      m_features.set(DxvkContextFeature::TrackGraphicsPipeline);
   }
   
   
@@ -4483,6 +4488,9 @@ namespace dxvk {
       m_state.gp.flags = DxvkGraphicsPipelineFlags();
       return false;
     }
+
+    if (m_features.test(DxvkContextFeature::TrackGraphicsPipeline))
+      m_cmd->trackGraphicsPipeline(newPipeline);
 
     if (unlikely(newPipeline->getSpecConstantMask() != m_state.gp.constants.mask))
       this->resetSpecConstants<VK_PIPELINE_BIND_POINT_GRAPHICS>(newPipeline->getSpecConstantMask());

--- a/src/dxvk/dxvk_context_state.h
+++ b/src/dxvk/dxvk_context_state.h
@@ -60,7 +60,8 @@ namespace dxvk {
   /**
    * \brief Context feature bits
    */
-  enum class DxvkContextFeature {
+  enum class DxvkContextFeature : uint32_t {
+    TrackGraphicsPipeline,
     FeatureCount
   };
 

--- a/src/dxvk/dxvk_device.cpp
+++ b/src/dxvk/dxvk_device.cpp
@@ -68,6 +68,13 @@ namespace dxvk {
   }
 
 
+  bool DxvkDevice::mustTrackPipelineLifetime() const {
+    bool result = env::is32BitHostPlatform();
+    applyTristate(result, m_options.trackPipelineLifetime);
+    return result && canUseGraphicsPipelineLibrary();
+  }
+
+
   DxvkFramebufferSize DxvkDevice::getDefaultFramebufferSize() const {
     return DxvkFramebufferSize {
       m_properties.core.properties.limits.maxFramebufferWidth,

--- a/src/dxvk/dxvk_device.h
+++ b/src/dxvk/dxvk_device.h
@@ -210,6 +210,12 @@ namespace dxvk {
     bool canUsePipelineCacheControl() const;
 
     /**
+     * \brief Checks whether pipelines should be tracked
+     * \returns \c true if pipelines need to be tracked
+     */
+    bool mustTrackPipelineLifetime() const;
+
+    /**
      * \brief Queries default framebuffer size
      * \returns Default framebuffer size
      */

--- a/src/dxvk/dxvk_graphics.cpp
+++ b/src/dxvk/dxvk_graphics.cpp
@@ -880,8 +880,12 @@ namespace dxvk {
   
   
   DxvkGraphicsPipeline::~DxvkGraphicsPipeline() {
-    for (const auto& instance : m_fastPipelines)
+    for (const auto& instance : m_fastPipelines) {
       this->destroyPipeline(instance.second);
+
+      m_vsLibrary->releasePipelineHandle();
+      m_fsLibrary->releasePipelineHandle();
+    }
 
     for (const auto& instance : m_basePipelines)
       this->destroyPipeline(instance.second);
@@ -1102,8 +1106,8 @@ namespace dxvk {
 
     std::array<VkPipeline, 4> libraries = {{
       key.viLibrary->getHandle(),
-      m_vsLibrary->getPipelineHandle(key.args),
-      m_fsLibrary->getPipelineHandle(key.args),
+      m_vsLibrary->acquirePipelineHandle(key.args),
+      m_fsLibrary->acquirePipelineHandle(key.args),
       key.foLibrary->getHandle(),
     }};
 

--- a/src/dxvk/dxvk_options.cpp
+++ b/src/dxvk/dxvk_options.cpp
@@ -7,6 +7,7 @@ namespace dxvk {
     enableStateCache      = config.getOption<bool>    ("dxvk.enableStateCache",       true);
     numCompilerThreads    = config.getOption<int32_t> ("dxvk.numCompilerThreads",     0);
     enableGraphicsPipelineLibrary = config.getOption<Tristate>("dxvk.enableGraphicsPipelineLibrary", Tristate::Auto);
+    trackPipelineLifetime = config.getOption<Tristate>("dxvk.trackPipelineLifetime",  Tristate::Auto);
     useRawSsbo            = config.getOption<Tristate>("dxvk.useRawSsbo",             Tristate::Auto);
     shrinkNvidiaHvvHeap   = config.getOption<bool>    ("dxvk.shrinkNvidiaHvvHeap",    false);
     hud                   = config.getOption<std::string>("dxvk.hud", "");

--- a/src/dxvk/dxvk_options.h
+++ b/src/dxvk/dxvk_options.h
@@ -21,6 +21,9 @@ namespace dxvk {
     /// Enable graphics pipeline library
     Tristate enableGraphicsPipelineLibrary;
 
+    /// Enables pipeline lifetime tracking
+    Tristate trackPipelineLifetime;
+
     /// Shader-related options
     Tristate useRawSsbo;
 

--- a/src/dxvk/dxvk_pipemanager.cpp
+++ b/src/dxvk/dxvk_pipemanager.cpp
@@ -64,6 +64,7 @@ namespace dxvk {
     std::unique_lock lock(m_queueLock);
     this->startWorkers();
 
+    pipeline->acquirePipeline();
     m_pendingTasks += 1;
 
     PipelineEntry e = { };
@@ -148,10 +149,12 @@ namespace dxvk {
       }
 
       if (p) {
-        if (p->computePipeline)
+        if (p->computePipeline) {
           p->computePipeline->compilePipeline(p->computeState);
-        else if (p->graphicsPipeline)
+        } else if (p->graphicsPipeline) {
           p->graphicsPipeline->compilePipeline(p->graphicsState);
+          p->graphicsPipeline->releasePipeline();
+        }
 
         m_pendingTasks -= 1;
       }

--- a/src/dxvk/dxvk_pipemanager.h
+++ b/src/dxvk/dxvk_pipemanager.h
@@ -238,16 +238,6 @@ namespace dxvk {
       DxvkHash, DxvkEq> m_pipelineLayouts;
 
     std::unordered_map<
-      DxvkComputePipelineShaders,
-      DxvkComputePipeline,
-      DxvkHash, DxvkEq> m_computePipelines;
-    
-    std::unordered_map<
-      DxvkGraphicsPipelineShaders,
-      DxvkGraphicsPipeline,
-      DxvkHash, DxvkEq> m_graphicsPipelines;
-
-    std::unordered_map<
       DxvkGraphicsPipelineVertexInputState,
       DxvkGraphicsPipelineVertexInputLibrary,
       DxvkHash, DxvkEq> m_vertexInputLibraries;
@@ -261,6 +251,16 @@ namespace dxvk {
       DxvkShaderPipelineLibraryKey,
       DxvkShaderPipelineLibrary,
       DxvkHash, DxvkEq> m_shaderLibraries;
+
+    std::unordered_map<
+      DxvkComputePipelineShaders,
+      DxvkComputePipeline,
+      DxvkHash, DxvkEq> m_computePipelines;
+
+    std::unordered_map<
+      DxvkGraphicsPipelineShaders,
+      DxvkGraphicsPipeline,
+      DxvkHash, DxvkEq> m_graphicsPipelines;
 
     DxvkBindingSetLayout* createDescriptorSetLayout(
       const DxvkBindingSetLayoutKey& key);

--- a/src/dxvk/dxvk_shader.h
+++ b/src/dxvk/dxvk_shader.h
@@ -433,22 +433,32 @@ namespace dxvk {
     VkPipeline compileShaderPipelineLocked(
       const DxvkShaderPipelineLibraryCompileArgs& args);
 
+    VkPipeline compileShaderPipeline(
+      const DxvkShaderPipelineLibraryCompileArgs& args,
+            VkShaderStageFlagBits                 stage,
+            VkPipelineCreateFlags                 flags);
+
     VkPipeline compileVertexShaderPipeline(
-      const DxvkShaderPipelineLibraryCompileArgs& args);
+      const DxvkShaderPipelineLibraryCompileArgs& args,
+      const DxvkShaderStageInfo&          stageInfo,
+            VkPipelineCreateFlags         flags);
 
-    VkPipeline compileFragmentShaderPipeline();
+    VkPipeline compileFragmentShaderPipeline(
+      const DxvkShaderStageInfo&          stageInfo,
+            VkPipelineCreateFlags         flags);
 
-    VkPipeline compileComputeShaderPipeline();
+    VkPipeline compileComputeShaderPipeline(
+      const DxvkShaderStageInfo&          stageInfo,
+            VkPipelineCreateFlags         flags);
 
     SpirvCodeBuffer getShaderCode() const;
-
-    void generateModuleIdentifier(
-      const SpirvCodeBuffer& spirvCode);
 
     void generateModuleIdentifierLocked(
       const SpirvCodeBuffer& spirvCode);
 
     VkShaderStageFlagBits getShaderStage() const;
+
+    bool canUsePipelineCacheControl() const;
 
   };
   

--- a/src/dxvk/dxvk_shader.h
+++ b/src/dxvk/dxvk_shader.h
@@ -425,9 +425,13 @@ namespace dxvk {
     dxvk::mutex     m_mutex;
     VkPipeline      m_pipeline             = VK_NULL_HANDLE;
     VkPipeline      m_pipelineNoDepthClip  = VK_NULL_HANDLE;
+    bool            m_compiledOnce         = false;
 
     dxvk::mutex                 m_identifierMutex;
     VkShaderModuleIdentifierEXT m_identifier = { VK_STRUCTURE_TYPE_SHADER_MODULE_IDENTIFIER_EXT };
+
+    VkPipeline compileShaderPipelineLocked(
+      const DxvkShaderPipelineLibraryCompileArgs& args);
 
     VkPipeline compileVertexShaderPipeline(
       const DxvkShaderPipelineLibraryCompileArgs& args);
@@ -443,6 +447,8 @@ namespace dxvk {
 
     void generateModuleIdentifierLocked(
       const SpirvCodeBuffer& spirvCode);
+
+    VkShaderStageFlagBits getShaderStage() const;
 
   };
   

--- a/src/dxvk/dxvk_shader.h
+++ b/src/dxvk/dxvk_shader.h
@@ -396,15 +396,25 @@ namespace dxvk {
     VkShaderModuleIdentifierEXT getModuleIdentifier();
 
     /**
-     * \brief Queries pipeline handle for the given set of arguments
+     * \brief Acquires pipeline handle for the given set of arguments
      *
      * Either returns an already compiled pipeline library object, or
      * performs the compilation step if that has not happened yet.
+     * Increments the use count by one.
      * \param [in] args Compile arguments
      * \returns Vulkan pipeline handle
      */
-    VkPipeline getPipelineHandle(
+    VkPipeline acquirePipelineHandle(
       const DxvkShaderPipelineLibraryCompileArgs& args);
+
+    /**
+     * \brief Releases pipeline
+     *
+     * Decrements the use count by 1. If the use count reaches 0,
+     * any previously compiled pipeline library object may be
+     * destroyed in order to save memory.
+     */
+    void releasePipelineHandle();
 
     /**
      * \brief Compiles the pipeline with default arguments
@@ -425,10 +435,13 @@ namespace dxvk {
     dxvk::mutex     m_mutex;
     VkPipeline      m_pipeline             = VK_NULL_HANDLE;
     VkPipeline      m_pipelineNoDepthClip  = VK_NULL_HANDLE;
+    uint32_t        m_useCount             = 0u;
     bool            m_compiledOnce         = false;
 
     dxvk::mutex                 m_identifierMutex;
     VkShaderModuleIdentifierEXT m_identifier = { VK_STRUCTURE_TYPE_SHADER_MODULE_IDENTIFIER_EXT };
+
+    void destroyShaderPipelinesLocked();
 
     VkPipeline compileShaderPipelineLocked(
       const DxvkShaderPipelineLibraryCompileArgs& args);


### PR DESCRIPTION
In order to reduce address space issues with graphics pipeline libraries in 32-bit apps, we need to aggressively destroy libraries as well as linked pipelines.

Pipeline libraries that are compiled on the background threads after a `Create*Shader` call will be destroyed immediately, rather than written back. When recreating these, we'll rely on `VK_EXT_shader_module_identifier` and the driver's disk cache to give us a new one very quickly. In my testing, this is still orders of magitude faster than compiling a pipeline (100-200 µs per pipeline library) and does not lead to any noticeable stutter in games.

Base pipelines will be kept alive as long as they are potentially in use by the GPU **and** as long as there are compile jobs for optimized pipelines on the worker threads. This way we avoid extreme scenarios like compiling and destroying the same set of base pipelines every frame if the app is CPU-bound. We never destroy optimized pipelines.

This is fairly ugly and it is rather unfortunate that this is needed, but in RE6 we save ~500MB of address space in the menu on Nvidia, and even more during gameplay.