### PR TITLE
[d3d9] Try to match either top or bottom mips in UpdateTexture

### DIFF
--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -823,9 +823,19 @@ namespace dxvk {
     uint32_t mipLevels = dstTexInfo->IsAutomaticMip() ? 1 : dstTexInfo->Desc()->MipLevels;
     uint32_t arraySlices = std::min(srcTexInfo->Desc()->ArraySize, dstTexInfo->Desc()->ArraySize);
 
-    uint32_t srcMipOffset = srcTexInfo->Desc()->MipLevels - mipLevels;
-    VkExtent3D srcFirstMipExtent = util::computeMipLevelExtent(srcTexInfo->GetExtent(), srcMipOffset);
+    uint32_t srcMipOffset = 0;
+    VkExtent3D srcFirstMipExtent = srcTexInfo->GetExtent();
     VkExtent3D dstFirstMipExtent = dstTexInfo->GetExtent();
+
+    if (srcFirstMipExtent != dstFirstMipExtent) {
+      // UpdateTexture can be used with textures that have different mip lengths.
+      // It will either match the the top mips or the bottom ones.
+
+      srcMipOffset = srcTexInfo->Desc()->MipLevels - mipLevels;
+      srcFirstMipExtent = util::computeMipLevelExtent(srcTexInfo->GetExtent(), srcMipOffset);
+      dstFirstMipExtent = dstTexInfo->GetExtent();
+    }
+
     if (srcFirstMipExtent != dstFirstMipExtent)
       return D3DERR_INVALIDCALL;
 


### PR DESCRIPTION
Fixes a regression in Ys 7.

UpdateTexture can work with textures that have different mip lengths. The docs and ARMA 2 have a case where the destination only matches with the smallest mips of the source texture.

Ys7 does the opposite and has 2 textures that are the same size but the destination only has 1 mip. So here we need to mip the first mipmap.
