### PR TITLE
Add DXVK profiles to express Vulkan requirements

### DIFF
--- a/VP_DXVK_requirements.json
+++ b/VP_DXVK_requirements.json
@@ -1,0 +1,585 @@
+{
+    "$schema": "https://schema.khronos.org/vulkan/profiles-0.8.0-224.json#",
+    "capabilities": {
+        "vulkan10requirements": {
+            "features": {
+                "VkPhysicalDeviceFeatures": {
+                    "robustBufferAccess": true
+                }
+            }
+        },
+        "vulkan11requirements": {
+            "features": {
+                "VkPhysicalDeviceVulkan11Features": {
+                    "multiview": true
+                }
+            },
+            "properties": {
+                "VkPhysicalDeviceVulkan11Properties": {
+                    "maxMultiviewViewCount": 6,
+                    "maxMultiviewInstanceIndex": 134217727
+                }
+            }
+        },
+        "vulkan12requirements": {
+            "features": {
+                "VkPhysicalDeviceVulkan12Features": {
+                    "uniformBufferStandardLayout": true,
+                    "subgroupBroadcastDynamicId": true,
+                    "imagelessFramebuffer": true,
+                    "separateDepthStencilLayouts": true,
+                    "hostQueryReset": true,
+                    "timelineSemaphore": true,
+                    "shaderSubgroupExtendedTypes": true
+                }
+            },
+            "properties": {
+                "VkPhysicalDeviceVulkan12Properties": {
+                    "maxTimelineSemaphoreValueDifference": 2147483647
+                }
+            }
+        },
+        "vulkan13requirements": {
+            "features": {
+                "VkPhysicalDeviceVulkan12Features": {
+                    "vulkanMemoryModel": true,
+                    "vulkanMemoryModelDeviceScope": true,
+                    "bufferDeviceAddress": true
+                },
+                "VkPhysicalDeviceVulkan13Features": {
+                    "robustImageAccess": true,
+                    "shaderTerminateInvocation": true,
+                    "shaderZeroInitializeWorkgroupMemory": true,
+                    "synchronization2": true,
+                    "shaderIntegerDotProduct": true,
+                    "maintenance4": true,
+                    "pipelineCreationCacheControl": true,
+                    "subgroupSizeControl": true,
+                    "computeFullSubgroups": true,
+                    "shaderDemoteToHelperInvocation": true,
+                    "inlineUniformBlock": true,
+                    "dynamicRendering": true
+                }
+            },
+            "properties": {
+                "VkPhysicalDeviceVulkan13Properties": {
+                    "maxBufferSize": 1073741824,
+                    "maxInlineUniformBlockSize": 256,
+                    "maxPerStageDescriptorInlineUniformBlocks": 4,
+                    "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": 4,
+                    "maxDescriptorSetInlineUniformBlocks": 4,
+                    "maxDescriptorSetUpdateAfterBindInlineUniformBlocks": 4,
+                    "maxInlineUniformTotalSize": 4
+                }
+            }
+        },
+        "d3d9_baseline": {
+            "extensions": {
+                "VK_EXT_robustness2": 1
+            },
+            "features": {
+                "VkPhysicalDeviceFeatures": {
+                    "geometryShader": true,
+                    "shaderStorageImageWriteWithoutFormat": true,
+                    "imageCubeArray": true,
+                    "depthClamp": true,
+                    "depthBiasClamp": true,
+                    "fillModeNonSolid": true,
+                    "sampleRateShading": true,
+                    "shaderClipDistance": true,
+                    "shaderCullDistance": true,
+                    "textureCompressionBC": true,
+                    "occlusionQueryPrecise": true,
+                    "independentBlend": true,
+                    "fullDrawIndexUint32": true,
+
+                    "shaderImageGatherExtended": true
+                },
+                "VkPhysicalDeviceVulkan12Features": {
+                    "samplerMirrorClampToEdge": true
+                },
+                "VkPhysicalDeviceRobustness2FeaturesEXT": {
+                    "nullDescriptor": true,
+                    "robustBufferAccess2": true
+                }
+            }
+        },
+        "d3d9_optional": {
+            "extensions": {
+                "VK_EXT_memory_priority": 1,
+                "VK_EXT_vertex_attribute_divisor": 1,
+                "VK_EXT_depth_clip_enable": 1,
+                "VK_EXT_custom_border_color": 1,
+                "VK_EXT_attachment_feedback_loop_layout": 1,
+                "VK_EXT_non_seamless_cube_map": 1
+            },
+            "features": {
+                "VkPhysicalDeviceFeatures": {
+                    "depthBounds": true,
+                    "vertexPipelineStoresAndAtomics": true,
+                    "pipelineStatisticsQuery": true,
+                    "samplerAnisotropy": true
+                },
+                "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+                    "memoryPriority": true
+                },
+                "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+                    "vertexAttributeInstanceRateDivisor": true,
+                    "vertexAttributeInstanceRateZeroDivisor": true
+                },
+                "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+                    "depthClipEnable": true
+                },
+                "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+                    "customBorderColors": true,
+                    "customBorderColorWithoutFormat": true,
+                },
+                "VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT": {
+                    "attachmentFeedbackLoopLayout": true
+                },
+                "VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT": {
+                    "nonSeamlessCubeMap": true
+                }
+            }
+        },
+        "d3d11_baseline": {
+            "extensions": {
+                "VK_EXT_robustness2": 1
+            },
+            "features": {
+                "VkPhysicalDeviceFeatures": {
+                	"geometryShader": true,
+                    "shaderStorageImageWriteWithoutFormat": true,
+                    "depthBounds": true,
+
+                    "imageCubeArray": true,
+                    "depthClamp": true,
+                    "depthBiasClamp": true,
+                    "fillModeNonSolid": true,
+                    "sampleRateShading": true,
+                    "shaderClipDistance": true,
+                    "shaderCullDistance": true,
+                    "textureCompressionBC": true,
+                    "occlusionQueryPrecise": true,
+                    "multiViewport": true,
+                    "independentBlend": true,
+                    "fullDrawIndexUint32": true,
+
+                    "shaderImageGatherExtended": true
+                },
+                "VkPhysicalDeviceVulkan11Features": {
+                    "shaderDrawParameters": true
+                },
+                "VkPhysicalDeviceVulkan12Features": {
+                    "samplerMirrorClampToEdge": true
+                },
+                "VkPhysicalDeviceRobustness2FeaturesEXT": {
+                    "nullDescriptor": true,
+                    "robustBufferAccess2": true
+                }
+            }
+        },
+        "d3d11_baseline_optional":{
+            "extensions": {
+                "VK_EXT_memory_priority": 1,
+                "VK_EXT_vertex_attribute_divisor": 1,
+                "VK_EXT_custom_border_color": 1
+            },
+            "features": {
+                "VkPhysicalDeviceFeatures": {
+                    "depthBounds": true
+                },
+                "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+                    "memoryPriority": true
+                },
+                "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+                    "vertexAttributeInstanceRateDivisor": true,
+                    "vertexAttributeInstanceRateZeroDivisor": true
+                },
+
+                "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+                    "customBorderColors": true,
+                    "customBorderColorWithoutFormat": true,
+                }
+            }
+        },
+        "d3d11_level9_1": {
+            "extensions": {
+                "VK_EXT_transform_feedback": 1,
+                "VK_EXT_depth_clip_enable": 1
+            },
+            "features": {
+                "VkPhysicalDeviceFeatures": {
+                    "depthClamp": true,
+                    "depthBiasClamp": true,
+                    "fillModeNonSolid": true,
+                    "sampleRateShading": true,
+                    "shaderClipDistance": true,
+                    "shaderCullDistance": true,
+                    "textureCompressionBC": true
+                },
+                "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+                    "depthClipEnable": true
+                },
+            }
+        },
+        "d3d11_level9_1_optional": {
+            "extensions": {
+                "VK_EXT_depth_clip_enable": 1
+            },
+            "features": {
+                "VkPhysicalDeviceFeatures": {
+                    "pipelineStatisticsQuery": true,
+                    "samplerAnisotropy": true
+                },
+                "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+                    "depthClipEnable": true
+                }
+            }
+        },
+        "d3d11_level9_2": {
+            "features": {
+                "VkPhysicalDeviceFeatures": {
+                    "occlusionQueryPrecise": true
+                }
+            }
+        },
+        "d3d11_level9_3": {
+            "features": {
+                "VkPhysicalDeviceFeatures": {
+                    "independentBlend": true,
+                    "multiViewport": true
+                }
+            }
+        },
+        "d3d11_level10_0": {
+            "extensions": {
+                "VK_EXT_transform_feedback": 1
+            },
+            "features": {
+                "VkPhysicalDeviceFeatures": {
+                    "fullDrawIndexUint32": true,
+                    "shaderImageGatherExtended": true
+                },
+                "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+                    "transformFeedback": true,
+                    "geometryStreams": true
+                }
+            }
+        },
+        "d3d11_level10_0_optional": {
+            "features": {
+                "VkPhysicalDeviceFeatures": {
+                    "logicOp": true,
+                    "variableMultisampleRate": true
+                }
+            }
+        },
+        "d3d11_level10_1": {
+            "features": {
+                "VkPhysicalDeviceFeatures": {
+                    "dualSrcBlend": true,
+                    "imageCubeArray": true
+                }
+            }
+        },
+        "d3d11_level11_0": {
+            "features": {
+                "VkPhysicalDeviceFeatures": {
+                    "drawIndirectFirstInstance": true,
+                    "fragmentStoresAndAtomics": true,
+                    "multiDrawIndirect": true,
+                    "tessellationShader": true
+                }
+            }
+        },
+        "d3d11_level11_0_optional": {
+            "features": {
+                "VkPhysicalDeviceFeatures": {
+                    "shaderFloat64": true,
+                    "shaderInt64": true,
+                    "shaderStorageImageReadWithoutFormat": true
+                }
+            }
+        },
+        "d3d11_level11_1": {
+            "features": {
+                "VkPhysicalDeviceFeatures": {
+                    "logicOp": true,
+                    "variableMultisampleRate": true,
+                    "vertexPipelineStoresAndAtomics": true
+                }
+            }
+        },
+        "d3d11_level12_0": {
+            "properties": {
+                "VkPhysicalDeviceProperties": {
+                    "sparseProperties": {
+                        "residencyStandard2DBlockShape": true,
+                        "residencyAlignedMipSize": true
+                    }
+                }
+            }
+        }
+    },
+    "profiles": {
+        "VP_DXVK_d3d9_baseline": {
+            "version": 1,
+            "api-version": "1.3.204",
+            "label": "DXVK D3D9 Baseline profile",
+            "description": "DXVK for D3D9 minimum requirements",
+            "contributors": {
+                "Philip Rebohle": {
+                    "company": "Valve"
+                },
+                "Joshua Ashton": {
+                    "company": "Valve"
+                },
+                "Pierre-Loup A. Griffais": {
+                    "company": "Valve"
+                },
+                "Georg Lehmann": {
+                    "company": "DXVK"
+                },
+                "Christophe Riccio": {
+                    "company": "LunarG"
+                }
+            },
+            "history": [
+                {
+                    "revision": 1,
+                    "date": "2022-08-22",
+                    "author": "Christophe Riccio",
+                    "comment": "Initial revision"
+                }
+            ],
+            "capabilities": [
+                "vulkan10requirements",
+                "vulkan11requirements",
+                "vulkan12requirements",
+                "vulkan13requirements",
+                "d3d9_baseline"
+            ]
+        },
+        "VP_DXVK_d3d9_optimal": {
+            "version": 1,
+            "api-version": "1.3.224",
+            "label": "DXVK D3D9 Optimal profile",
+            "description": "DXVK for D3D9 including optional capabilities",
+            "contributors": {
+                "Philip Rebohle": {
+                    "company": "Valve"
+                },
+                "Joshua Ashton": {
+                    "company": "Valve"
+                },
+                "Pierre-Loup A. Griffais": {
+                    "company": "Valve"
+                },
+                "Georg Lehmann": {
+                    "company": "DXVK"
+                },
+                "Christophe Riccio": {
+                    "company": "LunarG"
+                }
+            },
+            "history": [
+                {
+                    "revision": 1,
+                    "date": "2022-08-22",
+                    "author": "Christophe Riccio",
+                    "comment": "Initial revision"
+                }
+            ],
+            "capabilities": [
+                "vulkan10requirements",
+                "vulkan11requirements",
+                "vulkan12requirements",
+                "vulkan13requirements",
+                "d3d9_baseline",
+                "d3d9_optional"
+            ]
+        },
+        "VP_DXVK_d3d10_level_10_1_baseline": {
+            "version": 1,
+            "api-version": "1.3.204",
+            "label": "DXVK D3D10 Level 10.1 Baseline profile",
+            "description": "DXVK for D3D10 Feature Level 10.1 minimum requirements",
+            "contributors": {
+                "Philip Rebohle": {
+                    "company": "Valve"
+                },
+                "Joshua Ashton": {
+                    "company": "Valve"
+                },
+                "Pierre-Loup A. Griffais": {
+                    "company": "Valve"
+                },
+                "Georg Lehmann": {
+                    "company": "DXVK"
+                },
+                "Christophe Riccio": {
+                    "company": "LunarG"
+                }
+            },
+            "history": [
+                {
+                    "revision": 1,
+                    "date": "2022-08-22",
+                    "author": "Christophe Riccio",
+                    "comment": "Initial revision"
+                }
+            ],
+            "capabilities": [
+                "vulkan10requirements",
+                "vulkan11requirements",
+                "vulkan12requirements",
+                "vulkan13requirements",
+                "d3d11_baseline",
+                "d3d11_level9_1",
+                "d3d11_level9_2",
+                "d3d11_level9_3",
+                "d3d11_level10_0",
+                "d3d11_level10_1"
+            ]
+        },
+        "VP_DXVK_d3d11_level_11_0_baseline": {
+            "version": 1,
+            "api-version": "1.3.204",
+            "label": "DXVK D3D11 Level 11.0 Baseline profile",
+            "description": "DXVK for D3D11 Feature Level 11.0 minimum requirements",
+            "contributors": {
+                "Philip Rebohle": {
+                    "company": "Valve"
+                },
+                "Joshua Ashton": {
+                    "company": "Valve"
+                },
+                "Pierre-Loup A. Griffais": {
+                    "company": "Valve"
+                },
+                "Georg Lehmann": {
+                    "company": "DXVK"
+                },
+                "Christophe Riccio": {
+                    "company": "LunarG"
+                }
+            },
+            "history": [
+                {
+                    "revision": 1,
+                    "date": "2022-08-22",
+                    "author": "Christophe Riccio",
+                    "comment": "Initial revision"
+                }
+            ],
+            "capabilities": [
+                "vulkan10requirements",
+                "vulkan11requirements",
+                "vulkan12requirements",
+                "vulkan13requirements",
+                "d3d11_baseline",
+                "d3d11_level9_1",
+                "d3d11_level9_2",
+                "d3d11_level9_3",
+                "d3d11_level10_0",
+                "d3d11_level10_1",
+                "d3d11_level11_0"
+            ]
+        },
+        "VP_DXVK_d3d11_level_11_1_baseline": {
+            "version": 1,
+            "api-version": "1.3.204",
+            "label": "DXVK D3D11 Level 11.1 Baseline profile",
+            "description": "DXVK for D3D11 Feature Level 11.1 minimum requirements",
+            "contributors": {
+                "Philip Rebohle": {
+                    "company": "Valve"
+                },
+                "Joshua Ashton": {
+                    "company": "Valve"
+                },
+                "Pierre-Loup A. Griffais": {
+                    "company": "Valve"
+                },
+                "Georg Lehmann": {
+                    "company": "DXVK"
+                },
+                "Christophe Riccio": {
+                    "company": "LunarG"
+                }
+            },
+            "history": [
+                {
+                    "revision": 1,
+                    "date": "2022-08-22",
+                    "author": "Christophe Riccio",
+                    "comment": "Initial revision"
+                }
+            ],
+            "capabilities": [
+                "vulkan10requirements",
+                "vulkan11requirements",
+                "vulkan12requirements",
+                "vulkan13requirements",
+                "baseline",
+                "d3d11_level9_1",
+                "d3d11_level9_2",
+                "d3d11_level9_3",
+                "d3d11_level10_0",
+                "d3d11_level10_1",
+                "d3d11_level11_0",
+                "d3d11_level11_1"
+            ]
+        },
+        "VP_DXVK_d3d11_level_11_1_optimal": {
+            "version": 1,
+            "api-version": "1.3.204",
+            "label": "DXVK D3D11 Level 11.1 Optimal profile",
+            "description": "DXVK for D3D11 Feature Level 11.1 including optional capabilities",
+            "contributors": {
+                "Philip Rebohle": {
+                    "company": "Valve"
+                },
+                "Joshua Ashton": {
+                    "company": "Valve"
+                },
+                "Pierre-Loup A. Griffais": {
+                    "company": "Valve"
+                },
+                "Georg Lehmann": {
+                    "company": "DXVK"
+                },
+                "Christophe Riccio": {
+                    "company": "LunarG"
+                }
+            },
+            "history": [
+                {
+                    "revision": 1,
+                    "date": "2022-08-22",
+                    "author": "Christophe Riccio",
+                    "comment": "Initial revision"
+                }
+            ],
+            "capabilities": [
+                "vulkan10requirements",
+                "vulkan11requirements",
+                "vulkan12requirements",
+                "vulkan13requirements",
+                "d3d11_baseline",
+                "d3d11_baseline_optional",
+                "d3d11_level9_1",
+                "d3d11_level9_1_optional",
+                "d3d11_level9_2",
+                "d3d11_level9_3",
+                "d3d11_level10_0",
+                "d3d11_level10_0_optional",
+                "d3d11_level10_1",
+                "d3d11_level11_0",
+                "d3d11_level11_0_optional",
+                "d3d11_level11_1"
+            ]
+        }
+    }
+}


### PR DESCRIPTION
I created a Vulkan profiles JSON file to express DXVK minimum requirements for each D3D level. This JSON files are defined by Vulkan Profiles schemas avaiable [here](https://schema.khronos.org/vulkan/) and can be used as part of the Vulkan SDK Profiles Toolset. ([PDF](https://www.lunarg.com/wp-content/uploads/2022/03/The-Vulkan-Profiles-Toolset-Solution-FEB2022.pdf), [Presentation](https://www.lunarg.com/wp-content/uploads/2022/08/Vulkan-SDK-Tools-to-Use-and-Create-Vulkan-Profiles-AUG-SIGGRAPH-2022.pdf))

I based myself on https://github.com/doitsujin/dxvk/wiki/Driver-support but it would certainly be necessary to validate that my interpretation is correct.

This Vulkan profiles JSON file could help users of the project to track new requirements. For the case of IHVs, it will allows them to prioritize implementing new features and for ISVs it will help them to figure out the ecosystem of devices where the project versions could run.

Further use of this file could be to express future requirements by adding "roadmap" profiles or "optimal" profiles to express the requirement for the best level of performance with DXVK.

Finally, having these information baked into this file allows some level of automation to the users of the projects and make sure that each revision of the project comes the corresponding explicit set of Vulkan requirements.

I am creating this PR first for the purpose of discussion and evaluate whether you could be interested by such features.
