### PR TITLE
[util] Add new "Zusi 3" exe filename

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -457,7 +457,7 @@ namespace dxvk {
       { "d3d9.allowDiscard",                "False" },
     }} },
     /* ZUSI 3 - Aerosoft Edition                  */
-    { R"(\\ZusiSim\.exe$)", {{
+    { R"(\\ZusiSim(\.64)?\.exe$)", {{
       { "d3d9.noExplicitFrontBuffer",       "True" },
     }} },
     /* GTA IV (NVAPI)                             */


### PR DESCRIPTION
Hopefully the regex is correct. It works for ZusiSim.64.exe (which is the executable launched by steam), but I'm not sure how to launch the legacy 32 bit "ZusiSim.exe" in steam, so I have not tested if that still works correctly.

Commit message:
---
In addition to the legacy "ZusiSim.exe" executable, the recent 3.5 release added a 64-bit "ZusiSim.64.exe" executable. This is now the default executable when launching the game in Steam. The game is unplayable without this option, so update the regex for Zusi 3.

Fixes #3250.