### PR TITLE
[util] set Beyond Good and Evil allowDiscard to false

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -582,9 +582,11 @@ namespace dxvk {
       { "d3d9.enableDialogMode",          "True" },
     }} },
     /* Beyond Good And Evil                     *
-     * UI breaks at high fps                     */
+     * UI breaks at high fps                    *
+     * allowDiscard causes graphical glitches   */
     { R"(\\BGE\.exe$)", {{
       { "d3d9.maxFrameRate",                "60" },
+      { "d3d9.allowDiscard",                "False" },
     }} },
     /* King Of Fighters XIII                     *
      * In-game speed increases on high FPS       */


### PR DESCRIPTION
In some scenes there can be graphical glitches unless allowDiscard is set to false
Tested on R9 380

<details>
  <summary>Example screenshot</summary>

This will correctly show her holding a blue orb when allowDiscard is set to false

![Screenshot_20221001_183139](https://user-images.githubusercontent.com/47954800/193419110-7273ba24-4ff7-45d5-9219-b4c817f2a85c.png)
</details>