### PR TITLE
[d3d9] Clamp stage and type in [G,S]etTextureStageState

### DIFF
--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -2304,13 +2304,8 @@ namespace dxvk {
     if (unlikely(pValue == nullptr))
       return D3DERR_INVALIDCALL;
 
-    *pValue = 0;
-
-    if (unlikely(Stage >= caps::TextureStageCount))
-      return D3DERR_INVALIDCALL;
-
-    if (unlikely(dxvkType >= TextureStageStateCount))
-      return D3DERR_INVALIDCALL;
+    Stage = std::min(Stage, DWORD(caps::TextureStageCount - 1));
+    dxvkType = std::min(dxvkType, D3D9TextureStageStateTypes(DXVK_TSS_COUNT - 1));
 
     *pValue = m_state.textureStages[Stage][dxvkType];
 
@@ -3876,13 +3871,13 @@ namespace dxvk {
           DWORD                      Stage,
           D3D9TextureStageStateTypes Type,
           DWORD                      Value) {
+    
+    // Clamp values instead of checking and returning INVALID_CALL
+    // Matches tests + Dawn of Magic 2 relies on it.
+    Stage = std::min(Stage, DWORD(caps::TextureStageCount - 1));
+    Type = std::min(Type, D3D9TextureStageStateTypes(DXVK_TSS_COUNT - 1));
+
     D3D9DeviceLock lock = LockDevice();
-
-    if (unlikely(Stage >= caps::TextureStageCount))
-      return D3DERR_INVALIDCALL;
-
-    if (unlikely(Type >= TextureStageStateCount))
-      return D3DERR_INVALIDCALL;
 
     if (unlikely(ShouldRecord()))
       return m_recorder->SetStateTextureStageState(Stage, Type, Value);

--- a/src/d3d9/d3d9_stateblock.cpp
+++ b/src/d3d9/d3d9_stateblock.cpp
@@ -213,6 +213,9 @@ namespace dxvk {
           DWORD                      Stage,
           D3D9TextureStageStateTypes Type,
           DWORD                      Value) {
+    Stage = std::min(Stage, DWORD(caps::TextureStageCount - 1));
+    Type = std::min(Type, D3D9TextureStageStateTypes(DXVK_TSS_COUNT - 1));
+
     m_state.textureStages[Stage][Type] = Value;
 
     m_captures.flags.set(D3D9CapturedStateFlag::TextureStages);


### PR DESCRIPTION
Fixes #3271

This is what happens on the Nvidia D3D9 driver.
Dawn of Magic 2 calls SetTextureStageState with a
stage > 7 and expects that to succeed.

```cpp
    HRESULT test = device->SetTextureStageState(13000, (D3DTEXTURESTAGESTATETYPE)99, D3DTTFF_COUNT1); // S_OK
    test = device->SetTextureStageState(13000, D3DTSS_TEXTURETRANSFORMFLAGS, D3DTTFF_COUNT2); // S_OK
    test = device->SetTextureStageState(6, D3DTSS_TEXTURETRANSFORMFLAGS, D3DTTFF_COUNT3); // S_OK
    test = device->SetTextureStageState(13001, (D3DTEXTURESTAGESTATETYPE)100, D3DTTFF_COUNT4); // S_OK
    DWORD val = 0xdeadbeef;
    test = device->GetTextureStageState(13000, D3DTSS_TEXTURETRANSFORMFLAGS, &val); // S_OK, val = D3DTTFF_COUNT2
    val = 0xdeadbeef;
    test = device->GetTextureStageState(13000, (D3DTEXTURESTAGESTATETYPE)99, &val); // S_OK, val = D3DTTFF_COUNT4
    val = 0xdeadbeef;
    test = device->GetTextureStageState(13001, (D3DTEXTURESTAGESTATETYPE)98, &val); // S_OK, val = D3DTTFF_COUNT4
    val = 0xdeadbeef;
    test = device->GetTextureStageState(8, (D3DTEXTURESTAGESTATETYPE)33, &val); // S_OK, val = D3DTTFF_COUNT4
    test = device->GetTextureStageState(7, (D3DTEXTURESTAGESTATETYPE)33, &val); // S_OK, val = D3DTTFF_COUNT4
    test = device->GetTextureStageState(7, D3DTSS_TEXTURETRANSFORMFLAGS, &val); // S_OK, val = D3DTTFF_COUNT2
    test = device->GetTextureStageState(6, D3DTSS_TEXTURETRANSFORMFLAGS, &val); // S_OK, val = D3DTTFF_COUNT3
    test = device->GetTextureStageState(3, (D3DTEXTURESTAGESTATETYPE)33, &val); // S_OK, val = D3DTTFF_DISABLE
    test = device->GetTextureStageState(3, D3DTSS_TEXTURETRANSFORMFLAGS, &val); // S_OK, val = D3DTTFF_DISABLE
```