### PR TITLE
Introduce array_of helper to make dealing with std::arrays easier

### DIFF
--- a/src/dxvk/dxvk_adapter.cpp
+++ b/src/dxvk/dxvk_adapter.cpp
@@ -5,6 +5,8 @@
 #include "dxvk_device.h"
 #include "dxvk_instance.h"
 
+#include "../util/util_array.h"
+
 namespace dxvk {
   
   DxvkAdapter::DxvkAdapter(
@@ -285,7 +287,7 @@ namespace dxvk {
           DxvkDeviceFeatures  enabledFeatures) {
     DxvkDeviceExtensions devExtensions;
 
-    std::array<DxvkExt*, 22> devExtensionList = {{
+    auto devExtensionList = array_of<DxvkExt*>(
       &devExtensions.amdMemoryOverallocationBehaviour,
       &devExtensions.amdShaderFragmentMask,
       &devExtensions.extAttachmentFeedbackLoopLayout,
@@ -307,8 +309,8 @@ namespace dxvk {
       &devExtensions.khrPipelineLibrary,
       &devExtensions.khrSwapchain,
       &devExtensions.nvxBinaryImport,
-      &devExtensions.nvxImageViewHandle,
-    }};
+      &devExtensions.nvxImageViewHandle
+    );
 
     // Only enable Cuda interop extensions in 64-bit builds in
     // order to avoid potential driver or address space issues.

--- a/src/util/util_array.h
+++ b/src/util/util_array.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <array>
+#include <utility>
+
+namespace dxvk {
+
+  template <typename V, typename... T>
+  constexpr std::array<V, sizeof...(T)> array_of(T&&... t) {
+    return {{ std::forward<T>(t)... }};
+  }
+
+}


### PR DESCRIPTION
Uses this for the devExtensionList, as this will be getting ifdefs in future, and we need the size to be dynamic.