### PR TITLE
[util] Enable memoryTrackTest for SiN Episodes Emergence

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -607,6 +607,10 @@ namespace dxvk {
     { R"(\\ship\.exe$)", {{
       { "d3d9.memoryTrackTest",             "True" },
     }} },
+    /* SiN Episodes Emergence                   */
+    { R"(\\SinEpisodes\.exe$)", {{
+      { "d3d9.memoryTrackTest",             "True" },
+    }} },
   }};
 
 


### PR DESCRIPTION
Prevents it from consuming all the memory in the world.