### PR TITLE
[dgxi] Fix potential division by zero in log statement

### DIFF
--- a/src/dxgi/dxgi_swapchain.cpp
+++ b/src/dxgi/dxgi_swapchain.cpp
@@ -713,7 +713,7 @@ namespace dxvk {
         "DXGI: Failed to query closest mode:",
         "\n  Format: ", preferredMode.Format,
         "\n  Mode:   ", preferredMode.Width, "x", preferredMode.Height,
-          "@", preferredMode.RefreshRate.Numerator / preferredMode.RefreshRate.Denominator));
+          "@", preferredMode.RefreshRate.Numerator / std::max(preferredMode.RefreshRate.Denominator, 1u)));
       return hr;
     }
 


### PR DESCRIPTION
Apparently 0/0 is legal and should be interpreted as 0/1.
See https://learn.microsoft.com/en-us/windows/win32/api/dxgicommon/ns-dxgicommon-dxgi_rational#remarks

I found this while tricking UE4 by enabling HDR and then wanting 64bpp. This leads to this log statement which lets UE4 crash with division-by-zero.