### PR TITLE
[dxgi] Also support use after free in IDXGISwapChain::SetFullscreenState()

### DIFF
--- a/src/dxgi/dxgi_swapchain_dispatcher.h
+++ b/src/dxgi/dxgi_swapchain_dispatcher.h
@@ -224,7 +224,9 @@ namespace dxvk {
     HRESULT STDMETHODCALLTYPE SetFullscreenState(
             BOOL                      Fullscreen,
             IDXGIOutput*              pTarget) final {
-      return m_dispatch->SetFullscreenState(Fullscreen, pTarget);
+      if (likely(m_dispatch != nullptr))
+        return m_dispatch->SetFullscreenState(Fullscreen, pTarget);
+      return S_OK;
     }
 
 


### PR DESCRIPTION
Fixes hang on exit in Call of Duty: Black Ops II Zombies and Multiplayer.