### PR TITLE
[d3d9] Don't advertise support for MS INTZ format

### DIFF
--- a/src/d3d9/d3d9_adapter.cpp
+++ b/src/d3d9/d3d9_adapter.cpp
@@ -186,7 +186,8 @@ namespace dxvk {
     if (MultiSampleType != D3DMULTISAMPLE_NONE
      && (SurfaceFormat == D3D9Format::D32_LOCKABLE
       || SurfaceFormat == D3D9Format::D32F_LOCKABLE
-      || SurfaceFormat == D3D9Format::D16_LOCKABLE))
+      || SurfaceFormat == D3D9Format::D16_LOCKABLE
+      || SurfaceFormat == D3D9Format::INTZ))
       return D3DERR_NOTAVAILABLE;
 
     uint32_t sampleCount = std::max<uint32_t>(MultiSampleType, 1u);


### PR DESCRIPTION
Fixes #3017

D3D9 does not allow sampling the depth buffer directly. So the INTZ format driver hack exists as a hack to make that possible.
D3D9 also does not allow sampling multi sampled textures. `CreateTexture` doesn't even have a sample count parameter. So it makes no sense to advertise support for multisampled INTZ.

Empire Total War checks whether INTZ is supported with MSAA and if it is, it will always use that format for depth buffers. Problem is that it can only create a 1 sample texture with that format but tries to use that with the multi sampled render target regardless. This PR fixes that.