### PR TITLE
Emulate depth bias

### DIFF
--- a/src/d3d11/d3d11_rasterizer.cpp
+++ b/src/d3d11/d3d11_rasterizer.cpp
@@ -38,6 +38,7 @@ namespace dxvk {
     m_state.conservativeMode  = DecodeConservativeRasterizationMode(desc.ConservativeRaster);
     m_state.sampleCount       = VkSampleCountFlags(desc.ForcedSampleCount);
     m_state.flatShading       = VK_FALSE;
+    m_state.depthReplacing    = VK_FALSE;
 
     m_depthBias.depthBiasConstant = float(desc.DepthBias);
     m_depthBias.depthBiasSlope    = desc.SlopeScaledDepthBias;

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -1997,6 +1997,10 @@ namespace dxvk {
           break;
 
         case D3DRS_DEPTHBIAS:
+          if (old == 0.0f || Value == 0.0f) {
+            m_flags.set(D3D9DeviceFlag::DirtyRasterizerState);
+          }
+
           UpdatePushConstant<D3D9RenderStateItem::ConstantDepthBias>();
           break;
 
@@ -5833,7 +5837,7 @@ namespace dxvk {
     state.frontFace       = VK_FRONT_FACE_CLOCKWISE;
     state.polygonMode     = DecodeFillMode(D3DFILLMODE(rs[D3DRS_FILLMODE]));
     state.flatShading     = m_state.renderStates[D3DRS_SHADEMODE] == D3DSHADE_FLAT;
-    state.depthReplacing  = VK_FALSE;
+    state.depthReplacing  = m_state.renderStates[D3DRS_DEPTHBIAS] != 0.0f;
 
     EmitCs([
       cState  = state

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -5833,6 +5833,7 @@ namespace dxvk {
     state.frontFace       = VK_FRONT_FACE_CLOCKWISE;
     state.polygonMode     = DecodeFillMode(D3DFILLMODE(rs[D3DRS_FILLMODE]));
     state.flatShading     = m_state.renderStates[D3DRS_SHADEMODE] == D3DSHADE_FLAT;
+    state.depthReplacing  = VK_FALSE;
 
     EmitCs([
       cState  = state

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -804,10 +804,9 @@ namespace dxvk {
     inline bool IsDepthBiasEnabled() {
       const auto& rs = m_state.renderStates;
 
-      float depthBias            = bit::cast<float>(rs[D3DRS_DEPTHBIAS]);
       float slopeScaledDepthBias = bit::cast<float>(rs[D3DRS_SLOPESCALEDEPTHBIAS]);
 
-      return depthBias != 0.0f || slopeScaledDepthBias != 0.0f;
+      return slopeScaledDepthBias != 0.0f;
     }
 
     inline bool IsAlphaTestEnabled() {

--- a/src/d3d9/d3d9_fixed_function.cpp
+++ b/src/d3d9/d3d9_fixed_function.cpp
@@ -2459,7 +2459,7 @@ namespace dxvk {
     uint32_t depthOutPtrId = m_module.newVar(depthOutPointerType, spv::StorageClassOutput);
     m_module.setDebugName(depthOutPtrId, "ps_depth_bias_out");
     m_module.decorateBuiltIn(depthOutPtrId, spv::BuiltInFragDepth);
-    m_module.setExecutionMode(m_entryPointId, spv::ExecutionModeDepthReplacing);
+    m_module.setExecutionMode(m_entryPointId, spv::ExecutionModeDepthUnchanged);
 
     DxsoRegister fragDepthReg;
     fragDepthReg.id.type = DxsoRegisterType::DepthOut;

--- a/src/d3d9/d3d9_state.h
+++ b/src/d3d9/d3d9_state.h
@@ -38,6 +38,8 @@ namespace dxvk {
 
     uint32_t alphaRef = 0u;
 
+    float constantDepthBias = 0.0f;
+
     float pointSize    = 1.0f;
     float pointSizeMin = 1.0f;
     float pointSizeMax = 64.0f;
@@ -52,6 +54,7 @@ namespace dxvk {
     FogEnd,
     FogDensity,
     AlphaRef,
+    ConstantDepthBias,
 
     PointSize,
     PointSizeMin,

--- a/src/dxso/dxso_compiler.cpp
+++ b/src/dxso/dxso_compiler.cpp
@@ -3559,13 +3559,13 @@ void DxsoCompiler::emitControlFlowGenericLoop(
         m_pushConstSize   = offsetof(D3D9RenderStateInfo, pointSize);
       }
 
-      count = 5;
+      count = 6;
     }
     else {
       m_pushConstOffset = offsetof(D3D9RenderStateInfo, pointSize);
       // Point scale never triggers on programmable
       m_pushConstSize   = sizeof(float) * 3;
-      count = 8;
+      count = 9;
     }
 
     m_rsBlock = SetupRenderStateBlock(m_module, count);
@@ -3646,8 +3646,39 @@ void DxsoCompiler::emitControlFlowGenericLoop(
         m_ps.oDepth.id,
         result.id);
     }
-}
+  }
 
+  void DxsoCompiler::emitEmulatedDepthBias() {
+    const uint32_t floatType = m_module.defFloatType(32);
+
+    uint32_t originalDepthId;
+    if (m_ps.oDepth.id == 0) {
+      DxsoRegisterPointer fragCoordPtr = this->emitRegisterPtr(
+        "ps_depth_bias_frag_coord", DxsoScalarType::Float32, 4, 0,
+        spv::StorageClassInput, spv::BuiltInFragCoord);
+      DxsoRegisterValue fragCoordId = this->emitValueLoad(fragCoordPtr);
+      uint32_t index = 2;
+      originalDepthId = m_module.opCompositeExtract(floatType, fragCoordId.id, 1, &index);
+    } else {
+      originalDepthId = emitValueLoad(m_ps.oDepth).id;
+    }
+
+    uint32_t constantDepthBiasMember =  m_module.constu32(uint32_t(D3D9RenderStateItem::ConstantDepthBias));
+    uint32_t constantDepthBiasId = m_module.opLoad(floatType, m_module.opAccessChain(floatType,  m_rsBlock, 1, &constantDepthBiasMember));
+
+    uint32_t resultId = m_module.opFAdd(floatType, originalDepthId, constantDepthBiasId);
+
+    if (m_ps.oDepth.id == 0) {
+      uint32_t depthOutPointerType = m_module.defPointerType(floatType, spv::StorageClassInput);
+      uint32_t depthOutPtrId = m_module.newVar(depthOutPointerType, spv::StorageClassOutput);
+      m_module.setDebugName(depthOutPtrId, "ps_depth_bias_out");
+      m_module.decorateBuiltIn(depthOutPtrId, spv::BuiltInFragDepth);
+      m_module.setExecutionMode(m_entryPointId, spv::ExecutionModeDepthReplacing);
+      m_module.opStore(depthOutPtrId, resultId);
+    } else {
+      m_module.opStore(m_ps.oDepth.id, resultId);
+    }
+  }
 
   void DxsoCompiler::emitVsFinalize() {
     this->emitMainFunctionBegin();
@@ -3728,6 +3759,7 @@ void DxsoCompiler::emitControlFlowGenericLoop(
 
     this->emitPsProcessing();
     this->emitOutputDepthClamp();
+    this->emitEmulatedDepthBias();
     this->emitFunctionEnd();
   }
 

--- a/src/dxso/dxso_compiler.cpp
+++ b/src/dxso/dxso_compiler.cpp
@@ -3673,7 +3673,7 @@ void DxsoCompiler::emitControlFlowGenericLoop(
       uint32_t depthOutPtrId = m_module.newVar(depthOutPointerType, spv::StorageClassOutput);
       m_module.setDebugName(depthOutPtrId, "ps_depth_bias_out");
       m_module.decorateBuiltIn(depthOutPtrId, spv::BuiltInFragDepth);
-      m_module.setExecutionMode(m_entryPointId, spv::ExecutionModeDepthReplacing);
+      m_module.setExecutionMode(m_entryPointId, spv::ExecutionModeDepthUnchanged);
       m_module.opStore(depthOutPtrId, resultId);
     } else {
       m_module.opStore(m_ps.oDepth.id, resultId);

--- a/src/dxso/dxso_compiler.h
+++ b/src/dxso/dxso_compiler.h
@@ -681,6 +681,7 @@ namespace dxvk {
     void emitFog();
     void emitPsProcessing();
     void emitOutputDepthClamp();
+    void emitEmulatedDepthBias();
 
     void emitLinkerOutputSetup();
 

--- a/src/dxvk/dxvk_constant_state.h
+++ b/src/dxvk/dxvk_constant_state.h
@@ -106,6 +106,7 @@ namespace dxvk {
     VkConservativeRasterizationModeEXT conservativeMode;
     VkSampleCountFlags  sampleCount;
     VkBool32            flatShading;
+    VkBool32            depthReplacing;
   };
   
   

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -2476,7 +2476,8 @@ namespace dxvk {
       rs.polygonMode,
       rs.sampleCount,
       rs.conservativeMode,
-      rs.flatShading);
+      rs.flatShading,
+      rs.depthReplacing);
 
     if (!m_state.gp.state.rs.eq(rsInfo)) {
       m_flags.set(DxvkContextFlag::GpDirtyPipelineState);

--- a/src/dxvk/dxvk_graphics.cpp
+++ b/src/dxvk/dxvk_graphics.cpp
@@ -721,6 +721,7 @@ namespace dxvk {
     if (shaderInfo.stage == VK_SHADER_STAGE_FRAGMENT_BIT) {
       info.fsDualSrcBlend = state.useDualSourceBlending();
       info.fsFlatShading = state.rs.flatShading() && shader->info().flatShadingInputs;
+      info.fsDepthReplacing = state.rs.depthReplacing();
 
       for (uint32_t i = 0; i < MaxNumRenderTargets; i++) {
         if ((shaderInfo.outputMask & (1u << i)) && state.writesRenderTarget(i))
@@ -1093,6 +1094,9 @@ namespace dxvk {
 
       // Flat shading requires patching the fragment shader
       if (state.rs.flatShading() && m_shaders.fs->info().flatShadingInputs)
+        return false;
+
+      if (state.rs.depthReplacing())
         return false;
 
       // Multisample state must match in this case, and the

--- a/src/dxvk/dxvk_graphics_state.h
+++ b/src/dxvk/dxvk_graphics_state.h
@@ -223,13 +223,15 @@ namespace dxvk {
             VkPolygonMode         polygonMode,
             VkSampleCountFlags    sampleCount,
             VkConservativeRasterizationModeEXT conservativeMode,
-            VkBool32              flatShading)
+            VkBool32              flatShading,
+            VkBool32              depthReplacing)
     : m_depthClipEnable (uint16_t(depthClipEnable)),
       m_depthBiasEnable (uint16_t(depthBiasEnable)),
       m_polygonMode     (uint16_t(polygonMode)),
       m_sampleCount     (uint16_t(sampleCount)),
       m_conservativeMode(uint16_t(conservativeMode)),
       m_flatShading     (uint16_t(flatShading)),
+      m_depthReplacing  (uint16_t(depthReplacing)),
       m_reserved        (0) { }
     
     VkBool32 depthClipEnable() const {
@@ -256,6 +258,10 @@ namespace dxvk {
       return VkBool32(m_flatShading);
     }
 
+    VkBool32 depthReplacing() const {
+      return VkBool32(m_depthReplacing);
+    }
+
     bool eq(const DxvkRsInfo& other) const {
       return !std::memcmp(this, &other, sizeof(*this));
     }
@@ -268,7 +274,8 @@ namespace dxvk {
     uint16_t m_sampleCount            : 5;
     uint16_t m_conservativeMode       : 2;
     uint16_t m_flatShading            : 1;
-    uint16_t m_reserved               : 4;
+    uint16_t m_depthReplacing         : 1;
+    uint16_t m_reserved               : 3;
   
   };
 

--- a/src/dxvk/dxvk_shader.cpp
+++ b/src/dxvk/dxvk_shader.cpp
@@ -205,6 +205,9 @@ namespace dxvk {
     if (m_info.stage == VK_SHADER_STAGE_FRAGMENT_BIT && state.fsFlatShading)
       emitFlatShadingDeclarations(spirvCode, m_info.flatShadingInputs);
 
+    if (m_info.stage == VK_SHADER_STAGE_FRAGMENT_BIT && state.fsDepthReplacing)
+      replaceDepthExecutionMode(spirvCode);
+
     return spirvCode;
   }
 
@@ -802,6 +805,16 @@ namespace dxvk {
     }
 
     code.endInsertion();
+  }
+
+  void DxvkShader::replaceDepthExecutionMode(
+          SpirvCodeBuffer&          code) {
+    for (auto ins : code) {
+      if (ins.opCode() == spv::OpExecutionMode && ins.arg(2) == spv::ExecutionModeDepthUnchanged) {
+        ins.setArg(2, spv::ExecutionModeDepthReplacing);
+        break;
+      }
+    }
   }
 
 

--- a/src/dxvk/dxvk_shader.h
+++ b/src/dxvk/dxvk_shader.h
@@ -67,9 +67,10 @@ namespace dxvk {
    * \brief Shader module create info
    */
   struct DxvkShaderModuleCreateInfo {
-    bool      fsDualSrcBlend  = false;
-    bool      fsFlatShading   = false;
-    uint32_t  undefinedInputs = 0;
+    bool      fsDualSrcBlend   = false;
+    bool      fsFlatShading    = false;
+    uint32_t  undefinedInputs  = 0;
+    bool      fsDepthReplacing = false;
 
     std::array<VkComponentMapping, MaxNumRenderTargets> rtSwizzles = { };
 
@@ -275,6 +276,9 @@ namespace dxvk {
     static void emitFlatShadingDeclarations(
             SpirvCodeBuffer&          code,
             uint32_t                  inputMask);
+
+    static void replaceDepthExecutionMode(
+            SpirvCodeBuffer&          code);
 
   };
   

--- a/src/dxvk/dxvk_state_cache.cpp
+++ b/src/dxvk/dxvk_state_cache.cpp
@@ -78,6 +78,16 @@ namespace dxvk {
         return true;
       }
 
+      if (version < 16) {
+        DxvkRsInfoV15 v15;
+
+        if (!read(v15))
+          return false;
+
+        data = v15.convert();
+        return true;
+      }
+
       return read(data);
     }
 

--- a/src/dxvk/dxvk_state_cache_types.h
+++ b/src/dxvk/dxvk_state_cache_types.h
@@ -52,7 +52,7 @@ namespace dxvk {
    */
   struct DxvkStateCacheHeader {
     char     magic[4]   = { 'D', 'X', 'V', 'K' };
-    uint32_t version    = 15;
+    uint32_t version    = 16;
     uint32_t entrySize  = 0; /* no longer meaningful */
   };
 
@@ -162,6 +162,32 @@ namespace dxvk {
         VkSampleCountFlags(m_sampleCount),
         VkConservativeRasterizationModeEXT(m_conservativeMode),
         VK_FALSE,
+        VK_FALSE);
+    }
+
+  };
+
+
+  class DxvkRsInfoV15 {
+
+  public:
+
+    uint16_t m_depthClipEnable        : 1;
+    uint16_t m_depthBiasEnable        : 1;
+    uint16_t m_polygonMode            : 2;
+    uint16_t m_sampleCount            : 5;
+    uint16_t m_conservativeMode       : 2;
+    uint16_t m_flatShading            : 1;
+    uint16_t m_reserved               : 4;
+
+    DxvkRsInfo convert() const {
+      return DxvkRsInfo(
+        VkBool32(m_depthClipEnable),
+        VkBool32(m_depthBiasEnable),
+        VkPolygonMode(m_polygonMode),
+        VkSampleCountFlags(m_sampleCount),
+        VkConservativeRasterizationModeEXT(m_conservativeMode),
+        VkBool32(m_flatShading),
         VK_FALSE);
     }
 

--- a/src/dxvk/dxvk_state_cache_types.h
+++ b/src/dxvk/dxvk_state_cache_types.h
@@ -134,6 +134,7 @@ namespace dxvk {
         VkPolygonMode(m_polygonMode),
         VkSampleCountFlags(m_sampleCount),
         VkConservativeRasterizationModeEXT(m_conservativeMode),
+        VK_FALSE,
         VK_FALSE);
     }
 
@@ -160,6 +161,7 @@ namespace dxvk {
         VkPolygonMode(m_polygonMode),
         VkSampleCountFlags(m_sampleCount),
         VkConservativeRasterizationModeEXT(m_conservativeMode),
+        VK_FALSE,
         VK_FALSE);
     }
 


### PR DESCRIPTION
To get this out of the way: Yes, an extension would be the much nicer solution and when (if?) we ever get an extension for an unscaled depth bias this, I'll open a PR to remove these changes again.

 #2892

This PR emulates the constant depth bias in the fragment shader. D3D9 doesn't use depthBiasClamp, so we can just use the regular fixed function depth bias for the slope scaled part of it.

If the fragment shader doesn't already replace the fragment depth, the execution mode is set to `DepthUnchanged`. Once the game sets a non 0 depth bias constant, a SPIR-V pass will change that to DepthReplacing and the pipeline will be recompiled. That is an unfortunate late pipeline compile but IMO it's not the end of the world.

We could optionally merge this with a cleaned up version of #2931 and only emulate it in the shader if the depth buffer uses a float format. That might especially benefit Nvidia GPUs which natively support D24S8. Let me know if you think that's worth doing.

Another thing we could do is emit DepthGreater or DepthLess instead of DepthReplacing.