### PR TITLE
Fix for illegal OpCompositeConstruct while translating Crs opcode.

### DIFF
--- a/src/dxso/dxso_compiler.cpp
+++ b/src/dxso/dxso_compiler.cpp
@@ -2024,7 +2024,10 @@ namespace dxvk {
             indices[index++] = m_module.opCompositeExtract(m_module.defFloatType(32), crossValue.id, 1, &i);
         }
 
-        result.id = m_module.opCompositeConstruct(getVectorTypeId(result.type), result.type.ccount, indices.data());
+        if (result.type.ccount == 1)
+          result.id = indices[0];
+        else
+          result.id = m_module.opCompositeConstruct(typeId, result.type.ccount, indices.data());
 
         break;
       }


### PR DESCRIPTION
During the translation of the Crs opcode to SPIR-V there is an assumption that the result type is a composite type. This is not always true. If the result is a scalar type the translation adds an OpCompositeConstruct with a scalar result type. This is a spec violation.

This change checks if the result type is a composite type and does not add the OpCompositeConstruct in case of scalar types.