### PR TITLE
[D3D9] Fix for back buffer data loss during D3D9 present

### DIFF
--- a/src/d3d9/d3d9_options.cpp
+++ b/src/d3d9/d3d9_options.cpp
@@ -48,7 +48,6 @@ namespace dxvk {
     this->strictPow                     = config.getOption<bool>        ("d3d9.strictPow",                     true);
     this->lenientClear                  = config.getOption<bool>        ("d3d9.lenientClear",                  false);
     this->numBackBuffers                = config.getOption<int32_t>     ("d3d9.numBackBuffers",                0);
-    this->noExplicitFrontBuffer         = config.getOption<bool>        ("d3d9.noExplicitFrontBuffer",         false);
     this->deferSurfaceCreation          = config.getOption<bool>        ("d3d9.deferSurfaceCreation",          false);
     this->samplerAnisotropy             = config.getOption<int32_t>     ("d3d9.samplerAnisotropy",             -1);
     this->maxAvailableMemory            = config.getOption<int32_t>     ("d3d9.maxAvailableMemory",            4096);

--- a/src/d3d9/d3d9_options.h
+++ b/src/d3d9/d3d9_options.h
@@ -54,16 +54,6 @@ namespace dxvk {
     /// Overrides buffer count in present parameters.
     int32_t numBackBuffers;
 
-    /// Don't create an explicit front buffer in our own swapchain. The Vulkan swapchain is unaffected.
-    /// Some games don't handle front/backbuffer flipping very well because they don't always redraw
-    /// each frame completely, and rely on old pixel data from the previous frame to still be there.
-    /// When this option is set and a game only requests one backbuffer, there will be no flipping in
-    /// our own swapchain, so the game will always draw to the same buffer and can rely on old pixel
-    /// data to still be there after a Present call.
-    /// This means that D3D9SwapChainEx::GetFrontBufferData returns data from the backbuffer of the
-    /// previous frame, which is the same as the current backbuffer if only 1 backbuffer was requested.
-    bool noExplicitFrontBuffer;
-
     /// Defer surface creation
     bool deferSurfaceCreation;
 

--- a/src/d3d9/d3d9_swapchain.cpp
+++ b/src/d3d9/d3d9_swapchain.cpp
@@ -673,8 +673,7 @@ namespace dxvk {
       m_context->beginRecording(
         m_device->createCommandList());
 
-      if (m_presentParams.SwapEffect != D3DSWAPEFFECT_DISCARD)
-      {
+      if (m_presentParams.SwapEffect != D3DSWAPEFFECT_DISCARD) {
         VkOffset3D srcOffset = { int32_t(m_srcRect.left), int32_t(m_srcRect.top), 0 };
         VkOffset3D dstOffset = { int32_t(m_dstRect.left), int32_t(m_dstRect.top), 0 };
         VkImageSubresourceLayers singleLayerSubresource = { VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1 };

--- a/src/d3d9/d3d9_swapchain.h
+++ b/src/d3d9/d3d9_swapchain.h
@@ -100,7 +100,8 @@ namespace dxvk {
     Rc<hud::Hud>              m_hud;
 
     std::vector<Com<D3D9Surface, false>> m_backBuffers;
-    
+    Com<D3D9Surface, false>   m_frontBuffer;
+
     RECT                      m_srcRect;
     RECT                      m_dstRect;
 

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -404,10 +404,6 @@ namespace dxvk {
     { R"(\\ToEE\.exe$)", {{
       { "d3d9.allowDiscard",                "False" },
     }} },
-    /* ZUSI 3 - Aerosoft Edition                  */
-    { R"(\\ZusiSim\.exe$)", {{
-      { "d3d9.noExplicitFrontBuffer",       "True" },
-    }} },
     /* GTA IV (NVAPI)                             */
     /* Also thinks we're always on Intel          *
      * and will report/use bad amounts of VRAM.
@@ -481,10 +477,6 @@ namespace dxvk {
     /* Sine Mora EX */
     { R"(\\SineMoraEX\.exe$)", {{
       { "d3d9.maxFrameRate",                "60" },
-    }} },
-    /* Fantasy Grounds                           */
-    { R"(\\FantasyGrounds\.exe$)", {{
-      { "d3d9.noExplicitFrontBuffer",       "True" },
     }} },
     /* Red Orchestra 2                           */
     { R"(\\ROGame\.exe$)", {{


### PR DESCRIPTION
Acording to the D3D9 spec the content of the back buffer can be altered only if the SwapEffect is D3DSWAPEFFECT_DISCARD. The current implementation of the front buffer caused the previous back buffers to have their content lost.

This change keeps a similar present back buffer swapping logic for D3DSWAPEFFECT_DISCARD. For other swap effects the front buffer is a copy of the last presented back buffer.