### PR TITLE
Add options to enforce sample rate shading

### DIFF
--- a/dxvk.conf
+++ b/dxvk.conf
@@ -201,6 +201,15 @@
 # d3d9.invariantPosition = True
 
 
+# Forces per-sample rate shading when MSAA is enabled, rather than per-pixel
+# shading. May improve visual clarity at a significant performance cost, but
+# may also introduce visual issues in some games.
+#
+# Supported values: True, False
+
+# d3d11.forceSampleRateShading = False
+
+
 # Forces the sample count of all textures to 1, and performs
 # the needed fixups in resolve operations and shaders.
 #

--- a/dxvk.conf
+++ b/dxvk.conf
@@ -208,6 +208,7 @@
 # Supported values: True, False
 
 # d3d11.forceSampleRateShading = False
+# d3d9.forceSampleRateShading = False
 
 
 # Forces the sample count of all textures to 1, and performs

--- a/src/d3d11/d3d11_options.cpp
+++ b/src/d3d11/d3d11_options.cpp
@@ -23,6 +23,7 @@ namespace dxvk {
     this->samplerLodBias        = config.getOption<float>("d3d11.samplerLodBias", 0.0f);
     this->invariantPosition     = config.getOption<bool>("d3d11.invariantPosition", true);
     this->floatControls         = config.getOption<bool>("d3d11.floatControls", true);
+    this->forceSampleRateShading = config.getOption<bool>("d3d11.forceSampleRateShading", false);
     this->disableMsaa           = config.getOption<bool>("d3d11.disableMsaa", false);
     this->enableContextLock     = config.getOption<bool>("d3d11.enableContextLock", false);
     this->deferSurfaceCreation  = config.getOption<bool>("dxgi.deferSurfaceCreation", false);

--- a/src/d3d11/d3d11_options.h
+++ b/src/d3d11/d3d11_options.h
@@ -99,6 +99,11 @@ namespace dxvk {
     /// for a single window that may interfere with each other.
     bool deferSurfaceCreation;
 
+    /// Enables sample rate shading by interpolating fragment shader
+    /// inputs at the sample location rather than pixel center,
+    /// unless otherwise specified by the application.
+    bool forceSampleRateShading;
+
     /// Forces the sample count of all textures to be 1, and
     /// performs the required shader and resolve fixups.
     bool disableMsaa;

--- a/src/d3d9/d3d9_fixed_function.cpp
+++ b/src/d3d9/d3d9_fixed_function.cpp
@@ -14,6 +14,7 @@ namespace dxvk {
 
   D3D9FixedFunctionOptions::D3D9FixedFunctionOptions(const D3D9Options* options) {
     invariantPosition = options->invariantPosition;
+    forceSampleRateShading = options->forceSampleRateShading;
   }
 
   uint32_t DoFixedFunctionFog(D3D9ShaderSpecConstantManager& spec, SpirvModule& spvModule, const D3D9FogContext& fogCtx) {
@@ -933,10 +934,16 @@ namespace dxvk {
 
     uint32_t ptr = m_module.newVar(ptrType, storageClass);
 
-    if (builtin == spv::BuiltInMax)
+    if (builtin == spv::BuiltInMax) {
       m_module.decorateLocation(ptr, slot);
-    else
+
+      if (isPS() && input && m_options.forceSampleRateShading) {
+        m_module.enableCapability(spv::CapabilitySampleRateShading);
+        m_module.decorate(ptr, spv::DecorationSample);
+      }
+    } else {
       m_module.decorateBuiltIn(ptr, builtin);
+    }
 
     bool diffuseOrSpec = semantic == DxsoSemantic{ DxsoUsage::Color, 0 }
                       || semantic == DxsoSemantic{ DxsoUsage::Color, 1 };

--- a/src/d3d9/d3d9_fixed_function.h
+++ b/src/d3d9/d3d9_fixed_function.h
@@ -49,6 +49,7 @@ namespace dxvk {
     D3D9FixedFunctionOptions(const D3D9Options* options);
 
     bool invariantPosition;
+    bool forceSampleRateShading;
   };
 
   // Returns new oFog if VS

--- a/src/d3d9/d3d9_options.cpp
+++ b/src/d3d9/d3d9_options.cpp
@@ -63,6 +63,7 @@ namespace dxvk {
     this->enableDialogMode              = config.getOption<bool>        ("d3d9.enableDialogMode",              false);
     this->forceSamplerTypeSpecConstants = config.getOption<bool>        ("d3d9.forceSamplerTypeSpecConstants", false);
     this->forceSwapchainMSAA            = config.getOption<int32_t>     ("d3d9.forceSwapchainMSAA",            -1);
+    this->forceSampleRateShading        = config.getOption<bool>        ("d3d9.forceSampleRateShading",        false);
     this->forceAspectRatio              = config.getOption<std::string> ("d3d9.forceAspectRatio",              "");
     this->allowDiscard                  = config.getOption<bool>        ("d3d9.allowDiscard",                  true);
     this->enumerateByDisplays           = config.getOption<bool>        ("d3d9.enumerateByDisplays",           true);

--- a/src/d3d9/d3d9_options.h
+++ b/src/d3d9/d3d9_options.h
@@ -123,6 +123,9 @@ namespace dxvk {
     /// Forces an MSAA level on the swapchain
     int32_t forceSwapchainMSAA;
 
+    /// Forces sample rate shading
+    bool forceSampleRateShading;
+
     /// Allow D3DLOCK_DISCARD
     bool allowDiscard;
 

--- a/src/dxbc/dxbc_compiler.cpp
+++ b/src/dxbc/dxbc_compiler.cpp
@@ -726,6 +726,14 @@ namespace dxvk {
         m_module.decorate(varId, spv::DecorationSample);
       }
 
+      if (m_moduleInfo.options.forceSampleRateShading) {
+        if (im == DxbcInterpolationMode::Linear
+         || im == DxbcInterpolationMode::LinearNoPerspective) {
+          m_module.enableCapability(spv::CapabilitySampleRateShading);
+          m_module.decorate(varId, spv::DecorationSample);
+        }
+      }
+
       // Declare the input slot as defined
       m_inputMask |= 1u << regIdx;
       m_vArrayLength = std::max(m_vArrayLength, regIdx + 1);

--- a/src/dxbc/dxbc_options.cpp
+++ b/src/dxbc/dxbc_options.cpp
@@ -38,6 +38,7 @@ namespace dxvk {
     zeroInitWorkgroupMemory  = options.zeroInitWorkgroupMemory;
     forceVolatileTgsmAccess  = options.forceVolatileTgsmAccess;
     disableMsaa              = options.disableMsaa;
+    forceSampleRateShading   = options.forceSampleRateShading;
     enableSampleShadingInterlock = device->features().extFragmentShaderInterlock.fragmentShaderSampleInterlock;
 
     // Figure out float control flags to match D3D11 rules

--- a/src/dxbc/dxbc_options.h
+++ b/src/dxbc/dxbc_options.h
@@ -43,6 +43,10 @@ namespace dxvk {
     /// Replace ld_ms with ld
     bool disableMsaa = false;
 
+    /// Force sample rate shading by using sample
+    /// interpolation for fragment shader inputs
+    bool forceSampleRateShading = false;
+
     // Enable per-sample interlock if supported
     bool enableSampleShadingInterlock = false;
 

--- a/src/dxso/dxso_compiler.cpp
+++ b/src/dxso/dxso_compiler.cpp
@@ -3192,6 +3192,12 @@ void DxsoCompiler::emitControlFlowGenericLoop(
 
       m_module.decorateLocation(inputPtr.id, slot);
 
+      if (m_programInfo.type() == DxsoProgramType::PixelShader
+       && m_moduleInfo.options.forceSampleRateShading) {
+        m_module.enableCapability(spv::CapabilitySampleRateShading);
+        m_module.decorate(inputPtr.id, spv::DecorationSample);
+      }
+
       std::string name =
         str::format("in_", elem.semantic.usage, elem.semantic.usageIndex);
       m_module.setDebugName(inputPtr.id, name.c_str());

--- a/src/dxso/dxso_options.cpp
+++ b/src/dxso/dxso_options.cpp
@@ -25,6 +25,7 @@ namespace dxvk {
     invariantPosition    = options.invariantPosition;
 
     forceSamplerTypeSpecConstants = options.forceSamplerTypeSpecConstants;
+    forceSampleRateShading = options.forceSampleRateShading;
 
     vertexFloatConstantBufferAsSSBO = pDevice->GetVertexConstantLayout().floatSize() > devInfo.core.properties.limits.maxUniformBufferRange;
 

--- a/src/dxso/dxso_options.h
+++ b/src/dxso/dxso_options.h
@@ -36,6 +36,9 @@ namespace dxvk {
     /// Works around a game bug in Halo CE where it gives cube textures to 2d/volume samplers
     bool forceSamplerTypeSpecConstants;
 
+    /// Interpolate pixel shader inputs at the sample location rather than pixel center
+    bool forceSampleRateShading;
+
     /// Should the SWVP float constant buffer be a SSBO (because of the size on NV)
     bool vertexFloatConstantBufferAsSSBO;
 


### PR DESCRIPTION
Or suplersampling in simple terms.

Main motivation was to fix the annoing shimmering in Cold Steel 3 and 4 that's caused by normal mapping. Obviously the GPU performance impact is a bit on the absurd side of things, but MSAA is only really supported in old/simple games that run on a toaster anyway.

Regular 4xMSAA:
![off](https://user-images.githubusercontent.com/25567304/211190058-f7038c64-a5bf-4f25-9f46-f1c36563b0e7.png)

4xMSAA with sample rate shading:
![on](https://user-images.githubusercontent.com/25567304/211190063-beece205-f0a7-4421-9473-f1d57cf89842.png)

Haven't really tested the D3D9 side of things much.