### PR TITLE
D3D11 Flush heuristic rework

### DIFF
--- a/src/d3d11/d3d11_cmdlist.cpp
+++ b/src/d3d11/d3d11_cmdlist.cpp
@@ -41,44 +41,64 @@ namespace dxvk {
   }
   
   
-  void D3D11CommandList::AddChunk(DxvkCsChunkRef&& Chunk) {
-    m_chunks.push_back(std::move(Chunk));
-  }
-  
-  
   void D3D11CommandList::AddQuery(D3D11Query* pQuery) {
     m_queries.emplace_back(pQuery);
   }
 
 
-  void D3D11CommandList::EmitToCommandList(ID3D11CommandList* pCommandList) {
-    auto cmdList = static_cast<D3D11CommandList*>(pCommandList);
-    
-    for (const auto& chunk : m_chunks)
-      cmdList->m_chunks.push_back(chunk);
-
-    for (const auto& query : m_queries)
-      cmdList->m_queries.push_back(query);
-
-    for (const auto& resource : m_resources)
-      cmdList->m_resources.push_back(resource);
-
-    MarkSubmitted();
+  uint64_t D3D11CommandList::AddChunk(DxvkCsChunkRef&& Chunk) {
+    m_chunks.push_back(std::move(Chunk));
+    return m_chunks.size() - 1;
   }
   
   
+  uint64_t D3D11CommandList::AddCommandList(
+          D3D11CommandList*   pCommandList) {
+    // This will be the chunk ID of the first chunk
+    // added, for the purpose of resource tracking.
+    uint64_t baseChunkId = m_chunks.size();
+    
+    for (const auto& chunk : pCommandList->m_chunks)
+      m_chunks.push_back(chunk);
+
+    for (const auto& query : pCommandList->m_queries)
+      m_queries.push_back(query);
+
+    for (const auto& resource : pCommandList->m_resources) {
+      TrackedResource entry = resource;
+      entry.chunkId += baseChunkId;
+
+      m_resources.push_back(std::move(entry));
+    }
+
+    pCommandList->MarkSubmitted();
+
+    // Return ID of the last chunk added. The command list
+    // added can never be empty, so do not handle zero.
+    return m_chunks.size() - 1;
+  }
+
+
   void D3D11CommandList::EmitToCsThread(
     const D3D11ChunkDispatchProc& DispatchProc) {
-    uint64_t seq = 0;
-
     for (const auto& query : m_queries)
       query->DoDeferredEnd();
 
-    for (const auto& chunk : m_chunks)
-      seq = DispatchProc(DxvkCsChunkRef(chunk));
-    
-    for (const auto& resource : m_resources)
-      TrackResourceSequenceNumber(resource, seq);
+    for (size_t i = 0, j = 0; i < m_chunks.size(); i++) {
+      // If there are resources to track for the current chunk,
+      // use a strong flush hint to dispatch GPU work quickly.
+      GpuFlushType flushType = GpuFlushType::ImplicitWeakHint;
+
+      if (j < m_resources.size() && m_resources[j].chunkId == i)
+        flushType = GpuFlushType::ImplicitStrongHint;
+
+      // Dispatch the chunk and capture its sequence number
+      uint64_t seq = DispatchProc(DxvkCsChunkRef(m_chunks[i]), flushType);
+
+      // Track resource sequence numbers for the added chunk
+      while (j < m_resources.size() && m_resources[j].chunkId == i)
+        TrackResourceSequenceNumber(m_resources[j++].ref, seq);
+    }
 
     MarkSubmitted();
   }
@@ -87,8 +107,13 @@ namespace dxvk {
   void D3D11CommandList::TrackResourceUsage(
           ID3D11Resource*     pResource,
           D3D11_RESOURCE_DIMENSION ResourceType,
-          UINT                Subresource) {
-    m_resources.emplace_back(pResource, Subresource, ResourceType);
+          UINT                Subresource,
+          uint64_t            ChunkId) {
+    TrackedResource entry;
+    entry.ref = D3D11ResourceRef(pResource, Subresource, ResourceType);
+    entry.chunkId = ChunkId;
+
+    m_resources.push_back(std::move(entry));
   }
 
 
@@ -96,7 +121,6 @@ namespace dxvk {
     const D3D11ResourceRef&   Resource,
           uint64_t            Seq) {
     ID3D11Resource* iface = Resource.Get();
-    UINT subresource = Resource.GetSubresource();
 
     switch (Resource.GetType()) {
       case D3D11_RESOURCE_DIMENSION_UNKNOWN:
@@ -109,17 +133,17 @@ namespace dxvk {
 
       case D3D11_RESOURCE_DIMENSION_TEXTURE1D: {
         auto impl = static_cast<D3D11Texture1D*>(iface)->GetCommonTexture();
-        impl->TrackSequenceNumber(subresource, Seq);
+        impl->TrackSequenceNumber(Resource.GetSubresource(), Seq);
       } break;
 
       case D3D11_RESOURCE_DIMENSION_TEXTURE2D: {
         auto impl = static_cast<D3D11Texture2D*>(iface)->GetCommonTexture();
-        impl->TrackSequenceNumber(subresource, Seq);
+        impl->TrackSequenceNumber(Resource.GetSubresource(), Seq);
       } break;
 
       case D3D11_RESOURCE_DIMENSION_TEXTURE3D: {
         auto impl = static_cast<D3D11Texture3D*>(iface)->GetCommonTexture();
-        impl->TrackSequenceNumber(subresource, Seq);
+        impl->TrackSequenceNumber(Resource.GetSubresource(), Seq);
       } break;
     }
   }

--- a/src/d3d11/d3d11_cmdlist.cpp
+++ b/src/d3d11/d3d11_cmdlist.cpp
@@ -67,20 +67,20 @@ namespace dxvk {
   }
   
   
-  uint64_t D3D11CommandList::EmitToCsThread(DxvkCsThread* CsThread) {
+  void D3D11CommandList::EmitToCsThread(
+    const D3D11ChunkDispatchProc& DispatchProc) {
     uint64_t seq = 0;
 
     for (const auto& query : m_queries)
       query->DoDeferredEnd();
 
     for (const auto& chunk : m_chunks)
-      seq = CsThread->dispatchChunk(DxvkCsChunkRef(chunk));
+      seq = DispatchProc(DxvkCsChunkRef(chunk));
     
     for (const auto& resource : m_resources)
       TrackResourceSequenceNumber(resource, seq);
 
     MarkSubmitted();
-    return seq;
   }
   
   

--- a/src/d3d11/d3d11_cmdlist.h
+++ b/src/d3d11/d3d11_cmdlist.h
@@ -6,7 +6,7 @@
 
 namespace dxvk {
   
-  using D3D11ChunkDispatchProc = std::function<uint64_t (DxvkCsChunkRef&&)>;
+  using D3D11ChunkDispatchProc = std::function<uint64_t (DxvkCsChunkRef&&, GpuFlushType)>;
 
   class D3D11CommandList : public D3D11DeviceChild<ID3D11CommandList> {
     
@@ -24,34 +24,36 @@ namespace dxvk {
     
     UINT STDMETHODCALLTYPE GetContextFlags() final;
     
-    void AddChunk(
-            DxvkCsChunkRef&&    Chunk);
-
     void AddQuery(
             D3D11Query*         pQuery);
     
-    void EmitToCommandList(
-            ID3D11CommandList*  pCommandList);
-    
+    uint64_t AddChunk(
+            DxvkCsChunkRef&&    Chunk);
+
+    uint64_t AddCommandList(
+            D3D11CommandList*   pCommandList);
+
     void EmitToCsThread(
       const D3D11ChunkDispatchProc& DispatchProc);
 
     void TrackResourceUsage(
             ID3D11Resource*     pResource,
             D3D11_RESOURCE_DIMENSION ResourceType,
-            UINT                Subresource);
-
-    bool HasTrackedResources() const {
-      return !m_resources.empty();
-    }
+            UINT                Subresource,
+            uint64_t            ChunkId);
 
   private:
 
-    UINT         const m_contextFlags;
+    struct TrackedResource {
+      D3D11ResourceRef  ref;
+      uint64_t          chunkId;
+    };
+
+    UINT m_contextFlags;
     
     std::vector<DxvkCsChunkRef>         m_chunks;
     std::vector<Com<D3D11Query, false>> m_queries;
-    std::vector<D3D11ResourceRef>       m_resources;
+    std::vector<TrackedResource>        m_resources;
 
     std::atomic<bool> m_submitted = { false };
     std::atomic<bool> m_warned    = { false };

--- a/src/d3d11/d3d11_cmdlist.h
+++ b/src/d3d11/d3d11_cmdlist.h
@@ -1,9 +1,13 @@
 #pragma once
 
+#include <functional>
+
 #include "d3d11_context.h"
 
 namespace dxvk {
   
+  using D3D11ChunkDispatchProc = std::function<uint64_t (DxvkCsChunkRef&&)>;
+
   class D3D11CommandList : public D3D11DeviceChild<ID3D11CommandList> {
     
   public:
@@ -29,13 +33,17 @@ namespace dxvk {
     void EmitToCommandList(
             ID3D11CommandList*  pCommandList);
     
-    uint64_t EmitToCsThread(
-            DxvkCsThread*       CsThread);
+    void EmitToCsThread(
+      const D3D11ChunkDispatchProc& DispatchProc);
 
     void TrackResourceUsage(
             ID3D11Resource*     pResource,
             D3D11_RESOURCE_DIMENSION ResourceType,
             UINT                Subresource);
+
+    bool HasTrackedResources() const {
+      return !m_resources.empty();
+    }
 
   private:
 

--- a/src/d3d11/d3d11_context.cpp
+++ b/src/d3d11/d3d11_context.cpp
@@ -2194,9 +2194,6 @@ namespace dxvk {
           ID3D11DepthStencilView*           pDepthStencilView) {
     D3D10DeviceLock lock = LockContext();
 
-    if constexpr (!IsDeferred)
-      GetTypedContext()->FlushImplicit(true);
-
     SetRenderTargetsAndUnorderedAccessViews(
       NumViews, ppRenderTargetViews, pDepthStencilView,
       NumViews, 0, nullptr, nullptr);
@@ -2213,9 +2210,6 @@ namespace dxvk {
           ID3D11UnorderedAccessView* const* ppUnorderedAccessViews,
     const UINT*                             pUAVInitialCounts) {
     D3D10DeviceLock lock = LockContext();
-
-    if constexpr (!IsDeferred)
-      GetTypedContext()->FlushImplicit(true);
 
     SetRenderTargetsAndUnorderedAccessViews(
       NumRTVs, ppRenderTargetViews, pDepthStencilView,
@@ -2671,7 +2665,7 @@ namespace dxvk {
       return E_INVALIDARG;
 
     if constexpr (!IsDeferred)
-      GetTypedContext()->FlushImplicit(false);
+      GetTypedContext()->ConsiderFlush(GpuFlushType::ImplicitWeakHint);
 
     DxvkSparseBindInfo bindInfo;
     bindInfo.dstResource = GetPagedResource(pDestTiledResource);
@@ -2808,7 +2802,7 @@ namespace dxvk {
       return E_INVALIDARG;
 
     if constexpr (!IsDeferred)
-      GetTypedContext()->FlushImplicit(false);
+      GetTypedContext()->ConsiderFlush(GpuFlushType::ImplicitWeakHint);
 
     // Find sparse allocator if the tile pool is defined
     DxvkSparseBindInfo bindInfo;
@@ -4921,8 +4915,12 @@ namespace dxvk {
       }
     }
 
-    if (needsUpdate)
+    if (needsUpdate) {
       BindFramebuffer();
+
+      if constexpr (!IsDeferred)
+        GetTypedContext()->ConsiderFlush(GpuFlushType::ImplicitWeakHint);
+    }
   }
 
 

--- a/src/d3d11/d3d11_context.cpp
+++ b/src/d3d11/d3d11_context.cpp
@@ -4918,8 +4918,10 @@ namespace dxvk {
     if (needsUpdate) {
       BindFramebuffer();
 
-      if constexpr (!IsDeferred)
+      if constexpr (!IsDeferred) {
+        // Doing this makes it less likely to flush during render passes
         GetTypedContext()->ConsiderFlush(GpuFlushType::ImplicitWeakHint);
+      }
     }
   }
 

--- a/src/d3d11/d3d11_context_def.h
+++ b/src/d3d11/d3d11_context_def.h
@@ -96,6 +96,9 @@ namespace dxvk {
     // Begun and ended queries, will also be stored in command list
     std::vector<Com<D3D11Query, false>> m_queriesBegun;
 
+    // Chunk ID within the current command list
+    uint64_t m_chunkId = 0ull;
+
     HRESULT MapBuffer(
             ID3D11Resource*               pResource,
             D3D11_MAPPED_SUBRESOURCE*     pMappedResource);
@@ -117,6 +120,8 @@ namespace dxvk {
     Com<D3D11CommandList> CreateCommandList();
     
     void EmitCsChunk(DxvkCsChunkRef&& chunk);
+
+    uint64_t GetCurrentChunkId() const;
 
     void TrackTextureSequenceNumber(
             D3D11CommonTexture*           pResource,

--- a/src/d3d11/d3d11_context_imm.cpp
+++ b/src/d3d11/d3d11_context_imm.cpp
@@ -238,7 +238,7 @@ namespace dxvk {
     ConsiderFlush(GpuFlushType::ImplicitWeakHint);
 
     // Dispatch command list to the CS thread
-    commandList->EmitToCsThread([this] (DxvkCsChunkRef&& chunk) {
+    commandList->EmitToCsThread([this] (DxvkCsChunkRef&& chunk, GpuFlushType flushType) {
       EmitCsChunk(std::move(chunk));
 
       // Return the sequence number from before the flush since
@@ -247,13 +247,9 @@ namespace dxvk {
 
       // Consider a flush after every chunk in case the app
       // submits a very large command list or the GPU is idle
-      ConsiderFlush(GpuFlushType::ImplicitWeakHint);
+      ConsiderFlush(flushType);
       return csSeqNum;
     });
-
-    // If any resource tracking took place, flush with a strong hint
-    if (commandList->HasTrackedResources())
-      ConsiderFlush(GpuFlushType::ImplicitStrongHint);
 
     // Restore the immediate context's state
     if (RestoreContextState)

--- a/src/d3d11/d3d11_context_imm.cpp
+++ b/src/d3d11/d3d11_context_imm.cpp
@@ -236,7 +236,7 @@ namespace dxvk {
     // As an optimization, flush everything if the
     // number of pending draw calls is high enough.
     ConsiderFlush(GpuFlushType::ImplicitWeakHint);
-    
+
     // Dispatch command list to the CS thread and
     // restore the immediate context's state
     uint64_t csSeqNum = commandList->EmitToCsThread(&m_csThread);
@@ -247,7 +247,7 @@ namespace dxvk {
     else
       ResetContextState();
 
-    // Flush after if the command list was sufficiently long
+    // Flush again if the command list was sufficiently long
     ConsiderFlush(GpuFlushType::ImplicitWeakHint);
   }
   
@@ -378,8 +378,6 @@ namespace dxvk {
       }
 
       if (doInvalidatePreserve) {
-        ConsiderFlush(GpuFlushType::ImplicitWeakHint);
-
         auto prevSlice = pResource->GetMappedSlice();
         auto physSlice = pResource->DiscardSlice();
 
@@ -525,8 +523,6 @@ namespace dxvk {
       }
 
       if (doFlags & DoInvalidate) {
-        ConsiderFlush(GpuFlushType::ImplicitWeakHint);
-
         DxvkBufferSliceHandle prevSlice = pResource->GetMappedSlice(Subresource);
         DxvkBufferSliceHandle physSlice = pResource->DiscardSlice(Subresource);
 
@@ -770,7 +766,7 @@ namespace dxvk {
   void D3D11ImmediateContext::EndFrame() {
     D3D10DeviceLock lock = LockContext();
 
-    EmitCs([] (DxvkContext* ctx) {
+    EmitCs<false>([] (DxvkContext* ctx) {
       ctx->endFrame();
     });
   }
@@ -887,7 +883,7 @@ namespace dxvk {
       });
     }
 
-    EmitCs([
+    EmitCs<false>([
       cSubmissionFence  = m_submissionFence,
       cSubmissionId     = submissionId
     ] (DxvkContext* ctx) {

--- a/src/d3d11/d3d11_context_imm.h
+++ b/src/d3d11/d3d11_context_imm.h
@@ -88,13 +88,15 @@ namespace dxvk {
     
     DxvkCsThread            m_csThread;
     uint64_t                m_csSeqNum = 0ull;
-    bool                    m_csIsBusy = false;
 
     Rc<sync::CallbackFence> m_eventSignal;
     uint64_t                m_eventCount = 0ull;
     uint32_t                m_mappedImageCount = 0u;
 
     VkDeviceSize            m_maxImplicitDiscardSize = 0ull;
+
+    uint64_t                m_flushSeqNum = 0ull;
+
 
     dxvk::high_resolution_clock::time_point m_lastFlush
       = dxvk::high_resolution_clock::now();
@@ -157,6 +159,8 @@ namespace dxvk {
             D3D11Buffer*                pResource);
 
     uint64_t GetCurrentSequenceNumber();
+
+    uint64_t GetPendingCsChunks();
 
     void FlushImplicit(BOOL StrongHint);
 

--- a/src/d3d11/d3d11_context_imm.h
+++ b/src/d3d11/d3d11_context_imm.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "../util/util_flush.h"
 #include "../util/util_time.h"
 
 #include "../util/sync/sync_signal.h"

--- a/src/dxvk/dxvk_limits.h
+++ b/src/dxvk/dxvk_limits.h
@@ -12,7 +12,7 @@ namespace dxvk {
     MaxNumXfbStreams            =     4,
     MaxNumViewports             =    16,
     MaxNumResourceSlots         =  1216,
-    MaxNumQueuedCommandBuffers  =    18,
+    MaxNumQueuedCommandBuffers  =    32,
     MaxNumQueryCountPerPool     =   128,
     MaxNumSpecConstants         =    12,
     MaxUniformBufferSize        = 65536,

--- a/src/util/meson.build
+++ b/src/util/meson.build
@@ -2,6 +2,7 @@ util_src = files([
   'util_env.cpp',
   'util_string.cpp',
   'util_fps_limiter.cpp',
+  'util_flush.cpp',
   'util_gdi.cpp',
   'util_luid.cpp',
   'util_matrix.cpp',

--- a/src/util/util_flush.cpp
+++ b/src/util/util_flush.cpp
@@ -1,0 +1,79 @@
+#include "util_flush.h"
+
+namespace dxvk {
+
+  bool GpuFlushTracker::considerFlush(
+          GpuFlushType          flushType,
+          uint64_t              chunkId,
+          uint32_t              lastCompleteSubmissionId) {
+    constexpr uint32_t minPendingSubmissions = 2;
+
+    constexpr uint32_t minChunkCount =  3u;
+    constexpr uint32_t maxChunkCount = 20u;
+
+    // Do not flush if there is nothing to flush
+    uint32_t chunkCount = uint32_t(chunkId - m_lastFlushChunkId);
+
+    if (!chunkCount)
+      return false;
+
+    // Take any earlier missed flush with a stronger hint into account, so
+    // that we still flush those as soon as possible. Ignore synchronization
+    // commands since they will either perform a flush or not need it at all.
+    flushType = std::min(flushType, m_lastMissedType);
+
+    if (flushType != GpuFlushType::ImplicitSynchronization)
+      m_lastMissedType = flushType;
+
+    switch (flushType) {
+      case GpuFlushType::ExplicitFlush: {
+        // This shouldn't really be called for explicit flushes,
+        // but handle them anyway for the sake of completeness
+        return true;
+      }
+
+      case GpuFlushType::ImplicitStrongHint: {
+        // Flush aggressively with a strong hint to reduce readback latency.
+        return chunkCount >= minChunkCount;
+      }
+
+      case GpuFlushType::ImplicitWeakHint: {
+        // Aim for a higher number of chunks per submission with
+        // a weak hint in order to avoid submitting too often.
+        if (chunkCount < 2 * minChunkCount)
+          return false;
+
+        // Actual heuristic is shared with synchronization commands
+      } [[fallthrough]];
+
+      case GpuFlushType::ImplicitSynchronization: {
+        // If the GPU is about to go idle, flush aggressively. This may be
+        // required if the application is spinning on a query or resource.
+        uint32_t pendingSubmissions = uint32_t(m_lastFlushSubmissionId - lastCompleteSubmissionId);
+
+        if (pendingSubmissions < minPendingSubmissions)
+          return true;
+
+        // Use the number of pending submissions to decide whether to flush. Other
+        // than ignoring the minimum chunk count condition, we should treat this
+        // the same as weak hints to avoid unnecessary synchronization.
+        uint32_t threshold = std::min(maxChunkCount, pendingSubmissions * minChunkCount);
+        return chunkCount >= threshold;
+      }
+    }
+
+    // Should be unreachable
+    return false;
+  }
+
+
+  void GpuFlushTracker::notifyFlush(
+          uint64_t              chunkId,
+          uint64_t              submissionId) {
+    m_lastMissedType = GpuFlushType::ImplicitWeakHint;
+
+    m_lastFlushChunkId = chunkId;
+    m_lastFlushSubmissionId = submissionId;
+  }
+
+}

--- a/src/util/util_flush.h
+++ b/src/util/util_flush.h
@@ -1,0 +1,71 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+namespace dxvk {
+
+  /**
+   * \brief GPU context flush type
+   */
+  enum class GpuFlushType : uint32_t {
+    /** Flush or Present called by application */
+    ExplicitFlush           = 0,
+    /** Function that requires GPU synchronization and
+     *  may require a flush called by application */
+    ImplicitSynchronization = 1,
+    /** GPU command that applications are likely to synchronize
+     *  with soon has been recorded into the command list */
+    ImplicitStrongHint      = 2,
+    /** GPU commands have been recorded and a flush should be
+     *  performed if the current command list is large enough. */
+    ImplicitWeakHint        = 3,
+  };
+
+
+  /**
+   * \brief GPU flush tracker
+   *
+   * Helper class that implements a context flush
+   * heuristic for various scenarios.
+   */
+  class GpuFlushTracker {
+
+  public:
+
+    /**
+     * \brief Checks whether a context flush should be performed
+     *
+     * Note that this modifies internal state, and depending on the
+     * flush type, this may influence the decision for future flushes.
+     * \param [in] flushType Flush type
+     * \param [in] chunkId GPU command sequence number
+     * \param [in] lastCompleteSubmissionId Last completed command submission ID
+     * \returns \c true if a flush should be performed
+     */
+    bool considerFlush(
+            GpuFlushType          flushType,
+            uint64_t              chunkId,
+            uint32_t              lastCompleteSubmissionId);
+
+    /**
+     * \brief Notifies tracker about a context flush
+     *
+     * \param [in] chunkId GPU command sequence number
+     * \param [in] submissionId Command submission ID
+     */
+    void notifyFlush(
+            uint64_t              chunkId,
+            uint64_t              submissionId);
+
+  private:
+
+    GpuFlushType  m_lastMissedType        = GpuFlushType::ImplicitWeakHint;
+
+    uint64_t      m_lastFlushChunkId      = 0ull;
+    uint64_t      m_lastFlushSubmissionId = 0ull;
+
+  };
+
+}


### PR DESCRIPTION
Aims to fix inconsistent resource readback latencies, and in general just brings flushing behaviour more in line with what a D3D11 driver would do.

The old code was really designed for a world in which interrupting a render pass was a really bad idea due to image layout transitions, but we're no longer doing those when a render pass instance is merely suspended anyway, so flushing in the middle of a draw sequence isn't a problem anymore.

This is kind of scary anyway though so any testing is highly appreciated.