### PR TITLE
[util] Limit King Of Fighters XIII to 60 FPS

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -571,6 +571,11 @@ namespace dxvk {
     { R"(\\BGE\.exe$)", {{
       { "d3d9.maxFrameRate",                "60" },
     }} },
+    /* King Of Fighters XIII                     *
+     * In-game speed increases on high FPS       */
+    { R"(\\kofxiii\.exe$)", {{
+      { "d3d9.maxFrameRate",                "60" },
+    }} },
     /* YS Origin                                *
      * Helps very bad frametimes in some areas  */
     { R"(\\yso_win\.exe$)", {{


### PR DESCRIPTION
Game speed is tied to FPS
fixes #2647