### PR TITLE
[build] Add optional modern-cpu flag

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -25,6 +25,12 @@ compiler_args = [
   '-Wno-missing-braces',
 ]
 
+if get_option('modern_cpu')
+  compiler_args += [
+    '-march=x86-64-v3',
+  ]
+endif
+
 link_args = []
 
 if get_option('build_id')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -3,3 +3,4 @@ option('enable_d3d9',  type : 'boolean', value : true, description: 'Build D3D9'
 option('enable_d3d10', type : 'boolean', value : true, description: 'Build D3D10')
 option('enable_d3d11', type : 'boolean', value : true, description: 'Build D3D11')
 option('build_id',     type : 'boolean', value : false)
+option('modern_cpu',   type : 'boolean', value : false, description: 'Optimize for Haswell-or-later')

--- a/package-native.sh
+++ b/package-native.sh
@@ -5,7 +5,7 @@ set -e
 shopt -s extglob
 
 if [ -z "$1" ] || [ -z "$2" ]; then
-  echo "Usage: $0 version destdir [--no-package] [--dev-build]"
+  echo "Usage: $0 version destdir [--no-package] [--dev-build] [--modern-cpu]"
   exit 1
 fi
 
@@ -24,6 +24,7 @@ shift 2
 opt_nopackage=0
 opt_devbuild=0
 opt_buildid=false
+opt_moderncpu=false
 
 CC=${CC:="gcc"}
 CXX=${CXX:="g++"}
@@ -39,6 +40,9 @@ while [ $# -gt 0 ]; do
     ;;
   "--build-id")
     opt_buildid=true
+    ;;
+  "--modern-cpu")
+    opt_moderncpu=true
     ;;
   *)
     echo "Unrecognized option: $1" >&2
@@ -62,6 +66,7 @@ function build_arch {
         --bindir "$2"                       \
         --libdir "$2"                       \
         -Dbuild_id=$opt_buildid             \
+        -Dmodern_cpu=$opt_moderncpu         \
         "$DXVK_BUILD_DIR/build.$1"
 
   cd "$DXVK_BUILD_DIR/build.$1"

--- a/package-release.sh
+++ b/package-release.sh
@@ -5,7 +5,7 @@ set -e
 shopt -s extglob
 
 if [ -z "$1" ] || [ -z "$2" ]; then
-  echo "Usage: $0 version destdir [--no-package] [--dev-build]"
+  echo "Usage: $0 version destdir [--no-package] [--dev-build] [--modern-cpu]"
   exit 1
 fi
 
@@ -24,6 +24,7 @@ shift 2
 opt_nopackage=0
 opt_devbuild=0
 opt_buildid=false
+opt_moderncpu=false
 
 crossfile="build-win"
 
@@ -38,6 +39,9 @@ while [ $# -gt 0 ]; do
     ;;
   "--build-id")
     opt_buildid=true
+    ;;
+  "--modern-cpu")
+    opt_moderncpu=true
     ;;
   *)
     echo "Unrecognized option: $1" >&2
@@ -64,6 +68,7 @@ function build_arch {
         --bindir "x$1"                                      \
         --libdir "x$1"                                      \
         -Dbuild_id=$opt_buildid                             \
+        -Dmodern_cpu=$opt_moderncpu                         \
         "$DXVK_BUILD_DIR/build.$1"
 
   cd "$DXVK_BUILD_DIR/build.$1"


### PR DESCRIPTION
Adds optional build flag to enable generic modern CPU optimizations, specifically x86-64-v3.

- x86-64: (baseline: all x86-64 CPUs) CMOV, CMPXCHG8B, FPU, FXSR, MMX, FXSR, SCE, SSE, SSE2 
- x86-64-v2: (circa 2009: Nehalem and Jaguar) CMPXCHG16B, LAHF-SAHF, POPCNT, SSE3, SSE4.1, SSE4.2, SSSE3 
- x86-64-v3: (circa 2015: Haswell and Excavator) AVX, AVX2, BMI1, BMI2, F16C, FMA, LZCNT, MOVBE, XSAVE 
- x86-64-v4: AVX512F, AVX512BW, AVX512CD, AVX512DQ, AVX512VL

Could potentially offer some performance gains on modern CPUs, some non-DXVK specific benchmarks even show upwards of a [10-20%](https://lists.archlinux.org/pipermail/arch-general/2021-March/048739.html) performance increase compared to baseline x86-64 on average.