### PR TITLE
[d3d9] Fix query reset counter underflow

### DIFF
--- a/src/d3d9/d3d9_query.cpp
+++ b/src/d3d9/d3d9_query.cpp
@@ -101,8 +101,10 @@ namespace dxvk {
 
     if (dwIssueFlags == D3DISSUE_BEGIN) {
       if (QueryBeginnable(m_queryType)) {
-        if (m_state == D3D9_VK_QUERY_BEGUN && QueryEndable(m_queryType))
+        if (m_state == D3D9_VK_QUERY_BEGUN && QueryEndable(m_queryType)) {
+          m_resetCtr.fetch_add(1, std::memory_order_acquire);
           m_parent->End(this);
+        }
 
         m_parent->Begin(this);
 


### PR DESCRIPTION
Fixes #1650 

The queries never finished because of a `m_resetCtr` underflow. 