### PR TITLE
[dxvk] Use bottom-of-pipe stage for writeTimestamp

### DIFF
--- a/src/dxvk/dxvk_gpu_query.cpp
+++ b/src/dxvk/dxvk_gpu_query.cpp
@@ -306,7 +306,7 @@ namespace dxvk {
       handle.queryId);
     
     cmd->cmdWriteTimestamp(
-      VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
+      VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
       handle.queryPool,
       handle.queryId);
     


### PR DESCRIPTION
The Vulkan specifications says:
> VUID-vkCmdWriteTimestamp2-stage-03859
> stage must only include a single pipeline stage

`VK_PIPELINE_STAGE_ALL_COMMANDS_BIT` is a union of stages, so use `VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT` which is logically equivalent instead.