### PR TITLE
[build] Fix submodule url for libdisplay-info

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,5 +9,5 @@
 	url = https://github.com/KhronosGroup/SPIRV-Headers.git
 [submodule "subprojects/libdisplay-info"]
 	path = subprojects/libdisplay-info
-	url = https://gitlab.freedesktop.org/JoshuaAshton/libdisplay-info
+	url = https://gitlab.freedesktop.org/JoshuaAshton/libdisplay-info.git
 	branch = windows


### PR DESCRIPTION
Fixes warning on `git fetch --recurse-submodules`:
```
warning: redirecting to https://gitlab.freedesktop.org/JoshuaAshton/libdisplay-info.git/
```