### PR TITLE
[native] Add substitute Windows headers

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "include/native/directx"]
+	path = include/native/directx
+	url = https://github.com/Joshua-Ashton/mingw-directx-headers

--- a/include/native/windows/oaidl.h
+++ b/include/native/windows/oaidl.h
@@ -1,0 +1,3 @@
+#pragma once
+
+// Don't care.

--- a/include/native/windows/objbase.h
+++ b/include/native/windows/objbase.h
@@ -1,0 +1,3 @@
+#pragma once
+
+// Don't care.

--- a/include/native/windows/ocidl.h
+++ b/include/native/windows/ocidl.h
@@ -1,0 +1,3 @@
+#pragma once
+
+// Don't care.

--- a/include/native/windows/ole2.h
+++ b/include/native/windows/ole2.h
@@ -1,0 +1,3 @@
+#pragma once
+
+// Don't care.

--- a/include/native/windows/poppack.h
+++ b/include/native/windows/poppack.h
@@ -1,0 +1,8 @@
+/**
+ * This file has no copyright assigned and is placed in the Public Domain.
+ * This file is part of the mingw-w64 runtime package.
+ * No warranty is given; refer to the file DISCLAIMER.PD within this package.
+ */
+#if !(defined(lint) || defined(RC_INVOKED))
+#pragma pack(pop)
+#endif

--- a/include/native/windows/pshpack4.h
+++ b/include/native/windows/pshpack4.h
@@ -1,0 +1,8 @@
+/**
+ * This file has no copyright assigned and is placed in the Public Domain.
+ * This file is part of the mingw-w64 runtime package.
+ * No warranty is given; refer to the file DISCLAIMER.PD within this package.
+ */
+#if !(defined(lint) || defined(RC_INVOKED))
+#pragma pack(push,4)
+#endif

--- a/include/native/windows/rpc.h
+++ b/include/native/windows/rpc.h
@@ -1,0 +1,3 @@
+#pragma once
+
+// Don't care.

--- a/include/native/windows/rpcndr.h
+++ b/include/native/windows/rpcndr.h
@@ -1,0 +1,3 @@
+#pragma once
+
+// Don't care.

--- a/include/native/windows/unknwn.h
+++ b/include/native/windows/unknwn.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include "windows_base.h"
+
+typedef interface IUnknown IUnknown;
+
+DEFINE_GUID(IID_IUnknown, 0x00000000,0x0000,0x0000,0xC0,0x00,0x00,0x00,0x00,0x00,0x00,0x46)
+
+#ifdef __cplusplus
+struct IUnknown {
+
+public:
+
+  virtual HRESULT QueryInterface(REFIID riid, void** ppvObject) = 0;
+
+  virtual ULONG AddRef()  = 0;
+  virtual ULONG Release() = 0;
+
+};
+#else
+typedef struct IUnknownVtbl
+{
+BEGIN_INTERFACE
+
+  HRESULT (STDMETHODCALLTYPE *QueryInterface)(
+    IUnknown *This,
+    REFIID riid,
+    void **ppvObject
+  );
+  ULONG (STDMETHODCALLTYPE *AddRef)(IUnknown *This);
+  ULONG (STDMETHODCALLTYPE *Release)(IUnknown *This);
+
+END_INTERFACE
+} IUnknownVtbl;
+
+interface IUnknown
+{
+    CONST_VTBL struct IUnknownVtbl *lpVtbl;
+};
+
+#define IUnknown_AddRef(This) ((This)->lpVtbl->AddRef(This))
+#define IUnknown_Release(This) ((This)->lpVtbl->Release(This))
+
+#endif // __cplusplus
+
+DECLARE_UUIDOF_HELPER(IUnknown, 0x00000000,0x0000,0x0000,0xC0,0x00,0x00,0x00,0x00,0x00,0x00,0x46)
+
+#define IID_PPV_ARGS(ppType) __uuidof(decltype(**(ppType))), [](auto** pp) { (void)static_cast<IUnknown*>(*pp); return reinterpret_cast<void**>(pp); }(ppType)

--- a/include/native/windows/windows.h
+++ b/include/native/windows/windows.h
@@ -1,0 +1,4 @@
+#pragma once
+
+#include "windows_base.h"
+#include "unknwn.h"

--- a/include/native/windows/windows_base.h
+++ b/include/native/windows/windows_base.h
@@ -1,0 +1,314 @@
+#pragma once
+
+#ifdef __cplusplus
+#include <cstdint>
+#include <cstring>
+#else
+#include <stdint.h>
+#include <string.h>
+#include <wchar.h>
+#endif // __cplusplus
+
+// GCC complains about the COM interfaces
+// not having virtual destructors
+
+// and class conversion for C...DESC helper types
+#if defined(__GNUC__) && defined(__cplusplus)
+#pragma GCC diagnostic ignored "-Wnon-virtual-dtor"
+#pragma GCC diagnostic ignored "-Wclass-conversion"
+#endif // __GNUC__ && __cplusplus
+
+typedef int32_t INT;
+typedef uint32_t UINT;
+
+typedef int32_t LONG;
+typedef uint32_t ULONG;
+
+typedef int32_t HRESULT;
+
+typedef wchar_t WCHAR;
+
+typedef INT BOOL;
+typedef BOOL WINBOOL;
+
+typedef uint16_t UINT16;
+typedef uint32_t UINT32;
+typedef uint64_t UINT64;
+typedef void VOID;
+typedef void* LPVOID;
+typedef const void* LPCVOID;
+
+typedef size_t SIZE_T;
+
+typedef uint8_t UINT8;
+typedef uint8_t BYTE;
+
+typedef int16_t SHORT;
+typedef uint16_t USHORT;
+
+typedef int64_t LONGLONG;
+typedef uint64_t ULONGLONG;
+
+typedef float FLOAT;
+
+#ifndef GUID_DEFINED
+#define GUID_DEFINED
+typedef struct GUID {
+  uint32_t Data1;
+  uint16_t Data2;
+  uint16_t Data3;
+  uint8_t  Data4[8];
+} GUID;
+#endif // GUID_DEFINED
+
+typedef GUID UUID;
+typedef GUID IID;
+#ifdef __cplusplus
+#define REFIID const IID&
+#define REFGUID const GUID&
+#else
+#define REFIID const IID*
+#define REFGUID const GUID*
+#endif // __cplusplus
+
+#ifdef __cplusplus
+
+template <typename T>
+constexpr GUID __uuidof_helper();
+
+#define __uuidof(T) __uuidof_helper<T>()
+#define __uuidof_var(T) __uuidof_helper<decltype(T)>()
+
+inline bool operator==(const GUID& a, const GUID& b) { return std::memcmp(&a, &b, sizeof(GUID)) == 0; }
+inline bool operator!=(const GUID& a, const GUID& b) { return std::memcmp(&a, &b, sizeof(GUID)) != 0; }
+
+#endif // __cplusplus
+
+typedef uint32_t DWORD;
+typedef uint16_t WORD;
+
+typedef void* HANDLE;
+typedef HANDLE HMONITOR;
+typedef HANDLE HDC;
+typedef HANDLE HMODULE;
+typedef HANDLE HINSTANCE;
+typedef HANDLE HWND;
+typedef HANDLE HKEY;
+typedef DWORD COLORREF;
+
+typedef char* LPSTR;
+typedef const char* LPCSTR;
+typedef const wchar_t* LPCWSTR;
+
+typedef struct LUID {
+  DWORD LowPart;
+  LONG  HighPart;
+} LUID;
+
+typedef struct POINT {
+  LONG x;
+  LONG y;
+} POINT;
+
+typedef POINT* LPPOINT;
+
+typedef struct RECT {
+  LONG left;
+  LONG top;
+  LONG right;
+  LONG bottom;
+} RECT;
+
+typedef struct SIZE {
+  LONG cx;
+  LONG cy;
+} SIZE;
+
+typedef union {
+  struct {
+    DWORD LowPart;
+    LONG HighPart;
+  };
+
+  struct {
+    DWORD LowPart;
+    LONG HighPart;
+  } u;
+
+  LONGLONG QuadPart;
+} LARGE_INTEGER;
+
+typedef struct MEMORYSTATUS {
+  DWORD  dwLength;
+  SIZE_T dwTotalPhys;
+} MEMORYSTATUS;
+
+typedef struct SECURITY_ATTRIBUTES {
+  DWORD nLength;
+  void* lpSecurityDescriptor;
+  BOOL  bInheritHandle;
+} SECURITY_ATTRIBUTES;
+
+typedef struct PALETTEENTRY {
+  BYTE peRed;
+  BYTE peGreen;
+  BYTE peBlue;
+  BYTE peFlags;
+} PALETTEENTRY;
+
+typedef struct RGNDATAHEADER {
+  DWORD dwSize;
+  DWORD iType;
+  DWORD nCount;
+  DWORD nRgnSize;
+  RECT  rcBound;
+} RGNDATAHEADER;
+
+typedef struct RGNDATA {
+  RGNDATAHEADER rdh;
+  char          Buffer[1];
+} RGNDATA;
+
+// Ignore these.
+#define STDMETHODCALLTYPE
+#define __stdcall
+
+#define CONST const
+#define CONST_VTBL const
+
+#define TRUE 1
+#define FALSE 0
+
+#define interface struct
+#define MIDL_INTERFACE(x) struct
+
+#ifdef __cplusplus
+
+#define DEFINE_GUID(iid, a, b, c, d, e, f, g, h, i, j, k) \
+  constexpr GUID iid = {a,b,c,{d,e,f,g,h,i,j,k}};
+
+#define DECLARE_UUIDOF_HELPER(type, a, b, c, d, e, f, g, h, i, j, k) \
+  extern "C++" { template <> constexpr GUID __uuidof_helper<type>() { return GUID{a,b,c,{d,e,f,g,h,i,j,k}}; } } \
+  extern "C++" { template <> constexpr GUID __uuidof_helper<type*>() { return __uuidof_helper<type>(); } } \
+  extern "C++" { template <> constexpr GUID __uuidof_helper<const type*>() { return __uuidof_helper<type>(); } } \
+  extern "C++" { template <> constexpr GUID __uuidof_helper<type&>() { return __uuidof_helper<type>(); } } \
+  extern "C++" { template <> constexpr GUID __uuidof_helper<const type&>() { return __uuidof_helper<type>(); } }
+
+#else
+#define DEFINE_GUID(iid, a, b, c, d, e, f, g, h, i, j, k) \
+  static const GUID iid = {a,b,c,{d,e,f,g,h,i,j,k}};
+#define DECLARE_UUIDOF_HELPER(type, a, b, c, d, e, f, g, h, i, j, k)
+#endif // __cplusplus
+
+#define __CRT_UUID_DECL(type, a, b, c, d, e, f, g, h, i, j, k) DECLARE_UUIDOF_HELPER(type, a, b, c, d, e, f, g, h, i, j, k)
+
+#define S_OK     0
+#define S_FALSE  1
+
+#define E_INVALIDARG  ((HRESULT)0x80070057)
+#define E_FAIL        ((HRESULT)0x80004005)
+#define E_NOINTERFACE ((HRESULT)0x80004002)
+#define E_NOTIMPL     ((HRESULT)0x80004001)
+#define E_OUTOFMEMORY ((HRESULT)0x8007000E)
+#define E_POINTER     ((HRESULT)0x80004003)
+
+#define DXGI_STATUS_OCCLUDED                     ((HRESULT)0x087a0001)
+#define DXGI_STATUS_CLIPPED                      ((HRESULT)0x087a0002)
+#define DXGI_STATUS_NO_REDIRECTION               ((HRESULT)0x087a0004)
+#define DXGI_STATUS_NO_DESKTOP_ACCESS            ((HRESULT)0x087a0005)
+#define DXGI_STATUS_GRAPHICS_VIDPN_SOURCE_IN_USE ((HRESULT)0x087a0006)
+#define DXGI_STATUS_MODE_CHANGED                 ((HRESULT)0x087a0007)
+#define DXGI_STATUS_MODE_CHANGE_IN_PROGRESS      ((HRESULT)0x087a0008)
+#define DXGI_STATUS_UNOCCLUDED                   ((HRESULT)0x087a0009)
+#define DXGI_STATUS_DDA_WAS_STILL_DRAWING        ((HRESULT)0x087a000a)
+#define DXGI_STATUS_PRESENT_REQUIRED             ((HRESULT)0x087a002f)
+
+#define DXGI_ERROR_INVALID_CALL                  ((HRESULT)0x887A0001)
+#define DXGI_ERROR_NOT_FOUND                     ((HRESULT)0x887A0002)
+#define DXGI_ERROR_MORE_DATA                     ((HRESULT)0x887A0003)
+#define DXGI_ERROR_UNSUPPORTED                   ((HRESULT)0x887A0004)
+#define DXGI_ERROR_DEVICE_REMOVED                ((HRESULT)0x887A0005)
+#define DXGI_ERROR_DEVICE_HUNG                   ((HRESULT)0x887A0006)
+#define DXGI_ERROR_DEVICE_RESET                  ((HRESULT)0x887A0007)
+#define DXGI_ERROR_WAS_STILL_DRAWING             ((HRESULT)0x887A000A)
+#define DXGI_ERROR_FRAME_STATISTICS_DISJOINT     ((HRESULT)0x887A000B)
+#define DXGI_ERROR_GRAPHICS_VIDPN_SOURCE_IN_USE  ((HRESULT)0x887A000C)
+#define DXGI_ERROR_DRIVER_INTERNAL_ERROR         ((HRESULT)0x887A0020)
+#define DXGI_ERROR_NONEXCLUSIVE                  ((HRESULT)0x887A0021)
+#define DXGI_ERROR_NOT_CURRENTLY_AVAILABLE       ((HRESULT)0x887A0022)
+#define DXGI_ERROR_REMOTE_CLIENT_DISCONNECTED    ((HRESULT)0x887A0023)
+#define DXGI_ERROR_REMOTE_OUTOFMEMORY            ((HRESULT)0x887A0024)
+#define DXGI_ERROR_ACCESS_LOST                   ((HRESULT)0x887A0026)
+#define DXGI_ERROR_WAIT_TIMEOUT                  ((HRESULT)0x887A0027)
+#define DXGI_ERROR_SESSION_DISCONNECTED          ((HRESULT)0x887A0028)
+#define DXGI_ERROR_RESTRICT_TO_OUTPUT_STALE      ((HRESULT)0x887A0029)
+#define DXGI_ERROR_CANNOT_PROTECT_CONTENT        ((HRESULT)0x887A002A)
+#define DXGI_ERROR_ACCESS_DENIED                 ((HRESULT)0x887A002B)
+#define DXGI_ERROR_NAME_ALREADY_EXISTS           ((HRESULT)0x887A002C)
+#define DXGI_ERROR_SDK_COMPONENT_MISSING         ((HRESULT)0x887A002D)
+
+#define WINAPI
+#define WINUSERAPI
+
+#define RGB(r,g,b)          ((COLORREF)(((BYTE)(r)|((WORD)((BYTE)(g))<<8))|(((DWORD)(BYTE)(b))<<16)))
+
+#define MAKE_HRESULT(sev,fac,code) \
+    ((HRESULT) (((unsigned long)(sev)<<31) | ((unsigned long)(fac)<<16) | ((unsigned long)(code))) )
+
+#ifdef __cplusplus
+#define STDMETHOD(name) virtual HRESULT name
+#define STDMETHOD_(type, name) virtual type name
+#else
+#define STDMETHOD(name) HRESULT (STDMETHODCALLTYPE *name)
+#define STDMETHOD_(type, name) type (STDMETHODCALLTYPE *name)
+#endif // __cplusplus
+
+#define THIS_
+#define THIS
+
+#define __C89_NAMELESSUNIONNAME
+#define __C89_NAMELESSUNIONNAME1
+#define __C89_NAMELESSUNIONNAME2
+#define __C89_NAMELESSUNIONNAME3
+#define __C89_NAMELESSUNIONNAME4
+#define __C89_NAMELESSUNIONNAME5
+#define __C89_NAMELESSUNIONNAME6
+#define __C89_NAMELESSUNIONNAME7
+#define __C89_NAMELESSUNIONNAME8
+#define __C89_NAMELESS
+#define DUMMYUNIONNAME
+#define DUMMYSTRUCTNAME
+
+#ifdef __cplusplus
+#define DECLARE_INTERFACE(x)     struct x
+#define DECLARE_INTERFACE_(x, y) struct x : public y
+#else
+#define DECLARE_INTERFACE(x) \
+    typedef interface x { \
+        const struct x##Vtbl *lpVtbl; \
+    } x; \
+    typedef const struct x##Vtbl x##Vtbl; \
+    const struct x##Vtbl
+#define DECLARE_INTERFACE_(x, y) DECLARE_INTERFACE(x)
+#endif // __cplusplus
+
+#define BEGIN_INTERFACE
+#define END_INTERFACE
+
+#ifdef __cplusplus
+#define PURE = 0
+#else
+#define PURE
+#endif // __cplusplus
+
+#define DECLSPEC_SELECTANY
+
+#define __MSABI_LONG(x) x
+
+#define ENUM_CURRENT_SETTINGS ((DWORD)-1)
+#define ENUM_REGISTRY_SETTINGS ((DWORD)-2)
+
+#define INVALID_HANDLE_VALUE ((HANDLE)-1)
+
+#define FAILED(hr) ((HRESULT)(hr) < 0)
+#define SUCCEEDED(hr) ((HRESULT)(hr) >= 0)

--- a/include/native/wsi/native_sdl2.h
+++ b/include/native/wsi/native_sdl2.h
@@ -1,0 +1,25 @@
+#include <windows.h>
+
+#include <SDL2/SDL.h>
+
+namespace dxvk::wsi {
+
+  inline SDL_Window* fromHwnd(HWND hWindow) {
+    return reinterpret_cast<SDL_Window*>(hWindow);
+  }
+
+  inline HWND toHwnd(SDL_Window* pWindow) {
+    return reinterpret_cast<HWND>(pWindow);
+  }
+
+  // Offset so null HMONITORs go to -1
+  inline int32_t fromHmonitor(HMONITOR hMonitor) {
+    return static_cast<int32_t>(reinterpret_cast<intptr_t>(hMonitor)) - 1;
+  }
+
+  // Offset so -1 display id goes to 0 == NULL
+  inline HMONITOR toHmonitor(int32_t displayId) {
+    return reinterpret_cast<HMONITOR>(static_cast<intptr_t>(displayId + 1));
+  }
+
+}

--- a/include/native/wsi/native_wsi.h
+++ b/include/native/wsi/native_wsi.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#ifdef DXVK_WSI_WIN32
+#error You shouldnt be using this code path.
+#elif DXVK_WSI_SDL2
+#include "wsi/native_sdl2.h"
+#else
+#error Unknown wsi!
+#endif

--- a/src/vulkan/vulkan_loader.h
+++ b/src/vulkan/vulkan_loader.h
@@ -3,9 +3,7 @@
 #include "../util/rc/util_rc.h"
 #include "../util/rc/util_rc_ptr.h"
 
-#ifdef _WIN32
 #define VK_USE_PLATFORM_WIN32_KHR 1
-#endif
 #include <vulkan/vulkan.h>
 
 #define VULKAN_FN(name) \


### PR DESCRIPTION
Adds substutite Windows + DirectX headers for use when building DXVK natively for Linux