### PR TITLE
[dxgi, d3d9] Don't declspec dllexport on MinGW builds

### DIFF
--- a/src/d3d9/d3d9_include.h
+++ b/src/d3d9/d3d9_include.h
@@ -11,7 +11,7 @@
 #include <d3d9.h>
 
 //for some reason we need to specify __declspec(dllexport) for MinGW
-#if defined(__WINE__)
+#if defined(__WINE__) || !defined(_WIN32)
 #define DLLEXPORT __attribute__((visibility("default")))
 #else
 #define DLLEXPORT

--- a/src/dxgi/dxgi_include.h
+++ b/src/dxgi/dxgi_include.h
@@ -1,7 +1,7 @@
 #pragma once
 
 //for some reason we need to specify __declspec(dllexport) for MinGW
-#if defined(__WINE__)
+#if defined(__WINE__) || !defined(_WIN32)
 #define DLLEXPORT __attribute__((visibility("default")))
 #else
 #define DLLEXPORT

--- a/src/dxgi/dxgi_include.h
+++ b/src/dxgi/dxgi_include.h
@@ -2,11 +2,9 @@
 
 //for some reason we need to specify __declspec(dllexport) for MinGW
 #if defined(__WINE__)
-  #define DLLEXPORT __attribute__((visibility("default")))
-#elif defined(_MSC_VER)
-  #define DLLEXPORT
+#define DLLEXPORT __attribute__((visibility("default")))
 #else
-  #define DLLEXPORT __declspec(dllexport)
+#define DLLEXPORT
 #endif
 
 #include "../util/com/com_guid.h"


### PR DESCRIPTION
Also has a fix for 32-bit ordinals that got missed, but was in D3D9 for a long time.