### PR TITLE
[dxvk] Periodically flush handles for long-running queries

### DIFF
--- a/src/dxvk/dxvk_gpu_query.h
+++ b/src/dxvk/dxvk_gpu_query.h
@@ -224,10 +224,12 @@ namespace dxvk {
     uint32_t            m_index;
     bool                m_ended;
 
-    DxvkGpuQueryHandle  m_handle;
-    
-    std::vector<DxvkGpuQueryHandle> m_handles;
-    
+    mutable DxvkQueryData                  m_queryData;
+    mutable DxvkGpuQueryHandle             m_handle;
+    mutable std::deque<DxvkGpuQueryHandle> m_handles;
+
+    DxvkGpuQueryStatus flushHandles() const;
+
     DxvkGpuQueryStatus getDataForHandle(
             DxvkQueryData&      queryData,
       const DxvkGpuQueryHandle& handle) const;


### PR DESCRIPTION
Some apps (e.g. Halo: MCC) misuse D3D11 queries: they'll Begin(...) a query, and then only afterward decide that they don't actually want the results, returning the query object back to the engine's internal query pool without first calling End(...). The query thus continues to remain active until the engine decides to allocate the query for another purpose... if it ever does.

While this is misuse of the D3D API and is definitely a bug in the app, DXVK ought to tolerate this situation at least as well as D3D itself apparently does. This change will try to free up Vulkan query handles if they're in the available state, tracking their totals on the DxvkGpuQuery object itself instead.

As a bonus, this change should also reduce the CPU time consumed by repeated GetData(...) calls, since it avoids redundantly summing query handle results.