### PR TITLE
Disable locking non-dynamic default textures

### DIFF
--- a/src/d3d9/d3d9_common_buffer.h
+++ b/src/d3d9/d3d9_common_buffer.h
@@ -229,7 +229,6 @@ namespace dxvk {
     const D3D9_BUFFER_DESC      m_desc;
     DWORD                       m_mapFlags;
     bool                        m_needsReadback = false;
-    bool                        m_uploadUsingStaging = false;
     D3D9_COMMON_BUFFER_MAP_MODE m_mapMode;
 
     Rc<DxvkBuffer>              m_buffer;

--- a/src/d3d9/d3d9_common_texture.h
+++ b/src/d3d9/d3d9_common_texture.h
@@ -512,8 +512,6 @@ namespace dxvk {
 
     int64_t                       m_size = 0;
 
-    bool                          m_systemmemModified = false;
-
     bool                          m_hazardous = false;
 
     D3D9ColorView                 m_sampleView;
@@ -525,8 +523,6 @@ namespace dxvk {
     D3D9SubresourceBitset         m_needsReadback = { };
 
     D3D9SubresourceBitset         m_needsUpload = { };
-
-    D3D9SubresourceBitset         m_uploadUsingStaging = { };
 
     DWORD                         m_exposedMipLevels = 0;
 

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -4241,6 +4241,15 @@ namespace dxvk {
 
     auto& desc = *(pResource->Desc());
 
+    // MSDN:
+    // Textures placed in the D3DPOOL_DEFAULT pool cannot be locked
+    // unless they are dynamic textures or they are private, FOURCC, driver formats.
+    // Also note that - unlike textures - swap chain back buffers, render targets [..] can be locked
+    if (unlikely(desc.Pool == D3DPOOL_DEFAULT
+      && !(desc.Usage & (D3DUSAGE_DYNAMIC | D3DUSAGE_RENDERTARGET | D3DUSAGE_DEPTHSTENCIL))
+      && !IsFourCCFormat(desc.Format)))
+      return D3DERR_INVALIDCALL;
+
     auto& formatMapping = pResource->GetFormatMapping();
 
     const DxvkFormatInfo* formatInfo = formatMapping.IsValid()

--- a/src/d3d9/d3d9_format.h
+++ b/src/d3d9/d3d9_format.h
@@ -219,4 +219,9 @@ namespace dxvk {
     bool m_d32supportFinal;
   };
 
+  inline bool IsFourCCFormat(D3D9Format format) {
+    // BINARYBUFFER is the largest non-fourcc format
+    return format > D3D9Format::BINARYBUFFER;
+  }
+
 }


### PR DESCRIPTION
Sonic Generations is slow with DXVK because it syncs with the GPU every frame:

It has a single 4x4 D3DPOOL_DEFAULT texture with a 0 usage.
`400 @0 IDirect3DDevice9::CreateTexture(this = 0xef20020, Width = 4, Height = 4, Levels = 1, Usage = 0x0, Format = D3DFMT_A8R8G8B8, Pool = D3DPOOL_DEFAULT, ppTexture = [0x12973030], pSharedHandle = NULL) = D3D_OK`

That texture gets locked every frame without any lockflags such as discard. `D3DPOOL_DEFAULT` without `D3DUSAGE_DYNAMIC` means that we do not keep the texture in memory. Therefore it has to do a GPU copy every single time and then wait for that to finish.

The fun part is that:
- the game doesn't even use the texture for anything. It just writes data to it.
- that `LockRect` call doesn't succeed on the Nvidia D3D9 driver. Which the game is perfectly fine with because all of this is pointless.

So I guess the docs aren't lying after all:
> D3DPOOL_DEFAULT pool cannot be locked unless they are dynamic textures or they are private, FOURCC, driver formats.

This improves perf quite a lot in some scenes. The game still drops below 60 but that seems to be related to asset/level streaming and not caused by DXVK.
