### PR TITLE
[d3d9] Fix for missing mapping of VertexElements declarations to FVF bits.

### DIFF
--- a/src/d3d9/d3d9_vertex_declaration.cpp
+++ b/src/d3d9/d3d9_vertex_declaration.cpp
@@ -23,6 +23,7 @@ namespace dxvk {
     , m_elements        ( DeclCount )
     , m_fvf             ( 0 ) {
     std::copy(pVertexElements, pVertexElements + DeclCount, m_elements.begin());
+    this->MapD3D9VertexElementsToFvf();
     this->Classify();
   }
 
@@ -194,7 +195,7 @@ namespace dxvk {
 
     for (uint32_t i = 0; i < elemCount; i++) {
       elements[i].Stream = 0;
-      elements[i].Offset = (i == 0) 
+      elements[i].Offset = (i == 0)
         ? 0
         : (elements[i - 1].Offset + GetDecltypeSize(D3DDECLTYPE(elements[i - 1].Type)));
 
@@ -205,6 +206,106 @@ namespace dxvk {
     std::copy(elements.begin(), elements.begin() + elemCount, m_elements.data());
   }
 
+  DWORD D3D9VertexDecl::MapD3DDeclToFvf(
+    const D3DVERTEXELEMENT9& element,
+          DWORD fvf,
+          DWORD& texCountPostUpdate) {
+
+  // Mapping between a Direct3D Declaration and FVF Codes (Direct3D 9)
+  // This table maps members of a D3DVERTEXELEMENT9 declaration to a FVF code.
+  //
+  // Data type              Usage                       Usage index     FVF
+  // ----------------------------------------------------------------------------------------
+  // D3DDECLTYPE_FLOAT3     D3DDECLUSAGE_POSITION       0               D3DFVF_XYZ
+  // D3DDECLTYPE_FLOAT4     D3DDECLUSAGE_POSITIONT      0               D3DFVF_XYZRHW
+  // D3DDECLTYPE_FLOATn     D3DDECLUSAGE_BLENDWEIGHT    0               D3DFVF_XYZBn
+  // D3DDECLTYPE_UBYTE4     D3DDECLUSAGE_BLENDINDICES   0               D3DFVF_XYZB(nWeights + 1)
+  // D3DDECLTYPE_FLOAT3     D3DDECLUSAGE_NORMAL         0               D3DFVF_NORMAL
+  // D3DDECLTYPE_FLOAT1     D3DDECLUSAGE_PSIZE          0               D3DFVF_PSIZE
+  // D3DDECLTYPE_D3DCOLOR   D3DDECLUSAGE_COLOR          0               D3DFVF_DIFFUSE
+  // D3DDECLTYPE_D3DCOLOR   D3DDECLUSAGE_COLOR          1               D3DFVF_SPECULAR
+  // D3DDECLTYPE_FLOATm     D3DDECLUSAGE_TEXCOORD       n               D3DFVF_TEXCOORDSIZEm(n)
+  // D3DDECLTYPE_FLOAT3     D3DDECLUSAGE_POSITION       1               N / A
+  // D3DDECLTYPE_FLOAT3     D3DDECLUSAGE_NORMAL         1               N / A
+
+  if (element.Usage == D3DDECLUSAGE_POSITION && element.Type == D3DDECLTYPE_FLOAT3 && element.UsageIndex == 0)
+    return D3DFVF_XYZ;
+  else if (element.Usage == D3DDECLUSAGE_POSITIONT && element.Type == D3DDECLTYPE_FLOAT4 && element.UsageIndex == 0)
+    return D3DFVF_XYZRHW;
+  else if (element.Usage == D3DDECLUSAGE_BLENDWEIGHT && element.UsageIndex == 0) {
+    switch (element.Type)
+    {
+    case D3DDECLTYPE_FLOAT1:
+      return D3DFVF_XYZB1;
+    case D3DDECLTYPE_FLOAT2:
+      return D3DFVF_XYZB2;
+    case D3DDECLTYPE_FLOAT3:
+      return D3DFVF_XYZB3;
+    case D3DDECLTYPE_FLOAT4:
+      return D3DFVF_XYZB4;
+    default:;
+    }
+  }
+  else if (element.Usage == D3DDECLUSAGE_BLENDINDICES && element.Type == D3DDECLTYPE_UBYTE4 && element.UsageIndex == 0)
+    return D3DFVF_XYZB1;
+  else if (element.Usage == D3DDECLUSAGE_NORMAL && element.Type == D3DDECLTYPE_FLOAT3 && element.UsageIndex == 0)
+    return D3DFVF_NORMAL;
+  else if (element.Usage == D3DDECLUSAGE_PSIZE && element.Type == D3DDECLTYPE_FLOAT1 && element.UsageIndex == 0)
+    return D3DFVF_PSIZE;
+  else if (element.Usage == D3DDECLUSAGE_COLOR && element.Type == D3DDECLTYPE_D3DCOLOR) {
+    switch (element.UsageIndex)
+    {
+    case 0:
+      return D3DFVF_DIFFUSE;
+    case 1:
+      return D3DFVF_SPECULAR;
+    default:;
+    }
+  }
+  else if (element.Usage == D3DDECLUSAGE_TEXCOORD && element.UsageIndex < 8) {
+      DWORD localFvf = 0;
+      do {
+        // Check if bits of format for current UsageIndex are free in the fvf
+        // It is necessary to skip multiple initializations of the bitfield because
+        // returned value is bitwise or-ed to final fvf DWORD.
+        if (D3DFVF_TEXCOORDSIZE1(element.UsageIndex) & fvf != 0)
+          break;
+  
+        // Update max texture's index in fvf
+        DWORD lastMaxTexCount = (fvf >> 8) & 0x7;
+        DWORD currentTexCount = element.UsageIndex + 1;
+        if (lastMaxTexCount < currentTexCount) {
+          texCountPostUpdate = currentTexCount << 8;
+        }
+  
+        if (element.Type == D3DDECLTYPE_FLOAT1)
+          localFvf = D3DFVF_TEXCOORDSIZE1(element.UsageIndex);
+        else if (element.Type == D3DDECLTYPE_FLOAT2)
+          localFvf = D3DFVF_TEXCOORDSIZE2(element.UsageIndex);
+        else if (element.Type == D3DDECLTYPE_FLOAT3)
+          localFvf = D3DFVF_TEXCOORDSIZE3(element.UsageIndex);
+        else if (element.Type == D3DDECLTYPE_FLOAT4)
+          localFvf = D3DFVF_TEXCOORDSIZE4(element.UsageIndex);
+        else
+          break;
+  
+        return localFvf;
+      } while (1);
+    }
+    Logger::warn("D3D9VertexDecl::MapD3DDeclToFvf: Unsupported set of D3DDECLUSAGE_* / D3DDECLTYPE_* / UsageIndex");
+    return 0;
+  }
+
+  void D3D9VertexDecl::MapD3D9VertexElementsToFvf() {
+    if (!m_fvf) {
+      DWORD texCountPostUpdate = 0;
+      for (const auto& element : m_elements)
+        m_fvf |= MapD3DDeclToFvf(element, m_fvf, texCountPostUpdate);
+
+      if (texCountPostUpdate)
+        m_fvf |= texCountPostUpdate;
+    }
+  }
 
   void D3D9VertexDecl::Classify() {
     for (const auto& element : m_elements) {

--- a/src/d3d9/d3d9_vertex_declaration.cpp
+++ b/src/d3d9/d3d9_vertex_declaration.cpp
@@ -263,6 +263,7 @@ namespace dxvk {
     return 0;
   }
 
+
   DWORD D3D9VertexDecl::MapD3DDeclTypeFloatToFvfXYZBn(BYTE type) {
 
     switch (type)
@@ -279,6 +280,7 @@ namespace dxvk {
         return D3DFVF_XYZB4;
     }
   }
+
 
   DWORD D3D9VertexDecl::MapD3DDeclUsageTexCoordToFvfTexCoordSize(
       const D3DVERTEXELEMENT9& element,
@@ -310,6 +312,7 @@ namespace dxvk {
     return 0;
   }
 
+
   DWORD D3D9VertexDecl::MapD3D9VertexElementsToFvf() {
     DWORD fvf = 0;
     DWORD texCountPostUpdate = 0;
@@ -321,6 +324,8 @@ namespace dxvk {
 
     return fvf;
   }
+
+
   void D3D9VertexDecl::Classify() {
     for (const auto& element : m_elements) {
       if (element.Stream == 0 && element.Type != D3DDECLTYPE_UNUSED)

--- a/src/d3d9/d3d9_vertex_declaration.h
+++ b/src/d3d9/d3d9_vertex_declaration.h
@@ -77,9 +77,10 @@ namespace dxvk {
 
     DWORD MapD3DDeclTypeFloatToFvfXYZBn(BYTE type);
 
-    DWORD MapD3DDeclUsageTexCoordToFvfTexCoordSize(
+    bool MapD3DDeclUsageTexCoordToFvfTexCoordSize(
       const D3DVERTEXELEMENT9& element,
             DWORD fvf,
+            DWORD& outFvf,
             DWORD& texCountPostUpdate);
 
     void Classify();

--- a/src/d3d9/d3d9_vertex_declaration.h
+++ b/src/d3d9/d3d9_vertex_declaration.h
@@ -68,6 +68,13 @@ namespace dxvk {
 
   private:
 
+    DWORD MapD3DDeclToFvf(
+      const D3DVERTEXELEMENT9& element,
+            DWORD fvf,
+            DWORD& texCountPostUpdate);
+
+    void MapD3D9VertexElementsToFvf();
+
     void Classify();
 
     D3D9VertexDeclFlags            m_flags;

--- a/src/d3d9/d3d9_vertex_declaration.h
+++ b/src/d3d9/d3d9_vertex_declaration.h
@@ -73,7 +73,14 @@ namespace dxvk {
             DWORD fvf,
             DWORD& texCountPostUpdate);
 
-    void MapD3D9VertexElementsToFvf();
+    DWORD MapD3D9VertexElementsToFvf();
+
+    DWORD MapD3DDeclTypeFloatToFvfXYZBn(BYTE type);
+
+    DWORD MapD3DDeclUsageTexCoordToFvfTexCoordSize(
+      const D3DVERTEXELEMENT9& element,
+            DWORD fvf,
+            DWORD& texCountPostUpdate);
 
     void Classify();
 


### PR DESCRIPTION
When Vertex declaration is created by CreateVertexDeclaration
and SetFVF is not called then GetFVF returns 0.
This code change implements mapping of D3D declarations to FVF mask
and sets it if FVF was not set previously.