### PR TITLE
README: fix wine dll path

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ Release builds can be found [here](https://github.com/doitsujin/dxvk/releases).
 In order to install a DXVK package obtained from the [release](https://github.com/doitsujin/dxvk/releases) page into a given wine prefix, copy or symlink the DLLs into the following directories as follows, then open `winecfg` and manually add DLL overrides for `d3d11`, `d3d10core`, `dxgi`, and `d3d9`:
 ```
 WINEPREFIX=/path/to/wineprefix
-cp x64/*.dll $WINEPREFIX/drive_c/system32
-cp x32/*.dll $WINEPREFIX/drive_c/syswow64
+cp x64/*.dll $WINEPREFIX/drive_c/windows/system32
+cp x32/*.dll $WINEPREFIX/drive_c/windows/syswow64
 winecfg
 ```
 


### PR DESCRIPTION
`$WINEPREFIX/drive_c/system32` does not exist for me on wine 7.20

`drive_c/`
```
./windows
./users
./Program Files
./ProgramData
./Program Files (x86)
```