### PR TITLE
[d3d9] Allow locking DEFAULT pool based on texture type

### DIFF
--- a/src/d3d9/d3d9_common_texture.h
+++ b/src/d3d9/d3d9_common_texture.h
@@ -47,6 +47,7 @@ namespace dxvk {
     bool                Discard;
     bool                IsBackBuffer;
     bool                IsAttachmentOnly;
+    bool                IsLockable;
   };
 
   struct D3D9ColorView {

--- a/src/d3d9/d3d9_format.h
+++ b/src/d3d9/d3d9_format.h
@@ -226,4 +226,17 @@ namespace dxvk {
     return format > D3D9Format::BINARYBUFFER;
   }
 
+  inline bool IsVendorFormat(D3D9Format format) {
+    return IsFourCCFormat(format)
+      && format != D3D9Format::MULTI2_ARGB8
+      && format != D3D9Format::UYVY
+      && format != D3D9Format::R8G8_B8G8
+      && format != D3D9Format::G8R8_G8B8
+      && format != D3D9Format::DXT1
+      && format != D3D9Format::DXT2
+      && format != D3D9Format::DXT3
+      && format != D3D9Format::DXT4
+      && format != D3D9Format::DXT5;
+  }
+
 }

--- a/src/d3d9/d3d9_swapchain.cpp
+++ b/src/d3d9/d3d9_swapchain.cpp
@@ -897,6 +897,8 @@ namespace dxvk {
     desc.Discard            = FALSE;
     desc.IsBackBuffer       = TRUE;
     desc.IsAttachmentOnly   = FALSE;
+    // Docs: Also note that - unlike textures - swap chain back buffers, render targets [..] can be locked
+    desc.IsLockable         = TRUE;
 
     for (uint32_t i = 0; i < m_backBuffers.size(); i++)
       m_backBuffers[i] = new D3D9Surface(m_parent, &desc, this, nullptr);


### PR DESCRIPTION
More accurate implementation of the locking rules around D3DPOOL_DEFAULT textures & surfaces.

Fixes a regression in COD 2 while retaining the performance in Sonic Generations.