### PR TITLE
[d3d9] Re-bind framebuffer if RT hazards change

### DIFF
--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -6055,9 +6055,11 @@ namespace dxvk {
     if (unlikely(m_activeHazardsRT != 0))
       MarkRenderHazards();
 
-    if (unlikely((m_lastHazardsDS == 0) != (m_activeHazardsDS == 0))) {
+    if (unlikely((!m_lastHazardsDS) != (!m_activeHazardsDS))
+     || unlikely((!m_lastHazardsRT) != (!m_activeHazardsRT))) {
       m_flags.set(D3D9DeviceFlag::DirtyFramebuffer);
       m_lastHazardsDS = m_activeHazardsDS;
+      m_lastHazardsRT = m_activeHazardsRT;
     }
 
     for (uint32_t i = 0; i < caps::MaxStreams; i++) {

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -1261,6 +1261,7 @@ namespace dxvk {
     uint32_t                        m_fetch4        = 0;
 
     uint32_t                        m_lastHazardsDS = 0;
+    uint32_t                        m_lastHazardsRT = 0;
     uint32_t                        m_lastSamplerTypesFF = 0;
 
     D3D9SpecializationInfo          m_specInfo = D3D9SpecializationInfo();


### PR DESCRIPTION
Otherwise we never set the feedback loop bits in the backend.