### PR TITLE
[dxgi] Implement DXGIOutput::GetDesc1's ColorSpace

### DIFF
--- a/dxvk.conf
+++ b/dxvk.conf
@@ -1,3 +1,15 @@
+# Expose the HDR10 ColorSpace (DXGI_COLOR_SPACE_RGB_FULL_G2084_NONE_P2020)
+# to the application by default.
+# This shows to the game that the global Windows 'HDR Mode' is enabled.
+# Many (broken) games will need this to be set to consider exposing HDR output
+# as determine it based on the DXGIOutput's current ColorSpace instead of
+# using CheckColorSpaceSupport.
+# This defaults to the value of the DXVK_HDR environment variable.
+# 
+# Supported values: True, False
+
+# dxgi.enableHDR = True
+
 # Create the VkSurface on the first call to IDXGISwapChain::Present,
 # rather than when creating the swap chain. Some games that start
 # rendering with a different graphics API may require this option,

--- a/src/dxgi/dxgi_factory.cpp
+++ b/src/dxgi/dxgi_factory.cpp
@@ -7,8 +7,8 @@ namespace dxvk {
 
   DxgiFactory::DxgiFactory(UINT Flags)
   : m_instance    (new DxvkInstance()),
-    m_monitorInfo (this),
     m_options     (m_instance->config()),
+    m_monitorInfo (this),
     m_flags       (Flags) {
     for (uint32_t i = 0; m_instance->enumAdapters(i) != nullptr; i++)
       m_instance->enumAdapters(i)->logAdapterInfo();

--- a/src/dxgi/dxgi_factory.cpp
+++ b/src/dxgi/dxgi_factory.cpp
@@ -8,7 +8,7 @@ namespace dxvk {
   DxgiFactory::DxgiFactory(UINT Flags)
   : m_instance    (new DxvkInstance()),
     m_options     (m_instance->config()),
-    m_monitorInfo (this),
+    m_monitorInfo (this, m_options),
     m_flags       (Flags) {
     for (uint32_t i = 0; m_instance->enumAdapters(i) != nullptr; i++)
       m_instance->enumAdapters(i)->logAdapterInfo();

--- a/src/dxgi/dxgi_factory.h
+++ b/src/dxgi/dxgi_factory.h
@@ -146,8 +146,8 @@ namespace dxvk {
   private:
     
     Rc<DxvkInstance> m_instance;
-    DxgiMonitorInfo  m_monitorInfo;
     DxgiOptions      m_options;
+    DxgiMonitorInfo  m_monitorInfo;
     UINT             m_flags;
     
     HWND m_associatedWindow = nullptr;

--- a/src/dxgi/dxgi_interfaces.h
+++ b/src/dxgi/dxgi_interfaces.h
@@ -200,6 +200,30 @@ IDXGIVkMonitorInfo : public IUnknown {
    */
   virtual void STDMETHODCALLTYPE ReleaseMonitorData() = 0;
 
+  /**
+   * \brief Punt global colorspace
+   *
+   * This exists to satiate a requirement for
+   * IDXGISwapChain::SetColorSpace1 punting Windows into
+   * the global "HDR mode".
+   *
+   * This operation is atomic and does not require
+   * owning any monitor data.
+   *
+   * \param [in] ColorSpace The colorspace
+   */
+  virtual void STDMETHODCALLTYPE PuntColorSpace(DXGI_COLOR_SPACE_TYPE ColorSpace) = 0;
+
+  /**
+   * \brief Get current global colorspace
+   *
+   * This operation is atomic and does not require
+   * owning any monitor data.
+   *
+   * \returns Current global colorspace
+   */
+  virtual DXGI_COLOR_SPACE_TYPE STDMETHODCALLTYPE CurrentColorSpace() const = 0;
+
 };
 
 

--- a/src/dxgi/dxgi_monitor.cpp
+++ b/src/dxgi/dxgi_monitor.cpp
@@ -2,8 +2,9 @@
 
 namespace dxvk {
 
-  DxgiMonitorInfo::DxgiMonitorInfo(IUnknown* pParent)
+  DxgiMonitorInfo::DxgiMonitorInfo(IUnknown* pParent, const DxgiOptions& options)
   : m_parent(pParent)
+  , m_options(options)
   , m_globalColorSpace(DefaultColorSpace()) {
 
   }
@@ -80,8 +81,8 @@ namespace dxvk {
   }
 
 
-  DXGI_COLOR_SPACE_TYPE DxgiMonitorInfo::DefaultColorSpace() {
-    return env::getEnvVar("DXVK_HDR") == "1"
+  DXGI_COLOR_SPACE_TYPE DxgiMonitorInfo::DefaultColorSpace() const {
+    return m_options.enableHDR
       ? DXGI_COLOR_SPACE_RGB_FULL_G2084_NONE_P2020
       : DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P709;
   }

--- a/src/dxgi/dxgi_monitor.cpp
+++ b/src/dxgi/dxgi_monitor.cpp
@@ -3,7 +3,8 @@
 namespace dxvk {
 
   DxgiMonitorInfo::DxgiMonitorInfo(IUnknown* pParent)
-  : m_parent(pParent) {
+  : m_parent(pParent)
+  , m_globalColorSpace(DefaultColorSpace()) {
 
   }
 
@@ -66,6 +67,23 @@ namespace dxvk {
 
   void STDMETHODCALLTYPE DxgiMonitorInfo::ReleaseMonitorData() {
     m_monitorMutex.unlock();
+  }
+
+
+  void STDMETHODCALLTYPE DxgiMonitorInfo::PuntColorSpace(DXGI_COLOR_SPACE_TYPE ColorSpace) {
+    m_globalColorSpace = ColorSpace;
+  }
+
+
+  DXGI_COLOR_SPACE_TYPE STDMETHODCALLTYPE DxgiMonitorInfo::CurrentColorSpace() const {
+    return m_globalColorSpace;
+  }
+
+
+  DXGI_COLOR_SPACE_TYPE DxgiMonitorInfo::DefaultColorSpace() {
+    return env::getEnvVar("DXVK_HDR") == "1"
+      ? DXGI_COLOR_SPACE_RGB_FULL_G2084_NONE_P2020
+      : DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P709;
   }
 
 

--- a/src/dxgi/dxgi_monitor.h
+++ b/src/dxgi/dxgi_monitor.h
@@ -37,12 +37,20 @@ namespace dxvk {
 
     void STDMETHODCALLTYPE ReleaseMonitorData();
 
+    void STDMETHODCALLTYPE PuntColorSpace(DXGI_COLOR_SPACE_TYPE ColorSpace);
+
+    DXGI_COLOR_SPACE_TYPE STDMETHODCALLTYPE CurrentColorSpace() const;
+
+    static DXGI_COLOR_SPACE_TYPE DefaultColorSpace();
+
   private:
 
     IUnknown* m_parent;
 
     dxvk::mutex                                        m_monitorMutex;
     std::unordered_map<HMONITOR, DXGI_VK_MONITOR_DATA> m_monitorData;
+
+    std::atomic<DXGI_COLOR_SPACE_TYPE> m_globalColorSpace;
 
   };
 

--- a/src/dxgi/dxgi_monitor.h
+++ b/src/dxgi/dxgi_monitor.h
@@ -4,6 +4,7 @@
 #include <unordered_map>
 
 #include "dxgi_interfaces.h"
+#include "dxgi_options.h"
 
 #include "../wsi/wsi_monitor.h"
 
@@ -15,7 +16,7 @@ namespace dxvk {
 
   public:
 
-    DxgiMonitorInfo(IUnknown* pParent);
+    DxgiMonitorInfo(IUnknown* pParent, const DxgiOptions& options);
 
     ~DxgiMonitorInfo();
 
@@ -41,11 +42,12 @@ namespace dxvk {
 
     DXGI_COLOR_SPACE_TYPE STDMETHODCALLTYPE CurrentColorSpace() const;
 
-    static DXGI_COLOR_SPACE_TYPE DefaultColorSpace();
+    DXGI_COLOR_SPACE_TYPE DefaultColorSpace() const;
 
   private:
 
     IUnknown* m_parent;
+    const DxgiOptions& m_options;
 
     dxvk::mutex                                        m_monitorMutex;
     std::unordered_map<HMONITOR, DXGI_VK_MONITOR_DATA> m_monitorData;

--- a/src/dxgi/dxgi_options.cpp
+++ b/src/dxgi/dxgi_options.cpp
@@ -45,6 +45,8 @@ namespace dxvk {
       this->nvapiHack = false;
     else
       this->nvapiHack = config.getOption<bool>("dxgi.nvapiHack", true);
+
+    this->enableHDR = config.getOption<bool>("dxgi.enableHDR", env::getEnvVar("DXVK_HDR") == "1");
   }
   
 }

--- a/src/dxgi/dxgi_options.h
+++ b/src/dxgi/dxgi_options.h
@@ -35,6 +35,9 @@ namespace dxvk {
 
     /// Enables nvapi workaround
     bool nvapiHack;
+
+    /// Enable HDR
+    bool enableHDR;
   };
   
 }

--- a/src/dxgi/dxgi_output.cpp
+++ b/src/dxgi/dxgi_output.cpp
@@ -19,6 +19,61 @@
 #include "../util/util_time.h"
 
 namespace dxvk {
+
+  static void NormalizeDisplayMetadata(wsi::WsiDisplayMetadata& metadata) {
+    // Use some dummy info when we have no hdr static metadata for the
+    // display or we were unable to obtain an EDID.
+    //
+    // These dummy values are the same as what Windows DXGI will output
+    // for panels with broken EDIDs such as LG OLEDs displays which
+    // have an entirely zeroed out luminance section in the hdr static
+    // metadata block.
+    //
+    // (Spec has 0 as 'undefined', which isn't really useful for an app
+    // to tonemap against.)
+    if (metadata.minLuminance == 0.0f)
+      metadata.minLuminance = 0.01f;
+
+    if (metadata.maxLuminance == 0.0f)
+      metadata.maxLuminance = 1499.0f;
+
+    if (metadata.maxFullFrameLuminance == 0.0f)
+      metadata.maxFullFrameLuminance = 799.0f;
+
+    // If we have no RedPrimary/GreenPrimary/BluePrimary/WhitePoint due to
+    // the lack of a monitor exposing the chroma block or the lack of an EDID,
+    // simply just fall back to Rec.709 or Rec.2020 values depending on the default
+    // ColorSpace we started in.
+    // (Don't change based on punting, as this should be static for a display.)
+    if (metadata.redPrimary[0]   == 0.0f && metadata.redPrimary[1]   == 0.0f
+     && metadata.greenPrimary[0] == 0.0f && metadata.greenPrimary[1] == 0.0f
+     && metadata.bluePrimary[0]  == 0.0f && metadata.bluePrimary[1]  == 0.0f
+     && metadata.whitePoint[0]   == 0.0f && metadata.whitePoint[1]   == 0.0f) {
+      if (DxgiMonitorInfo::DefaultColorSpace() == DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P709) {
+        // sRGB ColorSpace -> Rec.709 Primaries
+        metadata.redPrimary[0]   = 0.640f;
+        metadata.redPrimary[1]   = 0.330f;
+        metadata.greenPrimary[0] = 0.300f;
+        metadata.greenPrimary[1] = 0.600f;
+        metadata.bluePrimary[0]  = 0.150f;
+        metadata.bluePrimary[1]  = 0.060f;
+        metadata.whitePoint[0]   = 0.3127f;
+        metadata.whitePoint[1]   = 0.3290f;
+      } else {
+        // HDR10 ColorSpace -> Rec.2020 Primaries
+        // (Notably much bigger than any display is actually going to expose.)
+        metadata.redPrimary[0]   = 0.708f;
+        metadata.redPrimary[1]   = 0.292f;
+        metadata.greenPrimary[0] = 0.170f;
+        metadata.greenPrimary[1] = 0.797f;
+        metadata.bluePrimary[0]  = 0.131f;
+        metadata.bluePrimary[1]  = 0.046f;
+        metadata.whitePoint[0]   = 0.3127f;
+        metadata.whitePoint[1]   = 0.3290f;
+      }
+    }
+  }
+
   
   DxgiOutput::DxgiOutput(
     const Com<DxgiFactory>& factory,
@@ -664,6 +719,10 @@ namespace dxvk {
       m_metadata = metadata.value();
     else
       Logger::err("DXGI: Failed to parse display metadata + colorimetry info, using blank.");
+
+    // Normalize either the display metadata we got back, or our
+    // blank one to get something sane here.
+    NormalizeDisplayMetadata(m_metadata);
 
     monitorData.FrameStats.SyncQPCTime.QuadPart = dxvk::high_resolution_clock::get_counter();
     monitorData.GammaCurve.Scale = { 1.0f, 1.0f, 1.0f };

--- a/src/dxgi/dxgi_output.cpp
+++ b/src/dxgi/dxgi_output.cpp
@@ -218,21 +218,17 @@ namespace dxvk {
     pDesc->AttachedToDesktop     = 1;
     pDesc->Rotation              = DXGI_MODE_ROTATION_UNSPECIFIED;
     pDesc->Monitor               = m_monitor;
-    // TODO: When in HDR, flip this to 10 to appease apps that the
-    // transition has occured.
-    // If we support more than HDR10 in future, then we may want
-    // to visit that assumption.
     pDesc->BitsPerColor          = 8;
     // This should only return DXGI_COLOR_SPACE_RGB_FULL_G2084_NONE_P2020
     // (HDR) if the user has the HDR setting enabled in Windows.
     // Games can still punt into HDR mode by using CheckColorSpaceSupport
     // and SetColorSpace1.
-    // 
-    // TODO: When we have a swapchain using SetColorSpace1 to
-    // DXGI_COLOR_SPACE_RGB_FULL_G2084_NONE_P2020, we should use our monitor
-    // info to flip this over to that.
-    // As on Windows this would automatically engage HDR mode.
-    pDesc->ColorSpace            = DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P709;
+    //
+    // We have no way of checking the actual Windows colorspace as the
+    // only public method for this *is* DXGI which we are re-implementing.
+    // So we just pick our color space based on the DXVK_HDR env var
+    // and the punting from SetColorSpace1.
+    pDesc->ColorSpace            = m_monitorInfo->CurrentColorSpace();
     pDesc->RedPrimary[0]         = m_metadata.redPrimary[0];
     pDesc->RedPrimary[1]         = m_metadata.redPrimary[1];
     pDesc->GreenPrimary[0]       = m_metadata.greenPrimary[0];

--- a/src/dxgi/dxgi_output.cpp
+++ b/src/dxgi/dxgi_output.cpp
@@ -20,7 +20,7 @@
 
 namespace dxvk {
 
-  static void NormalizeDisplayMetadata(wsi::WsiDisplayMetadata& metadata) {
+  static void NormalizeDisplayMetadata(const DxgiMonitorInfo *pMonitorInfo, wsi::WsiDisplayMetadata& metadata) {
     // Use some dummy info when we have no hdr static metadata for the
     // display or we were unable to obtain an EDID.
     //
@@ -49,7 +49,7 @@ namespace dxvk {
      && metadata.greenPrimary[0] == 0.0f && metadata.greenPrimary[1] == 0.0f
      && metadata.bluePrimary[0]  == 0.0f && metadata.bluePrimary[1]  == 0.0f
      && metadata.whitePoint[0]   == 0.0f && metadata.whitePoint[1]   == 0.0f) {
-      if (DxgiMonitorInfo::DefaultColorSpace() == DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P709) {
+      if (pMonitorInfo->DefaultColorSpace() == DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P709) {
         // sRGB ColorSpace -> Rec.709 Primaries
         metadata.redPrimary[0]   = 0.640f;
         metadata.redPrimary[1]   = 0.330f;
@@ -722,7 +722,7 @@ namespace dxvk {
 
     // Normalize either the display metadata we got back, or our
     // blank one to get something sane here.
-    NormalizeDisplayMetadata(m_metadata);
+    NormalizeDisplayMetadata(m_monitorInfo, m_metadata);
 
     monitorData.FrameStats.SyncQPCTime.QuadPart = dxvk::high_resolution_clock::get_counter();
     monitorData.GammaCurve.Scale = { 1.0f, 1.0f, 1.0f };

--- a/src/dxgi/dxgi_swapchain.cpp
+++ b/src/dxgi/dxgi_swapchain.cpp
@@ -536,7 +536,13 @@ namespace dxvk {
       return E_INVALIDARG;
 
     std::lock_guard<dxvk::mutex> lock(m_lockBuffer);
-    return m_presenter->SetColorSpace(ColorSpace);
+    HRESULT hr = m_presenter->SetColorSpace(ColorSpace);
+    if (SUCCEEDED(hr)) {
+      // If this was a colorspace other than our current one,
+      // punt us into that one on the DXGI output.
+      m_monitorInfo->PuntColorSpace(ColorSpace);
+    }
+    return hr;
   }
 
   


### PR DESCRIPTION
Adds the ability to punt the global colorspace into HDR from SetColorSpace1.

We have no way of checking the actual Windows colorspace as the only public method for this *is* DXGI which we are re-implementing. So we just pick our color space based on the DXVK_HDR env var and the punting from SetColorSpace1.

We might expand on this in future, but this is good enough for an initial implementation.