### PR TITLE
Cap Warhammer Online to 100 FPS

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -439,6 +439,7 @@ namespace dxvk {
     /* Warhammer: Online                         */
     { R"(\\WAR(-64)?\.exe$)", {{
       { "d3d9.customVendorId",              "1002" },
+      { "d3d9.maxFrameRate",                "100" },
     }} },
     /* Dragon Nest                               */
     { R"(\\DragonNest_x64\.exe$)", {{


### PR DESCRIPTION
Animations break with 100+ FPS. Engine Limitation. WAR-64.exe is affected by this. WAR.exe is capped to 100 by default.