### PR TITLE
[util] enableDialogMode for Codename Panzers Phase One/Two

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -729,6 +729,11 @@ namespace dxvk {
     { R"(\\WILD HEARTS(_Trial)?\.exe$)", {{
       { "dxvk.maxChunkSize",                 "4" },
     }} },
+    /* Codename Panzers Phase One/Two          *
+     * Main menu won't render after intros     */
+    { R"(\\(PANZERS|PANZERS_Phase_2)\.exe$)", {{
+      { "d3d9.enableDialogMode",         "True"   },
+    }} },
   }};
 
 


### PR DESCRIPTION
Works around the main menu not rendering after the intro video but instead shows the last image on skip or video end.

Closes https://github.com/doitsujin/dxvk/issues/3196