### PR TITLE
[util] Force SM1 for the Escape from Tarkov launcher

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -538,6 +538,11 @@ namespace dxvk {
     { R"(\\spv3\.exe$)", {{
       { "d3d9.shaderModel",                 "1" },
     }} },
+    /* Escape from Tarkov launcher
+       Same issue as Warhammer: RoR above       */
+    { R"(\\BsgLauncher\.exe$)", {{
+      { "d3d9.shaderModel",                 "1" },
+    }} },
     /* Star Wars The Force Unleashed 2          *
      * Black particles because it tries to bind *
      * a 2D texture for a shader that           *


### PR DESCRIPTION
The launcher for Escape from Tarkov uses DX9 with partial present and therefore suffers from flickering, black screens and crashes without that config option. With the config option, it runs a bit sluggish, but at least works correctly and without the graphical issues and crashes.