### PR TITLE
[util] Remove fps cap from Warhammer Online

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -439,7 +439,6 @@ namespace dxvk {
     /* Warhammer: Online                         */
     { R"(\\WAR(-64)?\.exe$)", {{
       { "d3d9.customVendorId",              "1002" },
-      { "d3d9.maxFrameRate",                "100" },
     }} },
     /* Dragon Nest                               */
     { R"(\\DragonNest_x64\.exe$)", {{


### PR DESCRIPTION
This is a bit embarrassing. Added this config few days ago to counter the animation breakages, but now Return of Reckoning devs patched the executable on their side to cap the framerate by default. So the workaround is not needed anymore.