### PR TITLE
setup_dxvk.sh: install with reflinks if supported

### DIFF
--- a/setup_dxvk.sh
+++ b/setup_dxvk.sh
@@ -25,7 +25,7 @@ esac
 shift
 
 with_dxgi=true
-file_cmd="cp -v"
+file_cmd="cp -v --reflink=auto"
 
 while (($# > 0)); do
   case "$1" in


### PR DESCRIPTION
Some filesystems, such as XFS and BTRFS, may perform a lightweight copy with CoW. This is most useful for rarely changing content, and the usecase of installing DXVK is one of such usecases, as library files are usually not modified (might be removed, but it's not modification).

So make use of it whenever supported.