### PR TITLE
[util] disable unmapping for Final Fantasy XIV d3d9

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -681,6 +681,11 @@ namespace dxvk {
     { R"(\\bms\.exe$)", {{
       { "d3d9.customVendorId",              "10de" },
     }} },
+    /* Final Fantasy XIV - Direct3D 9 mode     *
+     * Can crash with unmapping                */
+    { R"(\\ffxiv\.exe$)", {{
+      { "d3d9.textureMemory",                "0"   },
+    }} },
   }};
 
 


### PR DESCRIPTION
Can crash during gameplay with unmapping. 
The d3d9 version is not officially supported anymore and is expected to be deprecated in the near feature, so the work around here is just to disable this feature for now.

Closes https://github.com/doitsujin/dxvk/issues/3099