### PR TITLE
[d3d9, dxso] Clamp Dref to [0.0, 1.0] if the texture is emulated UNORM

### DIFF
--- a/dxvk.conf
+++ b/dxvk.conf
@@ -451,6 +451,15 @@
 
 # d3d9.supportDFFormats = True
 
+# Use D32f for D24
+#
+# Useful for reproducing AMD issues on other hw.
+#
+# Supported values:
+# - True/False
+
+# d3d9.useD32forD24 = False
+
 # Support X4R4G4B4
 #
 # Support the X4R4G4B4 format.

--- a/src/d3d9/d3d9_common_texture.cpp
+++ b/src/d3d9/d3d9_common_texture.cpp
@@ -40,6 +40,8 @@ namespace dxvk {
 
     m_mapMode        = DetermineMapMode();
     m_shadow         = DetermineShadowState();
+    m_upgradedToD32f = ConvertFormatUnfixed(m_desc.Format).FormatColor != VK_FORMAT_D32_SFLOAT_S8_UINT &&
+                       m_mapping.FormatColor == VK_FORMAT_D32_SFLOAT_S8_UINT;
     m_supportsFetch4 = DetermineFetch4Compatibility();
 
     const bool createImage = m_desc.Pool != D3DPOOL_SYSTEMMEM && m_desc.Pool != D3DPOOL_SCRATCH && m_desc.Format != D3D9Format::NULL_FORMAT;

--- a/src/d3d9/d3d9_common_texture.h
+++ b/src/d3d9/d3d9_common_texture.h
@@ -204,6 +204,14 @@ namespace dxvk {
     }
 
     /**
+     * \brief Dref Clamp
+     * \returns Whether the texture emulates an UNORM format with D32f
+     */
+    bool IsUpgradedToD32f() const {
+      return m_upgradedToD32f;
+    }
+
+    /**
      * \brief FETCH4 compatibility
      * \returns Whether the format of the texture supports the FETCH4 hack
      */
@@ -499,6 +507,7 @@ namespace dxvk {
     D3D9_VK_FORMAT_MAPPING        m_mapping;
 
     bool                          m_shadow; //< Depth Compare-ness
+    bool                          m_upgradedToD32f; // Dref Clamp
     bool                          m_supportsFetch4;
 
     int64_t                       m_size = 0;

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -1145,7 +1145,7 @@ namespace dxvk {
     void UpdateVertexBoolSpec(uint32_t value);
     void UpdatePixelBoolSpec(uint32_t value);
     void UpdatePixelShaderSamplerSpec(uint32_t types, uint32_t projections, uint32_t fetch4);
-    void UpdateCommonSamplerSpec(uint32_t boundMask, uint32_t depthMask);
+    void UpdateCommonSamplerSpec(uint32_t boundMask, uint32_t depthMask, uint32_t drefMask);
     void UpdatePointModeSpec(uint32_t mode);
     void UpdateFogModeSpec(bool fogEnabled, D3DFOGMODE vertexFogMode, D3DFOGMODE pixelFogMode);
 
@@ -1237,6 +1237,7 @@ namespace dxvk {
     uint32_t                        m_instancedData = 0;
 
     uint32_t                        m_depthTextures = 0;
+    uint32_t                        m_drefClamp = 0;
     uint32_t                        m_cubeTextures = 0;
     uint32_t                        m_textureTypes = 0;
     uint32_t                        m_projectionBitfield  = 0;

--- a/src/d3d9/d3d9_format.cpp
+++ b/src/d3d9/d3d9_format.cpp
@@ -434,7 +434,8 @@ namespace dxvk {
 
     // AMD do not support 24-bit depth buffers on Vulkan,
     // so we have to fall back to a 32-bit depth format.
-    m_d24s8Support = CheckImageFormatSupport(adapter, VK_FORMAT_D24_UNORM_S8_UINT,
+    m_d24s8Support = !options.useD32forD24 &&
+                     CheckImageFormatSupport(adapter, VK_FORMAT_D24_UNORM_S8_UINT,
       VK_FORMAT_FEATURE_2_DEPTH_STENCIL_ATTACHMENT_BIT |
       VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT);
 
@@ -444,7 +445,6 @@ namespace dxvk {
       VK_FORMAT_FEATURE_2_DEPTH_STENCIL_ATTACHMENT_BIT |
       VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT);
 
-    // VK_EXT_4444_formats
     if (!m_d24s8Support)
       Logger::info("D3D9: VK_FORMAT_D24_UNORM_S8_UINT -> VK_FORMAT_D32_SFLOAT_S8_UINT");
 

--- a/src/d3d9/d3d9_options.cpp
+++ b/src/d3d9/d3d9_options.cpp
@@ -55,6 +55,7 @@ namespace dxvk {
     this->supportDFFormats              = config.getOption<bool>        ("d3d9.supportDFFormats",              true);
     this->supportX4R4G4B4               = config.getOption<bool>        ("d3d9.supportX4R4G4B4",               true);
     this->supportD32                    = config.getOption<bool>        ("d3d9.supportD32",                    true);
+    this->useD32forD24                  = config.getOption<bool>        ("d3d9.useD32forD24",                  false);
     this->disableA8RT                   = config.getOption<bool>        ("d3d9.disableA8RT",                   false);
     this->invariantPosition             = config.getOption<bool>        ("d3d9.invariantPosition",             true);
     this->memoryTrackTest               = config.getOption<bool>        ("d3d9.memoryTrackTest",               false);

--- a/src/d3d9/d3d9_options.h
+++ b/src/d3d9/d3d9_options.h
@@ -91,6 +91,9 @@ namespace dxvk {
     /// Support D32
     bool supportD32;
 
+    /// Use D32f for D24
+    bool useD32forD24;
+
     /// Disable D3DFMT_A8 for render targets.
     /// Specifically to work around a game
     /// bug in The Sims 2 that happens on native too!

--- a/src/d3d9/d3d9_spec_constants.h
+++ b/src/d3d9/d3d9_spec_constants.h
@@ -27,6 +27,7 @@ namespace dxvk {
     SpecVertexShaderBools,  // 16 bools                       | Bits: 16
     SpecPixelShaderBools,   // 16 bools                       | Bits: 16
 
+    SpecDrefClamp,          // 1 bit for 16 PS samplers       | Bits: 16
     SpecFetch4,             // 1 bit for 16 PS samplers       | Bits: 16
 
     SpecConstantCount,
@@ -62,7 +63,8 @@ namespace dxvk {
       { 3, 0,  16 }, // VertexShaderBools
       { 3, 16, 16 }, // PixelShaderBools
 
-      { 4, 0,  16 }, // Fetch4
+      { 4, 0,  16 }, // DrefClamp
+      { 4, 16, 16 }, // Fetch4
     }};
 
     template <D3D9SpecConstantId Id, typename T>

--- a/src/dxso/dxso_compiler.h
+++ b/src/dxso/dxso_compiler.h
@@ -664,7 +664,6 @@ namespace dxvk {
     void emitTextureDepth(const DxsoInstructionContext& ctx);
 
     uint32_t emitSample(
-            bool                    projected,
             uint32_t                resultType,
             DxsoSamplerInfo&        samplerInfo,
             DxsoRegisterValue       coordinates,


### PR DESCRIPTION
Fixes: https://github.com/doitsujin/dxvk/issues/2693
Fixes: https://github.com/doitsujin/dxvk/issues/2361
Fixes: https://github.com/doitsujin/dxvk/issues/1814
fixes shadows in https://github.com/doitsujin/dxvk/issues/2029 (no idea if the line is still an issue on amd)