### PR TITLE
[d3d9] add a A2R10G10B10 adapter format workaround for AquaNox 2

### DIFF
--- a/dxvk.conf
+++ b/dxvk.conf
@@ -475,6 +475,15 @@
 
 # d3d9.noExplicitFrontBuffer = False
 
+# Support the A2R10G10B10 adapter format
+#
+# Usually supported by native drivers, but may cause issues with some games
+#
+# Supported values:
+# - True/False
+
+# d3d9.supportAFA2R10G10B10 = True
+
 # Support DF formats
 #
 # Support the vendor extension DF floating point depth formats

--- a/src/d3d9/d3d9_adapter.cpp
+++ b/src/d3d9/d3d9_adapter.cpp
@@ -98,7 +98,7 @@ namespace dxvk {
           D3D9Format AdapterFormat,
           D3D9Format BackBufferFormat,
           BOOL       bWindowed) {
-    if (!IsSupportedAdapterFormat(AdapterFormat))
+    if (!IsSupportedAdapterFormat(AdapterFormat, m_parent->GetOptions()))
       return D3DERR_NOTAVAILABLE;
 
     if (!IsSupportedBackBufferFormat(AdapterFormat, BackBufferFormat, bWindowed))
@@ -114,7 +114,7 @@ namespace dxvk {
           DWORD           Usage,
           D3DRESOURCETYPE RType,
           D3D9Format      CheckFormat) {
-    if (!IsSupportedAdapterFormat(AdapterFormat))
+    if (!IsSupportedAdapterFormat(AdapterFormat, m_parent->GetOptions()))
       return D3DERR_NOTAVAILABLE;
 
     const bool dmap = Usage & D3DUSAGE_DMAP;
@@ -758,11 +758,11 @@ namespace dxvk {
     m_modes.clear();
     m_modeCacheFormat = Format;
 
-    // Skip unsupported formats
-    if (!IsSupportedAdapterFormat(Format))
-      return;
-
     auto& options = m_parent->GetOptions();
+
+    // Skip unsupported formats
+    if (!IsSupportedAdapterFormat(Format, options))
+      return;
 
     // Walk over all modes that the display supports and
     // return those that match the requested format etc.

--- a/src/d3d9/d3d9_monitor.cpp
+++ b/src/d3d9/d3d9_monitor.cpp
@@ -26,10 +26,11 @@ namespace dxvk {
 
 
   bool IsSupportedAdapterFormat(
-          D3D9Format Format) {
+          D3D9Format        Format,
+          const D3D9Options options) {
     // D3D9Format::X1R5G5B5 is unsupported by native drivers and some apps, 
     // such as the BGE SettingsApplication, rely on it not being exposed.
-    return Format == D3D9Format::A2R10G10B10
+    return (Format == D3D9Format::A2R10G10B10 && options.supportAFA2R10G10B10)
         || Format == D3D9Format::X8R8G8B8
         || Format == D3D9Format::R5G6B5;
   }

--- a/src/d3d9/d3d9_monitor.h
+++ b/src/d3d9/d3d9_monitor.h
@@ -26,7 +26,8 @@ namespace dxvk {
   * \returns If it is supported as a swapchain/backbuffer format.
   */
   bool IsSupportedAdapterFormat(
-          D3D9Format Format);
+          D3D9Format        Format,
+          const D3D9Options options);
 
   bool IsSupportedBackBufferFormat(
           D3D9Format AdapterFormat,

--- a/src/d3d9/d3d9_options.cpp
+++ b/src/d3d9/d3d9_options.cpp
@@ -51,6 +51,7 @@ namespace dxvk {
     this->deferSurfaceCreation          = config.getOption<bool>        ("d3d9.deferSurfaceCreation",          false);
     this->samplerAnisotropy             = config.getOption<int32_t>     ("d3d9.samplerAnisotropy",             -1);
     this->maxAvailableMemory            = config.getOption<int32_t>     ("d3d9.maxAvailableMemory",            4096);
+    this->supportAFA2R10G10B10          = config.getOption<bool>        ("d3d9.supportAFA2R10G10B10",          true);
     this->supportDFFormats              = config.getOption<bool>        ("d3d9.supportDFFormats",              true);
     this->supportX4R4G4B4               = config.getOption<bool>        ("d3d9.supportX4R4G4B4",               true);
     this->supportD32                    = config.getOption<bool>        ("d3d9.supportD32",                    true);

--- a/src/d3d9/d3d9_options.h
+++ b/src/d3d9/d3d9_options.h
@@ -72,6 +72,9 @@ namespace dxvk {
     /// D3D9 Floating Point Emulation (anything * 0 = 0)
     D3D9FloatEmulation d3d9FloatEmulation;
 
+    /// Support the A2R10G10B10 adapter format
+    bool supportAFA2R10G10B10;
+
     /// Support the DF16 & DF24 texture format
     bool supportDFFormats;
 

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -759,6 +759,13 @@ namespace dxvk {
     { R"(\\eldorado\.exe$)", {{
       { "d3d9.floatEmulation",        "Strict"   },
     }} },
+    /* AquaNox 2                               *
+     * Won't start or crashes on resolution    *
+     * change if the A2R10G10B10 adapter       *
+     * format is supported                     */
+    { R"(\\AN2\.dat$)", {{
+      { "d3d9.supportAFA2R10G10B10",     "False"  },
+    }} },
     
     /**********************************************/
     /* D3D12 GAMES (vkd3d-proton with dxvk dxgi)  */


### PR DESCRIPTION
Gets the game going on ANV and it should also now work with Wayland according to @Blisto91. The crashing that's observed on resolution change is only partially resolved, and seems to happen with WineD3D as well in my case, so not entirely sure what the problem is or how to fix it. The game's probably just very picky when it comes to supporting certain resolutions. I'll see if I can do more, but it will come in a separate PR.

The background of this PR is that A2R10G10B10 is supported at least by AMD on Windows, therefore there's no reason to outright remove it, so I've only included it as a config option and disabled it specifically for AquaNox 2.

Please do let me know if there's a better way of getting the option struct where I need it to be other than passing it around like a dog chew toy. As you may know, my C++-fu is mostly white belt level really :sweat_smile:. I'm also open to any naming changes if I'm braking any conventions I'm not aware of.

Fixes #3255. The game still hates ANV at times, but should be fine otherwise.