### PR TITLE
[build] Use newer glslang features

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -133,10 +133,13 @@ dll_ext = ''
 def_spec_ext = '.def'
 
 glsl_compiler = find_program('glslangValidator')
-glsl_args = [ '--target-env', 'vulkan1.2', '--vn', '@BASENAME@', '@INPUT@', '-o', '@OUTPUT@' ]
-if run_command(glsl_compiler, [ '--quiet', '--version' ], check : false).returncode() == 0
-    glsl_args += [ '--quiet' ]
-endif
+glsl_args = [
+  '--quiet',
+  '--target-env', 'vulkan1.2',
+  '--vn', '@BASENAME@',
+  '@INPUT@',
+  '-o', '@OUTPUT@',
+]
 glsl_generator = generator(glsl_compiler,
   output    : [ '@BASENAME@.h' ],
   arguments : glsl_args,

--- a/meson.build
+++ b/meson.build
@@ -137,11 +137,14 @@ glsl_args = [
   '--quiet',
   '--target-env', 'vulkan1.2',
   '--vn', '@BASENAME@',
+  '--depfile', '@DEPFILE@',
   '@INPUT@',
   '-o', '@OUTPUT@',
 ]
-glsl_generator = generator(glsl_compiler,
+glsl_generator = generator(
+  glsl_compiler,
   output    : [ '@BASENAME@.h' ],
+  depfile   : '@BASENAME@.h.d',
   arguments : glsl_args,
 )
 


### PR DESCRIPTION
We can use these unconditionally now that dxvk requires GLSL_EXT_spirv_intrinsics.