### PR TITLE
[build] Remove dead lib_d3dcompiler_43.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -63,16 +63,9 @@ if platform == 'windows'
   ]
   endif
 
-  if (cpu_family == 'x86_64')
-    dxvk_library_path = meson.current_source_dir() + '/lib'
-  else
-    dxvk_library_path = meson.current_source_dir() + '/lib32'
-  endif
-
   lib_d3d9    = cpp.find_library('d3d9')
   lib_d3d11   = cpp.find_library('d3d11')
   lib_dxgi    = cpp.find_library('dxgi')
-  lib_d3dcompiler_43 = cpp.find_library('d3dcompiler_43', dirs : dxvk_library_path)
 
   if dxvk_is_msvc
     lib_d3dcompiler_47 = cpp.find_library('d3dcompiler')


### PR DESCRIPTION
Fixes MSVC build.