### PR TITLE
[d3d11] Only store low 8 bits of stencil reference

### DIFF
--- a/src/d3d11/d3d11_context.cpp
+++ b/src/d3d11/d3d11_context.cpp
@@ -2261,6 +2261,10 @@ namespace dxvk {
       ApplyDepthStencilState();
     }
 
+    // The D3D11 runtime only appears to store the low 8 bits,
+    // and some games rely on this behaviour. Do the same here.
+    StencilRef &= 0xFF;
+
     if (m_state.om.stencilRef != StencilRef) {
       m_state.om.stencilRef = StencilRef;
       ApplyStencilRef();


### PR DESCRIPTION
Seems to match behaviour of the D3D11 runtime, in that OMGetDepthStencilState will not retain the high bits.

Should fix #1784.