### PR TITLE
[util] cap MGS V Ground Zeroes vram at 4095

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -289,6 +289,11 @@ namespace dxvk {
     { R"(\\Stray-Win64-Shipping\.exe$)", {{
       { "d3d11.ignoreGraphicsBarriers",     "True" },
     }} },
+    /* Metal Gear Solid V: Ground Zeroes          *
+     * Texture quality can break at high vram     */
+    { R"(\\MgsGroundZeroes\.exe$)", {{
+      { "dxgi.maxDeviceMemory",     "4095" },
+    }} },
 
     /**********************************************/
     /* D3D9 GAMES                                 */


### PR DESCRIPTION
Apparently some of the texture quality settings can break when the game sees vram values above 4095. Probably a integer overflow.

Fixes #2367 