### PR TITLE
Implement some small utilities in native headers

### DIFF
--- a/include/native/windows/unknwn.h
+++ b/include/native/windows/unknwn.h
@@ -12,6 +12,10 @@ struct IUnknown {
 public:
 
   virtual HRESULT QueryInterface(REFIID riid, void** ppvObject) = 0;
+  template<class Q>
+  HRESULT STDMETHODCALLTYPE QueryInterface(Q **pp) {
+    return QueryInterface(__uuidof(Q), (void **)pp);
+  }
 
   virtual ULONG AddRef()  = 0;
   virtual ULONG Release() = 0;

--- a/include/native/windows/windows_base.h
+++ b/include/native/windows/windows_base.h
@@ -70,9 +70,11 @@ typedef GUID IID;
 #ifdef __cplusplus
 #define REFIID const IID&
 #define REFGUID const GUID&
+#define REFCLSID const GUID&
 #else
 #define REFIID const IID*
 #define REFGUID const GUID*
+#define REFCLSID const GUID* const
 #endif // __cplusplus
 
 #ifdef __cplusplus

--- a/include/native/windows/windows_base.h
+++ b/include/native/windows/windows_base.h
@@ -332,4 +332,20 @@ typedef struct RGNDATA {
 #define FAILED(hr) ((HRESULT)(hr) < 0)
 #define SUCCEEDED(hr) ((HRESULT)(hr) >= 0)
 
-#define DEFINE_ENUM_FLAG_OPERATORS(T)
+#ifndef DEFINE_ENUM_FLAG_OPERATORS
+#ifdef __cplusplus
+# define DEFINE_ENUM_FLAG_OPERATORS(type) \
+extern "C++" \
+{ \
+    inline type operator &(type x, type y) { return (type)((int)x & (int)y); } \
+    inline type operator &=(type &x, type y) { return (type &)((int &)x &= (int)y); } \
+    inline type operator ~(type x) { return (type)~(int)x; } \
+    inline type operator |(type x, type y) { return (type)((int)x | (int)y); } \
+    inline type operator |=(type &x, type y) { return (type &)((int &)x |= (int)y); } \
+    inline type operator ^(type x, type y) { return (type)((int)x ^ (int)y); } \
+    inline type operator ^=(type &x, type y) { return (type &)((int &)x ^= (int)y); } \
+}
+#else
+# define DEFINE_ENUM_FLAG_OPERATORS(type)
+#endif
+#endif /* DEFINE_ENUM_FLAG_OPERATORS */


### PR DESCRIPTION
DEFINE_ENUM_FLAG_OPERATORS is used by WIDL 8.0 it seems, so this is
handy to have around if using more up to date headers.