### PR TITLE
[dxvk] Remove SDL dummy window

### DIFF
--- a/src/dxvk/platform/dxvk_sdl2_exts.cpp
+++ b/src/dxvk/platform/dxvk_sdl2_exts.cpp
@@ -13,29 +13,17 @@ namespace dxvk {
 
 
   DxvkNameSet DxvkPlatformExts::getInstanceExtensions() {
-    SDL_Window* window = SDL_CreateWindow(
-      "Dummy Window",
-      SDL_WINDOWPOS_UNDEFINED,
-      SDL_WINDOWPOS_UNDEFINED,
-      1, 1,
-      SDL_WINDOW_HIDDEN | SDL_WINDOW_VULKAN);
-
-    if (window == nullptr)
-      throw DxvkError(str::format("SDL2 WSI: Failed to create dummy window. ", SDL_GetError()));
-
     uint32_t extensionCount = 0;
-    if (!SDL_Vulkan_GetInstanceExtensions(window, &extensionCount, nullptr))
+    if (!SDL_Vulkan_GetInstanceExtensions(nullptr, &extensionCount, nullptr))
       throw DxvkError(str::format("SDL2 WSI: Failed to get instance extension count. ", SDL_GetError()));
 
     auto extensionNames = std::vector<const char *>(extensionCount);
-    if (!SDL_Vulkan_GetInstanceExtensions(window, &extensionCount, extensionNames.data()))
+    if (!SDL_Vulkan_GetInstanceExtensions(nullptr, &extensionCount, extensionNames.data()))
       throw DxvkError(str::format("SDL2 WSI: Failed to get instance extensions. ", SDL_GetError()));
 
     DxvkNameSet names;
     for (const char* name : extensionNames)
       names.add(name);
-
-    SDL_DestroyWindow(window);
 
     return names;
   }


### PR DESCRIPTION
SDL >= 2.0.9 permits passing a nullptr window to SDL_Vulkan_GetInstanceExtensions, so there's no point in going though the work of creating a window just to call this function.