### PR TITLE
[d3d9] Fall back to GDI blit for partial presents

### DIFF
--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -7332,7 +7332,8 @@ namespace dxvk {
       "    - Format:             ", backBufferFmt, "\n"
       "    - Auto Depth Stencil: ", pPresentationParameters->EnableAutoDepthStencil ? "true" : "false", "\n",
       "                ^ Format: ", EnumerateFormat(pPresentationParameters->AutoDepthStencilFormat), "\n",
-      "    - Windowed:           ", pPresentationParameters->Windowed ? "true" : "false", "\n"));
+      "    - Windowed:           ", pPresentationParameters->Windowed ? "true" : "false", "\n",
+      "    - Swap effect:        ", pPresentationParameters->SwapEffect, "\n"));
 
     if (backBufferFmt != D3D9Format::Unknown) {
       if (!IsSupportedBackBufferFormat(backBufferFmt)) {

--- a/src/d3d9/d3d9_surface.cpp
+++ b/src/d3d9/d3d9_surface.cpp
@@ -165,7 +165,9 @@ namespace dxvk {
     createInfo.hBitmap     = nullptr;
     createInfo.hDc         = nullptr;
 
-    D3DKMTCreateDCFromMemory(&createInfo);
+    if (D3DKMTCreateDCFromMemory(&createInfo))
+      Logger::err("D3D9: Failed to create GDI DC");
+
     DeleteDC(createInfo.hDeviceDc);
 
     // These should now be set...

--- a/src/d3d9/d3d9_swapchain.h
+++ b/src/d3d9/d3d9_swapchain.h
@@ -40,6 +40,10 @@ namespace dxvk {
       const RGNDATA* pDirtyRegion,
             DWORD    dwFlags);
 
+#ifdef _WIN32
+    HRESULT BlitGDI(HWND Window);
+#endif
+
     HRESULT STDMETHODCALLTYPE GetFrontBufferData(IDirect3DSurface9* pDestSurface);
 
     HRESULT STDMETHODCALLTYPE GetBackBuffer(
@@ -103,6 +107,7 @@ namespace dxvk {
     
     RECT                      m_srcRect;
     RECT                      m_dstRect;
+    bool                      m_partialCopy = false;
 
     DxvkSubmitStatus          m_presentStatus;
 
@@ -125,6 +130,8 @@ namespace dxvk {
     wsi::DxvkWindowState      m_windowState;
 
     double                    m_displayRefreshRate = 0.0;
+
+    bool                      m_warnedAboutFallback = false;
 
     void PresentImage(UINT PresentInterval);
 


### PR DESCRIPTION
Hopefully fixes #2749.

The idea is from Wine. When the present effect is COPY and the dst rect doesn't cover the entire screen, we read back the contents of the backbuffer and copy it to the screen using GDI.

It's slow but hopefully this only impacts launchers and weird japanese visual novels, where this isn't a problem. Slow is also much better than a black window.

The HUD is missing because I grab the contents from the D3D9Surface (because that already has the `GetDC` function). It's obviously possible to get the contents off of the DxvkImage after the HUD is rendered but the code is quite neat and tidy the way it is right now and I don't think it's a big deal.

It seems to work for DNSSpy (WPF) at least:
Before:
![image](https://user-images.githubusercontent.com/1131720/231795233-f7f70be8-1397-4109-9e83-59bfdc17d5af.png)
After:
![image](https://user-images.githubusercontent.com/1131720/231795034-14c395ce-192b-415e-be40-aadfe2a07c6a.png)

ESO Launcher:
Before:
![image](https://user-images.githubusercontent.com/1131720/231798059-010ec6b7-d60f-4334-85f6-239ea2746895.png)

After:
![image](https://user-images.githubusercontent.com/1131720/231797837-3028c538-b2e1-4676-9f3e-0b7a572dfc56.png)