### PR TITLE
[meta] Remove current year from copyright notice

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
-                  Copyright (c) 2017-2021 Philip Rebohle
-                  Copyright (c) 2019-2021 Joshua Ashton
+                  Copyright (c) 2017 Philip Rebohle
+                  Copyright (c) 2019 Joshua Ashton
 
                           zlib/libpng license
 


### PR DESCRIPTION
Just show the beginning year from when the copyright took effect so it's not necessary to always update to the current year.

Supersedes https://github.com/doitsujin/dxvk/pull/2786