### PR TITLE
build: Use a different SONAME for the glfw WSI

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -121,8 +121,12 @@ else
     lib_glfw = cpp.find_library('glfw')
     compiler_args += ['-DDXVK_WSI_GLFW']
   endif
-  
-  dxvk_name_prefix = 'libdxvk_'
+
+  if dxvk_wsi == 'sdl2'
+    dxvk_name_prefix = 'libdxvk_'
+  else
+    dxvk_name_prefix = 'libdxvk_@0@_'.format(dxvk_wsi)
+  endif
 
   link_args += [
     '-static-libgcc',


### PR DESCRIPTION
Selecting the GLFW WSI gives DXVK an incompatible ABI: for example, CreateDevice takes a `SDL_Window *` parameter in the default SDL WSI, but takes a `GLFWwindow *` instead in the GLFW WSI. This means it should get a different name, so that binaries expecting one WSI don't unexpectedly load the other.

Resolves: https://github.com/doitsujin/dxvk/issues/3321