### PR TITLE
[dxgi] Expose only sRGB when enableHDR is disabled

### DIFF
--- a/src/d3d11/d3d11_device.h
+++ b/src/d3d11/d3d11_device.h
@@ -723,41 +723,6 @@ namespace dxvk {
 
 
   /**
-   * \brief DXGI swap chain factory
-   */
-  class WineDXGISwapChainFactory : public IWineDXGISwapChainFactory {
-    
-  public:
-    
-    WineDXGISwapChainFactory(
-            D3D11DXGIDevice*        pContainer,
-            D3D11Device*            pDevice);
-    
-    ULONG STDMETHODCALLTYPE AddRef();
-    
-    ULONG STDMETHODCALLTYPE Release();
-    
-    HRESULT STDMETHODCALLTYPE QueryInterface(
-            REFIID                  riid,
-            void**                  ppvObject);
-    
-    HRESULT STDMETHODCALLTYPE CreateSwapChainForHwnd(
-            IDXGIFactory*           pFactory,
-            HWND                    hWnd,
-      const DXGI_SWAP_CHAIN_DESC1*  pDesc,
-      const DXGI_SWAP_CHAIN_FULLSCREEN_DESC* pFullscreenDesc,
-            IDXGIOutput*            pRestrictToOutput,
-            IDXGISwapChain1**       ppSwapChain);
-    
-  private:
-    
-    D3D11DXGIDevice* m_container;
-    D3D11Device*     m_device;
-    
-  };
-  
-
-  /**
    * \brief D3D11 device metadata shenanigans
    */
   class DXGIDXVKDevice : public IDXGIDXVKDevice {
@@ -884,7 +849,6 @@ namespace dxvk {
     DXGIDXVKDevice      m_metaDevice;
     
     DXGIVkSwapChainFactory   m_dxvkFactory;
-    WineDXGISwapChainFactory m_wineFactory;
     
     uint32_t m_frameLatency = DefaultFrameLatency;
 

--- a/src/d3d11/meson.build
+++ b/src/d3d11/meson.build
@@ -2,9 +2,6 @@ d3d11_res = wrc_generator.process('version.rc')
 
 dxgi_common_src = [
   '../dxgi/dxgi_format.cpp',
-  '../dxgi/dxgi_monitor.cpp',
-  '../dxgi/dxgi_surface.cpp',
-  '../dxgi/dxgi_swapchain.cpp',
 ]
 
 d3d10_src = [

--- a/src/dxgi/dxgi_factory.cpp
+++ b/src/dxgi/dxgi_factory.cpp
@@ -151,7 +151,6 @@ namespace dxvk {
     Com<IDXGISwapChain4> frontendSwapChain;
 
     Com<IDXGIVkSwapChainFactory> dxvkFactory;
-    Com<IWineDXGISwapChainFactory> wineFactory;
 
     if (SUCCEEDED(pDevice->QueryInterface(IID_PPV_ARGS(&dxvkFactory)))) {
       Com<IDXGIVkSurfaceFactory> surfaceFactory = new DxgiSurfaceFactory(
@@ -166,14 +165,6 @@ namespace dxvk {
       }
 
       frontendSwapChain = new DxgiSwapChain(this, presenter.ptr(), hWnd, &desc, &fsDesc);
-    } else if (SUCCEEDED(pDevice->QueryInterface(IID_PPV_ARGS(&wineFactory)))) {
-      HRESULT hr = wineFactory->CreateSwapChainForHwnd(this, hWnd, &desc, &fsDesc,
-        pRestrictToOutput, reinterpret_cast<IDXGISwapChain1**>(&frontendSwapChain));
-
-      if (FAILED(hr)) {
-        Logger::err(str::format("DXGI: CreateSwapChainForHwnd: Failed to create swap chain, hr ", hr));
-        return hr;
-      }
     } else {
       Logger::err("DXGI: CreateSwapChainForHwnd: Unsupported device type");
       return DXGI_ERROR_UNSUPPORTED;

--- a/src/dxgi/dxgi_interfaces.h
+++ b/src/dxgi/dxgi_interfaces.h
@@ -409,24 +409,6 @@ IDXGIVkInteropAdapter : public IUnknown {
 };
 
 
-/**
- * \brief IWineDXGISwapChainFactory device interface
- *
- * Allows a swap chain to be created from a device.
- * See include/wine/winedxgi.idl for definition.
- */
-MIDL_INTERFACE("53cb4ff0-c25a-4164-a891-0e83db0a7aac")
-IWineDXGISwapChainFactory : public IUnknown {
-    virtual HRESULT STDMETHODCALLTYPE CreateSwapChainForHwnd(
-            IDXGIFactory*           pFactory,
-            HWND                    hWnd,
-      const DXGI_SWAP_CHAIN_DESC1*  pDesc,
-      const DXGI_SWAP_CHAIN_FULLSCREEN_DESC* pFullscreenDesc,
-            IDXGIOutput*            pRestrictToOutput,
-            IDXGISwapChain1**       ppSwapChain) = 0;
-};
-
-
 #ifdef _MSC_VER
 struct __declspec(uuid("907bf281-ea3c-43b4-a8e4-9f231107b4ff")) IDXGIDXVKAdapter;
 struct __declspec(uuid("92a5d77b-b6e1-420a-b260-fdd701272827")) IDXGIDXVKDevice;
@@ -438,7 +420,6 @@ struct __declspec(uuid("5546cf8c-77e7-4341-b05d-8d4d5000e77d")) IDXGIVkInteropSu
 struct __declspec(uuid("1e7895a1-1bc3-4f9c-a670-290a4bc9581a")) IDXGIVkSurfaceFactory;
 struct __declspec(uuid("e4a9059e-b569-46ab-8de7-501bd2bc7f7a")) IDXGIVkSwapChain;
 struct __declspec(uuid("e7d6c3ca-23a0-4e08-9f2f-ea5231df6633")) IDXGIVkSwapChainFactory;
-struct __declspec(uuid("53cb4ff0-c25a-4164-a891-0e83db0a7aac")) IWineDXGISwapChainFactory;
 #else
 __CRT_UUID_DECL(IDXGIDXVKAdapter,          0x907bf281,0xea3c,0x43b4,0xa8,0xe4,0x9f,0x23,0x11,0x07,0xb4,0xff);
 __CRT_UUID_DECL(IDXGIDXVKDevice,           0x92a5d77b,0xb6e1,0x420a,0xb2,0x60,0xfd,0xf7,0x01,0x27,0x28,0x27);
@@ -450,5 +431,4 @@ __CRT_UUID_DECL(IDXGIVkInteropSurface,     0x5546cf8c,0x77e7,0x4341,0xb0,0x5d,0x
 __CRT_UUID_DECL(IDXGIVkSurfaceFactory,     0x1e7895a1,0x1bc3,0x4f9c,0xa6,0x70,0x29,0x0a,0x4b,0xc9,0x58,0x1a);
 __CRT_UUID_DECL(IDXGIVkSwapChain,          0xe4a9059e,0xb569,0x46ab,0x8d,0xe7,0x50,0x1b,0xd2,0xbc,0x7f,0x7a);
 __CRT_UUID_DECL(IDXGIVkSwapChainFactory,   0xe7d6c3ca,0x23a0,0x4e08,0x9f,0x2f,0xea,0x52,0x31,0xdf,0x66,0x33);
-__CRT_UUID_DECL(IWineDXGISwapChainFactory, 0x53cb4ff0,0xc25a,0x4164,0xa8,0x91,0x0e,0x83,0xdb,0x0a,0x7a,0xac);
 #endif

--- a/src/dxgi/dxgi_monitor.cpp
+++ b/src/dxgi/dxgi_monitor.cpp
@@ -72,6 +72,13 @@ namespace dxvk {
 
 
   void STDMETHODCALLTYPE DxgiMonitorInfo::PuntColorSpace(DXGI_COLOR_SPACE_TYPE ColorSpace) {
+    // Only allow punting if we started from sRGB.
+    // That way we can go from sRGB -> HDR10 or HDR10 -> sRGB if we started in sRGB.
+    // But if we started off by advertising HDR10 to the game, don't allow us to go back.
+    // This mirrors the behaviour of the global Windows HDR toggle more closely.
+    if (DefaultColorSpace() != DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P709)
+      return;
+
     m_globalColorSpace = ColorSpace;
   }
 

--- a/src/dxgi/dxgi_swapchain.cpp
+++ b/src/dxgi/dxgi_swapchain.cpp
@@ -7,7 +7,7 @@
 namespace dxvk {
   
   DxgiSwapChain::DxgiSwapChain(
-          IDXGIFactory*               pFactory,
+          DxgiFactory*                pFactory,
           IDXGIVkSwapChain*           pPresenter,
           HWND                        hWnd,
     const DXGI_SWAP_CHAIN_DESC1*      pDesc,

--- a/src/dxgi/dxgi_swapchain.cpp
+++ b/src/dxgi/dxgi_swapchain.cpp
@@ -523,6 +523,17 @@ namespace dxvk {
     if (!pColorSpaceSupport)
       return E_INVALIDARG;
 
+    // Don't expose any color spaces other than standard
+    // sRGB if the enableHDR option is not set.
+    //
+    // If we ever have a use for the non-SRGB non-HDR colorspaces
+    // some day, we may want to revisit this.
+    if (ColorSpace != DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P709
+     && !m_factory->GetOptions()->enableHDR) {
+      *pColorSpaceSupport = 0;
+      return S_OK;
+    }
+
     UINT support = m_presenter->CheckColorSpaceSupport(ColorSpace);
     *pColorSpaceSupport = support;
     return S_OK;

--- a/src/dxgi/dxgi_swapchain.h
+++ b/src/dxgi/dxgi_swapchain.h
@@ -27,7 +27,7 @@ namespace dxvk {
   public:
     
     DxgiSwapChain(
-            IDXGIFactory*               pFactory,
+            DxgiFactory*                pFactory,
             IDXGIVkSwapChain*           pPresenter,
             HWND                        hWnd,
       const DXGI_SWAP_CHAIN_DESC1*      pDesc,
@@ -175,7 +175,7 @@ namespace dxvk {
     dxvk::recursive_mutex           m_lockWindow;
     dxvk::mutex                     m_lockBuffer;
 
-    Com<IDXGIFactory>               m_factory;
+    Com<DxgiFactory>                m_factory;
     Com<IDXGIAdapter>               m_adapter;
     Com<IDXGIOutput1>               m_target;
     Com<IDXGIVkMonitorInfo>         m_monitorInfo;


### PR DESCRIPTION
 - Toss IWineDXGISwapChainFactory
 - Only expose HDR if enableHDR is set
 - Limit colorspace punting to more closely match Windows behaviour with the global HDR toggle.