### PR TITLE
[d3d9] Reduce size of state blocks

### DIFF
--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -6617,12 +6617,21 @@ namespace dxvk {
       }
     }
 
-    UpdateStateConstants<ProgramType, ConstantType, T>(
-      &m_state,
-      StartRegister,
-      pConstantData,
-      Count,
-      m_d3d9Options.d3d9FloatEmulation == D3D9FloatEmulation::Enabled);
+    if constexpr (ProgramType == DxsoProgramType::VertexShader) {
+      UpdateStateConstants<D3D9ShaderConstantsVSSoftware, ProgramType, ConstantType, T>(
+        m_state.vsConsts,
+        StartRegister,
+        pConstantData,
+        Count,
+        m_d3d9Options.d3d9FloatEmulation == D3D9FloatEmulation::Enabled);
+    } else {
+      UpdateStateConstants<D3D9ShaderConstantsPS, ProgramType, ConstantType, T>(
+        m_state.psConsts,
+        StartRegister,
+        pConstantData,
+        Count,
+        m_d3d9Options.d3d9FloatEmulation == D3D9FloatEmulation::Enabled);
+    }
 
     return D3D_OK;
   }

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -899,7 +899,7 @@ namespace dxvk {
       return &m_d3d9Options;
     }
 
-    Direct3DState9* GetRawState() {
+    D3D9DeviceState* GetRawState() {
       return &m_state;
     }
 
@@ -950,6 +950,10 @@ namespace dxvk {
     void TouchMappedTexture(D3D9CommonTexture* pTexture);
     void RemoveMappedTexture(D3D9CommonTexture* pTexture);
 
+    bool CanSWVP() {
+      return m_behaviorFlags & (D3DCREATE_MIXED_VERTEXPROCESSING | D3DCREATE_SOFTWARE_VERTEXPROCESSING);
+    }
+
   private:
 
     DxvkCsChunkRef AllocCsChunk() {
@@ -974,10 +978,6 @@ namespace dxvk {
         EmitCsChunk(std::move(m_csChunk));
         m_csChunk = AllocCsChunk();
       }
-    }
-
-    bool CanSWVP() {
-      return m_behaviorFlags & (D3DCREATE_MIXED_VERTEXPROCESSING | D3DCREATE_SOFTWARE_VERTEXPROCESSING);
     }
 
     void DetermineConstantLayouts(bool canSWVP);
@@ -1315,7 +1315,7 @@ namespace dxvk {
     std::atomic<int64_t>            m_availableMemory = { 0 };
     std::atomic<int32_t>            m_samplerCount    = { 0 };
 
-    Direct3DState9                  m_state;
+    D3D9DeviceState                 m_state;
 
 #ifdef D3D9_ALLOW_UNMAPPING
     lru_list<D3D9CommonTexture*>    m_mappedTextures;

--- a/src/d3d9/d3d9_state.cpp
+++ b/src/d3d9/d3d9_state.cpp
@@ -4,7 +4,7 @@
 
 namespace dxvk {
 
-  D3D9CapturableState::D3D9CapturableState() {
+  D3D9DeviceState::D3D9DeviceState() {
     for (uint32_t i = 0; i < streamFreq.size(); i++)
       streamFreq[i] = 1;
 
@@ -12,7 +12,7 @@ namespace dxvk {
       enabledLightIndices[i] = UINT32_MAX;
   }
 
-  D3D9CapturableState::~D3D9CapturableState() {
+  D3D9DeviceState::~D3D9DeviceState() {
     for (uint32_t i = 0; i < textures.size(); i++)
       TextureChangePrivate(textures[i], nullptr);
   }

--- a/src/d3d9/d3d9_stateblock.h
+++ b/src/d3d9/d3d9_stateblock.h
@@ -66,6 +66,60 @@ namespace dxvk {
     bit::bitvector                                      lightEnabledChanges;
   };
 
+  struct D3D9CapturedState {
+    typedef typename std::array<DWORD, RenderStateCount> RenderStatesArray;
+    typedef typename std::array<std::array<DWORD, SamplerStateCount>, SamplerCount> SamplerStatesArray;
+    typedef typename std::array<D3D9VBO, caps::MaxStreams> VertexBuffersArray;
+    typedef typename std::array<IDirect3DBaseTexture9*, SamplerCount> TexturesArray;
+    typedef typename std::array<std::array<DWORD, TextureStageStateCount>, caps::TextureStageCount> TextureStagesArray;
+    typedef typename std::array<Matrix4, caps::MaxTransforms> TransformsArray;
+
+    D3D9CapturedState();
+
+    ~D3D9CapturedState();
+
+    Com<D3D9VertexDecl,  false>                      vertexDecl;
+    Com<D3D9IndexBuffer, false>                      indices;
+
+    std::unique_ptr<RenderStatesArray>               renderStates = nullptr;
+
+    std::unique_ptr<SamplerStatesArray>              samplerStates = nullptr;
+
+    std::unique_ptr<VertexBuffersArray>              vertexBuffers = nullptr;
+
+    std::unique_ptr<TexturesArray>                   textures = nullptr;
+
+    Com<D3D9VertexShader, false>                     vertexShader;
+    Com<D3D9PixelShader,  false>                     pixelShader;
+
+    D3DVIEWPORT9                                     viewport = {};
+    RECT                                             scissorRect = {};
+
+    std::array<
+      D3D9ClipPlane,
+      caps::MaxClipPlanes>                           clipPlanes = {};
+
+    std::unique_ptr<TextureStagesArray>              textureStages = nullptr;
+
+    std::unique_ptr<D3D9ShaderConstantsVSHardware>   vsConsts = nullptr;
+    std::unique_ptr<D3D9ShaderConstantsVSSoftware>   vsConstsSW = nullptr;
+    std::unique_ptr<D3D9ShaderConstantsPS>           psConsts = nullptr;
+
+    std::array<UINT, caps::MaxStreams>               streamFreq = {};
+
+    std::unique_ptr<TransformsArray>                 transforms = nullptr;
+
+    std::unique_ptr<D3DMATERIAL9>                    material = nullptr;
+
+    std::vector<std::optional<D3DLIGHT9>>            lights;
+    std::array<DWORD, caps::MaxEnabledLights>        enabledLightIndices;
+
+    bool IsLightEnabled(DWORD Index) {
+      const auto& indices = enabledLightIndices;
+      return std::find(indices.begin(), indices.end(), Index) != indices.end();
+    }
+  };
+
   enum class D3D9StateBlockType :uint32_t {
     None,
     VertexState,
@@ -194,7 +248,10 @@ namespace dxvk {
           for (uint32_t rs : bit::BitMask(m_captures.renderStates.dword(i))) {
             uint32_t idx = i * 32 + rs;
 
-            dst->SetRenderState(D3DRENDERSTATETYPE(idx), src->renderStates[idx]);
+            if constexpr (std::is_same_v<Src, D3D9DeviceState>)
+              dst->SetRenderState(D3DRENDERSTATETYPE(idx), src->renderStates[idx]);
+            else
+              dst->SetRenderState(D3DRENDERSTATETYPE(idx), (*src->renderStates)[idx]);
           }
         }
       }
@@ -202,27 +259,44 @@ namespace dxvk {
       if (m_captures.flags.test(D3D9CapturedStateFlag::SamplerStates)) {
         for (uint32_t samplerIdx : bit::BitMask(m_captures.samplers.dword(0))) {
           for (uint32_t stateIdx : bit::BitMask(m_captures.samplerStates[samplerIdx].dword(0)))
-            dst->SetStateSamplerState(samplerIdx, D3DSAMPLERSTATETYPE(stateIdx), src->samplerStates[samplerIdx][stateIdx]);
+            if constexpr (std::is_same_v<Src, D3D9DeviceState>)
+              dst->SetStateSamplerState(samplerIdx, D3DSAMPLERSTATETYPE(stateIdx), src->samplerStates[samplerIdx][stateIdx]);
+            else
+              dst->SetStateSamplerState(samplerIdx, D3DSAMPLERSTATETYPE(stateIdx), (*src->samplerStates)[samplerIdx][stateIdx]);
         }
       }
 
       if (m_captures.flags.test(D3D9CapturedStateFlag::VertexBuffers)) {
         for (uint32_t idx : bit::BitMask(m_captures.vertexBuffers.dword(0))) {
-          const auto& vbo = src->vertexBuffers[idx];
+          const D3D9VBO* vbo;
+          if constexpr (std::is_same_v<Src, D3D9DeviceState>)
+            vbo = &src->vertexBuffers[idx];
+          else
+            vbo = &(*src->vertexBuffers)[idx];
+
           dst->SetStreamSource(
             idx,
-            vbo.vertexBuffer.ptr(),
-            vbo.offset,
-            vbo.stride);
+            vbo->vertexBuffer.ptr(),
+            vbo->offset,
+            vbo->stride);
         }
       }
 
-      if (m_captures.flags.test(D3D9CapturedStateFlag::Material))
-        dst->SetMaterial(&src->material);
+      if (m_captures.flags.test(D3D9CapturedStateFlag::Material)) {
+
+        if constexpr (std::is_same_v<Src, D3D9DeviceState>)
+          dst->SetMaterial(&src->material);
+        else
+          dst->SetMaterial(src->material.get());
+      }
 
       if (m_captures.flags.test(D3D9CapturedStateFlag::Textures)) {
-        for (uint32_t idx : bit::BitMask(m_captures.textures.dword(0)))
-          dst->SetStateTexture(idx, src->textures[idx]);
+        for (uint32_t idx : bit::BitMask(m_captures.textures.dword(0))) {
+          if constexpr (std::is_same_v<Src, D3D9DeviceState>)
+            dst->SetStateTexture(idx, src->textures[idx]);
+          else
+            dst->SetStateTexture(idx, (*src->textures)[idx]);
+        }
       }
 
       if (m_captures.flags.test(D3D9CapturedStateFlag::VertexShader))
@@ -236,15 +310,22 @@ namespace dxvk {
           for (uint32_t trans : bit::BitMask(m_captures.transforms.dword(i))) {
             uint32_t idx = i * 32 + trans;
 
-            dst->SetStateTransform(idx, reinterpret_cast<const D3DMATRIX*>(&src->transforms[idx]));
+            if constexpr (std::is_same_v<Src, D3D9DeviceState>)
+              dst->SetStateTransform(idx, reinterpret_cast<const D3DMATRIX*>(&src->transforms[idx]));
+            else
+              dst->SetStateTransform(idx, reinterpret_cast<const D3DMATRIX*>(&(*src->transforms)[idx]));
           }
         }
       }
 
       if (m_captures.flags.test(D3D9CapturedStateFlag::TextureStages)) {
         for (uint32_t stageIdx : bit::BitMask(m_captures.textureStages.dword(0))) {
-          for (uint32_t stateIdx : bit::BitMask(m_captures.textureStageStates[stageIdx].dword(0)))
-            dst->SetStateTextureStageState(stageIdx, D3D9TextureStageStateTypes(stateIdx), src->textureStages[stageIdx][stateIdx]);
+          for (uint32_t stateIdx : bit::BitMask(m_captures.textureStageStates[stageIdx].dword(0))) {
+            if constexpr (std::is_same_v<Src, D3D9DeviceState>)
+              dst->SetStateTextureStageState(stageIdx, D3D9TextureStageStateTypes(stateIdx), src->textureStages[stageIdx][stateIdx]);
+            else
+              dst->SetStateTextureStageState(stageIdx, D3D9TextureStageStateTypes(stateIdx), (*src->textureStages)[stageIdx][stateIdx]);
+          }
         }
       }
 
@@ -260,34 +341,95 @@ namespace dxvk {
       }
 
       if (m_captures.flags.test(D3D9CapturedStateFlag::VsConstants)) {
-        for (uint32_t i = 0; i < m_captures.vsConsts.fConsts.dwordCount(); i++) {
-          for (uint32_t consts : bit::BitMask(m_captures.vsConsts.fConsts.dword(i))) {
-            uint32_t idx = i * 32 + consts;
+        if (unlikely(m_parent->CanSWVP())) {
+          if (unlikely(!m_state.vsConstsSW))
+            m_state.vsConstsSW = std::make_unique<D3D9ShaderConstantsVSSoftware>();
 
-            dst->SetVertexShaderConstantF(idx, (float*)&src->vsConsts.fConsts[idx], 1);
+          for (uint32_t i = 0; i < m_captures.vsConsts.fConsts.dwordCount(); i++) {
+            for (uint32_t consts : bit::BitMask(m_captures.vsConsts.fConsts.dword(i))) {
+              uint32_t idx = i * 32 + consts;
+
+              if constexpr (std::is_same_v<Src, D3D9DeviceState>) {
+                dst->SetVertexShaderConstantF(idx, (float*)&src->vsConsts.fConsts[idx], 1);
+              } else {
+                dst->SetVertexShaderConstantF(idx, (float*)&src->vsConstsSW->fConsts[idx], 1);
+              }
+            }
           }
-        }
 
-        for (uint32_t i = 0; i < m_captures.vsConsts.iConsts.dwordCount(); i++) {
-          for (uint32_t consts : bit::BitMask(m_captures.vsConsts.iConsts.dword(i))) {
-            uint32_t idx = i * 32 + consts;
+          for (uint32_t i = 0; i < m_captures.vsConsts.iConsts.dwordCount(); i++) {
+            for (uint32_t consts : bit::BitMask(m_captures.vsConsts.iConsts.dword(i))) {
+              uint32_t idx = i * 32 + consts;
 
-            dst->SetVertexShaderConstantI(idx, (int*)&src->vsConsts.iConsts[idx], 1);
+              if constexpr (std::is_same_v<Src, D3D9DeviceState>) {
+                dst->SetVertexShaderConstantI(idx, (int*)&src->vsConsts.iConsts[idx], 1);
+              } else {
+                dst->SetVertexShaderConstantI(idx, (int*)&src->vsConstsSW->iConsts[idx], 1);
+              }
+            }
           }
-        }
 
-        if (m_captures.vsConsts.bConsts.any()) {
-          for (uint32_t i = 0; i < m_captures.vsConsts.bConsts.dwordCount(); i++)
-            dst->SetVertexBoolBitfield(i, m_captures.vsConsts.bConsts.dword(i), src->vsConsts.bConsts[i]);
+          if (m_captures.vsConsts.bConsts.any()) {
+            for (uint32_t i = 0; i < m_captures.vsConsts.bConsts.dwordCount(); i++)
+              if constexpr (std::is_same_v<Src, D3D9DeviceState>) {
+                dst->SetVertexBoolBitfield(i, m_captures.vsConsts.bConsts.dword(i), src->vsConsts.bConsts[i]);
+              } else {
+                dst->SetVertexBoolBitfield(i, m_captures.vsConsts.bConsts.dword(i), src->vsConstsSW->bConsts[i]);
+              }
+          }
+        } else {
+          if (unlikely(!m_state.vsConsts))
+            m_state.vsConsts = std::make_unique<D3D9ShaderConstantsVSHardware>();
+
+          for (uint32_t i = 0; i < m_captures.vsConsts.fConsts.dwordCount(); i++) {
+            for (uint32_t consts : bit::BitMask(m_captures.vsConsts.fConsts.dword(i))) {
+              uint32_t idx = i * 32 + consts;
+
+              if constexpr (std::is_same_v<Src, D3D9DeviceState>) {
+                dst->SetVertexShaderConstantF(idx, (float*)&src->vsConsts.fConsts[idx], 1);
+              } else {
+                dst->SetVertexShaderConstantF(idx, (float*)&src->vsConsts->fConsts[idx], 1);
+              }
+            }
+          }
+
+          for (uint32_t i = 0; i < m_captures.vsConsts.iConsts.dwordCount(); i++) {
+            for (uint32_t consts : bit::BitMask(m_captures.vsConsts.iConsts.dword(i))) {
+              uint32_t idx = i * 32 + consts;
+
+              if constexpr (std::is_same_v<Src, D3D9DeviceState>) {
+                dst->SetVertexShaderConstantI(idx, (int*)&src->vsConsts.iConsts[idx], 1);
+              } else {
+                dst->SetVertexShaderConstantI(idx, (int*)&src->vsConsts->iConsts[idx], 1);
+              }
+            }
+          }
+
+          if (m_captures.vsConsts.bConsts.any()) {
+            for (uint32_t i = 0; i < m_captures.vsConsts.bConsts.dwordCount(); i++)
+              if constexpr (std::is_same_v<Src, D3D9DeviceState>) {
+                dst->SetVertexBoolBitfield(i, m_captures.vsConsts.bConsts.dword(i), src->vsConsts.bConsts[i]);
+              } else {
+                dst->SetVertexBoolBitfield(i, m_captures.vsConsts.bConsts.dword(i), src->vsConsts->bConsts[i]);
+              }
+          }
         }
       }
 
       if (m_captures.flags.test(D3D9CapturedStateFlag::PsConstants)) {
+        if (unlikely(!m_state.psConsts)) {
+          m_state.psConsts = std::make_unique<D3D9ShaderConstantsPS>();
+        }
+
         for (uint32_t i = 0; i < m_captures.psConsts.fConsts.dwordCount(); i++) {
           for (uint32_t consts : bit::BitMask(m_captures.psConsts.fConsts.dword(i))) {
             uint32_t idx = i * 32 + consts;
 
-            dst->SetPixelShaderConstantF(idx, (float*)&src->psConsts.fConsts[idx], 1);
+            if constexpr (std::is_same_v<Src, D3D9DeviceState>) {
+              dst->SetPixelShaderConstantF(idx, (float*)&src->psConsts.fConsts[idx], 1);
+            } else {
+              dst->SetPixelShaderConstantF(idx, (float*)&src->psConsts->fConsts[idx], 1);
+            }
           }
         }
 
@@ -295,13 +437,21 @@ namespace dxvk {
           for (uint32_t consts : bit::BitMask(m_captures.psConsts.iConsts.dword(i))) {
             uint32_t idx = i * 32 + consts;
 
-            dst->SetPixelShaderConstantI(idx, (int*)&src->psConsts.iConsts[idx], 1);
+            if constexpr (std::is_same_v<Src, D3D9DeviceState>) {
+              dst->SetPixelShaderConstantI(idx, (int*)&src->psConsts.iConsts[idx], 1);
+            } else {
+              dst->SetPixelShaderConstantI(idx, (int*)&src->psConsts->iConsts[idx], 1);
+            }
           }
         }
 
         if (m_captures.psConsts.bConsts.any()) {
           for (uint32_t i = 0; i < m_captures.psConsts.bConsts.dwordCount(); i++)
-            dst->SetPixelBoolBitfield(i, m_captures.psConsts.bConsts.dword(i), src->psConsts.bConsts[i]);
+            if constexpr (std::is_same_v<Src, D3D9DeviceState>) {
+              dst->SetPixelBoolBitfield(i, m_captures.psConsts.bConsts.dword(i), src->psConsts.bConsts[i]);
+            } else {
+              dst->SetPixelBoolBitfield(i, m_captures.psConsts.bConsts.dword(i), src->psConsts->bConsts[i]);
+            }
         }
       }
 
@@ -354,15 +504,51 @@ namespace dxvk {
             setCaptures.bConsts.set(reg, true);
         }
 
-        UpdateStateConstants<
-          ProgramType,
-          ConstantType,
-          T>(
-            &m_state,
-            StartRegister,
-            pConstantData,
-            Count,
-            false);
+        if constexpr (ProgramType == DxsoProgramTypes::VertexShader) {
+          if (m_parent->CanSWVP()) {
+            if (unlikely(!m_state.vsConstsSW))
+              m_state.vsConstsSW = std::make_unique<D3D9ShaderConstantsVSSoftware>();
+
+            UpdateStateConstants<
+              D3D9ShaderConstantsVSSoftware,
+              ProgramType,
+              ConstantType,
+              T>(
+                (*m_state.vsConstsSW),
+                StartRegister,
+                pConstantData,
+                Count,
+                false);
+          } else {
+            if (unlikely(!m_state.vsConsts))
+              m_state.vsConsts = std::make_unique<D3D9ShaderConstantsVSHardware>();
+
+            UpdateStateConstants<
+              D3D9ShaderConstantsVSHardware,
+              ProgramType,
+              ConstantType,
+              T>(
+                (*m_state.vsConsts),
+                StartRegister,
+                pConstantData,
+                Count,
+                false);
+          }
+        } else {
+            if (unlikely(!m_state.psConsts))
+              m_state.psConsts = std::make_unique<D3D9ShaderConstantsPS>();
+
+          UpdateStateConstants<
+            D3D9ShaderConstantsPS,
+            ProgramType,
+            ConstantType,
+            T>(
+              (*m_state.psConsts),
+              StartRegister,
+              pConstantData,
+              Count,
+              false);
+        }
 
         return D3D_OK;
       };
@@ -391,10 +577,10 @@ namespace dxvk {
 
     void CaptureType(D3D9StateBlockType State);
 
-    D3D9CapturableState  m_state;
+    D3D9CapturedState    m_state;
     D3D9StateCaptures    m_captures;
 
-    D3D9CapturableState* m_deviceState;
+    D3D9DeviceState*     m_deviceState;
 
     bool                 m_applying = false;
 


### PR DESCRIPTION
Fixes #2703

Reduces the size of an empty state block from ~190 KB to 2.2 KB. The actual state is down to 352 bytes and 1816 bytes is the capture bit sets (remember, we need 8192 bits for just the vs float consts). I also changed it to only allocate the hardware vertex constant set if software vertex processing isn't enabled on the device.

It's pretty ugly but it works and we avoided having to completely rewrite state blocks.