### PR TITLE
[util] Enable cached vertex buffers for SpellForce 3

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -337,6 +337,11 @@ namespace dxvk {
     { R"(\\RapaNui-Win64-Shipping\.exe$)", {{
       { "dxgi.customVendorId",              "8086" },
     }} },
+    /* SpellForce 3 Reforced & expansions         *
+     * Greatly improves CPU bound performance     */
+    { R"(\\SF3ClientFinal\.exe$)", {{
+      { "d3d11.cachedDynamicResources",        "v" },
+    }} },
 
     /**********************************************/
     /* D3D9 GAMES                                 */


### PR DESCRIPTION
Greatly improves CPU bound performance in SpellForce 3 and it's expansions (legacy edition does not benefit).

<details>
  <summary>Without config</summary>
  
![Screenshot_20230311_135652](https://user-images.githubusercontent.com/47954800/224488296-3e84870e-73f2-4086-9b42-36506059a8ea.png)
![Screenshot_20230311_144011](https://user-images.githubusercontent.com/47954800/224488302-0713b127-f127-4a8a-a7b9-636d063cf028.png)
</details>

<details>
  <summary>With config</summary>
  
![Screenshot_20230311_135558](https://user-images.githubusercontent.com/47954800/224488316-2b3e6874-3ac3-4c82-9ed9-7ae8772b5c51.png)
![Screenshot_20230311_143908](https://user-images.githubusercontent.com/47954800/224488317-03eca00f-fefd-43d0-af49-8abe9f04e867.png)
</details>