### PR TITLE
[d3d9] FF: Don't change flatShadingMask for outputs

### DIFF
--- a/src/d3d9/d3d9_fixed_function.cpp
+++ b/src/d3d9/d3d9_fixed_function.cpp
@@ -790,7 +790,7 @@ namespace dxvk {
     bool diffuseOrSpec = semantic == DxsoSemantic{ DxsoUsage::Color, 0 }
                       || semantic == DxsoSemantic{ DxsoUsage::Color, 1 };
 
-    if (diffuseOrSpec)
+    if (diffuseOrSpec && input)
       m_flatShadingMask |= 1u << slot;
 
     std::string name = str::format(input ? "in_" : "out_", semantic.usage, semantic.usageIndex);


### PR DESCRIPTION
Fixes #2818

Fun fact: older versions of DXVK would emit DecorationFlat for fragment shader outputs.