### PR TITLE
[util] Enable d3d9.memoryTrackTest for The Ship

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -602,6 +602,10 @@ namespace dxvk {
       { "d3d9.memoryTrackTest",             "True" },
       { "d3d9.maxAvailableMemory",          "2048" },
     }} },
+    /* The Ship (2004)                          */
+    { R"(\\ship\.exe$)", {{
+      { "d3d9.memoryTrackTest",             "True" },
+    }} },
   }};
 
 


### PR DESCRIPTION
Fixes #2893

I think we should ship this.