### PR TITLE
Limit D3D9 staging memory v2

### DIFF
--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -4533,6 +4533,7 @@ namespace dxvk {
         slice.slice);
     }
     UnmapTextures();
+    FlushImplicit(false);
   }
 
   void D3D9DeviceEx::EmitGenerateMips(
@@ -4688,6 +4689,7 @@ namespace dxvk {
     TrackBufferMappingBufferSequenceNumber(pResource);
 
     UnmapTextures();
+    FlushImplicit(false);
     return D3D_OK;
   }
 
@@ -4709,8 +4711,6 @@ namespace dxvk {
 
     if (pResource->Desc()->Pool != D3DPOOL_DEFAULT)
       return D3D_OK;
-
-    FlushImplicit(FALSE);
 
     FlushBuffer(pResource);
 

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -96,6 +96,13 @@ namespace dxvk {
     void*           mapPtr = nullptr;
   };
 
+  struct D3D9StagingBufferMarkerPayload {
+    uint64_t        sequenceNumber;
+    VkDeviceSize    allocated;
+  };
+
+  using D3D9StagingBufferMarker = DxvkMarker<D3D9StagingBufferMarkerPayload>;
+
   class D3D9DeviceEx final : public ComObjectClamp<IDirect3DDevice9Ex> {
     constexpr static uint32_t DefaultFrameLatency = 3;
     constexpr static uint32_t MaxFrameLatency     = 20;
@@ -977,6 +984,10 @@ namespace dxvk {
 
     D3D9BufferSlice AllocStagingBuffer(VkDeviceSize size);
 
+    void EmitStagingBufferMarker();
+
+    void WaitStagingBuffer();
+
     bool ShouldRecord();
 
     HRESULT               CreateShaderModule(
@@ -1188,6 +1199,10 @@ namespace dxvk {
     void*                           m_upBufferMapPtr  = nullptr;
 
     DxvkStagingBuffer               m_stagingBuffer;
+    VkDeviceSize                    m_stagingBufferAllocated      = 0ull;
+    VkDeviceSize                    m_stagingBufferLastAllocated  = 0ull;
+    VkDeviceSize                    m_stagingBufferLastSignaled   = 0ull;
+    std::queue<Rc<D3D9StagingBufferMarker>> m_stagingBufferMarkers;
 
     D3D9Cursor                      m_cursor;
 

--- a/src/dxvk/dxvk_context.h
+++ b/src/dxvk/dxvk_context.h
@@ -8,6 +8,7 @@
 #include "dxvk_objects.h"
 #include "dxvk_resource.h"
 #include "dxvk_util.h"
+#include "dxvk_marker.h"
 
 namespace dxvk {
   
@@ -1251,6 +1252,15 @@ namespace dxvk {
      * tools to mark different workloads within a frame.
      */
     void insertDebugLabel(VkDebugUtilsLabelEXT *label);
+
+    /**
+     * \brief Inserts a marker object
+     * \param [in] marker The marker
+     */
+    template<typename T>
+    void insertMarker(const Rc<DxvkMarker<T>>& marker) {
+      m_cmd->trackResource<DxvkAccess::Write>(marker);
+    }
 
     /**
      * \brief Increments a given stat counter

--- a/src/dxvk/dxvk_device.h
+++ b/src/dxvk/dxvk_device.h
@@ -22,6 +22,7 @@
 #include "dxvk_shader.h"
 #include "dxvk_stats.h"
 #include "dxvk_unbound.h"
+#include "dxvk_marker.h"
 
 #include "../vulkan/vulkan_presenter.h"
 
@@ -348,7 +349,7 @@ namespace dxvk {
      */
     Rc<DxvkSampler> createSampler(
       const DxvkSamplerCreateInfo&  createInfo);
-    
+
     /**
      * \brief Retrieves stat counters
      * 

--- a/src/dxvk/dxvk_marker.h
+++ b/src/dxvk/dxvk_marker.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "dxvk_resource.h"
+
+namespace dxvk {
+
+  /**
+   * \brief Marker
+   *
+   * Arbitrary marker that can be used to track whether
+   * the GPU has finished processing certain commands,
+   * and stores some data.
+   */
+  template<typename T>
+  class DxvkMarker : public DxvkResource {
+
+  public:
+
+    DxvkMarker(T&& payload)
+    : m_payload(std::move(payload)) { }
+
+    DxvkMarker(const T& payload)
+    : m_payload(payload) { }
+
+    const T& payload() const {
+      return m_payload;
+    }
+
+  private:
+
+    T m_payload;
+
+  };
+
+}

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -607,6 +607,11 @@ namespace dxvk {
     { R"(\\witcher\.exe$)", {{
       { "d3d9.apitraceMode",              "True" },
     }} },
+    /* Guitar Hero World Tour                   *
+     * Very prone to address space crashes      */
+    { R"(\\(GHWT|GHWT_Definitive)\.exe$)", {{
+      { "d3d9.textureMemory",               "16" },
+    }} },
   }};
 
 


### PR DESCRIPTION
Similar idea as PR #2800: We stall until the amount of staging memory in flight drops below a certain threshold.

The limit enforced here is not a hard limit, we can have up to two more staging buffers in flight: One that's being tracked by the command list if we had to allocate a new buffer in the meantime (this will pretty much always be the case), and potentially one from subsequent `AllocStagingBuffer` calls. This might be unfortunate, but calling `Flush` does not appear to be safe at the time we compute the amount of memory needed. With some work we should be able to sort this out and reduce the number of potential extra staging buffers to just one.

I don't know if 8M is a good limit or if we should try to allow more (maybe 12 once we can take the required memory into account, so peaks will be no more than 16M?).