### PR TITLE
[dxgi] Leave current fullscreen mode when SetFullscreenState changes output

### DIFF
--- a/src/dxgi/dxgi_swapchain.cpp
+++ b/src/dxgi/dxgi_swapchain.cpp
@@ -425,8 +425,18 @@ namespace dxvk {
 
     Com<IDXGIOutput1> target;
 
-    if (pTarget)
+    if (pTarget) {
+      DXGI_OUTPUT_DESC desc;
+
       pTarget->QueryInterface(IID_PPV_ARGS(&target));
+      target->GetDesc(&desc);
+
+      if (!m_descFs.Windowed && Fullscreen && m_monitor != desc.Monitor) {
+        HRESULT hr = this->LeaveFullscreenMode();
+        if (FAILED(hr))
+          return hr;
+      }
+    }
 
     if (m_descFs.Windowed && Fullscreen)
       return this->EnterFullscreenMode(target.ptr());


### PR DESCRIPTION
This fixes RiME not moving its window when output display is changed in the game settings.