### PR TITLE
[util] Disable unmapping for BlazBlue Centralfiction

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -703,6 +703,11 @@ namespace dxvk {
       { "d3d9.customDeviceId",              "05E0" },
       { "dxgi.nvapiHack",                   "False" },
     }} },
+    /* BlazBlue Centralfiction                 *
+     * Temporary crash workaround              */
+    { R"(\\BBCF\.exe$)", {{
+      { "d3d9.textureMemory",               "0"   },
+    }} },
   }};
 
 


### PR DESCRIPTION
Temporary workaround for https://github.com/doitsujin/dxvk/issues/3142 until issue has been fixed.
Does not close it.