### PR TITLE
[dxvk] Ignore queue with VK_QUEUE_FAMILY_IGNORED index

### DIFF
--- a/src/dxvk/dxvk_adapter.cpp
+++ b/src/dxvk/dxvk_adapter.cpp
@@ -481,6 +481,10 @@ namespace dxvk {
     this->logQueueFamilies(queueFamilies);
     
     for (uint32_t family : queueFamiliySet) {
+
+      if (family == VK_QUEUE_FAMILY_IGNORED)
+        continue;
+
       VkDeviceQueueCreateInfo graphicsQueue = { VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO };
       graphicsQueue.queueFamilyIndex  = family;
       graphicsQueue.queueCount        = 1;


### PR DESCRIPTION
Do not add queue to set (and create info too) for queue with
`VK_QUEUE_FAMILY_IGNORED` family index.

Some drivers doesn't support sparse queue. More information in Mesa MR:
https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/18384

Signed-off-by: Mykhailo Skorokhodov <mykhailo.skorokhodov@globallogic.com>