### PR TITLE
[d3d9] Only upload mip 0 of managed automipgen textures

### DIFF
--- a/src/d3d9/d3d9_common_texture.cpp
+++ b/src/d3d9/d3d9_common_texture.cpp
@@ -22,15 +22,17 @@ namespace dxvk {
                     ? D3D9Format::D32
                     : D3D9Format::X8R8G8B8;
 
+    m_exposedMipLevels = m_desc.MipLevels;
+
+    if (m_desc.Usage & D3DUSAGE_AUTOGENMIPMAP)
+      m_exposedMipLevels = 1;
+
     for (uint32_t i = 0; i < m_dirtyBoxes.size(); i++) {
       AddDirtyBox(nullptr, i);
     }
 
     if (m_desc.Pool != D3DPOOL_DEFAULT) {
-      const uint32_t subresources = CountSubresources();
-      for (uint32_t i = 0; i < subresources; i++) {
-        SetNeedsUpload(i, true);
-      }
+      SetAllNeedUpload();
       if (pSharedHandle) {
         throw DxvkError("D3D9: Incompatible pool type for texture sharing.");
       }
@@ -88,11 +90,6 @@ namespace dxvk {
       m_data = m_device->GetAllocator()->Alloc(m_totalSize);
     else if (m_mapMode != D3D9_COMMON_TEXTURE_MAP_MODE_NONE && m_desc.Pool != D3DPOOL_DEFAULT)
       CreateBuffer(false);
-
-    m_exposedMipLevels = m_desc.MipLevels;
-
-    if (m_desc.Usage & D3DUSAGE_AUTOGENMIPMAP)
-      m_exposedMipLevels = 1;
   }
 
 

--- a/src/d3d9/d3d9_common_texture.h
+++ b/src/d3d9/d3d9_common_texture.h
@@ -370,7 +370,15 @@ namespace dxvk {
     D3D9SubresourceBitset& GetUploadBitmask() { return m_needsUpload; }
 
     void SetAllNeedUpload() {
-      m_needsUpload.setAll();
+      if (likely(!IsAutomaticMip())) {
+        m_needsUpload.setAll();
+      } else {
+        for (uint32_t a = 0; a < m_desc.ArraySize; a++) {
+          for (uint32_t m = 0; m < ExposedMipLevels(); m++) {
+            SetNeedsUpload(CalcSubresource(a, m), true);
+          }
+        }
+      }
     }
     void SetNeedsUpload(UINT Subresource, bool upload) { m_needsUpload.set(Subresource, upload); }
     bool NeedsUpload(UINT Subresource) const { return m_needsUpload.get(Subresource); }
@@ -380,7 +388,7 @@ namespace dxvk {
     void SetNeedsMipGen(bool value) { m_needsMipGen = value; }
     bool NeedsMipGen() const { return m_needsMipGen; }
 
-    DWORD ExposedMipLevels() { return m_exposedMipLevels; }
+    DWORD ExposedMipLevels() const { return m_exposedMipLevels; }
 
     void SetMipFilter(D3DTEXTUREFILTERTYPE filter) { m_mipFilter = filter; }
     D3DTEXTUREFILTERTYPE GetMipFilter() const { return m_mipFilter; }

--- a/src/d3d9/d3d9_texture.cpp
+++ b/src/d3d9/d3d9_texture.cpp
@@ -279,7 +279,7 @@ namespace dxvk {
     // and purely rely on AddDirtyRect to notify D3D9 that contents have changed.
     // We have no way of knowing which mip levels were actually changed.
     if (m_texture.IsManaged()) {
-      for (uint32_t m = 0; m < m_texture.Desc()->MipLevels; m++) {
+      for (uint32_t m = 0; m < m_texture.ExposedMipLevels(); m++) {
         m_texture.SetNeedsUpload(m_texture.CalcSubresource(Face, m), true);
       }
     }


### PR DESCRIPTION
Fixes #3058

I really hate automatic mipmap generation.

We currently upload the non 0 mip maps even though those can't be locked.