### PR TITLE
Install headers and pkg-config files

### DIFF
--- a/include/native/meson.build
+++ b/include/native/meson.build
@@ -1,0 +1,17 @@
+install_subdir(
+  'directx',
+  install_dir: get_option('includedir') / 'dxvk',
+  strip_directory: true,
+)
+
+install_subdir(
+  'windows',
+  install_dir: get_option('includedir') / 'dxvk',
+  strip_directory: true,
+)
+
+install_headers(
+  'wsi/native_wsi.h',
+  'wsi/native_@0@.h'.format(dxvk_wsi),
+  subdir: 'dxvk/wsi',
+)

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,6 @@
 project('dxvk', ['c', 'cpp'], version : '2.1', meson_version : '>= 0.49', default_options : [ 'cpp_std=c++17', 'warning_level=2' ])
 
+pkg = import('pkgconfig')
 cpu_family = target_machine.cpu_family()
 platform   = target_machine.system()
 
@@ -124,8 +125,10 @@ else
 
   if dxvk_wsi == 'sdl2'
     dxvk_name_prefix = 'dxvk_'
+    dxvk_pkg_prefix = 'dxvk-'
   else
     dxvk_name_prefix = 'dxvk_@0@_'.format(dxvk_wsi)
+    dxvk_pkg_prefix = 'dxvk-@0@-'.format(dxvk_wsi)
   endif
 
   link_args += [

--- a/meson.build
+++ b/meson.build
@@ -121,8 +121,12 @@ else
     lib_glfw = cpp.find_library('glfw')
     compiler_args += ['-DDXVK_WSI_GLFW']
   endif
-  
-  dxvk_name_prefix = 'libdxvk_'
+
+  if dxvk_wsi == 'sdl2'
+    dxvk_name_prefix = 'libdxvk_'
+  else
+    dxvk_name_prefix = 'libdxvk_@0@_'.format(dxvk_wsi)
+  endif
 
   link_args += [
     '-static-libgcc',

--- a/meson.build
+++ b/meson.build
@@ -115,10 +115,10 @@ else
   dxvk_wsi = get_option('dxvk_native_wsi')
   
   if dxvk_wsi == 'sdl2'
-    lib_sdl2 = cpp.find_library('SDL2')
+    sdl2_dep = dependency('sdl2')
     compiler_args += ['-DDXVK_WSI_SDL2']
   elif dxvk_wsi == 'glfw'
-    lib_glfw = cpp.find_library('glfw')
+    glfw_dep = dependency('glfw3')
     compiler_args += ['-DDXVK_WSI_GLFW']
   endif
 

--- a/meson.build
+++ b/meson.build
@@ -166,4 +166,8 @@ dxvk_version = vcs_tag(
   output: 'version.h',
 )
 
+if platform != 'windows'
+  subdir('include/native')
+endif
+
 subdir('src')

--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,4 @@
-project('dxvk', ['c', 'cpp'], version : 'v2.1', meson_version : '>= 0.49', default_options : [ 'cpp_std=c++17', 'warning_level=2' ])
+project('dxvk', ['c', 'cpp'], version : '2.1', meson_version : '>= 0.49', default_options : [ 'cpp_std=c++17', 'warning_level=2' ])
 
 cpu_family = target_machine.cpu_family()
 platform   = target_machine.system()

--- a/meson.build
+++ b/meson.build
@@ -123,9 +123,9 @@ else
   endif
 
   if dxvk_wsi == 'sdl2'
-    dxvk_name_prefix = 'libdxvk_'
+    dxvk_name_prefix = 'dxvk_'
   else
-    dxvk_name_prefix = 'libdxvk_@0@_'.format(dxvk_wsi)
+    dxvk_name_prefix = 'dxvk_@0@_'.format(dxvk_wsi)
   endif
 
   link_args += [
@@ -142,7 +142,6 @@ add_project_link_arguments(cpp.get_supported_link_arguments(link_args), language
 add_project_link_arguments(cc.get_supported_link_arguments(link_args), language: 'c')
 
 exe_ext = ''
-dll_ext = ''
 def_spec_ext = '.def'
 
 glsl_compiler = find_program('glslangValidator')

--- a/src/d3d10/meson.build
+++ b/src/d3d10/meson.build
@@ -12,8 +12,7 @@ if platform != 'windows'
   d3d10_core_link_depends += files('d3d10core.sym')
 endif
 
-d3d10_core_dll = shared_library('d3d10core'+dll_ext, d3d10_core_src, d3d10_core_res,
-  name_prefix         : dxvk_name_prefix,
+d3d10_core_dll = shared_library(dxvk_name_prefix+'d3d10core', d3d10_core_src, d3d10_core_res,
   dependencies        : [ d3d11_dep ],
   include_directories : dxvk_include_path,
   install             : true,

--- a/src/d3d10/meson.build
+++ b/src/d3d10/meson.build
@@ -24,3 +24,10 @@ d3d10_core_dll = shared_library(dxvk_name_prefix+'d3d10core', d3d10_core_src, d3
 d3d10_core_dep = declare_dependency(
   link_with           : [ d3d10_core_dll ],
 )
+
+if platform != 'windows'
+  pkg.generate(d3d10_core_dll,
+    filebase: dxvk_pkg_prefix + 'd3d10core',
+    subdirs:  'dxvk',
+  )
+endif

--- a/src/d3d11/meson.build
+++ b/src/d3d11/meson.build
@@ -74,9 +74,8 @@ if platform != 'windows'
   d3d11_link_depends += files('d3d11.sym')
 endif
 
-d3d11_dll = shared_library('d3d11'+dll_ext, dxgi_common_src + d3d11_src + d3d10_src,
+d3d11_dll = shared_library(dxvk_name_prefix+'d3d11', dxgi_common_src + d3d11_src + d3d10_src,
     glsl_generator.process(d3d11_shaders), d3d11_res,
-  name_prefix         : dxvk_name_prefix,
   dependencies        : [ dxgi_dep, dxbc_dep, dxvk_dep ],
   include_directories : dxvk_include_path,
   install             : true,

--- a/src/d3d11/meson.build
+++ b/src/d3d11/meson.build
@@ -88,3 +88,10 @@ d3d11_dep = declare_dependency(
   link_with           : [ d3d11_dll ],
   include_directories : [ dxvk_include_path ],
 )
+
+if platform != 'windows'
+  pkg.generate(d3d11_dll,
+    filebase: dxvk_pkg_prefix + 'd3d11',
+    subdirs:  'dxvk',
+  )
+endif

--- a/src/d3d9/meson.build
+++ b/src/d3d9/meson.build
@@ -68,3 +68,10 @@ d3d9_dep = declare_dependency(
   link_with           : [ d3d9_dll ],
   include_directories : [ dxvk_include_path ],
 )
+
+if platform != 'windows'
+  pkg.generate(d3d9_dll,
+    filebase: dxvk_pkg_prefix + 'd3d9',
+    subdirs:  'dxvk',
+  )
+endif

--- a/src/d3d9/meson.build
+++ b/src/d3d9/meson.build
@@ -55,8 +55,7 @@ if platform != 'windows'
   d3d9_link_depends += files('d3d9.sym')
 endif
 
-d3d9_dll = shared_library('d3d9'+dll_ext, d3d9_src, glsl_generator.process(d3d9_shaders), d3d9_res,
-  name_prefix         : dxvk_name_prefix,
+d3d9_dll = shared_library(dxvk_name_prefix+'d3d9', d3d9_src, glsl_generator.process(d3d9_shaders), d3d9_res,
   dependencies        : [ dxso_dep, dxvk_dep ],
   include_directories : dxvk_include_path,
   install             : true,

--- a/src/dxgi/meson.build
+++ b/src/dxgi/meson.build
@@ -34,3 +34,10 @@ dxgi_dep = declare_dependency(
   link_with           : [ dxgi_dll ],
   include_directories : [ dxvk_include_path ],
 )
+
+if platform != 'windows'
+  pkg.generate(dxgi_dll,
+    filebase: dxvk_pkg_prefix + 'dxgi',
+    subdirs:  'dxvk',
+  )
+endif

--- a/src/dxgi/meson.build
+++ b/src/dxgi/meson.build
@@ -21,8 +21,7 @@ if platform != 'windows'
   dxgi_link_depends += files('dxgi.sym')
 endif
 
-dxgi_dll = shared_library('dxgi'+dll_ext, dxgi_src, dxgi_res,
-  name_prefix         : dxvk_name_prefix,
+dxgi_dll = shared_library(dxvk_name_prefix+'dxgi', dxgi_src, dxgi_res,
   dependencies        : [ dxvk_dep ],
   include_directories : dxvk_include_path,
   install             : true,

--- a/src/wsi/meson.build
+++ b/src/wsi/meson.build
@@ -22,10 +22,10 @@ if dxvk_wsi == 'win32'
   wsi_deps = [ dep_displayinfo ]
 elif dxvk_wsi == 'sdl2'
   wsi_src  = wsi_common_src + wsi_sdl2_src
-  wsi_deps = [ dep_displayinfo, lib_sdl2 ]
+  wsi_deps = [ dep_displayinfo, sdl2_dep ]
 elif dxvk_wsi == 'glfw'
   wsi_src  = wsi_common_src + wsi_glfw_src
-  wsi_deps = [ dep_displayinfo, lib_glfw ]
+  wsi_deps = [ dep_displayinfo, glfw_dep ]
 else
   error('Unknown wsi')
 endif


### PR DESCRIPTION
This is just a prototype at this stage, and I haven't gone all the way down the stack to distro-style packages to test it. I'm aware DXVK isn't yet officially API- and ABI-stable, but I want to go through the motions of packaging it before it gets to that point, so that if there are any blockers that involve incompatible changes they can be resolved before it's too late.

It probably doesn't make sense to install the pkg-config files and headers until DXVK is officially API- and ABI-stable, but some of the refactoring on the way might be useful.

Based on #3324.

---

* build: Omit v prefix from the version number
    
    It's conventional for version numbers to start with a digit. This isn't
    important yet, but will become significant when generating pkg-config
    metadata that can be queried for a sufficient version number.

* Set the stem of library names instead of the name_prefix
    
    This is necessary for compatibility with Meson's pkg module, which
    generates pkg-config metadata containing "-lNAME" where NAME is the
    first argument to shared_library(). Changing the name_prefix parameter
    would break that.
    
    Conversely, including .dll or .so in the first parameter would also
    break that, so remove the `+dll_ext` part (in practice this is not a
    functional change, because `dll_ext` is always set to an empty string).

* build: Use Meson default mechanisms to find WSI dependencies
    
    The dependency name `sdl2` is special-cased to be found via either
    pkg-config or `sdl2-config`.
    
    `glfw3` will be found via pkg-config, as recommended in its build
    documentation.
    
    This allows use of a SDL or GLFW library that is not in the compiler's
    default search paths, and is also useful when using pkg.generate():
    a dependency on a library found via pkg-config will result in the
    generation of correct Requires.private in dxvk's own pkg-config metadata.

* build: Install headers for native builds
    
    When building a game that has been ported to Linux using DXVK Native,
    these headers are necessary to provide the Direct3D and DXVK APIs.

* Set the stem of library names instead of the name_prefix
    
    This is necessary for compatibility with Meson's pkg module, which
    generates pkg-config metadata containing "-lNAME" where NAME is the
    first argument to shared_library(). Changing the name_prefix parameter
    would break that.
    
    Conversely, including .dll or .so in the first parameter would also
    break that, so remove the `+dll_ext` part (in practice this is not a
    functional change, because `dll_ext` is always set to an empty string).

* build: Use Meson default mechanisms to find WSI dependencies
    
    The dependency name `sdl2` is special-cased to be found via either
    pkg-config or `sdl2-config`.
    
    `glfw3` will be found via pkg-config, as recommended in its build
    documentation.
    
    This allows use of a SDL or GLFW library that is not in the compiler's
    default search paths, and is also useful when using pkg.generate():
    a dependency on a library found via pkg-config will result in the
    generation of correct Requires.private in dxvk's own pkg-config metadata.

* build: Install headers for native builds
    
    When building a game that has been ported to Linux using DXVK Native,
    these headers are necessary to provide the Direct3D and DXVK APIs.

* build: Generate pkg-config metadata to link to DXVK libraries
    
    This allows dependent projects to query the version and location of DXVK
    via the pkg-config interface.
    
    The include directories aren't yet set, because the headers aren't
    installed; that will follow in a subsequent commit.
    
    The naming of these pkg-config files is based on proposed Fedora packages
    for DXVK 2.0, and is not compatible with older Fedora packages for DXVK
    1.x (which used the naming convention dxvk-native-d3d9 and so on).
    Packagers can create symlinks such as dxvk-native-d3d9.pc -> dxvk-d3d9.pc
    if they want to retain compatibility with older names.