### PR TITLE
[util] Fix strlcpy compiler warning

### DIFF
--- a/src/util/util_string.h
+++ b/src/util/util_string.h
@@ -205,9 +205,10 @@ namespace dxvk::str {
   }
 
   inline void strlcpy(char* dst, const char* src, size_t count) {
-    std::strncpy(dst, src, count);
-    if (count > 0)
+    if (count > 0) {
+      std::strncpy(dst, src, count - 1);
       dst[count - 1] = '\0';
+    }
   }
   
 }


### PR DESCRIPTION
GCC complains when using strncpy(..., 32) on a 32-byte array.