### PR TITLE
Ensure setup_dxvk.sh works with spaces in basedir

### DIFF
--- a/setup_dxvk.sh
+++ b/setup_dxvk.sh
@@ -5,7 +5,7 @@ dxvk_lib32=${dxvk_lib32:-"x32"}
 dxvk_lib64=${dxvk_lib64:-"x64"}
 
 # figure out where we are
-basedir=$(dirname "$(readlink -f $0)")
+basedir="$(dirname "$(readlink -f "$0")")"
 
 # figure out which action to perform
 action="$1"


### PR DESCRIPTION
If `setup_dxvk.sh` is run from a directory with spaces in the path, it will fail and do nothing. Ensure spaces are handled correctly for `basedir`.