### PR TITLE
[dxvk] Add DXVK_DISABLE_EXTENSIONS variable 

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ The following environment variables can be used for **debugging** purposes.
 - `DXVK_LOG_PATH=/some/directory` Changes path where log files are stored. Set to `none` to disable log file creation entirely, without disabling logging.
 - `DXVK_CONFIG_FILE=/xxx/dxvk.conf` Sets path to the configuration file.
 - `DXVK_PERF_EVENTS=1` Enables use of the VK_EXT_debug_utils extension for translating performance event markers.
+- `DXVK_DISABLE_EXTENSIONS` A list of Vulkan extensions that DXVK should not use even if available.
 
 ## Troubleshooting
 DXVK requires threading support from your mingw-w64 build environment. If you

--- a/src/dxvk/dxvk_adapter.cpp
+++ b/src/dxvk/dxvk_adapter.cpp
@@ -335,6 +335,20 @@ namespace dxvk {
     
     // Enable additional extensions if necessary
     extensionsEnabled.merge(m_extraExtensions);
+
+    const auto& disableExtEnv = env::getEnvVar("DXVK_DISABLE_EXTENSIONS");
+
+      if (!disableExtEnv.empty()) {
+          for (const auto& extName : env::parseEnvValue(disableExtEnv)) {
+              auto result = std::find_if(devExtensionList.begin(), devExtensionList.end(), [&] (DxvkExt* ext) {
+                  return extName == ext->name();
+              });
+
+              if (result != devExtensionList.end())
+                  extensionsEnabled.disableExtension(**result);
+          }
+      }
+
     DxvkNameList extensionNameList = extensionsEnabled.toNameList();
 
     // Optionally used by some client API extensions

--- a/src/dxvk/dxvk_instance.cpp
+++ b/src/dxvk/dxvk_instance.cpp
@@ -115,6 +115,19 @@ namespace dxvk {
     for (const auto& provider : m_extProviders)
       extensionsEnabled.merge(provider->getInstanceExtensions());
 
+    const auto& disableExtEnv = env::getEnvVar("DXVK_DISABLE_EXTENSIONS");
+
+    if (!disableExtEnv.empty()) {
+        for (const auto& extName : env::parseEnvValue(disableExtEnv)) {
+            auto result = std::find_if(insExtensionList.begin(), insExtensionList.end(), [&] (DxvkExt* ext) {
+                return extName == ext->name();
+            });
+
+            if (result != insExtensionList.end())
+                extensionsEnabled.disableExtension(**result);
+        }
+    }
+
     DxvkNameList extensionNameList = extensionsEnabled.toNameList();
     
     Logger::info("Enabled instance extensions:");

--- a/src/util/util_env.cpp
+++ b/src/util/util_env.cpp
@@ -2,6 +2,7 @@
 #include <cstdlib>
 #include <filesystem>
 #include <numeric>
+#include <algorithm>
 
 #ifdef __linux__
 #include <unistd.h>
@@ -29,6 +30,19 @@ namespace dxvk::env {
 #endif
   }
 
+  std::vector<std::string> parseEnvValue(const std::string& env) {
+      std::vector<std::string> result {};
+
+      if (env.empty())
+          return result;
+
+      std::stringstream ss(env);
+      for (std::string str; std::getline(ss, str, ',');) {
+          str.erase(std::remove(str.begin(), str.end(), ' '), str.end());
+          result.push_back(str);
+      }
+      return result;
+  }
 
   size_t matchFileExtension(const std::string& name, const char* ext) {
     auto pos = name.find_last_of('.');

--- a/src/util/util_env.h
+++ b/src/util/util_env.h
@@ -27,6 +27,16 @@ namespace dxvk::env {
    * \returns Value of the variable
    */
   std::string getEnvVar(const char* name);
+
+  /**
+    * \brief Parses the value of environmental variable by comma
+    *
+    * If the variable is not defined, this
+    * will return an empty vector.
+    * \param [in] env Value of the variable
+    * \returns Parsed and packed the value of the variable into a vector
+    */
+  std::vector<std::string> parseEnvValue(const std::string& env);
   
   /**
    * \brief Checks whether a file name has a given extension


### PR DESCRIPTION
Added variable for disabling Vulkan extensions at runtime.
That's needed for debugging purposes.
Similar to `VKD3D_DISABLE_EXTENSIONS` in Vkd3d.