### PR TITLE
[d3d9] Correctly mask alpha reference push constant

### DIFF
--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -5187,7 +5187,7 @@ namespace dxvk {
     auto& rs = m_state.renderStates;
 
     if constexpr (Item == D3D9RenderStateItem::AlphaRef) {
-      uint32_t alpha = rs[D3DRS_ALPHAREF];
+      uint32_t alpha = rs[D3DRS_ALPHAREF] & 0xFF;
       UpdatePushConstant<offsetof(D3D9RenderStateInfo, alphaRef), sizeof(uint32_t)>(&alpha);
     }
     else if constexpr (Item == D3D9RenderStateItem::FogColor) {


### PR DESCRIPTION
We accidentally lost this during the rework, since the initial implementation scaled the alpha ref value on the CPU.

Fixes #3123.