### PR TITLE
[d3d9] Only apply viewport zBias if minZ is below 0.5

### DIFF
--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -5673,7 +5673,13 @@ namespace dxvk {
 
     // How much to bias MinZ by to avoid a depth
     // degenerate viewport.
-    constexpr float zBias = 0.001f;
+    // Tests show that the bias is only applied below minZ values of 0.5
+    float zBias;
+    if (vp.MinZ >= 0.5f) {
+      zBias = 0.0f;
+    } else {
+      zBias = 0.001f;
+    }
 
     viewport = VkViewport{
       float(vp.X)     + cf,    float(vp.Height + vp.Y) + cf,


### PR DESCRIPTION
Fixes  #3298

Tests show that Windows D3D9 (Nvidia) works like that.

The code I used to test it is here: https://github.com/K0bin/dxvk-tests/commit/53bb43cb4a30712dafaca66ba667d1382152f7b0
But it involved some manual adjusting + trial and error.