### PR TITLE
[util] Disable DF support for pretty mirrors in GTA IV

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -405,10 +405,14 @@ namespace dxvk {
     }} },
     /* GTA IV (NVAPI)                             */
     /* Also thinks we're always on Intel          *
-     * and will report/use bad amounts of VRAM.   */
+     * and will report/use bad amounts of VRAM.
+     * Disabling support for DF texture formats
+     * makes the game use a better looking render
+     * path for mirrors                           */
     { R"(\\GTAIV\.exe$)", {{
       { "d3d9.customVendorId",              "1002" },
       { "dxgi.emulateUMA",                  "True" },
+      { "d3d9.supportDFFormats",            "False" },
     }} },
     /* Battlefield 2 (bad z-pass)                 */
     { R"(\\BF2\.exe$)", {{

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -409,7 +409,7 @@ namespace dxvk {
      * Disabling support for DF texture formats
      * makes the game use a better looking render
      * path for mirrors                           */
-    { R"(\\GTAIV\.exe$)", {{
+    { R"(\\(GTAIV|EFLC)\.exe$)", {{
       { "d3d9.customVendorId",              "1002" },
       { "dxgi.emulateUMA",                  "True" },
       { "d3d9.supportDFFormats",            "False" },


### PR DESCRIPTION
Fixes: #2901

The comment in the code explains the rational.