### PR TITLE
[util] Disable unmapping for known broken games

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -634,6 +634,21 @@ namespace dxvk {
     { R"(\\(hammer(plusplus)?|mallet|wc)\.exe$)", {{
       { "d3d9.apitraceMode",                "True" },
     }} },
+    /* theHunter - Primal                       *
+     * Temporary crash workaround               */
+    { R"(\\theHunterPrimal\.exe$)", {{
+      { "d3d9.textureMemory",                "0" },
+    }} },
+    /* Cryostasis                               *
+     * Same as above                            */
+    { R"(\\cryostasis\.exe$)", {{
+      { "d3d9.textureMemory",                "0" },
+    }} },
+    /* Warlock - Master of the Arcane           *
+     * Same as above                            */
+    { R"(\\Warlock - Master of the Arcane\Game\.exe$)", {{
+      { "d3d9.textureMemory",                "0" },
+    }} },
   }};
 
 


### PR DESCRIPTION
Some games crash after the memory unmapping changes were merged. This disables the feature for games that are known to not work with it. 
To be reverted once https://github.com/doitsujin/dxvk/pull/2833 or another fix has been merged.