### PR TITLE
[util] Set syncInterval to 1 for Crash Bandicoot N sane trilogy

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -350,6 +350,11 @@ namespace dxvk {
     { R"(\\GTA5\.exe$)", {{
       { "d3d11.cachedDynamicResources",     "vi"   },
     }} },
+    /* Crash Bandicoot N. Sane Trilogy            *
+     * Work around some vsync funkiness           */
+    { R"(\\CrashBandicootNSaneTrilogy\.exe$)", {{
+      { "dxgi.syncInterval",                "1"   },
+    }} },
 
     /**********************************************/
     /* D3D9 GAMES                                 */


### PR DESCRIPTION
Closes https://github.com/doitsujin/dxvk/issues/3028

Works around some game vsync funkiness