### PR TITLE
[util] Add config for Alien Rage

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -696,6 +696,13 @@ namespace dxvk {
     { R"(\\Secret World Legends\\ClientPatcher\.exe$)", {{
       { "d3d9.shaderModel",                 "2" },
     }} },
+    /* Alien Rage                              *
+     * GTX 295 & disable Hack to fix shadows   */
+    { R"(\\(ShippingPC-AFEARGame|ARageMP)\.exe$)", {{
+      { "d3d9.customVendorId",              "10de" },
+      { "d3d9.customDeviceId",              "05E0" },
+      { "dxgi.nvapiHack",                   "False" },
+    }} },
   }};
 
 


### PR DESCRIPTION
Reporting a GTX 295 puts us into the highest behind the scenes graphics settings preset bucket and prevents the shadow issue with `FloatingPointRenderTargets` set to false in the lower preset bucket. 
NvapiHack needs to be disabled on Linux since the game pings it in the Windows system folder and want's the VendorId to match your GPU. Else the issue will still happen on Nvidia Linux

This will take effect on fresh new installs as the file responsible for the above is generated on first launch.
On already installed games or prefix with left over config files one will have to delete `AFEAREngine.ini` in `C:/users/USERNAME/Documents/My Games/AlienRage/SinglePlayer/AFEARGame/Config/` so the game can generate it again.
If one instead want's to edit the file one will need [a special tool](https://www.pcgamingwiki.com/wiki/Alien_Rage_-_Unlimited#Encrypted_configuration_files) as they are encrypted.

Fixes https://github.com/doitsujin/dxvk/issues/2613