### PR TITLE
[vulkan] Toss obsolete fullscreen exclusive hack

### DIFF
--- a/src/vulkan/vulkan_presenter.cpp
+++ b/src/vulkan/vulkan_presenter.cpp
@@ -13,14 +13,6 @@ namespace dxvk::vk {
           PresenterDevice device,
     const PresenterDesc&  desc)
   : m_vki(vki), m_vkd(vkd), m_device(device), m_window(window) {
-    // As of Wine 5.9, winevulkan provides this extension, but does
-    // not filter the pNext chain for VkSwapchainCreateInfoKHR properly
-    // before passing it to the Linux sude, which breaks RenderDoc.
-    if (m_device.features.fullScreenExclusive && ::GetModuleHandle("winevulkan.dll")) {
-      Logger::warn("winevulkan detected, disabling exclusive fullscreen support");
-      m_device.features.fullScreenExclusive = false;
-    }
-
     if (createSurface() != VK_SUCCESS)
       throw DxvkError("Failed to create surface");
 


### PR DESCRIPTION
Wine never had support for VK_EXT_exclusive_fullscreen and Proton since dropped support for it now that Doom External does not require it.