### PR TITLE
[d3d9] Fix rare hang when waiting for staging buffer markers

### DIFF
--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -4081,7 +4081,7 @@ namespace dxvk {
         if (!needsStall)
           break;
 
-        m_csThread.synchronize(payload.sequenceNumber);
+        SynchronizeCsThread(payload.sequenceNumber);
         lastSequenceNumber = payload.sequenceNumber;
       }
 
@@ -4829,7 +4829,8 @@ namespace dxvk {
 
     // Dispatch current chunk so that all commands
     // recorded prior to this function will be run
-    FlushCsChunk();
+    if (SequenceNumber > m_csSeqNum)
+      FlushCsChunk();
 
     m_csThread.synchronize(SequenceNumber);
   }
@@ -5178,9 +5179,9 @@ namespace dxvk {
     m_initializer->Flush();
     m_converter->Flush();
 
-    EmitStagingBufferMarker();
-
     if (m_csIsBusy || !m_csChunk->empty()) {
+      EmitStagingBufferMarker();
+
       // Add commands to flush the threaded
       // context, then flush the command list
       EmitCs([](DxvkContext* ctx) {


### PR DESCRIPTION
I'm getting very rare and racy dead locks with DXVK. I've tracked it down to `DxvkCsThread::synchronize` in `WaitStagingBuffer`.

Calling the DxvkCsThread function directly means we're not flushing the current chunk if necessary and could end up waiting for a sequence number that hasn't been dispatched yet.

Besides that, I also changed it so we're not emitting a marker when trying to flush an empty chunk and ported over a tiny optimization in `SynchronizeCsThread` from the d3d11 frontend.

I'm not entirely sure, this fixes the bug.