### PR TITLE
[util] Enable strict float emulation for NFS Carbon

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -739,6 +739,10 @@ namespace dxvk {
     { R"(\\(PANZERS|PANZERS_Phase_2)\.exe$)", {{
       { "d3d9.enableDialogMode",         "True"   },
     }} },
+    /* Need for Speed Carbon                   */
+    { R"(\\NFSC\.exe$)", {{
+      { "d3d9.floatEmulation",           "Strict" },
+    }} },
     
     /**********************************************/
     /* D3D12 GAMES (vkd3d-proton with dxvk dxgi)  */


### PR DESCRIPTION
This fixes a random segfault with NVIDIA drivers (not sure if NVK is affected though because I didn't test it with NVK yet 😄)

I've been meaning to push this for a while but I didn't do it until now 🐸