### PR TITLE
d3d9: Use a different rvalue for depth bias on NV

### DIFF
--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -1382,7 +1382,8 @@ namespace dxvk {
     m_flags.set(D3D9DeviceFlag::DirtyFramebuffer);
 
     if (ds != nullptr) {
-      float rValue = GetDepthBufferRValue(ds->GetCommonTexture()->GetFormatMapping().FormatColor);
+      const int32_t vendorId = m_dxvkDevice->adapter()->deviceProperties().vendorID;
+      float rValue = GetDepthBufferRValue(ds->GetCommonTexture()->GetFormatMapping().FormatColor, vendorId);
       if (m_depthBiasScale != rValue) {
         m_depthBiasScale = rValue;
         m_flags.set(D3D9DeviceFlag::DirtyDepthBias);

--- a/src/d3d9/d3d9_util.h
+++ b/src/d3d9/d3d9_util.h
@@ -176,14 +176,14 @@ namespace dxvk {
 
   void ConvertRect(RECT rect, VkOffset2D& offset, VkExtent2D& extent);
 
-  inline float GetDepthBufferRValue(VkFormat Format) {
+  inline float GetDepthBufferRValue(VkFormat Format, int32_t vendorId) {
     switch (Format) {
       case VK_FORMAT_D16_UNORM_S8_UINT:
       case VK_FORMAT_D16_UNORM:
-        return float(1 << 16);
+        return vendorId == 0x10de ? float(1 << 15) : float(1 << 16);
 
       case VK_FORMAT_D24_UNORM_S8_UINT:
-        return float(1 << 24);
+        return vendorId == 0x10de ? float(1 << 23) : float(1 << 24);
 
       default:
       case VK_FORMAT_D32_SFLOAT_S8_UINT:


### PR DESCRIPTION
This should mitigate some issues of #2892 like FEAR (#1461), Guild Wars 2 (#1329) and NosTale (#1811, tho this issue still has some FFP fun).