### PR TITLE
[util] Disable direct buffer mapping for Dragon Age Origins

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -634,6 +634,13 @@ namespace dxvk {
     { R"(\\(hammer(plusplus)?|mallet|wc)\.exe$)", {{
       { "d3d9.apitraceMode",                "True" },
     }} },
+    /* Dragon Age Origins                       *
+     * Keeps unmapping the same 3 1MB buffers   *
+     * thousands of times when you alt-tab out  *
+     * Causing it to crash OOM                  */
+    { R"(\\DAOrigins\.exe$)" , {{
+      { "d3d9.allowDirectBufferMapping",    "False" },
+    }} },
   }};
 
 


### PR DESCRIPTION
Fixes #3022

I would still like to just get rid of direct buffer mapping because it causes nothing but problems.

Also, curiously I've tried calling Lock(0) and then Lock(DISCARD) a bunch of times on a POOL_DEFAULT + USAGE_WRITEONLY | USAGE_DYNAMIC buffer on Windows and I got the same pointer every time.

So either it straight up ignores DISCARD or it does some tracking whether the buffer is currently in use on the GPU.
We could of course also do that but I would rather not synchronize with the CS thread for every Lock(DISCARD) call.
So this is the solution for now.

Disabling direct buffer mapping makes it ignore DISCARD and go through the staging buffer upload path.
We recently added a memory limit to that which saves the day for Dragon Age Origins.