### PR TITLE
[util] Rename always_inline to force_inline

### DIFF
--- a/src/util/rc/util_rc.h
+++ b/src/util/rc/util_rc.h
@@ -17,7 +17,7 @@ namespace dxvk {
      * \brief Increments reference count
      * \returns New reference count
      */
-    always_inline uint32_t incRef() {
+    force_inline uint32_t incRef() {
       return ++m_refCount;
     }
     
@@ -25,7 +25,7 @@ namespace dxvk {
      * \brief Decrements reference count
      * \returns New reference count
      */
-    always_inline uint32_t decRef() {
+    force_inline uint32_t decRef() {
       return --m_refCount;
     }
     

--- a/src/util/rc/util_rc_ptr.h
+++ b/src/util/rc/util_rc_ptr.h
@@ -102,12 +102,12 @@ namespace dxvk {
     
     T* m_object = nullptr;
     
-    always_inline void incRef() const {
+    force_inline void incRef() const {
       if (m_object != nullptr)
         m_object->incRef();
     }
     
-    always_inline void decRef() const {
+    force_inline void decRef() const {
       if (m_object != nullptr) {
         if (m_object->decRef() == 0)
           delete m_object;

--- a/src/util/util_likely.h
+++ b/src/util/util_likely.h
@@ -3,9 +3,9 @@
 #ifdef __GNUC__
 #define likely(x)   __builtin_expect((x),1)
 #define unlikely(x) __builtin_expect((x),0)
-#define always_inline inline __attribute__((always_inline))
+#define force_inline inline __attribute__((always_inline))
 #else
 #define likely(x)   (x)
 #define unlikely(x) (x)
-#define always_inline inline
+#define force_inline inline
 #endif


### PR DESCRIPTION
This conflicts with other libraries using the always_inline attribute in GCC as it defines it with the same name.