### PR TITLE
[util] Add a maxAvailableMemory limit for Heroes of Annihilated Empires

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -595,6 +595,13 @@ namespace dxvk {
       { "d3d9.textureMemory",               "16" },
       { "d3d9.allowDirectBufferMapping",    "False" },
     }} },
+    /* Heroes of Annihilated Empires            *
+     * Has issues with texture rendering and    *
+     * video memory detection otherwise.        */
+    { R"(\\Heroes (o|O)f Annihilated Empires.*\\engine\.exe$)", {{
+      { "d3d9.memoryTrackTest",             "True" },
+      { "d3d9.maxAvailableMemory",          "2048" },
+    }} },
   }};
 
 


### PR DESCRIPTION
Sort of the second half of the fix for #2879. Josh fixed the crash, but the game won't render textures correctly without a video memory limit.

The regex should cover the following scenarios (I'd appreciate a second pair of :eyes: on it, but seems to work fine based on my testing):
- install dir can be either `Heroes of Annihilated Empires` or `Heroes Of Annihilated Empires` (default on GOG and Steam versions of the game, no idea what a retail copy uses)
- `engine.exe` can be present either directly in the above install dir (allegedly, Steam) or within a `Data` subdirectory (GOG). Thanks to @Blisto91 for his checks on the matter.