### PR TITLE
Rework D3D9 alpha test

### DIFF
--- a/dxvk.conf
+++ b/dxvk.conf
@@ -414,16 +414,6 @@
 
 # d3d9.longMad = False
 
-# Alpha Test Wiggle Room
-#
-# Workaround for games using alpha test == 1.0, etc due to wonky interpolation or
-# misc. imprecision on some vendors
-#
-# Supported values:
-# - True/False
-
-# d3d9.alphaTestWiggleRoom = False
-
 # Device Local Constant Buffers
 #
 # Enables using device local, host accessible memory for constant buffers in D3D9.

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -5117,8 +5117,8 @@ namespace dxvk {
     auto& rs = m_state.renderStates;
 
     if constexpr (Item == D3D9RenderStateItem::AlphaRef) {
-      float alpha = float(rs[D3DRS_ALPHAREF] & 0xFF) / 255.0f;
-      UpdatePushConstant<offsetof(D3D9RenderStateInfo, alphaRef), sizeof(float)>(&alpha);
+      uint32_t alpha = rs[D3DRS_ALPHAREF];
+      UpdatePushConstant<offsetof(D3D9RenderStateInfo, alphaRef), sizeof(uint32_t)>(&alpha);
     }
     else if constexpr (Item == D3D9RenderStateItem::FogColor) {
       Vector4 color;

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -1135,9 +1135,11 @@ namespace dxvk {
 
     bool UseProgrammablePS();
 
+    uint32_t GetAlphaTestPrecision();
+
     void BindAlphaTestState();
 
-    void UpdateAlphaTestSpec(VkCompareOp alphaOp);
+    void UpdateAlphaTestSpec(VkCompareOp alphaOp, uint32_t precision);
     void UpdateVertexBoolSpec(uint32_t value);
     void UpdatePixelBoolSpec(uint32_t value);
     void UpdatePixelShaderSamplerSpec(uint32_t types, uint32_t projections, uint32_t fetch4);

--- a/src/d3d9/d3d9_fixed_function.cpp
+++ b/src/d3d9/d3d9_fixed_function.cpp
@@ -189,6 +189,86 @@ namespace dxvk {
   }
 
 
+  void DoFixedFunctionAlphaTest(SpirvModule& spvModule, const D3D9AlphaTestContext& ctx) {
+    // Labels for the alpha test
+    std::array<SpirvSwitchCaseLabel, 8> atestCaseLabels = {{
+      { uint32_t(VK_COMPARE_OP_NEVER),            spvModule.allocateId() },
+      { uint32_t(VK_COMPARE_OP_LESS),             spvModule.allocateId() },
+      { uint32_t(VK_COMPARE_OP_EQUAL),            spvModule.allocateId() },
+      { uint32_t(VK_COMPARE_OP_LESS_OR_EQUAL),    spvModule.allocateId() },
+      { uint32_t(VK_COMPARE_OP_GREATER),          spvModule.allocateId() },
+      { uint32_t(VK_COMPARE_OP_NOT_EQUAL),        spvModule.allocateId() },
+      { uint32_t(VK_COMPARE_OP_GREATER_OR_EQUAL), spvModule.allocateId() },
+      { uint32_t(VK_COMPARE_OP_ALWAYS),           spvModule.allocateId() },
+    }};
+
+    uint32_t atestBeginLabel   = spvModule.allocateId();
+    uint32_t atestTestLabel    = spvModule.allocateId();
+    uint32_t atestDiscardLabel = spvModule.allocateId();
+    uint32_t atestKeepLabel    = spvModule.allocateId();
+    uint32_t atestSkipLabel    = spvModule.allocateId();
+
+    // if (alpha_func != ALWAYS) { ... }
+    uint32_t boolType = spvModule.defBoolType();
+    uint32_t isNotAlways = spvModule.opINotEqual(boolType, ctx.alphaFuncId, spvModule.constu32(VK_COMPARE_OP_ALWAYS));
+    spvModule.opSelectionMerge(atestSkipLabel, spv::SelectionControlMaskNone);
+    spvModule.opBranchConditional(isNotAlways, atestBeginLabel, atestSkipLabel);
+    spvModule.opLabel(atestBeginLabel);
+
+    // switch (alpha_func) { ... }
+    spvModule.opSelectionMerge(atestTestLabel, spv::SelectionControlMaskNone);
+    spvModule.opSwitch(ctx.alphaFuncId,
+      atestCaseLabels[uint32_t(VK_COMPARE_OP_ALWAYS)].labelId,
+      atestCaseLabels.size(),
+      atestCaseLabels.data());
+
+    std::array<SpirvPhiLabel, 8> atestVariables;
+
+    for (uint32_t i = 0; i < atestCaseLabels.size(); i++) {
+      spvModule.opLabel(atestCaseLabels[i].labelId);
+
+      atestVariables[i].labelId = atestCaseLabels[i].labelId;
+      atestVariables[i].varId   = [&] {
+        switch (VkCompareOp(atestCaseLabels[i].literal)) {
+          case VK_COMPARE_OP_NEVER:            return spvModule.constBool(false);
+          case VK_COMPARE_OP_LESS:             return spvModule.opFOrdLessThan        (boolType, ctx.alphaId, ctx.alphaRefId);
+          case VK_COMPARE_OP_EQUAL:            return spvModule.opFOrdEqual           (boolType, ctx.alphaId, ctx.alphaRefId);
+          case VK_COMPARE_OP_LESS_OR_EQUAL:    return spvModule.opFOrdLessThanEqual   (boolType, ctx.alphaId, ctx.alphaRefId);
+          case VK_COMPARE_OP_GREATER:          return spvModule.opFOrdGreaterThan     (boolType, ctx.alphaId, ctx.alphaRefId);
+          case VK_COMPARE_OP_NOT_EQUAL:        return spvModule.opFOrdNotEqual        (boolType, ctx.alphaId, ctx.alphaRefId);
+          case VK_COMPARE_OP_GREATER_OR_EQUAL: return spvModule.opFOrdGreaterThanEqual(boolType, ctx.alphaId, ctx.alphaRefId);
+          default:
+          case VK_COMPARE_OP_ALWAYS:           return spvModule.constBool(true);
+        }
+      }();
+
+      spvModule.opBranch(atestTestLabel);
+    }
+
+    // end switch
+    spvModule.opLabel(atestTestLabel);
+
+    uint32_t atestResult = spvModule.opPhi(boolType,
+      atestVariables.size(),
+      atestVariables.data());
+    uint32_t atestDiscard = spvModule.opLogicalNot(boolType, atestResult);
+
+    // if (do_discard) { ... }
+    spvModule.opSelectionMerge(atestKeepLabel, spv::SelectionControlMaskNone);
+    spvModule.opBranchConditional(atestDiscard, atestDiscardLabel, atestKeepLabel);
+
+    spvModule.opLabel(atestDiscardLabel);
+    spvModule.opKill();
+
+    // end if (do_discard)
+    spvModule.opLabel(atestKeepLabel);
+    spvModule.opBranch(atestSkipLabel);
+
+    // end if (alpha_test)
+    spvModule.opLabel(atestSkipLabel);
+  }
+
+
   uint32_t SetupRenderStateBlock(SpirvModule& spvModule, uint32_t count) {
     uint32_t floatType = spvModule.defFloatType(32);
     uint32_t vec3Type  = spvModule.defVectorType(floatType, 3);
@@ -2220,101 +2300,22 @@ namespace dxvk {
 
 
   void D3D9FFShaderCompiler::alphaTestPS() {
-    // Alpha testing
-    uint32_t boolType = m_module.defBoolType();
     uint32_t floatPtr = m_module.defPointerType(m_floatType, spv::StorageClassPushConstant);
 
-    // Declare spec constants for render states
-    uint32_t alphaFuncId = m_spec.get(m_module, m_specUbo, SpecAlphaCompareOp);
-
-    // Implement alpha test
     auto oC0 = m_ps.out.COLOR;
-    // Labels for the alpha test
-    std::array<SpirvSwitchCaseLabel, 8> atestCaseLabels = { {
-      { uint32_t(VK_COMPARE_OP_NEVER),            m_module.allocateId() },
-      { uint32_t(VK_COMPARE_OP_LESS),             m_module.allocateId() },
-      { uint32_t(VK_COMPARE_OP_EQUAL),            m_module.allocateId() },
-      { uint32_t(VK_COMPARE_OP_LESS_OR_EQUAL),    m_module.allocateId() },
-      { uint32_t(VK_COMPARE_OP_GREATER),          m_module.allocateId() },
-      { uint32_t(VK_COMPARE_OP_NOT_EQUAL),        m_module.allocateId() },
-      { uint32_t(VK_COMPARE_OP_GREATER_OR_EQUAL), m_module.allocateId() },
-      { uint32_t(VK_COMPARE_OP_ALWAYS),           m_module.allocateId() },
-    } };
 
-    uint32_t atestBeginLabel = m_module.allocateId();
-    uint32_t atestTestLabel = m_module.allocateId();
-    uint32_t atestDiscardLabel = m_module.allocateId();
-    uint32_t atestKeepLabel = m_module.allocateId();
-    uint32_t atestSkipLabel = m_module.allocateId();
-
-    // if (alpha_test) { ... }
-    uint32_t isNotAlways = m_module.opINotEqual(boolType, alphaFuncId, m_module.constu32(VK_COMPARE_OP_ALWAYS));
-    m_module.opSelectionMerge(atestSkipLabel, spv::SelectionControlMaskNone);
-    m_module.opBranchConditional(isNotAlways, atestBeginLabel, atestSkipLabel);
-    m_module.opLabel(atestBeginLabel);
-
-    // Load alpha component
     uint32_t alphaComponentId = 3;
-    uint32_t alphaId = m_module.opCompositeExtract(m_floatType,
+    uint32_t alphaRefMember = m_module.constu32(uint32_t(D3D9RenderStateItem::AlphaRef));
+
+    D3D9AlphaTestContext alphaTestContext;
+    alphaTestContext.alphaFuncId = m_spec.get(m_module, m_specUbo, SpecAlphaCompareOp);
+    alphaTestContext.alphaRefId = m_module.opLoad(m_floatType,
+      m_module.opAccessChain(floatPtr, m_rsBlock, 1, &alphaRefMember));
+    alphaTestContext.alphaId = m_module.opCompositeExtract(m_floatType,
       m_module.opLoad(m_vec4Type, oC0),
       1, &alphaComponentId);
 
-    // Load alpha reference
-    uint32_t alphaRefMember = m_module.constu32(uint32_t(D3D9RenderStateItem::AlphaRef));
-    uint32_t alphaRefId = m_module.opLoad(m_floatType,
-      m_module.opAccessChain(floatPtr, m_rsBlock, 1, &alphaRefMember));
-
-    // switch (alpha_func) { ... }
-    m_module.opSelectionMerge(atestTestLabel, spv::SelectionControlMaskNone);
-    m_module.opSwitch(alphaFuncId,
-      atestCaseLabels[uint32_t(VK_COMPARE_OP_ALWAYS)].labelId,
-      atestCaseLabels.size(),
-      atestCaseLabels.data());
-
-    std::array<SpirvPhiLabel, 8> atestVariables;
-
-    for (uint32_t i = 0; i < atestCaseLabels.size(); i++) {
-      m_module.opLabel(atestCaseLabels[i].labelId);
-
-      atestVariables[i].labelId = atestCaseLabels[i].labelId;
-      atestVariables[i].varId = [&] {
-        switch (VkCompareOp(atestCaseLabels[i].literal)) {
-        case VK_COMPARE_OP_NEVER:            return m_module.constBool(false);
-        case VK_COMPARE_OP_LESS:             return m_module.opFOrdLessThan(boolType, alphaId, alphaRefId);
-        case VK_COMPARE_OP_EQUAL:            return m_module.opFOrdEqual(boolType, alphaId, alphaRefId);
-        case VK_COMPARE_OP_LESS_OR_EQUAL:    return m_module.opFOrdLessThanEqual(boolType, alphaId, alphaRefId);
-        case VK_COMPARE_OP_GREATER:          return m_module.opFOrdGreaterThan(boolType, alphaId, alphaRefId);
-        case VK_COMPARE_OP_NOT_EQUAL:        return m_module.opFOrdNotEqual(boolType, alphaId, alphaRefId);
-        case VK_COMPARE_OP_GREATER_OR_EQUAL: return m_module.opFOrdGreaterThanEqual(boolType, alphaId, alphaRefId);
-        default:
-        case VK_COMPARE_OP_ALWAYS:           return m_module.constBool(true);
-        }
-      }();
-
-      m_module.opBranch(atestTestLabel);
-    }
-
-    // end switch
-    m_module.opLabel(atestTestLabel);
-
-    uint32_t atestResult = m_module.opPhi(boolType,
-      atestVariables.size(),
-      atestVariables.data());
-    uint32_t atestDiscard = m_module.opLogicalNot(boolType, atestResult);
-
-    // if (do_discard) { ... }
-    m_module.opSelectionMerge(atestKeepLabel, spv::SelectionControlMaskNone);
-    m_module.opBranchConditional(atestDiscard, atestDiscardLabel, atestKeepLabel);
-
-    m_module.opLabel(atestDiscardLabel);
-    m_module.opKill();
-
-    // end if (do_discard)
-    m_module.opLabel(atestKeepLabel);
-    m_module.opBranch(atestSkipLabel);
-
-    // end if (alpha_test)
-    m_module.opLabel(atestSkipLabel);
+    DoFixedFunctionAlphaTest(m_module, alphaTestContext);
   }
 
 

--- a/src/d3d9/d3d9_fixed_function.h
+++ b/src/d3d9/d3d9_fixed_function.h
@@ -38,6 +38,12 @@ namespace dxvk {
     uint32_t SpecUBO;
   };
 
+  struct D3D9AlphaTestContext {
+    uint32_t alphaId;
+    uint32_t alphaFuncId;
+    uint32_t alphaRefId;
+  };
+
   struct D3D9FixedFunctionOptions {
     D3D9FixedFunctionOptions(const D3D9Options* options);
 
@@ -47,6 +53,8 @@ namespace dxvk {
   // Returns new oFog if VS
   // Returns new oColor if PS
   uint32_t DoFixedFunctionFog(D3D9ShaderSpecConstantManager& spec, SpirvModule& spvModule, const D3D9FogContext& fogCtx);
+
+  void DoFixedFunctionAlphaTest(SpirvModule& spvModule, const D3D9AlphaTestContext& ctx);
 
   // Returns a render state block
   uint32_t SetupRenderStateBlock(SpirvModule& spvModule, uint32_t count);

--- a/src/d3d9/d3d9_fixed_function.h
+++ b/src/d3d9/d3d9_fixed_function.h
@@ -40,6 +40,7 @@ namespace dxvk {
 
   struct D3D9AlphaTestContext {
     uint32_t alphaId;
+    uint32_t alphaPrecisionId;
     uint32_t alphaFuncId;
     uint32_t alphaRefId;
   };

--- a/src/d3d9/d3d9_options.cpp
+++ b/src/d3d9/d3d9_options.cpp
@@ -67,7 +67,6 @@ namespace dxvk {
     this->enumerateByDisplays           = config.getOption<bool>        ("d3d9.enumerateByDisplays",           true);
     this->longMad                       = config.getOption<bool>        ("d3d9.longMad",                       false);
     this->tearFree                      = config.getOption<Tristate>    ("d3d9.tearFree",                      Tristate::Auto);
-    this->alphaTestWiggleRoom           = config.getOption<bool>        ("d3d9.alphaTestWiggleRoom",           false);
     this->apitraceMode                  = config.getOption<bool>        ("d3d9.apitraceMode",                  false);
     this->deviceLocalConstantBuffers    = config.getOption<bool>        ("d3d9.deviceLocalConstantBuffers",    false);
     this->allowDirectBufferMapping      = config.getOption<bool>        ("d3d9.allowDirectBufferMapping",      true);

--- a/src/d3d9/d3d9_options.h
+++ b/src/d3d9/d3d9_options.h
@@ -135,10 +135,6 @@ namespace dxvk {
     /// Tearing mode if vsync is enabled
     Tristate tearFree;
 
-    /// Workaround for games using alpha test == 1.0, etc due to wonky interpolation or
-    /// misc. imprecision on some vendors
-    bool alphaTestWiggleRoom;
-
     /// Apitrace mode: Maps all buffers in cached memory.
     bool apitraceMode;
 

--- a/src/d3d9/d3d9_spec_constants.h
+++ b/src/d3d9/d3d9_spec_constants.h
@@ -22,6 +22,7 @@ namespace dxvk {
 
     SpecSamplerNull,        // 1 bit for 20 samplers          | Bits: 20
     SpecProjectionType,     // 1 bit for 6 PS 1.x samplers    | Bits: 6
+    SpecAlphaPrecisionBits, // Range: 0 -> 8 or 0xF           | Bits: 4
 
     SpecVertexShaderBools,  // 16 bools                       | Bits: 16
     SpecPixelShaderBools,   // 16 bools                       | Bits: 16
@@ -56,6 +57,7 @@ namespace dxvk {
 
       { 2, 0,  20 }, // SamplerNull
       { 2, 20, 6 },  // ProjectionType
+      { 2, 26, 4 },  // AlphaPrecisionBits
 
       { 3, 0,  16 }, // VertexShaderBools
       { 3, 16, 16 }, // PixelShaderBools

--- a/src/d3d9/d3d9_state.h
+++ b/src/d3d9/d3d9_state.h
@@ -36,7 +36,7 @@ namespace dxvk {
     float fogEnd     = 1.0f;
     float fogDensity = 1.0f;
 
-    float alphaRef   = 0.0f;
+    uint32_t alphaRef = 0u;
 
     float pointSize    = 1.0f;
     float pointSizeMin = 1.0f;

--- a/src/dxso/dxso_compiler.cpp
+++ b/src/dxso/dxso_compiler.cpp
@@ -3694,9 +3694,9 @@ void DxsoCompiler::emitControlFlowGenericLoop(
 
   
   void DxsoCompiler::emitPsProcessing() {
-    uint32_t boolType  = m_module.defBoolType();
     uint32_t floatType = m_module.defFloatType(32);
-    uint32_t floatPtr  = m_module.defPointerType(floatType, spv::StorageClassPushConstant);
+    uint32_t uintType  = m_module.defIntType(32, 0);
+    uint32_t uintPtr   = m_module.defPointerType(uintType, spv::StorageClassPushConstant);
     
     // Implement alpha test and fog
     DxsoRegister color0;
@@ -3712,8 +3712,9 @@ void DxsoCompiler::emitControlFlowGenericLoop(
 
       D3D9AlphaTestContext alphaTestContext;
       alphaTestContext.alphaFuncId = m_spec.get(m_module, m_specUbo, SpecAlphaCompareOp);
-      alphaTestContext.alphaRefId = m_module.opLoad(floatType,
-        m_module.opAccessChain(floatPtr, m_rsBlock, 1, &alphaRefMember));
+      alphaTestContext.alphaPrecisionId = m_spec.get(m_module, m_specUbo, SpecAlphaPrecisionBits);
+      alphaTestContext.alphaRefId = m_module.opLoad(uintType,
+        m_module.opAccessChain(uintPtr, m_rsBlock, 1, &alphaRefMember));
       alphaTestContext.alphaId = m_module.opCompositeExtract(floatType,
         m_module.opLoad(m_module.defVectorType(floatType, 4), oC0.id),
         1, &alphaComponentId);

--- a/src/dxso/dxso_options.cpp
+++ b/src/dxso/dxso_options.cpp
@@ -41,9 +41,6 @@ namespace dxvk {
     vertexFloatConstantBufferAsSSBO = pDevice->GetVertexConstantLayout().floatSize() > devInfo.core.properties.limits.maxUniformBufferRange;
 
     longMad = options.longMad;
-
-    alphaTestWiggleRoom = options.alphaTestWiggleRoom;
-
     robustness2Supported = devFeatures.extRobustness2.robustBufferAccess2;
   }
 

--- a/src/dxso/dxso_options.h
+++ b/src/dxso/dxso_options.h
@@ -51,10 +51,6 @@ namespace dxvk {
     /// don't match entirely to the regular vertex shader in this way.
     bool longMad;
 
-    /// Workaround for games using alpha test == 1.0, etc due to wonky interpolation or
-    /// misc. imprecision on some vendors
-    bool alphaTestWiggleRoom;
-
     /// Whether or not we can rely on robustness2 to handle oob constant access
     bool robustness2Supported;
   };

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -413,10 +413,6 @@ namespace dxvk {
     { R"(\\SpellForce2.*\.exe$)", {{
       { "d3d9.forceSamplerTypeSpecConstants", "True" },
     }} },
-    /* Everquest 2                                */
-    { R"(\\EverQuest2.*\.exe$)", {{
-      { "d3d9.alphaTestWiggleRoom", "True" },
-    }} },
     /* Tomb Raider: Legend                       */
     { R"(\\trl\.exe$)", {{
       { "d3d9.apitraceMode",                "True" },
@@ -574,11 +570,6 @@ namespace dxvk {
      * UI breaks at high fps                     */
     { R"(\\BGE\.exe$)", {{
       { "d3d9.maxFrameRate",                "60" },
-    }} },
-    /* Ninja Blade                              *
-     * Transparent main character on Nvidia     */
-    { R"(\\NinjaBlade\.exe$)", {{
-      { "d3d9.alphaTestWiggleRoom",       "True" },
     }} },
     /* YS Origin                                *
      * Helps very bad frametimes in some areas  */


### PR DESCRIPTION
In order to get rid of the `alphaTestWiggleRoom` option and have better behaviour out of the box without floating point math inaccuracies, we should pass in the alpha reference as an integer and quantize the `oC0` alpha value on the GPU.

This adjusts the alpha test precision based on the currently bound render target, which matches Nvidia's behaviour.