### PR TITLE
[util] Cap Sonic Adventure 2 to 60 fps

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -329,6 +329,7 @@ namespace dxvk {
     /* Sonic Adventure 2                          */
     { R"(\\Sonic Adventure 2\\(launcher|sonic2app)\.exe$)", {{
       { "d3d9.floatEmulation",              "Strict" },
+      { "d3d9.maxFrameRate",                "60" },
     }} },
     /* The Sims 2,
        Body Shop,


### PR DESCRIPTION
Game speed is tied to fps. 
Cutscene audio also start to overlap at higher than 60