### PR TITLE
[util] Also enable workaround for the "mod load exe" of ToEE

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -402,7 +402,7 @@ namespace dxvk {
       { "d3d9.forceAspectRatio",            "16:9" },
     }} },
     /* D&D - The Temple Of Elemental Evil          */
-    { R"(\\ToEE\.exe$)", {{
+    { R"(\\ToEE(a)?\.exe$)", {{
       { "d3d9.allowDiscard",                "False" },
     }} },
     /* ZUSI 3 - Aerosoft Edition                  */


### PR DESCRIPTION
Apparently D&D: Temple of Elemental Evil ships a second executable, ToEEa.exe, that is used by at least some mods (might be the way to actually enable mod support for the game, aka a loader, but I'm not really 100% sure to be honest). It exhibits the same "discard" problem as the main one anyway, so might as well capture it in the regex.