### PR TITLE
[d3d9] Fix crash when auto generating mip maps for unmappable textures

### DIFF
--- a/src/d3d9/d3d9_common_texture.h
+++ b/src/d3d9/d3d9_common_texture.h
@@ -153,7 +153,7 @@ namespace dxvk {
      */
     void* GetData(UINT Subresource);
 
-    const Rc<DxvkBuffer>& GetBuffer(UINT Subresource, bool Initialize);
+    const Rc<DxvkBuffer>& GetBuffer(UINT Subresource);
 
 
     DxvkBufferSliceHandle GetMappedSlice(UINT Subresource) {
@@ -466,6 +466,14 @@ namespace dxvk {
      */
     VkDeviceSize GetMipSize(UINT Subresource) const;
 
+    /**
+     * \brief Creates a buffer
+     * Creates mapping and staging buffers for a given subresource
+     * allocates new buffers if necessary
+     * \returns Whether an allocation happened
+     */
+    void CreateBufferSubresource(UINT Subresource, bool Initialize);
+
   private:
 
     D3D9DeviceEx*                 m_device;
@@ -543,14 +551,6 @@ namespace dxvk {
             UINT             Layer);
 
     /**
-     * \brief Creates a buffer
-     * Creates mapping and staging buffers for a given subresource
-     * allocates new buffers if necessary
-     * \returns Whether an allocation happened
-     */
-    void CreateBufferSubresource(UINT Subresource);
-
-    /**
      * \brief Creates buffers
      * Creates mapping and staging buffers for all subresources
      * allocates new buffers if necessary
@@ -559,7 +559,7 @@ namespace dxvk {
       // D3D9Initializer will handle clearing the buffers
       const uint32_t count = CountSubresources();
       for (uint32_t i = 0; i < count; i++)
-        CreateBufferSubresource(i);
+        CreateBufferSubresource(i, false);
     }
 
     void AllocData();

--- a/src/d3d9/d3d9_swapchain.cpp
+++ b/src/d3d9/d3d9_swapchain.cpp
@@ -180,7 +180,8 @@ namespace dxvk {
     VkExtent3D dstTexExtent = dstTexInfo->GetExtentMip(dst->GetMipLevel());
     VkExtent3D srcTexExtent = srcTexInfo->GetExtentMip(0);
 
-    Rc<DxvkBuffer> dstBuffer = dstTexInfo->GetBuffer(dst->GetSubresource(), dstTexExtent.width > srcTexExtent.width || dstTexExtent.height > srcTexExtent.height);
+    dstTexInfo->CreateBufferSubresource(dst->GetSubresource(), dstTexExtent.width > srcTexExtent.width || dstTexExtent.height > srcTexExtent.height);
+    Rc<DxvkBuffer> dstBuffer = dstTexInfo->GetBuffer(dst->GetSubresource());
     Rc<DxvkImage>  srcImage  = srcTexInfo->GetImage();
 
     if (srcImage->info().sampleCount != VK_SAMPLE_COUNT_1_BIT) {


### PR DESCRIPTION
Fixes #2837

Locking textures that had just generated mip maps could crash in the following scenario:

* retrieve the pointer from the memory mapped file locking data
* then realize that it needs to read back data written by the GPU
* lazily create a DXVKBuffer to do so and free the memory mapped file allocation
* the pointer is no longer valid => BOOM

This PR fixes that and makes it more explicit when we are actually creating a readback buffer for textures.