### PR TITLE
[util] correct maxFeatureLevel to 12_0 in example config

### DIFF
--- a/dxvk.conf
+++ b/dxvk.conf
@@ -129,7 +129,7 @@
 #
 # Supported values: 9_1, 9_2, 9_3, 10_0, 10_1, 11_0, 11_1
 
-# d3d11.maxFeatureLevel = 11_1
+# d3d11.maxFeatureLevel = 12_0
 
 
 # Overrides the maximum allowed tessellation factor. This can be used to


### PR DESCRIPTION
Missed in the recent work that exposed feature level 12_0