### PR TITLE
[spirv] Declare defaulted copy and move constructor for SpirvCodeBuffer.

### DIFF
--- a/src/spirv/spirv_code_buffer.h
+++ b/src/spirv/spirv_code_buffer.h
@@ -21,6 +21,8 @@ namespace dxvk {
     
     SpirvCodeBuffer();
     explicit SpirvCodeBuffer(uint32_t size);
+    SpirvCodeBuffer(const SpirvCodeBuffer &) = default;
+    SpirvCodeBuffer(SpirvCodeBuffer &&) = default;
     SpirvCodeBuffer(uint32_t size, const uint32_t* data);
     SpirvCodeBuffer(std::istream& stream);
     
@@ -29,6 +31,9 @@ namespace dxvk {
     : SpirvCodeBuffer(N, data) { }
     
     ~SpirvCodeBuffer();
+
+    SpirvCodeBuffer &operator=(const SpirvCodeBuffer &) = default;
+    SpirvCodeBuffer &operator=(SpirvCodeBuffer &&) = default;
     
     /**
      * \brief Code data


### PR DESCRIPTION
If a type has a destructor it will not get an implicit move constructor.

But if we declare a defaulted move constructor then we will get the copy constructor deleted. So declare both to be defaulted.

Cuts 8.8% off shader translation time during loading in Overwatch 2.