### PR TITLE
[d3d9] remove support for the A1/X1R5G5B5 formats

### DIFF
--- a/src/d3d9/d3d9_monitor.cpp
+++ b/src/d3d9/d3d9_monitor.cpp
@@ -27,9 +27,10 @@ namespace dxvk {
 
   bool IsSupportedAdapterFormat(
           D3D9Format Format) {
+    // D3D9Format::X1R5G5B5 is unsupported by native drivers and some apps, 
+    // such as the BGE SettingsApplication, rely on it not being exposed.
     return Format == D3D9Format::A2R10G10B10
         || Format == D3D9Format::X8R8G8B8
-        || Format == D3D9Format::X1R5G5B5
         || Format == D3D9Format::R5G6B5;
   }
 
@@ -42,8 +43,6 @@ namespace dxvk {
       return (AdapterFormat == D3D9Format::A2R10G10B10 && BackBufferFormat == D3D9Format::A2R10G10B10) ||
              (AdapterFormat == D3D9Format::X8R8G8B8    && BackBufferFormat == D3D9Format::X8R8G8B8) ||
              (AdapterFormat == D3D9Format::X8R8G8B8    && BackBufferFormat == D3D9Format::A8R8G8B8) ||
-             (AdapterFormat == D3D9Format::X1R5G5B5    && BackBufferFormat == D3D9Format::X1R5G5B5) ||
-             (AdapterFormat == D3D9Format::X1R5G5B5    && BackBufferFormat == D3D9Format::A1R5G5B5) ||
              (AdapterFormat == D3D9Format::R5G6B5      && BackBufferFormat == D3D9Format::R5G6B5);
     }
 
@@ -55,8 +54,6 @@ namespace dxvk {
     return BackBufferFormat == D3D9Format::A2R10G10B10
         || BackBufferFormat == D3D9Format::A8R8G8B8
         || BackBufferFormat == D3D9Format::X8R8G8B8
-        || BackBufferFormat == D3D9Format::A1R5G5B5
-        || BackBufferFormat == D3D9Format::X1R5G5B5
         || BackBufferFormat == D3D9Format::R5G6B5
         || BackBufferFormat == D3D9Format::Unknown;
   }


### PR DESCRIPTION
Fixes #1545 , namely the SettingsApplication crash. I don't think there are any other pending issues with BGE, and even if there were, they're probably best tracked separately by now.

Regarding the formats, @Riesi has done some testing on Windows and neither Intel nor Nvidia list any adapter modes for D3DFMT_X1R5G5B5. I've only commented them out since they're technically part of the spec (something we should still be aware of), but can also outright remove them if that's preferred.

X1R5G5B5 is a 16-bit format, so I don't expect it would see a lot of use anyway (hopefully), but more testing is welcome.