### PR TITLE
[util] Disable direct buffer mapping for GHWT

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -611,6 +611,7 @@ namespace dxvk {
      * Very prone to address space crashes      */
     { R"(\\(GHWT|GHWT_Definitive)\.exe$)", {{
       { "d3d9.textureMemory",               "16" },
+      { "d3d9.allowDirectBufferMapping",    "False" },
     }} },
   }};
 


### PR DESCRIPTION
Fixes #2730

Refer to the commit message for the reasoning behind the change.