### PR TITLE
[util] Support for fps limiter on non-Windows platforms

### DIFF
--- a/src/util/util_fps_limiter.cpp
+++ b/src/util/util_fps_limiter.cpp
@@ -111,14 +111,7 @@ namespace dxvk {
     while (remaining > sleepThreshold) {
       TimerDuration sleepDuration = remaining - sleepThreshold;
 
-      if (NtDelayExecution) {
-        LARGE_INTEGER ticks;
-        ticks.QuadPart = -sleepDuration.count();
-
-        NtDelayExecution(FALSE, &ticks);
-      } else {
-        std::this_thread::sleep_for(sleepDuration);
-      }
+      performSleep(sleepDuration);
 
       t1 = dxvk::high_resolution_clock::now();
       remaining -= std::chrono::duration_cast<TimerDuration>(t1 - t0);
@@ -170,6 +163,18 @@ namespace dxvk {
     } else {
       // Assume 1ms sleep granularity by default
       m_sleepGranularity = TimerDuration(10000);
+    }
+  }
+
+
+  void FpsLimiter::performSleep(TimerDuration sleepDuration) {
+    if (NtDelayExecution) {
+      LARGE_INTEGER ticks;
+      ticks.QuadPart = -sleepDuration.count();
+
+      NtDelayExecution(FALSE, &ticks);
+    } else {
+      std::this_thread::sleep_for(sleepDuration);
     }
   }
 

--- a/src/util/util_fps_limiter.cpp
+++ b/src/util/util_fps_limiter.cpp
@@ -140,6 +140,7 @@ namespace dxvk {
 
 
   void FpsLimiter::updateSleepGranularity() {
+#ifdef _WIN32
     HMODULE ntdll = ::GetModuleHandleW(L"ntdll.dll");
 
     if (ntdll) {
@@ -166,10 +167,15 @@ namespace dxvk {
       // Assume 1ms sleep granularity by default
       m_sleepGranularity = TimerDuration(1ms);
     }
+#else
+    // Assume 0.5ms sleep granularity by default
+    m_sleepGranularity = TimerDuration(500us);
+#endif
   }
 
 
   void FpsLimiter::performSleep(TimerDuration sleepDuration) {
+#ifdef _WIN32
     if (NtDelayExecution) {
       LARGE_INTEGER ticks;
       ticks.QuadPart = -sleepDuration.count();
@@ -178,6 +184,9 @@ namespace dxvk {
     } else {
       std::this_thread::sleep_for(sleepDuration);
     }
+#else
+    std::this_thread::sleep_for(sleepDuration);
+#endif
   }
 
 }

--- a/src/util/util_fps_limiter.cpp
+++ b/src/util/util_fps_limiter.cpp
@@ -137,6 +137,14 @@ namespace dxvk {
 
 
   void FpsLimiter::initialize() {
+    updateSleepGranularity();
+    m_sleepThreshold = 4 * m_sleepGranularity;
+    m_lastFrame = dxvk::high_resolution_clock::now();
+    m_initialized = true;
+  }
+
+
+  void FpsLimiter::updateSleepGranularity() {
     HMODULE ntdll = ::GetModuleHandleW(L"ntdll.dll");
 
     if (ntdll) {
@@ -163,10 +171,6 @@ namespace dxvk {
       // Assume 1ms sleep granularity by default
       m_sleepGranularity = TimerDuration(10000);
     }
-
-    m_sleepThreshold = 4 * m_sleepGranularity;
-    m_lastFrame = dxvk::high_resolution_clock::now();
-    m_initialized = true;
   }
 
 }

--- a/src/util/util_fps_limiter.cpp
+++ b/src/util/util_fps_limiter.cpp
@@ -7,6 +7,8 @@
 
 #include "./log/log.h"
 
+using namespace std::chrono_literals;
+
 namespace dxvk {
   
   FpsLimiter::FpsLimiter() {
@@ -162,7 +164,7 @@ namespace dxvk {
       }
     } else {
       // Assume 1ms sleep granularity by default
-      m_sleepGranularity = TimerDuration(10000);
+      m_sleepGranularity = TimerDuration(1ms);
     }
   }
 

--- a/src/util/util_fps_limiter.h
+++ b/src/util/util_fps_limiter.h
@@ -86,6 +86,8 @@ namespace dxvk {
 
     void updateSleepGranularity();
 
+    void performSleep(TimerDuration sleepDuration);
+
   };
 
 }

--- a/src/util/util_fps_limiter.h
+++ b/src/util/util_fps_limiter.h
@@ -60,10 +60,17 @@ namespace dxvk {
 
     using TimePoint = dxvk::high_resolution_clock::time_point;
 
+#ifdef _WIN32
+    // On Windows, we use NtDelayExecution which has units of 100ns.
     using TimerDuration = std::chrono::duration<int64_t, std::ratio<1, 10000000>>;
     using NtQueryTimerResolutionProc = UINT (WINAPI *) (ULONG*, ULONG*, ULONG*);
     using NtSetTimerResolutionProc = UINT (WINAPI *) (ULONG, BOOL, ULONG*);
     using NtDelayExecutionProc = UINT (WINAPI *) (BOOL, LARGE_INTEGER*);
+    NtDelayExecutionProc NtDelayExecution = nullptr;
+#else
+    // On other platforms, we use the std library, which calls through to nanosleep -- which is ns.
+    using TimerDuration = std::chrono::nanoseconds;
+#endif
 
     dxvk::mutex     m_mutex;
 
@@ -77,8 +84,6 @@ namespace dxvk {
 
     TimerDuration   m_sleepGranularity = TimerDuration::zero();
     TimerDuration   m_sleepThreshold   = TimerDuration::zero();
-
-    NtDelayExecutionProc NtDelayExecution = nullptr;
 
     TimePoint sleep(TimePoint t0, TimerDuration duration);
 

--- a/src/util/util_fps_limiter.h
+++ b/src/util/util_fps_limiter.h
@@ -53,34 +53,34 @@ namespace dxvk {
      * \returns \c true if the target frame rate is non-zero.
      */
     bool isEnabled() const {
-      return m_targetInterval != NtTimerDuration::zero();
+      return m_targetInterval != TimerDuration::zero();
     }
 
   private:
 
     using TimePoint = dxvk::high_resolution_clock::time_point;
 
-    using NtTimerDuration = std::chrono::duration<int64_t, std::ratio<1, 10000000>>;
+    using TimerDuration = std::chrono::duration<int64_t, std::ratio<1, 10000000>>;
     using NtQueryTimerResolutionProc = UINT (WINAPI *) (ULONG*, ULONG*, ULONG*);
     using NtSetTimerResolutionProc = UINT (WINAPI *) (ULONG, BOOL, ULONG*);
     using NtDelayExecutionProc = UINT (WINAPI *) (BOOL, LARGE_INTEGER*);
 
     dxvk::mutex     m_mutex;
 
-    NtTimerDuration m_targetInterval  = NtTimerDuration::zero();
-    NtTimerDuration m_refreshInterval = NtTimerDuration::zero();
-    NtTimerDuration m_deviation       = NtTimerDuration::zero();
+    TimerDuration   m_targetInterval  = TimerDuration::zero();
+    TimerDuration   m_refreshInterval = TimerDuration::zero();
+    TimerDuration   m_deviation       = TimerDuration::zero();
     TimePoint       m_lastFrame;
 
     bool            m_initialized     = false;
     bool            m_envOverride     = false;
 
-    NtTimerDuration m_sleepGranularity = NtTimerDuration::zero();
-    NtTimerDuration m_sleepThreshold   = NtTimerDuration::zero();
+    TimerDuration   m_sleepGranularity = TimerDuration::zero();
+    TimerDuration   m_sleepThreshold   = TimerDuration::zero();
 
     NtDelayExecutionProc NtDelayExecution = nullptr;
 
-    TimePoint sleep(TimePoint t0, NtTimerDuration duration);
+    TimePoint sleep(TimePoint t0, TimerDuration duration);
 
     void initialize();
 

--- a/src/util/util_fps_limiter.h
+++ b/src/util/util_fps_limiter.h
@@ -84,6 +84,8 @@ namespace dxvk {
 
     void initialize();
 
+    void updateSleepGranularity();
+
   };
 
 }


### PR DESCRIPTION
Defaults to a sleep granularity of 0.5ms, which is slightly on the cautious side.

Calls through to std::this_thread::sleep_for directly, which calls through to nanosleep.