### PR TITLE
[d3d9] Fix for missing restriction check in UpdateSurface.

### DIFF
--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -746,6 +746,12 @@ namespace dxvk {
     if (unlikely(srcTextureInfo->Desc()->Format != dstTextureInfo->Desc()->Format))
       return D3DERR_INVALIDCALL;
 
+    if (unlikely(srcTextureInfo->Desc()->MultiSample != D3DMULTISAMPLE_NONE))
+      return D3DERR_INVALIDCALL;
+
+    if (unlikely(dstTextureInfo->Desc()->MultiSample != D3DMULTISAMPLE_NONE))
+      return D3DERR_INVALIDCALL;
+
     const DxvkFormatInfo* formatInfo = lookupFormatInfo(dstTextureInfo->GetFormatMapping().FormatColor);
 
     VkOffset3D srcOffset = { 0u, 0u, 0u };


### PR DESCRIPTION
The spec of IDirect3DDevice9::UpdateSurface contains the following restriction:
- Neither surface can be created with multisampling.
  The only valid flag for both surfaces is D3DMULTISAMPLE_NONE.

This commit adds this check and returns D3DERR_INVALIDCALL
when source or destination surfaces are multisampled.