### PR TITLE
[util] Remove RE:REV2 and RE5 workarounds

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -504,8 +504,8 @@ namespace dxvk {
     { R"(\\BBCF\.exe$)", {{
       { "d3d9.floatEmulation",              "Strict" },
     }} },
-    /* Resident Evil games                      */
-    { R"(\\(rerev|rerev2|re0hd|bhd|re5dx9)\.exe$)", {{
+    /* Resident Evil games using MT Framework   */
+    { R"(\\(rerev|re0hd|bhd)\.exe$)", {{
       { "d3d9.allowDirectBufferMapping",                "False" },
     }} },
     /* Limbo                                    */


### PR DESCRIPTION
There's no real impact, it doesn't fix stuttering (for non-GPL drivers) and since GPL got merged this is not needed anymore.