### PR TITLE
[util] Add win32 compat header

### DIFF
--- a/src/d3d11/d3d11_annotation.cpp
+++ b/src/d3d11/d3d11_annotation.cpp
@@ -4,6 +4,7 @@
 #include "d3d11_device.h"
 
 #include "../util/util_misc.h"
+#include "../util/util_win32_compat.h"
 
 namespace dxvk {
 

--- a/src/d3d11/d3d11_context_imm.cpp
+++ b/src/d3d11/d3d11_context_imm.cpp
@@ -4,6 +4,8 @@
 #include "d3d11_fence.h"
 #include "d3d11_texture.h"
 
+#include "../util/util_win32_compat.h"
+
 constexpr static uint32_t MinFlushIntervalUs = 750;
 constexpr static uint32_t IncFlushIntervalUs = 250;
 constexpr static uint32_t MaxPendingSubmits  = 6;

--- a/src/d3d11/d3d11_fence.cpp
+++ b/src/d3d11/d3d11_fence.cpp
@@ -1,5 +1,6 @@
 #include "d3d11_fence.h"
 #include "d3d11_device.h"
+#include "../util/util_win32_compat.h"
 
 namespace dxvk {
   

--- a/src/d3d11/d3d11_gdi.cpp
+++ b/src/d3d11/d3d11_gdi.cpp
@@ -3,6 +3,7 @@
 #include "d3d11_gdi.h"
 
 #include "../util/util_gdi.h"
+#include "../util/util_win32_compat.h"
 
 namespace dxvk {
   

--- a/src/d3d11/d3d11_swapchain.cpp
+++ b/src/d3d11/d3d11_swapchain.cpp
@@ -2,6 +2,8 @@
 #include "d3d11_device.h"
 #include "d3d11_swapchain.h"
 
+#include "../util/util_win32_compat.h"
+
 namespace dxvk {
 
   static uint16_t MapGammaControlPoint(float x) {

--- a/src/d3d11/d3d11_texture.cpp
+++ b/src/d3d11/d3d11_texture.cpp
@@ -3,6 +3,7 @@
 #include "d3d11_texture.h"
 
 #include "../util/util_shared_res.h"
+#include "../util/util_win32_compat.h"
 
 namespace dxvk {
   

--- a/src/d3d9/d3d9_common_texture.cpp
+++ b/src/d3d9/d3d9_common_texture.cpp
@@ -4,6 +4,7 @@
 #include "d3d9_device.h"
 
 #include "../util/util_shared_res.h"
+#include "../util/util_win32_compat.h"
 
 #include <algorithm>
 

--- a/src/d3d9/d3d9_surface.cpp
+++ b/src/d3d9/d3d9_surface.cpp
@@ -4,6 +4,8 @@
 
 #include "d3d9_device.h"
 
+#include "../util/util_win32_compat.h"
+
 namespace dxvk {
 
   D3D9Surface::D3D9Surface(

--- a/src/d3d9/d3d9_util.cpp
+++ b/src/d3d9/d3d9_util.cpp
@@ -1,5 +1,7 @@
 #include "d3d9_util.h"
 
+#include "../util/util_win32_compat.h"
+
 namespace dxvk {
 
   typedef HRESULT (STDMETHODCALLTYPE *D3DXDisassembleShader) (

--- a/src/dxgi/dxgi_adapter.cpp
+++ b/src/dxgi/dxgi_adapter.cpp
@@ -11,6 +11,7 @@
 #include "dxgi_output.h"
 
 #include "../util/util_luid.h"
+#include "../util/util_win32_compat.h"
 
 #include "../wsi/wsi_monitor.h"
 

--- a/src/util/util_win32_compat.h
+++ b/src/util/util_win32_compat.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#if defined(__linux__)
+
+#include <windows.h>
+#include <dlfcn.h>
+
+#include "log/log.h"
+
+inline HMODULE LoadLibraryA(LPCSTR lpLibFileName) {
+  return dlopen(lpLibFileName, RTLD_NOW);
+}
+
+inline void CloseLibrary(HMODULE module) {
+  dlclose(module);
+}
+
+inline void* GetProcAddress(HMODULE module, LPCSTR lpProcName) {
+  return dlsym(module, lpProcName);
+}
+
+inline HANDLE CreateSemaphoreA(
+        SECURITY_ATTRIBUTES*  lpSemaphoreAttributes,
+        LONG                  lInitialCount,
+        LONG                  lMaximumCount,
+        LPCSTR                lpName) {
+  dxvk::Logger::warn("CreateSemaphoreA not implemented.");
+  return nullptr;
+}
+#define CreateSemaphore CreateSemaphoreA
+
+inline BOOL ReleaseSemaphore(
+        HANDLE hSemaphore,
+        LONG   lReleaseCount,
+        LONG*  lpPreviousCount) {
+  dxvk::Logger::warn("ReleaseSemaphore not implemented.");
+  return FALSE;
+}
+
+inline BOOL SetEvent(HANDLE hEvent) {
+  dxvk::Logger::warn("SetEvent not implemented.");
+  return FALSE;
+}
+
+inline BOOL CloseHandle(HANDLE hObject) {
+  dxvk::Logger::warn("CloseHandle not implemented.");
+  return FALSE;
+}
+
+inline HDC CreateCompatibleDC(HDC hdc) {
+  dxvk::Logger::warn("CreateCompatibleDC not implemented.");
+  return nullptr;
+}
+
+inline BOOL DeleteDC(HDC hdc) {
+  return FALSE;
+}
+
+#endif


### PR DESCRIPTION
Adds a header of miscellaneous stubs and reimplementations, uses them where appropriate.

When we want to implement stuff like this, we might want to move some of these to a CPP file.