### PR TITLE
[dxgi] Use high_resolution_clock get_counter instead of QPC for SyncQPCTime

### DIFF
--- a/src/dxgi/dxgi_swapchain.cpp
+++ b/src/dxgi/dxgi_swapchain.cpp
@@ -171,7 +171,7 @@ namespace dxvk {
     pStats->PresentCount = m_presentCount;
     pStats->PresentRefreshCount = 0;
     pStats->SyncRefreshCount = 0;
-    QueryPerformanceCounter(&pStats->SyncQPCTime);
+    pStats->SyncQPCTime.QuadPart = dxvk::high_resolution_clock::get_counter();
     pStats->SyncGPUTime.QuadPart = 0;
     return S_OK;
   }

--- a/src/util/util_time.h
+++ b/src/util/util_time.h
@@ -44,7 +44,15 @@ namespace dxvk {
     }
   };
 #else
-  using high_resolution_clock = std::chrono::high_resolution_clock;
+  struct high_resolution_clock : public std::chrono::high_resolution_clock {
+    static inline int64_t get_frequency() {
+      return period::den;
+    }
+
+    static inline int64_t get_counter() {
+      return dxvk::high_resolution_clock::now().time_since_epoch().count();
+    }
+  };
 #endif
 
 }

--- a/src/util/util_time.h
+++ b/src/util/util_time.h
@@ -20,8 +20,8 @@ namespace dxvk {
 
     static inline time_point now() noexcept {
       // Keep the frequency static, this doesn't change at all.
-      static const int64_t freq = getFrequency();
-      const int64_t counter     = getCounter();
+      static const int64_t freq = get_frequency();
+      const int64_t counter     = get_counter();
 
       const int64_t whole = (counter / freq) * period::den;
       const int64_t part  = (counter % freq) * period::den / freq;
@@ -29,14 +29,14 @@ namespace dxvk {
       return time_point(duration(whole + part));
     }
 
-    static inline int64_t getFrequency() {
+    static inline int64_t get_frequency() {
       LARGE_INTEGER freq;
       QueryPerformanceFrequency(&freq);
 
       return freq.QuadPart;
     }
 
-    static inline int64_t getCounter() {
+    static inline int64_t get_counter() {
       LARGE_INTEGER count;
       QueryPerformanceCounter(&count);
 


### PR DESCRIPTION
Abstracts this across platforms