### PR TITLE
[dxbc] Move shex check to constructor

### DIFF
--- a/src/dxbc/dxbc_module.cpp
+++ b/src/dxbc/dxbc_module.cpp
@@ -32,6 +32,9 @@ namespace dxvk {
       if ((tag == "PCSG") || (tag == "PSG1"))
         m_psgnChunk = new DxbcIsgn(chunkReader, tag);
     }
+
+    if (m_shexChunk == nullptr)
+      throw DxvkError("DxbcModule::compile: No SHDR/SHEX chunk");
   }
   
   
@@ -43,8 +46,6 @@ namespace dxvk {
   Rc<DxvkShader> DxbcModule::compile(
     const DxbcModuleInfo& moduleInfo,
     const std::string&    fileName) const {
-    if (m_shexChunk == nullptr)
-      throw DxvkError("DxbcModule::compile: No SHDR/SHEX chunk");
     
     DxbcAnalysisInfo analysisInfo;
     
@@ -70,9 +71,6 @@ namespace dxvk {
   Rc<DxvkShader> DxbcModule::compilePassthroughShader(
     const DxbcModuleInfo& moduleInfo,
     const std::string&    fileName) const {
-    if (m_shexChunk == nullptr)
-      throw DxvkError("DxbcModule::compile: No SHDR/SHEX chunk");
-    
     DxbcAnalysisInfo analysisInfo;
 
     DxbcCompiler compiler(


### PR DESCRIPTION
#3086

Otherwise we dereference a null pointer when accessing the DxbcProgramInfo.