### PR TITLE
Small 1.10.x backports

### DIFF
--- a/src/d3d11/d3d11_context_imm.cpp
+++ b/src/d3d11/d3d11_context_imm.cpp
@@ -40,6 +40,11 @@ namespace dxvk {
   
   
   D3D11ImmediateContext::~D3D11ImmediateContext() {
+    // Avoids hanging when in this state, see comment
+    // in DxvkDevice::~DxvkDevice.
+    if (this_thread::isInModuleDetachment())
+      return;
+
     Flush();
     SynchronizeCsThread(DxvkCsThread::SynchronizeAll);
     SynchronizeDevice();

--- a/src/d3d11/d3d11_swapchain.cpp
+++ b/src/d3d11/d3d11_swapchain.cpp
@@ -35,6 +35,11 @@ namespace dxvk {
 
 
   D3D11SwapChain::~D3D11SwapChain() {
+    // Avoids hanging when in this state, see comment
+    // in DxvkDevice::~DxvkDevice.
+    if (this_thread::isInModuleDetachment())
+      return;
+
     m_device->waitForSubmission(&m_presentStatus);
     m_device->waitForIdle();
     

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -145,6 +145,11 @@ namespace dxvk {
 
 
   D3D9DeviceEx::~D3D9DeviceEx() {
+    // Avoids hanging when in this state, see comment
+    // in DxvkDevice::~DxvkDevice.
+    if (this_thread::isInModuleDetachment())
+      return;
+
     Flush();
     SynchronizeCsThread(DxvkCsThread::SynchronizeAll);
 

--- a/src/d3d9/d3d9_swapchain.cpp
+++ b/src/d3d9/d3d9_swapchain.cpp
@@ -215,6 +215,11 @@ namespace dxvk {
 
 
   D3D9SwapChainEx::~D3D9SwapChainEx() {
+    // Avoids hanging when in this state, see comment
+    // in DxvkDevice::~DxvkDevice.
+    if (this_thread::isInModuleDetachment())
+      return;
+
     DestroyBackBuffers();
 
     ResetWindowProc(m_window);

--- a/src/dxvk/dxvk_device.cpp
+++ b/src/dxvk/dxvk_device.cpp
@@ -26,6 +26,13 @@ namespace dxvk {
   
   
   DxvkDevice::~DxvkDevice() {
+    // If we are being destroyed during/after DLL process detachment
+    // from TerminateProcess, etc, our CS threads are already destroyed
+    // and we cannot synchronize against them.
+    // The best we can do is just wait for the Vulkan device to be idle.
+    if (this_thread::isInModuleDetachment())
+      return;
+
     // Wait for all pending Vulkan commands to be
     // executed before we destroy any resources.
     this->waitForIdle();

--- a/src/util/thread.cpp
+++ b/src/util/thread.cpp
@@ -3,7 +3,22 @@
 
 #include <atomic>
 
-#ifndef _WIN32
+#ifdef _WIN32
+
+namespace dxvk::this_thread {
+
+  bool isInModuleDetachment() {
+    using PFN_RtlDllShutdownInProgress = BOOLEAN (WINAPI *)();
+
+    static auto RtlDllShutdownInProgress = reinterpret_cast<PFN_RtlDllShutdownInProgress>(
+      ::GetProcAddress(::GetModuleHandleW(L"ntdll.dll"), "RtlDllShutdownInProgress"));
+
+    return RtlDllShutdownInProgress();
+  }
+
+}
+
+#else
 
 namespace dxvk::this_thread {
   

--- a/src/util/thread.h
+++ b/src/util/thread.h
@@ -153,6 +153,8 @@ namespace dxvk {
     inline uint32_t get_id() {
       return uint32_t(GetCurrentThreadId());
     }
+
+    bool isInModuleDetachment();
   }
 
 
@@ -341,6 +343,10 @@ namespace dxvk {
     }
 
     uint32_t get_id();
+
+    inline bool isInModuleDetachment() {
+      return false;
+    }
   }
 #endif
 


### PR DESCRIPTION
Backport of the DLL shutdown fix, as requested by @alasky17.

I figured we might as well also backport the fix for Spider-Man Shattered Dimensions.