### PR TITLE
[util] Disable nvapiHack for Tom Clancy's Ghost Recon Breakpoint.

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -342,6 +342,10 @@ namespace dxvk {
     { R"(\\SF3ClientFinal\.exe$)", {{
       { "d3d11.cachedDynamicResources",        "v" },
     }} },
+    /* Tom Clancy's Ghost Recon Breakpoint        */
+    { R"(\\GRB\.exe$)", {{
+      { "dxgi.nvapiHack",                  "False" },
+    }} },
 
     /**********************************************/
     /* D3D9 GAMES                                 */


### PR DESCRIPTION
Otherwise, it shows a DirectX error dialog and exits when using an NVIDIA GPU.