### PR TITLE
[dxbc] Fix forceVolatileTgsmAccess for stores

### DIFF
--- a/src/dxbc/dxbc_compiler.cpp
+++ b/src/dxbc/dxbc_compiler.cpp
@@ -5331,7 +5331,7 @@ namespace dxvk {
     }
 
     if (coherence) {
-      memoryOperands.flags = spv::MemoryAccessNonPrivatePointerMask;
+      memoryOperands.flags |= spv::MemoryAccessNonPrivatePointerMask;
 
       if (coherence != spv::ScopeInvocation) {
         memoryOperands.flags |= spv::MemoryAccessMakePointerAvailableMask;


### PR DESCRIPTION
Found in F1 2020 while re-enabling memory access optimizations in RADV with MakePointerAvailable/etc