### PR TITLE
[d3d9] Implement rudimentary device loss

### DIFF
--- a/src/d3d9/d3d9_options.cpp
+++ b/src/d3d9/d3d9_options.cpp
@@ -74,6 +74,7 @@ namespace dxvk {
     this->allowDirectBufferMapping      = config.getOption<bool>        ("d3d9.allowDirectBufferMapping",      true);
     this->seamlessCubes                 = config.getOption<bool>        ("d3d9.seamlessCubes",                 false);
     this->textureMemory                 = config.getOption<int32_t>     ("d3d9.textureMemory",                100) << 20;
+    this->deviceLost                    = config.getOption<bool>        ("d3d9.deviceLost",                    false);
 
     std::string floatEmulation = Config::toLower(config.getOption<std::string>("d3d9.floatEmulation", "auto"));
     if (floatEmulation == "strict") {

--- a/src/d3d9/d3d9_options.h
+++ b/src/d3d9/d3d9_options.h
@@ -158,6 +158,9 @@ namespace dxvk {
 
     /// Shader dump path
     std::string shaderDumpPath;
+
+    /// Enable emulation of device loss when a fullscreen app loses focus
+    bool deviceLost;
   };
 
 }

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -470,11 +470,13 @@ namespace dxvk {
      * and will report/use bad amounts of VRAM.
      * Disabling support for DF texture formats
      * makes the game use a better looking render
-     * path for mirrors                           */
+     * path for mirrors.
+     * Also runs into issues after alt-tabbing.   */
     { R"(\\(GTAIV|EFLC)\.exe$)", {{
       { "d3d9.customVendorId",              "1002" },
       { "dxgi.emulateUMA",                  "True" },
       { "d3d9.supportDFFormats",            "False" },
+      { "d3d9.deviceLost",                  "True" },
     }} },
     /* Battlefield 2 (bad z-pass)                 */
     { R"(\\BF2\.exe$)", {{
@@ -756,6 +758,11 @@ namespace dxvk {
      * Works around black screen or blinking  */
     { R"(\\(DarkRomance_VampireInLove_CE)\.exe$)", {{
       { "d3d9.allowDirectBufferMapping", "False"   },
+    }} },
+    /* DC Universe Online                      *
+     * Freezes after alt tabbing               */
+    { R"(\\DCGAME\.EXE$)", {{
+      { "d3d9.deviceLost",              "True"   },
     }} },
     
     /**********************************************/


### PR DESCRIPTION
I hate that we have to do this but:

Fixes #3314

It's hidden behind a config option because pretty much all games work fine without it and enabling it would just cause unnecessary work for those games.

Aside from DC Online, I enabled it for GTA IV because that game also has a ton of issues with alt-tab. Maybe we'll get lucky and these changes finally fix it. 