### PR TITLE
Fix synchronization when copying from system mem texture to default texture 

### DIFF
--- a/src/d3d9/d3d9_common_texture.h
+++ b/src/d3d9/d3d9_common_texture.h
@@ -331,7 +331,7 @@ namespace dxvk {
 
     void SetNeedsReadback(UINT Subresource, bool value) { m_needsReadback.set(Subresource, value); }
 
-    bool NeedsReachback(UINT Subresource) const { return m_needsReadback.get(Subresource); }
+    bool NeedsReadback(UINT Subresource) const { return m_needsReadback.get(Subresource); }
 
     void MarkAllNeedReadback() { m_needsReadback.setAll(); }
 

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -4163,7 +4163,7 @@ namespace dxvk {
     // then we need to copy -> buffer
     // We are also always dirty if we are a render target,
     // a depth stencil, or auto generate mipmaps.
-    bool needsReadback = pResource->NeedsReachback(Subresource) || renderable;
+    bool needsReadback = pResource->NeedsReadback(Subresource) || renderable;
     pResource->SetNeedsReadback(Subresource, false);
 
     void* mapPtr;

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -4427,6 +4427,12 @@ namespace dxvk {
 
     auto convertFormat = pDestTexture->GetFormatMapping().ConversionFormatInfo;
 
+    if (unlikely(pSrcTexture->NeedsReadback(SrcSubresource))) {
+      const Rc<DxvkBuffer>& buffer = pSrcTexture->GetBuffer(SrcSubresource, false);
+      WaitForResource(buffer, pSrcTexture->GetMappingBufferSequenceNumber(SrcSubresource), 0);
+      pSrcTexture->SetNeedsReadback(SrcSubresource, false);
+    }
+
     if (likely(convertFormat.FormatType == D3D9ConversionFormat_None)) {
       VkOffset3D alignedDestOffset = {
         int32_t(alignDown(DestOffset.x, formatInfo->blockSize.width)),


### PR DESCRIPTION
Fixes: #2803

SR2 does the following:

- Render to texture
- GetRenderTargetData to copy that to a POOL_SYSTEMMEM texture
- UpdateSurface to copy from the POOL_SYSTEMMEM to a POOL_DEFAULT texture

I've never seen this pattern and it's honestly pretty stupid given that you could just call StretchRect and skip the system memory copy, so we'll just stall.
