### PR TITLE
[util] Set Secret World Legends launcher to SM 2

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
-                  Copyright (c) 2017-2021 Philip Rebohle
-                  Copyright (c) 2019-2021 Joshua Ashton
+                  Copyright (c) 2017 Philip Rebohle
+                  Copyright (c) 2019 Joshua Ashton
 
                           zlib/libpng license
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ git clone --recursive https://github.com/doitsujin/dxvk.git
 
 
 ### Requirements:
-- [wine 3.10](https://www.winehq.org/) or newer
+- [wine 7.1](https://www.winehq.org/) or newer
 - [Meson](https://mesonbuild.com/) build system (at least version 0.49)
 - [Mingw-w64](https://www.mingw-w64.org) compiler and headers (at least version 10.0)
 - [glslang](https://github.com/KhronosGroup/glslang) compiler

--- a/VP_DXVK_requirements.json
+++ b/VP_DXVK_requirements.json
@@ -185,7 +185,8 @@
                 "VK_EXT_memory_priority": 1,
                 "VK_EXT_vertex_attribute_divisor": 1,
                 "VK_EXT_custom_border_color": 1,
-                "VK_EXT_depth_clip_enable": 1
+                "VK_EXT_depth_clip_enable": 1,
+                "VK_EXT_swapchain_colorspace": 1
             },
             "features": {
                 "VkPhysicalDeviceFeatures": {
@@ -385,6 +386,12 @@
         }
     },
     "history": [
+        {
+            "revision": 4,
+            "date": "2022-12-18",
+            "author": "Joshua Ashton",
+            "comment": "Add VK_EXT_swapchain_colorspace to d3d11_baseline_optional"
+        },
         {
             "revision": 3,
             "date": "2022-10-13",

--- a/VP_DXVK_requirements.json
+++ b/VP_DXVK_requirements.json
@@ -186,7 +186,8 @@
                 "VK_EXT_vertex_attribute_divisor": 1,
                 "VK_EXT_custom_border_color": 1,
                 "VK_EXT_depth_clip_enable": 1,
-                "VK_EXT_swapchain_colorspace": 1
+                "VK_EXT_swapchain_colorspace": 1,
+                "VK_EXT_hdr_metadata": 1
             },
             "features": {
                 "VkPhysicalDeviceFeatures": {
@@ -390,7 +391,7 @@
             "revision": 4,
             "date": "2022-12-18",
             "author": "Joshua Ashton",
-            "comment": "Add VK_EXT_swapchain_colorspace to d3d11_baseline_optional"
+            "comment": "Add VK_EXT_swapchain_colorspace and VK_EXT_hdr_metadata to d3d11_baseline_optional"
         },
         {
             "revision": 3,

--- a/dxvk.conf
+++ b/dxvk.conf
@@ -1,3 +1,15 @@
+# Expose the HDR10 ColorSpace (DXGI_COLOR_SPACE_RGB_FULL_G2084_NONE_P2020)
+# to the application by default.
+# This shows to the game that the global Windows 'HDR Mode' is enabled.
+# Many (broken) games will need this to be set to consider exposing HDR output
+# as determine it based on the DXGIOutput's current ColorSpace instead of
+# using CheckColorSpaceSupport.
+# This defaults to the value of the DXVK_HDR environment variable.
+# 
+# Supported values: True, False
+
+# dxgi.enableHDR = True
+
 # Create the VkSurface on the first call to IDXGISwapChain::Present,
 # rather than when creating the swap chain. Some games that start
 # rendering with a different graphics API may require this option,

--- a/package-native.sh
+++ b/package-native.sh
@@ -10,7 +10,8 @@ if [ -z "$1" ] || [ -z "$2" ]; then
 fi
 
 DXVK_VERSION="$1"
-DXVK_SRC_DIR=`dirname $(readlink -f $0)`
+DXVK_SRC_DIR=$(readlink -f "$0")
+DXVK_SRC_DIR=$(dirname "$DXVK_SRC_DIR")
 DXVK_BUILD_DIR=$(realpath "$2")"/dxvk-native-$DXVK_VERSION"
 DXVK_ARCHIVE_PATH=$(realpath "$2")"/dxvk-native-$DXVK_VERSION.tar.gz"
 

--- a/package-release.sh
+++ b/package-release.sh
@@ -10,7 +10,8 @@ if [ -z "$1" ] || [ -z "$2" ]; then
 fi
 
 DXVK_VERSION="$1"
-DXVK_SRC_DIR=`dirname $(readlink -f $0)`
+DXVK_SRC_DIR=$(readlink -f "$0")
+DXVK_SRC_DIR=$(dirname "$DXVK_SRC_DIR")
 DXVK_BUILD_DIR=$(realpath "$2")"/dxvk-$DXVK_VERSION"
 DXVK_ARCHIVE_PATH=$(realpath "$2")"/dxvk-$DXVK_VERSION.tar.gz"
 

--- a/src/d3d11/d3d11_fence.cpp
+++ b/src/d3d11/d3d11_fence.cpp
@@ -81,13 +81,13 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE D3D11Fence::SetEventOnCompletion(
           UINT64              Value,
           HANDLE              hEvent) {
-    // TODO in case of rewinds, the stored value may be higher.
-    // For shared fences, calling vkWaitSemaphores here could alleviate the issue.
-
-    m_fence->enqueueWait(Value, [hEvent] {
-      SetEvent(hEvent);
-    });
-
+    if (hEvent) {
+      m_fence->enqueueWait(Value, [hEvent] {
+        SetEvent(hEvent);
+      });
+    } else {
+      m_fence->wait(Value);
+    }
     return S_OK;
   }
 

--- a/src/d3d11/d3d11_swapchain.cpp
+++ b/src/d3d11/d3d11_swapchain.cpp
@@ -446,6 +446,7 @@ namespace dxvk {
     presenterDevice.queue         = graphicsQueue.queueHandle;
     presenterDevice.adapter       = m_device->adapter()->handle();
     presenterDevice.features.fullScreenExclusive = m_device->features().extFullScreenExclusive;
+    presenterDevice.features.hdrMetadata = m_device->features().extHdrMetadata;
 
     vk::PresenterDesc presenterDesc;
     presenterDesc.imageExtent     = { m_desc.Width, m_desc.Height };

--- a/src/d3d11/d3d11_swapchain.h
+++ b/src/d3d11/d3d11_swapchain.h
@@ -121,6 +121,8 @@ namespace dxvk {
     bool                    m_dirty = true;
     bool                    m_vsync = true;
 
+    VkColorSpaceKHR         m_colorspace = VK_COLOR_SPACE_SRGB_NONLINEAR_KHR;
+
     HRESULT PresentImage(UINT SyncInterval);
 
     void SubmitPresent(

--- a/src/d3d11/d3d11_swapchain.h
+++ b/src/d3d11/d3d11_swapchain.h
@@ -123,6 +123,9 @@ namespace dxvk {
 
     VkColorSpaceKHR         m_colorspace = VK_COLOR_SPACE_SRGB_NONLINEAR_KHR;
 
+    std::optional<VkHdrMetadataEXT> m_hdrMetadata;
+    bool m_dirtyHdrMetadata = true;
+
     HRESULT PresentImage(UINT SyncInterval);
 
     void SubmitPresent(

--- a/src/d3d11/d3d11_texture.cpp
+++ b/src/d3d11/d3d11_texture.cpp
@@ -1176,27 +1176,24 @@ namespace dxvk {
   
   
   ULONG STDMETHODCALLTYPE D3D11Texture2D::AddRef() {
-    uint32_t refCount = m_refCount++;
+    uint32_t refCount = D3D11DeviceChild<ID3D11Texture2D1>::AddRef();
 
-    if (unlikely(!refCount)) {
-      if (m_swapChain)
+    if (unlikely(m_swapChain != nullptr)) {
+      if (refCount == 1)
         m_swapChain->AddRef();
-
-      AddRefPrivate();
     }
 
-    return refCount + 1;
+    return refCount;
   }
   
 
   ULONG STDMETHODCALLTYPE D3D11Texture2D::Release() {
-    uint32_t refCount = --m_refCount;
+    IUnknown* swapChain = m_swapChain;
+    uint32_t refCount = D3D11DeviceChild<ID3D11Texture2D1>::Release();
 
-    if (unlikely(!refCount)) {
-      if (m_swapChain)
-        m_swapChain->Release();
-
-      ReleasePrivate();
+    if (unlikely(swapChain != nullptr)) {
+      if (refCount == 0)
+        swapChain->Release();
     }
 
     return refCount;

--- a/src/d3d11/d3d11_view_uav.cpp
+++ b/src/d3d11/d3d11_view_uav.cpp
@@ -59,9 +59,11 @@ namespace dxvk {
       DxvkImageViewCreateInfo viewInfo;
       viewInfo.format  = formatInfo.Format;
       viewInfo.aspect  = formatInfo.Aspect;
-      viewInfo.swizzle = formatInfo.Swizzle;
       viewInfo.usage   = VK_IMAGE_USAGE_STORAGE_BIT;
-      
+
+      if (!util::isIdentityMapping(formatInfo.Swizzle))
+        Logger::warn(str::format("UAV format ", pDesc->Format, " has non-identity swizzle, but UAV swizzles are not supported"));
+
       switch (pDesc->ViewDimension) {
         case D3D11_UAV_DIMENSION_TEXTURE1D:
           viewInfo.type      = VK_IMAGE_VIEW_TYPE_1D;

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -2536,10 +2536,10 @@ namespace dxvk {
 
     PrepareDraw(PrimitiveType);
 
-    auto drawInfo = GenerateDrawInfo(PrimitiveType, PrimitiveCount, 0);
+    uint32_t vertexCount = GetVertexCount(PrimitiveType, PrimitiveCount);
 
-    const uint32_t dataSize = GetUPDataSize(drawInfo.vertexCount, VertexStreamZeroStride);
-    const uint32_t bufferSize = GetUPBufferSize(drawInfo.vertexCount, VertexStreamZeroStride);
+    const uint32_t dataSize = GetUPDataSize(vertexCount, VertexStreamZeroStride);
+    const uint32_t bufferSize = GetUPBufferSize(vertexCount, VertexStreamZeroStride);
 
     auto upSlice = AllocUPBuffer(bufferSize);
     FillUPVertexBuffer(upSlice.mapPtr, pVertexStreamZeroData, dataSize, bufferSize);
@@ -2589,13 +2589,13 @@ namespace dxvk {
 
     PrepareDraw(PrimitiveType);
 
-    auto drawInfo = GenerateDrawInfo(PrimitiveType, PrimitiveCount, 0);
+    uint32_t vertexCount = GetVertexCount(PrimitiveType, PrimitiveCount);
 
     const uint32_t vertexDataSize = GetUPDataSize(MinVertexIndex + NumVertices, VertexStreamZeroStride);
     const uint32_t vertexBufferSize = GetUPBufferSize(MinVertexIndex + NumVertices, VertexStreamZeroStride);
 
     const uint32_t indexSize = IndexDataFormat == D3DFMT_INDEX16 ? 2 : 4;
-    const uint32_t indicesSize = drawInfo.vertexCount * indexSize;
+    const uint32_t indicesSize = vertexCount * indexSize;
 
     const uint32_t upSize = vertexBufferSize + indicesSize;
 

--- a/src/dxbc/dxbc_compiler.cpp
+++ b/src/dxbc/dxbc_compiler.cpp
@@ -72,6 +72,17 @@ namespace dxvk {
     m_lastOp = m_currOp;
     m_currOp = ins.op;
 
+    if (!m_insideFunction
+     && ins.opClass != DxbcInstClass::CustomData
+     && ins.opClass != DxbcInstClass::Declaration
+     && ins.opClass != DxbcInstClass::HullShaderPhase
+     && ins.opClass != DxbcInstClass::NoOperation
+     && ins.op != DxbcOpcode::Label) {
+      if (!std::exchange(m_hasDeadCode, true))
+        Logger::warn("DxbcCompiler: Dead code detected");
+      return;
+    }
+
     switch (ins.opClass) {
       case DxbcInstClass::Declaration:
         return this->emitDcl(ins);

--- a/src/dxbc/dxbc_compiler.h
+++ b/src/dxbc/dxbc_compiler.h
@@ -531,6 +531,7 @@ namespace dxvk {
     //////////////////////
     // Global state stuff
     bool m_precise = true;
+    bool m_hasDeadCode = false;
 
     DxbcOpcode m_lastOp = DxbcOpcode::Nop;
     DxbcOpcode m_currOp = DxbcOpcode::Nop;

--- a/src/dxgi/dxgi_factory.cpp
+++ b/src/dxgi/dxgi_factory.cpp
@@ -7,8 +7,8 @@ namespace dxvk {
 
   DxgiFactory::DxgiFactory(UINT Flags)
   : m_instance    (new DxvkInstance()),
-    m_monitorInfo (this),
     m_options     (m_instance->config()),
+    m_monitorInfo (this),
     m_flags       (Flags) {
     for (uint32_t i = 0; m_instance->enumAdapters(i) != nullptr; i++)
       m_instance->enumAdapters(i)->logAdapterInfo();

--- a/src/dxgi/dxgi_factory.cpp
+++ b/src/dxgi/dxgi_factory.cpp
@@ -8,7 +8,7 @@ namespace dxvk {
   DxgiFactory::DxgiFactory(UINT Flags)
   : m_instance    (new DxvkInstance()),
     m_options     (m_instance->config()),
-    m_monitorInfo (this),
+    m_monitorInfo (this, m_options),
     m_flags       (Flags) {
     for (uint32_t i = 0; m_instance->enumAdapters(i) != nullptr; i++)
       m_instance->enumAdapters(i)->logAdapterInfo();

--- a/src/dxgi/dxgi_factory.h
+++ b/src/dxgi/dxgi_factory.h
@@ -146,8 +146,8 @@ namespace dxvk {
   private:
     
     Rc<DxvkInstance> m_instance;
-    DxgiMonitorInfo  m_monitorInfo;
     DxgiOptions      m_options;
+    DxgiMonitorInfo  m_monitorInfo;
     UINT             m_flags;
     
     HWND m_associatedWindow = nullptr;

--- a/src/dxgi/dxgi_interfaces.h
+++ b/src/dxgi/dxgi_interfaces.h
@@ -200,6 +200,30 @@ IDXGIVkMonitorInfo : public IUnknown {
    */
   virtual void STDMETHODCALLTYPE ReleaseMonitorData() = 0;
 
+  /**
+   * \brief Punt global colorspace
+   *
+   * This exists to satiate a requirement for
+   * IDXGISwapChain::SetColorSpace1 punting Windows into
+   * the global "HDR mode".
+   *
+   * This operation is atomic and does not require
+   * owning any monitor data.
+   *
+   * \param [in] ColorSpace The colorspace
+   */
+  virtual void STDMETHODCALLTYPE PuntColorSpace(DXGI_COLOR_SPACE_TYPE ColorSpace) = 0;
+
+  /**
+   * \brief Get current global colorspace
+   *
+   * This operation is atomic and does not require
+   * owning any monitor data.
+   *
+   * \returns Current global colorspace
+   */
+  virtual DXGI_COLOR_SPACE_TYPE STDMETHODCALLTYPE CurrentColorSpace() const = 0;
+
 };
 
 

--- a/src/dxgi/dxgi_monitor.cpp
+++ b/src/dxgi/dxgi_monitor.cpp
@@ -2,8 +2,9 @@
 
 namespace dxvk {
 
-  DxgiMonitorInfo::DxgiMonitorInfo(IUnknown* pParent)
+  DxgiMonitorInfo::DxgiMonitorInfo(IUnknown* pParent, const DxgiOptions& options)
   : m_parent(pParent)
+  , m_options(options)
   , m_globalColorSpace(DefaultColorSpace()) {
 
   }
@@ -80,8 +81,8 @@ namespace dxvk {
   }
 
 
-  DXGI_COLOR_SPACE_TYPE DxgiMonitorInfo::DefaultColorSpace() {
-    return env::getEnvVar("DXVK_HDR") == "1"
+  DXGI_COLOR_SPACE_TYPE DxgiMonitorInfo::DefaultColorSpace() const {
+    return m_options.enableHDR
       ? DXGI_COLOR_SPACE_RGB_FULL_G2084_NONE_P2020
       : DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P709;
   }

--- a/src/dxgi/dxgi_monitor.cpp
+++ b/src/dxgi/dxgi_monitor.cpp
@@ -3,7 +3,8 @@
 namespace dxvk {
 
   DxgiMonitorInfo::DxgiMonitorInfo(IUnknown* pParent)
-  : m_parent(pParent) {
+  : m_parent(pParent)
+  , m_globalColorSpace(DefaultColorSpace()) {
 
   }
 
@@ -66,6 +67,23 @@ namespace dxvk {
 
   void STDMETHODCALLTYPE DxgiMonitorInfo::ReleaseMonitorData() {
     m_monitorMutex.unlock();
+  }
+
+
+  void STDMETHODCALLTYPE DxgiMonitorInfo::PuntColorSpace(DXGI_COLOR_SPACE_TYPE ColorSpace) {
+    m_globalColorSpace = ColorSpace;
+  }
+
+
+  DXGI_COLOR_SPACE_TYPE STDMETHODCALLTYPE DxgiMonitorInfo::CurrentColorSpace() const {
+    return m_globalColorSpace;
+  }
+
+
+  DXGI_COLOR_SPACE_TYPE DxgiMonitorInfo::DefaultColorSpace() {
+    return env::getEnvVar("DXVK_HDR") == "1"
+      ? DXGI_COLOR_SPACE_RGB_FULL_G2084_NONE_P2020
+      : DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P709;
   }
 
 

--- a/src/dxgi/dxgi_monitor.h
+++ b/src/dxgi/dxgi_monitor.h
@@ -37,12 +37,20 @@ namespace dxvk {
 
     void STDMETHODCALLTYPE ReleaseMonitorData();
 
+    void STDMETHODCALLTYPE PuntColorSpace(DXGI_COLOR_SPACE_TYPE ColorSpace);
+
+    DXGI_COLOR_SPACE_TYPE STDMETHODCALLTYPE CurrentColorSpace() const;
+
+    static DXGI_COLOR_SPACE_TYPE DefaultColorSpace();
+
   private:
 
     IUnknown* m_parent;
 
     dxvk::mutex                                        m_monitorMutex;
     std::unordered_map<HMONITOR, DXGI_VK_MONITOR_DATA> m_monitorData;
+
+    std::atomic<DXGI_COLOR_SPACE_TYPE> m_globalColorSpace;
 
   };
 

--- a/src/dxgi/dxgi_monitor.h
+++ b/src/dxgi/dxgi_monitor.h
@@ -4,6 +4,7 @@
 #include <unordered_map>
 
 #include "dxgi_interfaces.h"
+#include "dxgi_options.h"
 
 #include "../wsi/wsi_monitor.h"
 
@@ -15,7 +16,7 @@ namespace dxvk {
 
   public:
 
-    DxgiMonitorInfo(IUnknown* pParent);
+    DxgiMonitorInfo(IUnknown* pParent, const DxgiOptions& options);
 
     ~DxgiMonitorInfo();
 
@@ -41,11 +42,12 @@ namespace dxvk {
 
     DXGI_COLOR_SPACE_TYPE STDMETHODCALLTYPE CurrentColorSpace() const;
 
-    static DXGI_COLOR_SPACE_TYPE DefaultColorSpace();
+    DXGI_COLOR_SPACE_TYPE DefaultColorSpace() const;
 
   private:
 
     IUnknown* m_parent;
+    const DxgiOptions& m_options;
 
     dxvk::mutex                                        m_monitorMutex;
     std::unordered_map<HMONITOR, DXGI_VK_MONITOR_DATA> m_monitorData;

--- a/src/dxgi/dxgi_options.cpp
+++ b/src/dxgi/dxgi_options.cpp
@@ -45,6 +45,8 @@ namespace dxvk {
       this->nvapiHack = false;
     else
       this->nvapiHack = config.getOption<bool>("dxgi.nvapiHack", true);
+
+    this->enableHDR = config.getOption<bool>("dxgi.enableHDR", env::getEnvVar("DXVK_HDR") == "1");
   }
   
 }

--- a/src/dxgi/dxgi_options.h
+++ b/src/dxgi/dxgi_options.h
@@ -35,6 +35,9 @@ namespace dxvk {
 
     /// Enables nvapi workaround
     bool nvapiHack;
+
+    /// Enable HDR
+    bool enableHDR;
   };
   
 }

--- a/src/dxgi/dxgi_output.cpp
+++ b/src/dxgi/dxgi_output.cpp
@@ -19,6 +19,61 @@
 #include "../util/util_time.h"
 
 namespace dxvk {
+
+  static void NormalizeDisplayMetadata(wsi::WsiDisplayMetadata& metadata) {
+    // Use some dummy info when we have no hdr static metadata for the
+    // display or we were unable to obtain an EDID.
+    //
+    // These dummy values are the same as what Windows DXGI will output
+    // for panels with broken EDIDs such as LG OLEDs displays which
+    // have an entirely zeroed out luminance section in the hdr static
+    // metadata block.
+    //
+    // (Spec has 0 as 'undefined', which isn't really useful for an app
+    // to tonemap against.)
+    if (metadata.minLuminance == 0.0f)
+      metadata.minLuminance = 0.01f;
+
+    if (metadata.maxLuminance == 0.0f)
+      metadata.maxLuminance = 1499.0f;
+
+    if (metadata.maxFullFrameLuminance == 0.0f)
+      metadata.maxFullFrameLuminance = 799.0f;
+
+    // If we have no RedPrimary/GreenPrimary/BluePrimary/WhitePoint due to
+    // the lack of a monitor exposing the chroma block or the lack of an EDID,
+    // simply just fall back to Rec.709 or Rec.2020 values depending on the default
+    // ColorSpace we started in.
+    // (Don't change based on punting, as this should be static for a display.)
+    if (metadata.redPrimary[0]   == 0.0f && metadata.redPrimary[1]   == 0.0f
+     && metadata.greenPrimary[0] == 0.0f && metadata.greenPrimary[1] == 0.0f
+     && metadata.bluePrimary[0]  == 0.0f && metadata.bluePrimary[1]  == 0.0f
+     && metadata.whitePoint[0]   == 0.0f && metadata.whitePoint[1]   == 0.0f) {
+      if (DxgiMonitorInfo::DefaultColorSpace() == DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P709) {
+        // sRGB ColorSpace -> Rec.709 Primaries
+        metadata.redPrimary[0]   = 0.640f;
+        metadata.redPrimary[1]   = 0.330f;
+        metadata.greenPrimary[0] = 0.300f;
+        metadata.greenPrimary[1] = 0.600f;
+        metadata.bluePrimary[0]  = 0.150f;
+        metadata.bluePrimary[1]  = 0.060f;
+        metadata.whitePoint[0]   = 0.3127f;
+        metadata.whitePoint[1]   = 0.3290f;
+      } else {
+        // HDR10 ColorSpace -> Rec.2020 Primaries
+        // (Notably much bigger than any display is actually going to expose.)
+        metadata.redPrimary[0]   = 0.708f;
+        metadata.redPrimary[1]   = 0.292f;
+        metadata.greenPrimary[0] = 0.170f;
+        metadata.greenPrimary[1] = 0.797f;
+        metadata.bluePrimary[0]  = 0.131f;
+        metadata.bluePrimary[1]  = 0.046f;
+        metadata.whitePoint[0]   = 0.3127f;
+        metadata.whitePoint[1]   = 0.3290f;
+      }
+    }
+  }
+
   
   DxgiOutput::DxgiOutput(
     const Com<DxgiFactory>& factory,
@@ -664,6 +719,10 @@ namespace dxvk {
       m_metadata = metadata.value();
     else
       Logger::err("DXGI: Failed to parse display metadata + colorimetry info, using blank.");
+
+    // Normalize either the display metadata we got back, or our
+    // blank one to get something sane here.
+    NormalizeDisplayMetadata(m_metadata);
 
     monitorData.FrameStats.SyncQPCTime.QuadPart = dxvk::high_resolution_clock::get_counter();
     monitorData.GammaCurve.Scale = { 1.0f, 1.0f, 1.0f };

--- a/src/dxgi/dxgi_output.cpp
+++ b/src/dxgi/dxgi_output.cpp
@@ -218,21 +218,17 @@ namespace dxvk {
     pDesc->AttachedToDesktop     = 1;
     pDesc->Rotation              = DXGI_MODE_ROTATION_UNSPECIFIED;
     pDesc->Monitor               = m_monitor;
-    // TODO: When in HDR, flip this to 10 to appease apps that the
-    // transition has occured.
-    // If we support more than HDR10 in future, then we may want
-    // to visit that assumption.
     pDesc->BitsPerColor          = 8;
     // This should only return DXGI_COLOR_SPACE_RGB_FULL_G2084_NONE_P2020
     // (HDR) if the user has the HDR setting enabled in Windows.
     // Games can still punt into HDR mode by using CheckColorSpaceSupport
     // and SetColorSpace1.
-    // 
-    // TODO: When we have a swapchain using SetColorSpace1 to
-    // DXGI_COLOR_SPACE_RGB_FULL_G2084_NONE_P2020, we should use our monitor
-    // info to flip this over to that.
-    // As on Windows this would automatically engage HDR mode.
-    pDesc->ColorSpace            = DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P709;
+    //
+    // We have no way of checking the actual Windows colorspace as the
+    // only public method for this *is* DXGI which we are re-implementing.
+    // So we just pick our color space based on the DXVK_HDR env var
+    // and the punting from SetColorSpace1.
+    pDesc->ColorSpace            = m_monitorInfo->CurrentColorSpace();
     pDesc->RedPrimary[0]         = m_metadata.redPrimary[0];
     pDesc->RedPrimary[1]         = m_metadata.redPrimary[1];
     pDesc->GreenPrimary[0]       = m_metadata.greenPrimary[0];

--- a/src/dxgi/dxgi_output.cpp
+++ b/src/dxgi/dxgi_output.cpp
@@ -20,7 +20,7 @@
 
 namespace dxvk {
 
-  static void NormalizeDisplayMetadata(wsi::WsiDisplayMetadata& metadata) {
+  static void NormalizeDisplayMetadata(const DxgiMonitorInfo *pMonitorInfo, wsi::WsiDisplayMetadata& metadata) {
     // Use some dummy info when we have no hdr static metadata for the
     // display or we were unable to obtain an EDID.
     //
@@ -49,7 +49,7 @@ namespace dxvk {
      && metadata.greenPrimary[0] == 0.0f && metadata.greenPrimary[1] == 0.0f
      && metadata.bluePrimary[0]  == 0.0f && metadata.bluePrimary[1]  == 0.0f
      && metadata.whitePoint[0]   == 0.0f && metadata.whitePoint[1]   == 0.0f) {
-      if (DxgiMonitorInfo::DefaultColorSpace() == DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P709) {
+      if (pMonitorInfo->DefaultColorSpace() == DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P709) {
         // sRGB ColorSpace -> Rec.709 Primaries
         metadata.redPrimary[0]   = 0.640f;
         metadata.redPrimary[1]   = 0.330f;
@@ -722,7 +722,7 @@ namespace dxvk {
 
     // Normalize either the display metadata we got back, or our
     // blank one to get something sane here.
-    NormalizeDisplayMetadata(m_metadata);
+    NormalizeDisplayMetadata(m_monitorInfo, m_metadata);
 
     monitorData.FrameStats.SyncQPCTime.QuadPart = dxvk::high_resolution_clock::get_counter();
     monitorData.GammaCurve.Scale = { 1.0f, 1.0f, 1.0f };

--- a/src/dxgi/dxgi_swapchain.cpp
+++ b/src/dxgi/dxgi_swapchain.cpp
@@ -536,7 +536,13 @@ namespace dxvk {
       return E_INVALIDARG;
 
     std::lock_guard<dxvk::mutex> lock(m_lockBuffer);
-    return m_presenter->SetColorSpace(ColorSpace);
+    HRESULT hr = m_presenter->SetColorSpace(ColorSpace);
+    if (SUCCEEDED(hr)) {
+      // If this was a colorspace other than our current one,
+      // punt us into that one on the DXGI output.
+      m_monitorInfo->PuntColorSpace(ColorSpace);
+    }
+    return hr;
   }
 
   

--- a/src/dxvk/dxvk_adapter.cpp
+++ b/src/dxvk/dxvk_adapter.cpp
@@ -441,9 +441,15 @@ namespace dxvk {
       m_deviceFeatures.extDepthClipEnable.depthClipEnable;
 
     // Used to make pipeline library stuff less clunky
+    enabledFeatures.extExtendedDynamicState3.extendedDynamicState3AlphaToCoverageEnable =
+      m_deviceFeatures.extExtendedDynamicState3.extendedDynamicState3AlphaToCoverageEnable;
     enabledFeatures.extExtendedDynamicState3.extendedDynamicState3DepthClipEnable =
       m_deviceFeatures.extExtendedDynamicState3.extendedDynamicState3DepthClipEnable &&
       m_deviceFeatures.extDepthClipEnable.depthClipEnable;
+    enabledFeatures.extExtendedDynamicState3.extendedDynamicState3RasterizationSamples =
+      m_deviceFeatures.extExtendedDynamicState3.extendedDynamicState3RasterizationSamples;
+    enabledFeatures.extExtendedDynamicState3.extendedDynamicState3SampleMask =
+      m_deviceFeatures.extExtendedDynamicState3.extendedDynamicState3SampleMask;
 
     // Used for both pNext shader module info, and fast-linking pipelines provided
     // that graphicsPipelineLibraryIndependentInterpolationDecoration is supported
@@ -1020,7 +1026,10 @@ namespace dxvk {
       "\n", VK_EXT_DEPTH_CLIP_ENABLE_EXTENSION_NAME,
       "\n  depthClipEnable                        : ", features.extDepthClipEnable.depthClipEnable ? "1" : "0",
       "\n", VK_EXT_EXTENDED_DYNAMIC_STATE_3_EXTENSION_NAME,
-      "\n  extendedDynamicState3DepthClipEnable   : ", features.extExtendedDynamicState3.extendedDynamicState3DepthClipEnable ? "1" : "0",
+      "\n  extDynamicState3AlphaToCoverageEnable  : ", features.extExtendedDynamicState3.extendedDynamicState3AlphaToCoverageEnable ? "1" : "0",
+      "\n  extDynamicState3DepthClipEnable        : ", features.extExtendedDynamicState3.extendedDynamicState3DepthClipEnable ? "1" : "0",
+      "\n  extDynamicState3RasterizationSamples   : ", features.extExtendedDynamicState3.extendedDynamicState3RasterizationSamples ? "1" : "0",
+      "\n  extDynamicState3SampleMask             : ", features.extExtendedDynamicState3.extendedDynamicState3SampleMask ? "1" : "0",
       "\n", VK_EXT_FRAGMENT_SHADER_INTERLOCK_EXTENSION_NAME,
       "\n  fragmentShaderSampleInterlock          : ", features.extFragmentShaderInterlock.fragmentShaderSampleInterlock ? "1" : "0",
       "\n  fragmentShaderPixelInterlock           : ", features.extFragmentShaderInterlock.fragmentShaderPixelInterlock ? "1" : "0",

--- a/src/dxvk/dxvk_adapter.cpp
+++ b/src/dxvk/dxvk_adapter.cpp
@@ -318,6 +318,8 @@ namespace dxvk {
                 || !required.extShaderStencilExport)
         && (m_deviceFeatures.extShaderStencilExport
                 || !required.extSwapchainColorSpace)
+        && (m_deviceFeatures.extHdrMetadata
+                || !required.extHdrMetadata)
         && (m_deviceFeatures.extTransformFeedback.transformFeedback
                 || !required.extTransformFeedback.transformFeedback)
         && (m_deviceFeatures.extVertexAttributeDivisor.vertexAttributeInstanceRateDivisor
@@ -337,7 +339,7 @@ namespace dxvk {
           DxvkDeviceFeatures  enabledFeatures) {
     DxvkDeviceExtensions devExtensions;
 
-    std::array<DxvkExt*, 25> devExtensionList = {{
+    std::array<DxvkExt*, 26> devExtensionList = {{
       &devExtensions.amdMemoryOverallocationBehaviour,
       &devExtensions.amdShaderFragmentMask,
       &devExtensions.extAttachmentFeedbackLoopLayout,
@@ -348,6 +350,7 @@ namespace dxvk {
       &devExtensions.extFragmentShaderInterlock,
       &devExtensions.extFullScreenExclusive,
       &devExtensions.extGraphicsPipelineLibrary,
+      &devExtensions.extHdrMetadata,
       &devExtensions.extMemoryBudget,
       &devExtensions.extMemoryPriority,
       &devExtensions.extNonSeamlessCubeMap,
@@ -542,6 +545,9 @@ namespace dxvk {
 
     if (devExtensions.extSwapchainColorSpace)
       enabledFeatures.extSwapchainColorSpace = VK_TRUE;
+
+    if (devExtensions.extHdrMetadata)
+      enabledFeatures.extHdrMetadata = VK_TRUE;
 
     if (devExtensions.extTransformFeedback) {
       enabledFeatures.extTransformFeedback.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TRANSFORM_FEEDBACK_FEATURES_EXT;
@@ -884,6 +890,9 @@ namespace dxvk {
     if (m_deviceExtensions.supports(VK_EXT_SWAPCHAIN_COLOR_SPACE_EXTENSION_NAME))
       m_deviceFeatures.extSwapchainColorSpace = VK_TRUE;
 
+    if (m_deviceExtensions.supports(VK_EXT_HDR_METADATA_EXTENSION_NAME))
+      m_deviceFeatures.extHdrMetadata = VK_TRUE;
+
     if (m_deviceExtensions.supports(VK_EXT_TRANSFORM_FEEDBACK_EXTENSION_NAME)) {
       m_deviceFeatures.extTransformFeedback.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TRANSFORM_FEEDBACK_FEATURES_EXT;
       m_deviceFeatures.extTransformFeedback.pNext = std::exchange(m_deviceFeatures.core.pNext, &m_deviceFeatures.extTransformFeedback);
@@ -1035,6 +1044,8 @@ namespace dxvk {
       "\n  extension supported                    : ", features.extShaderStencilExport ? "1" : "0",
       "\n", VK_EXT_SWAPCHAIN_COLOR_SPACE_EXTENSION_NAME,
       "\n  extension supported                    : ", features.extSwapchainColorSpace ? "1" : "0",
+      "\n", VK_EXT_HDR_METADATA_EXTENSION_NAME,
+      "\n  extension supported                    : ", features.extHdrMetadata ? "1" : "0",
       "\n", VK_EXT_TRANSFORM_FEEDBACK_EXTENSION_NAME,
       "\n  transformFeedback                      : ", features.extTransformFeedback.transformFeedback ? "1" : "0",
       "\n  geometryStreams                        : ", features.extTransformFeedback.geometryStreams ? "1" : "0",

--- a/src/dxvk/dxvk_adapter.cpp
+++ b/src/dxvk/dxvk_adapter.cpp
@@ -316,6 +316,8 @@ namespace dxvk {
                 || !required.extShaderModuleIdentifier.shaderModuleIdentifier)
         && (m_deviceFeatures.extShaderStencilExport
                 || !required.extShaderStencilExport)
+        && (m_deviceFeatures.extShaderStencilExport
+                || !required.extSwapchainColorSpace)
         && (m_deviceFeatures.extTransformFeedback.transformFeedback
                 || !required.extTransformFeedback.transformFeedback)
         && (m_deviceFeatures.extVertexAttributeDivisor.vertexAttributeInstanceRateDivisor
@@ -335,7 +337,7 @@ namespace dxvk {
           DxvkDeviceFeatures  enabledFeatures) {
     DxvkDeviceExtensions devExtensions;
 
-    std::array<DxvkExt*, 24> devExtensionList = {{
+    std::array<DxvkExt*, 25> devExtensionList = {{
       &devExtensions.amdMemoryOverallocationBehaviour,
       &devExtensions.amdShaderFragmentMask,
       &devExtensions.extAttachmentFeedbackLoopLayout,
@@ -352,6 +354,7 @@ namespace dxvk {
       &devExtensions.extRobustness2,
       &devExtensions.extShaderModuleIdentifier,
       &devExtensions.extShaderStencilExport,
+      &devExtensions.extSwapchainColorSpace,
       &devExtensions.extTransformFeedback,
       &devExtensions.extVertexAttributeDivisor,
       &devExtensions.khrExternalMemoryWin32,
@@ -536,6 +539,9 @@ namespace dxvk {
 
     if (devExtensions.extShaderStencilExport)
       enabledFeatures.extShaderStencilExport = VK_TRUE;
+
+    if (devExtensions.extSwapchainColorSpace)
+      enabledFeatures.extSwapchainColorSpace = VK_TRUE;
 
     if (devExtensions.extTransformFeedback) {
       enabledFeatures.extTransformFeedback.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TRANSFORM_FEEDBACK_FEATURES_EXT;
@@ -875,6 +881,9 @@ namespace dxvk {
     if (m_deviceExtensions.supports(VK_EXT_SHADER_STENCIL_EXPORT_EXTENSION_NAME))
       m_deviceFeatures.extShaderStencilExport = VK_TRUE;
 
+    if (m_deviceExtensions.supports(VK_EXT_SWAPCHAIN_COLOR_SPACE_EXTENSION_NAME))
+      m_deviceFeatures.extSwapchainColorSpace = VK_TRUE;
+
     if (m_deviceExtensions.supports(VK_EXT_TRANSFORM_FEEDBACK_EXTENSION_NAME)) {
       m_deviceFeatures.extTransformFeedback.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TRANSFORM_FEEDBACK_FEATURES_EXT;
       m_deviceFeatures.extTransformFeedback.pNext = std::exchange(m_deviceFeatures.core.pNext, &m_deviceFeatures.extTransformFeedback);
@@ -1024,6 +1033,8 @@ namespace dxvk {
       "\n  shaderModuleIdentifier                 : ", features.extShaderModuleIdentifier.shaderModuleIdentifier ? "1" : "0",
       "\n", VK_EXT_SHADER_STENCIL_EXPORT_EXTENSION_NAME,
       "\n  extension supported                    : ", features.extShaderStencilExport ? "1" : "0",
+      "\n", VK_EXT_SWAPCHAIN_COLOR_SPACE_EXTENSION_NAME,
+      "\n  extension supported                    : ", features.extSwapchainColorSpace ? "1" : "0",
       "\n", VK_EXT_TRANSFORM_FEEDBACK_EXTENSION_NAME,
       "\n  transformFeedback                      : ", features.extTransformFeedback.transformFeedback ? "1" : "0",
       "\n  geometryStreams                        : ", features.extTransformFeedback.geometryStreams ? "1" : "0",

--- a/src/dxvk/dxvk_cmdlist.h
+++ b/src/dxvk/dxvk_cmdlist.h
@@ -798,7 +798,13 @@ namespace dxvk {
       m_vkd->vkCmdUpdateBuffer(getCmdBuffer(cmdBuffer),
         dstBuffer, dstOffset, dataSize, pData);
     }
-    
+
+
+    void cmdSetAlphaToCoverageState(
+            VkBool32                alphaToCoverageEnable) {
+      m_vkd->vkCmdSetAlphaToCoverageEnableEXT(m_cmd.execBuffer, alphaToCoverageEnable);
+    }
+
     
     void cmdSetBlendConstants(const float blendConstants[4]) {
       m_vkd->vkCmdSetBlendConstants(m_cmd.execBuffer, blendConstants);
@@ -865,6 +871,14 @@ namespace dxvk {
       m_cmd.usedFlags.set(DxvkCmdBuffer::ExecBuffer);
 
       m_vkd->vkCmdSetEvent2(m_cmd.execBuffer, event, dependencyInfo);
+    }
+
+
+    void cmdSetMultisampleState(
+            VkSampleCountFlagBits   sampleCount,
+            VkSampleMask            sampleMask) {
+      m_vkd->vkCmdSetRasterizationSamplesEXT(m_cmd.execBuffer, sampleCount);
+      m_vkd->vkCmdSetSampleMaskEXT(m_cmd.execBuffer, sampleCount, &sampleMask);
     }
 
 

--- a/src/dxvk/dxvk_context_state.h
+++ b/src/dxvk/dxvk_context_state.h
@@ -35,6 +35,7 @@ namespace dxvk {
     GpDirtyDepthBias,           ///< Depth bias has changed
     GpDirtyDepthBounds,         ///< Depth bounds have changed
     GpDirtyStencilRef,          ///< Stencil reference has changed
+    GpDirtyMultisampleState,    ///< Multisample state has changed
     GpDirtyRasterizerState,     ///< Cull mode and front face have changed
     GpDirtyViewport,            ///< Viewport state has changed
     GpDirtySpecConstants,       ///< Graphics spec constants are out of date
@@ -43,6 +44,7 @@ namespace dxvk {
     GpDynamicDepthBias,         ///< Depth bias is dynamic
     GpDynamicDepthBounds,       ///< Depth bounds are dynamic
     GpDynamicStencilRef,        ///< Stencil reference is dynamic
+    GpDynamicMultisampleState,  ///< Multisample state is dynamic
     GpDynamicRasterizerState,   ///< Cull mode and front face are dynamic
     GpDynamicVertexStrides,     ///< Vertex buffer strides are dynamic
     GpIndependentSets,          ///< Graphics pipeline layout was created with independent sets

--- a/src/dxvk/dxvk_device_info.h
+++ b/src/dxvk/dxvk_device_info.h
@@ -55,6 +55,7 @@ namespace dxvk {
     VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT         extShaderModuleIdentifier;
     VkBool32                                                  extShaderStencilExport;
     VkBool32                                                  extSwapchainColorSpace;
+    VkBool32                                                  extHdrMetadata;
     VkPhysicalDeviceTransformFeedbackFeaturesEXT              extTransformFeedback;
     VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT         extVertexAttributeDivisor;
     VkBool32                                                  khrExternalMemoryWin32;

--- a/src/dxvk/dxvk_device_info.h
+++ b/src/dxvk/dxvk_device_info.h
@@ -54,6 +54,7 @@ namespace dxvk {
     VkPhysicalDeviceRobustness2FeaturesEXT                    extRobustness2;
     VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT         extShaderModuleIdentifier;
     VkBool32                                                  extShaderStencilExport;
+    VkBool32                                                  extSwapchainColorSpace;
     VkPhysicalDeviceTransformFeedbackFeaturesEXT              extTransformFeedback;
     VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT         extVertexAttributeDivisor;
     VkBool32                                                  khrExternalMemoryWin32;

--- a/src/dxvk/dxvk_extensions.h
+++ b/src/dxvk/dxvk_extensions.h
@@ -292,6 +292,7 @@ namespace dxvk {
     DxvkExt extRobustness2                    = { VK_EXT_ROBUSTNESS_2_EXTENSION_NAME,                       DxvkExtMode::Required };
     DxvkExt extShaderModuleIdentifier         = { VK_EXT_SHADER_MODULE_IDENTIFIER_EXTENSION_NAME,           DxvkExtMode::Optional };
     DxvkExt extShaderStencilExport            = { VK_EXT_SHADER_STENCIL_EXPORT_EXTENSION_NAME,              DxvkExtMode::Optional };
+    DxvkExt extSwapchainColorSpace            = { VK_EXT_SWAPCHAIN_COLOR_SPACE_EXTENSION_NAME,              DxvkExtMode::Optional };
     DxvkExt extTransformFeedback              = { VK_EXT_TRANSFORM_FEEDBACK_EXTENSION_NAME,                 DxvkExtMode::Optional };
     DxvkExt extVertexAttributeDivisor         = { VK_EXT_VERTEX_ATTRIBUTE_DIVISOR_EXTENSION_NAME,           DxvkExtMode::Optional };
     DxvkExt khrExternalMemoryWin32            = { VK_KHR_EXTERNAL_MEMORY_WIN32_EXTENSION_NAME,              DxvkExtMode::Optional };

--- a/src/dxvk/dxvk_extensions.h
+++ b/src/dxvk/dxvk_extensions.h
@@ -293,6 +293,7 @@ namespace dxvk {
     DxvkExt extShaderModuleIdentifier         = { VK_EXT_SHADER_MODULE_IDENTIFIER_EXTENSION_NAME,           DxvkExtMode::Optional };
     DxvkExt extShaderStencilExport            = { VK_EXT_SHADER_STENCIL_EXPORT_EXTENSION_NAME,              DxvkExtMode::Optional };
     DxvkExt extSwapchainColorSpace            = { VK_EXT_SWAPCHAIN_COLOR_SPACE_EXTENSION_NAME,              DxvkExtMode::Optional };
+    DxvkExt extHdrMetadata                    = { VK_EXT_HDR_METADATA_EXTENSION_NAME,                       DxvkExtMode::Optional };
     DxvkExt extTransformFeedback              = { VK_EXT_TRANSFORM_FEEDBACK_EXTENSION_NAME,                 DxvkExtMode::Optional };
     DxvkExt extVertexAttributeDivisor         = { VK_EXT_VERTEX_ATTRIBUTE_DIVISOR_EXTENSION_NAME,           DxvkExtMode::Optional };
     DxvkExt khrExternalMemoryWin32            = { VK_KHR_EXTERNAL_MEMORY_WIN32_EXTENSION_NAME,              DxvkExtMode::Optional };

--- a/src/dxvk/dxvk_fence.cpp
+++ b/src/dxvk/dxvk_fence.cpp
@@ -56,28 +56,51 @@ namespace dxvk {
         Logger::warn(str::format("Importing semaphores of type ", info.sharedType, " not supported by device"));
       }
     }
-
-    m_thread = dxvk::thread([this] { run(); });
   }
 
 
   DxvkFence::~DxvkFence() {
-    m_stop.store(true);
-    m_thread.join();
-
+    if (m_thread.joinable()) {
+      {
+        std::unique_lock<dxvk::mutex> lock(m_mutex);
+        m_running = false;
+        m_condVar.notify_one();
+      }
+      m_thread.join();
+    }
     m_vkd->vkDestroySemaphore(m_vkd->device(), m_semaphore, nullptr);
   }
 
 
   void DxvkFence::enqueueWait(uint64_t value, DxvkFenceEvent&& event) {
-    std::unique_lock<dxvk::mutex> lock(m_mutex);
-
-    if (value > m_lastValue.load())
+    if (value > getValue()) {
+      std::unique_lock<dxvk::mutex> lock(m_mutex);
       m_queue.emplace(value, std::move(event));
-    else
+
+      if (!m_running) {
+        m_running = true;
+        m_thread = dxvk::thread([this] { run(); });
+      } else {
+        m_condVar.notify_one();
+      }
+      lock.unlock();
+    } else {
       event();
+    }
   }
-  
+
+  void DxvkFence::wait(uint64_t value) {
+    VkSemaphoreWaitInfo waitInfo = { VK_STRUCTURE_TYPE_SEMAPHORE_WAIT_INFO };
+    waitInfo.semaphoreCount = 1;
+    waitInfo.pSemaphores = &m_semaphore;
+    waitInfo.pValues = &value;
+    VkResult vr = m_vkd->vkWaitSemaphores(
+      m_vkd->device(), &waitInfo, ~0ull);
+
+    if (vr != VK_SUCCESS) {
+      Logger::err(str::format("Failed to wait for semaphore: ", vr));
+    }
+  }
 
   void DxvkFence::run() {
     uint64_t value = 0ull;
@@ -87,8 +110,10 @@ namespace dxvk {
     waitInfo.pSemaphores = &m_semaphore;
     waitInfo.pValues = &value;
 
-    while (!m_stop.load()) {
+    while (true) {
       std::unique_lock<dxvk::mutex> lock(m_mutex);
+
+      m_condVar.wait(lock, [&]() { return !m_queue.empty() || !m_running; });
 
       // Query actual semaphore value and start from there, so that
       // we can skip over large increments in the semaphore value
@@ -99,8 +124,6 @@ namespace dxvk {
         return;
       }
 
-      m_lastValue.store(value);
-
       // Signal all enqueued events whose value is not greater than
       // the current semaphore value
       while (!m_queue.empty() && m_queue.top().value <= value) {
@@ -108,8 +131,11 @@ namespace dxvk {
         m_queue.pop();
       }
 
-      if (m_stop)
+      if (!m_running)
         return;
+
+      if (m_queue.empty())
+        continue;
 
       lock.unlock();
 
@@ -128,6 +154,15 @@ namespace dxvk {
         return;
       }
     }
+  }
+
+  uint64_t DxvkFence::getValue() {
+    uint64_t value = 0;
+    VkResult vr = m_vkd->vkGetSemaphoreCounterValue(m_vkd->device(), m_semaphore, &value);
+    if (vr != VK_SUCCESS) {
+      Logger::err(str::format("Failed to query semaphore value: ", vr));
+    }
+    return value;
   }
 
   HANDLE DxvkFence::sharedHandle() const {

--- a/src/dxvk/dxvk_fence.h
+++ b/src/dxvk/dxvk_fence.h
@@ -70,9 +70,7 @@ namespace dxvk {
      * \brief Retrieves current semaphore value
      * \returns Current semaphore value
      */
-    uint64_t getValue() {
-      return m_lastValue.load();
-    }
+    uint64_t getValue();
 
     /**
      * \brief Enqueues semaphore wait
@@ -89,6 +87,15 @@ namespace dxvk {
      * \returns The shared handle with the type given by DxvkFenceCreateInfo::sharedType
      */
     HANDLE sharedHandle() const;
+
+    /*
+     * \brief Waits for the given value
+     *
+     * Blocks the calling thread until
+     * the fence reaches the given value.
+     * \param [in] value Value to wait for
+    */
+    void wait(uint64_t value);
 
   private:
 
@@ -113,10 +120,10 @@ namespace dxvk {
     VkSemaphore                     m_semaphore;
 
     std::priority_queue<QueueItem>  m_queue;
-    std::atomic<uint64_t>           m_lastValue = { 0ull  };
-    std::atomic<bool>               m_stop      = { false };
+    bool                            m_running    = false;
 
     dxvk::mutex                     m_mutex;
+    dxvk::condition_variable        m_condVar;
     dxvk::thread                    m_thread;
 
     void run();

--- a/src/dxvk/dxvk_graphics.h
+++ b/src/dxvk/dxvk_graphics.h
@@ -113,7 +113,7 @@ namespace dxvk {
     VkPipelineColorBlendStateCreateInfo             cbInfo = { VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO };
     VkPipelineMultisampleStateCreateInfo            msInfo = { VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO };
 
-    uint32_t                                        msSampleMask               = 0u;
+    VkSampleMask                                    msSampleMask               = 0u;
     VkBool32                                        cbUseDynamicBlendConstants = VK_FALSE;
 
     std::array<VkPipelineColorBlendAttachmentState, MaxNumRenderTargets> cbAttachments  = { };

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -691,6 +691,11 @@ namespace dxvk {
     { R"(\\ffxiv\.exe$)", {{
       { "d3d9.textureMemory",                "0"   },
     }} },
+    /* Secret World Legends launcher           *
+     * Invisible UI                            */
+    { R"(\\Secret World Legends\\ClientPatcher\.exe$)", {{
+      { "d3d9.shaderModel",                 "2" },
+    }} },
   }};
 
 

--- a/src/vulkan/vulkan_loader.h
+++ b/src/vulkan/vulkan_loader.h
@@ -384,6 +384,10 @@ namespace dxvk::vk {
     VULKAN_FN(vkGetDeviceGroupSurfacePresentModes2EXT);
     #endif
 
+    #ifdef VK_EXT_hdr_metadata
+    VULKAN_FN(vkSetHdrMetadataEXT);
+    #endif
+
     #ifdef VK_EXT_shader_module_identifier
     VULKAN_FN(vkGetShaderModuleCreateInfoIdentifierEXT);
     VULKAN_FN(vkGetShaderModuleIdentifierEXT);

--- a/src/vulkan/vulkan_presenter.cpp
+++ b/src/vulkan/vulkan_presenter.cpp
@@ -220,6 +220,19 @@ namespace dxvk::vk {
   }
 
 
+  bool Presenter::supportsColorSpace(VkColorSpaceKHR colorspace) {
+    std::vector<VkSurfaceFormatKHR> surfaceFormats;
+    getSupportedFormats(surfaceFormats, VK_FULL_SCREEN_EXCLUSIVE_DEFAULT_EXT);
+
+    for (const auto& surfaceFormat : surfaceFormats) {
+      if (surfaceFormat.colorSpace == colorspace)
+        return true;
+    }
+
+    return false;
+  }
+
+
   void Presenter::setFrameRateLimit(double frameRate) {
     m_fpsLimiter.setTargetFrameRate(frameRate);
   }

--- a/src/vulkan/vulkan_presenter.cpp
+++ b/src/vulkan/vulkan_presenter.cpp
@@ -238,6 +238,12 @@ namespace dxvk::vk {
   }
 
 
+  void Presenter::setHdrMetadata(const VkHdrMetadataEXT& hdrMetadata) {
+    if (m_device.features.hdrMetadata)
+      m_vkd->vkSetHdrMetadataEXT(m_vkd->device(), 1, &m_swapchain, &hdrMetadata);
+  }
+
+
   VkResult Presenter::getSupportedFormats(std::vector<VkSurfaceFormatKHR>& formats, VkFullScreenExclusiveEXT fullScreenExclusive) const {
     uint32_t numFormats = 0;
 

--- a/src/vulkan/vulkan_presenter.cpp
+++ b/src/vulkan/vulkan_presenter.cpp
@@ -116,10 +116,10 @@ namespace dxvk::vk {
         m_device.adapter, m_surface, &caps)))
       return status;
 
-    if ((status = getSupportedFormats(formats, desc)))
+    if ((status = getSupportedFormats(formats, desc.fullScreenExclusive)))
       return status;
 
-    if ((status = getSupportedPresentModes(modes, desc)))
+    if ((status = getSupportedPresentModes(modes, desc.fullScreenExclusive)))
       return status;
 
     // Select actual swap chain properties and create swap chain
@@ -225,11 +225,11 @@ namespace dxvk::vk {
   }
 
 
-  VkResult Presenter::getSupportedFormats(std::vector<VkSurfaceFormatKHR>& formats, const PresenterDesc& desc) {
+  VkResult Presenter::getSupportedFormats(std::vector<VkSurfaceFormatKHR>& formats, VkFullScreenExclusiveEXT fullScreenExclusive) const {
     uint32_t numFormats = 0;
 
     VkSurfaceFullScreenExclusiveInfoEXT fullScreenInfo = { VK_STRUCTURE_TYPE_SURFACE_FULL_SCREEN_EXCLUSIVE_INFO_EXT };
-    fullScreenInfo.fullScreenExclusive = desc.fullScreenExclusive;
+    fullScreenInfo.fullScreenExclusive = fullScreenExclusive;
 
     VkPhysicalDeviceSurfaceInfo2KHR surfaceInfo = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SURFACE_INFO_2_KHR, &fullScreenInfo };
     surfaceInfo.surface = m_surface;
@@ -267,11 +267,11 @@ namespace dxvk::vk {
   }
 
   
-  VkResult Presenter::getSupportedPresentModes(std::vector<VkPresentModeKHR>& modes, const PresenterDesc& desc) {
+  VkResult Presenter::getSupportedPresentModes(std::vector<VkPresentModeKHR>& modes, VkFullScreenExclusiveEXT fullScreenExclusive) const {
     uint32_t numModes = 0;
 
     VkSurfaceFullScreenExclusiveInfoEXT fullScreenInfo = { VK_STRUCTURE_TYPE_SURFACE_FULL_SCREEN_EXCLUSIVE_INFO_EXT };
-    fullScreenInfo.fullScreenExclusive = desc.fullScreenExclusive;
+    fullScreenInfo.fullScreenExclusive = fullScreenExclusive;
 
     VkPhysicalDeviceSurfaceInfo2KHR surfaceInfo = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SURFACE_INFO_2_KHR, &fullScreenInfo };
     surfaceInfo.surface = m_surface;

--- a/src/vulkan/vulkan_presenter.h
+++ b/src/vulkan/vulkan_presenter.h
@@ -49,6 +49,7 @@ namespace dxvk::vk {
    */
   struct PresenterFeatures {
     bool                fullScreenExclusive : 1;
+    bool                hdrMetadata : 1;
   };
   
   /**
@@ -190,6 +191,13 @@ namespace dxvk::vk {
      * * \returns \c true if the presenter supports the colorspace
      */
     bool supportsColorSpace(VkColorSpaceKHR colorspace);
+
+    /**
+     * \brief Sets HDR metadata
+     *
+     * \param [in] hdrMetadata HDR Metadata
+     */
+    void setHdrMetadata(const VkHdrMetadataEXT& hdrMetadata);
 
   private:
 

--- a/src/vulkan/vulkan_presenter.h
+++ b/src/vulkan/vulkan_presenter.h
@@ -209,11 +209,11 @@ namespace dxvk::vk {
 
     VkResult getSupportedFormats(
             std::vector<VkSurfaceFormatKHR>& formats,
-      const PresenterDesc&            desc);
+            VkFullScreenExclusiveEXT         fullScreenExclusive) const;
     
     VkResult getSupportedPresentModes(
             std::vector<VkPresentModeKHR>& modes,
-      const PresenterDesc&            desc);
+            VkFullScreenExclusiveEXT       fullScreenExclusive) const;
     
     VkResult getSwapImages(
             std::vector<VkImage>&     images);

--- a/src/vulkan/vulkan_presenter.h
+++ b/src/vulkan/vulkan_presenter.h
@@ -183,6 +183,14 @@ namespace dxvk::vk {
       return m_swapchain;
     }
 
+    /**
+     * \brief Checks if a presenter supports the colorspace
+     *
+     * \param [in] colorspace The colorspace to test
+     * * \returns \c true if the presenter supports the colorspace
+     */
+    bool supportsColorSpace(VkColorSpaceKHR colorspace);
+
   private:
 
     Rc<InstanceFn>    m_vki;


### PR DESCRIPTION
With default shader model 3 the launcher UI elements are invisible.

<details>
  <summary>Screenshots without and with the option</summary>
  
![Screenshot_20221126_214912](https://user-images.githubusercontent.com/47954800/205483708-3326a012-9ae2-4bca-b6b2-3733c82cf370.png)
![Screenshot_20221126_214838](https://user-images.githubusercontent.com/47954800/205483712-35d32ffb-58e2-4e84-8f7d-957920fc3bec.png)
</details>