### PR TITLE
Pad texture allocation to work around off-by-one game bug

### DIFF
--- a/src/d3d9/d3d9_common_texture.cpp
+++ b/src/d3d9/d3d9_common_texture.cpp
@@ -85,6 +85,10 @@ namespace dxvk {
       m_totalSize += GetMipSize(i);
     }
 
+    // Blazblue Centralifiction has an off-by-one bug in how it writes texture data.
+    // So just pad the allocation a bit.
+    m_totalSize += 8;
+
     // Initialization is handled by D3D9Initializer
     if (m_mapMode == D3D9_COMMON_TEXTURE_MAP_MODE_UNMAPPABLE)
       m_data = m_device->GetAllocator()->Alloc(m_totalSize);

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -729,11 +729,6 @@ namespace dxvk {
       { "d3d9.customDeviceId",              "05E0" },
       { "dxgi.nvapiHack",                   "False" },
     }} },
-    /* BlazBlue Centralfiction                 *
-     * Temporary crash workaround              */
-    { R"(\\BBCF\.exe$)", {{
-      { "d3d9.textureMemory",               "0"   },
-    }} },
     /* Battle Fantasia Revised Edition         *
      * Speedup above 60fps                     */
     { R"(\\bf10\.exe$)", {{


### PR DESCRIPTION
Fixes #3142

```
warn:  LockRect: 365778792 ptr: 921436160 size: 1048576
FAULT ON: 922484736
```

So it writes exactly 1 too many byte. 