### PR TITLE
[dxvk] Fix value type in QueueItem

### DIFF
--- a/src/dxvk/dxvk_fence.h
+++ b/src/dxvk/dxvk_fence.h
@@ -94,7 +94,7 @@ namespace dxvk {
 
     struct QueueItem {
       QueueItem() { }
-      QueueItem(uint32_t v, DxvkFenceEvent&& e)
+      QueueItem(uint64_t v, DxvkFenceEvent&& e)
       : value(v), event(std::move(e)) { }
 
       uint64_t        value;


### PR DESCRIPTION
This was being truncated from uint64_t -> uint32_t then stored in a uint64_t which seems unintentional...