### PR TITLE
[d3d9] Fix issues with presentation

### DIFF
--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -1632,8 +1632,8 @@ namespace dxvk {
           0
         };
 
-        if (std::min<uint32_t>(pRects[i].x2, offset.x + extent.width) <= rectOffset.x
-          || std::min<uint32_t>(pRects[i].y2, offset.y + extent.height) <= rectOffset.y) {
+        if (std::min<int32_t>(pRects[i].x2, offset.x + extent.width) <= rectOffset.x
+          || std::min<int32_t>(pRects[i].y2, offset.y + extent.height) <= rectOffset.y) {
           continue;
         }
 

--- a/src/d3d9/d3d9_include.h
+++ b/src/d3d9/d3d9_include.h
@@ -44,6 +44,10 @@
 #define D3DPRESENT_FORCEIMMEDIATE              0x00000100L
 #endif
 
+#ifndef D3DSWAPEFFECT_COPY_VSYNC
+#define D3DSWAPEFFECT_COPY_VSYNC 4
+#endif
+
 // MinGW headers are broken. Who'dve guessed?
 #ifndef _MSC_VER
 typedef struct _D3DDEVINFO_RESOURCEMANAGER

--- a/src/d3d9/d3d9_options.cpp
+++ b/src/d3d9/d3d9_options.cpp
@@ -48,7 +48,6 @@ namespace dxvk {
     this->strictPow                     = config.getOption<bool>        ("d3d9.strictPow",                     true);
     this->lenientClear                  = config.getOption<bool>        ("d3d9.lenientClear",                  false);
     this->numBackBuffers                = config.getOption<int32_t>     ("d3d9.numBackBuffers",                0);
-    this->noExplicitFrontBuffer         = config.getOption<bool>        ("d3d9.noExplicitFrontBuffer",         false);
     this->deferSurfaceCreation          = config.getOption<bool>        ("d3d9.deferSurfaceCreation",          false);
     this->samplerAnisotropy             = config.getOption<int32_t>     ("d3d9.samplerAnisotropy",             -1);
     this->maxAvailableMemory            = config.getOption<int32_t>     ("d3d9.maxAvailableMemory",            4096);

--- a/src/d3d9/d3d9_options.h
+++ b/src/d3d9/d3d9_options.h
@@ -54,16 +54,6 @@ namespace dxvk {
     /// Overrides buffer count in present parameters.
     int32_t numBackBuffers;
 
-    /// Don't create an explicit front buffer in our own swapchain. The Vulkan swapchain is unaffected.
-    /// Some games don't handle front/backbuffer flipping very well because they don't always redraw
-    /// each frame completely, and rely on old pixel data from the previous frame to still be there.
-    /// When this option is set and a game only requests one backbuffer, there will be no flipping in
-    /// our own swapchain, so the game will always draw to the same buffer and can rely on old pixel
-    /// data to still be there after a Present call.
-    /// This means that D3D9SwapChainEx::GetFrontBufferData returns data from the backbuffer of the
-    /// previous frame, which is the same as the current backbuffer if only 1 backbuffer was requested.
-    bool noExplicitFrontBuffer;
-
     /// Defer surface creation
     bool deferSurfaceCreation;
 

--- a/src/d3d9/d3d9_swapchain.cpp
+++ b/src/d3d9/d3d9_swapchain.cpp
@@ -153,9 +153,9 @@ namespace dxvk {
     m_lastDialog = m_dialog;
 
 #ifdef _WIN32
-    const bool useGDIFallback = m_partialCopy && m_presentParams.SwapEffect == D3DSWAPEFFECT_COPY;
+    const bool useGDIFallback = m_partialCopy && !HasFrontBuffer();
     if (useGDIFallback)
-      return BlitGDI(window);
+      return PresentImageGDI(window);
 #endif
 
     try {
@@ -176,7 +176,7 @@ namespace dxvk {
     } catch (const DxvkError& e) {
       Logger::err(e.message());
 #ifdef _WIN32
-      return BlitGDI(window);
+      return PresentImageGDI(window);
 #else
       return D3DERR_DEVICEREMOVED;
 #endif
@@ -186,8 +186,11 @@ namespace dxvk {
 #ifdef _WIN32
   #define DCX_USESTYLE 0x00010000
 
-  HRESULT D3D9SwapChainEx::BlitGDI(HWND Window) {
-    if (!std::exchange(m_warnedAboutFallback, true))
+  HRESULT D3D9SwapChainEx::PresentImageGDI(HWND Window) {
+    m_parent->EndFrame();
+    m_parent->Flush();
+
+    if (!std::exchange(m_warnedGDIAboutFallback, true))
       Logger::warn("Using GDI for swapchain presentation. This will impact performance.");
 
     HDC hDC;
@@ -233,13 +236,18 @@ namespace dxvk {
     // of src onto a temp image of dst's extents,
     // then copy buffer back to dst (given dst is subresource)
 
+    // For SWAPEFFECT_COPY and windowed SWAPEFFECT_DISCARD with 1 backbuffer, we just copy the backbuffer data instead.
+    // We just copy from the backbuffer instead of the front buffer to avoid having to do another blit.
+    // This mostly impacts windowed mode and our implementation was not accurate in that case anyway as Windows D3D9
+    // takes a screenshot of the entire screen.
+
     D3D9Surface* dst = static_cast<D3D9Surface*>(pDestSurface);
 
     if (unlikely(dst == nullptr))
       return D3DERR_INVALIDCALL;
 
     D3D9CommonTexture* dstTexInfo = dst->GetCommonTexture();
-    D3D9CommonTexture* srcTexInfo = m_backBuffers.back()->GetCommonTexture();
+    D3D9CommonTexture* srcTexInfo = GetFrontBuffer()->GetCommonTexture();
 
     if (unlikely(dstTexInfo->Desc()->Pool != D3DPOOL_SYSTEMMEM && dstTexInfo->Desc()->Pool != D3DPOOL_SCRATCH))
       return D3DERR_INVALIDCALL;
@@ -730,8 +738,8 @@ namespace dxvk {
     m_parent->Flush();
 
     // Retrieve the image and image view to present
-    auto swapImage = m_backBuffers[0]->GetCommonTexture()->GetImage();
-    auto swapImageView = m_backBuffers[0]->GetImageView(false);
+    Rc<DxvkImage> swapImage = m_backBuffers[0]->GetCommonTexture()->GetImage();
+    Rc<DxvkImageView> swapImageView = m_backBuffers[0]->GetImageView(false);
 
     // Bump our frame id.
     ++m_frameId;
@@ -820,7 +828,6 @@ namespace dxvk {
     if (status != VK_SUCCESS)
       RecreateSwapChain(m_vsync);
   }
-
 
   void D3D9SwapChainEx::RecreateSwapChain(BOOL Vsync) {
     // Ensure that we can safely destroy the swap chain
@@ -954,7 +961,7 @@ namespace dxvk {
     // creating a new one to free up resources
     DestroyBackBuffers();
 
-    int NumFrontBuffer = m_parent->GetOptions()->noExplicitFrontBuffer ? 0 : 1;
+    int NumFrontBuffer = HasFrontBuffer() ? 1 : 0;
     const uint32_t NumBuffers = NumBackBuffers + NumFrontBuffer;
 
     m_backBuffers.reserve(NumBuffers);
@@ -1235,7 +1242,11 @@ namespace dxvk {
   }
 
   bool    D3D9SwapChainEx::UpdatePresentRegion(const RECT* pSourceRect, const RECT* pDestRect) {
-    if (pSourceRect == nullptr) {
+    const bool isWindowed = m_presentParams.Windowed;
+
+    // Tests show that present regions are ignored in fullscreen
+
+    if (pSourceRect == nullptr || !isWindowed) {
       m_srcRect.top    = 0;
       m_srcRect.left   = 0;
       m_srcRect.right  = m_presentParams.BackBufferWidth;
@@ -1249,7 +1260,7 @@ namespace dxvk {
     wsi::getWindowSize(m_window, &width, &height);
 
     RECT dstRect;
-    if (pDestRect == nullptr) {
+    if (pDestRect == nullptr || !isWindowed) {
       // TODO: Should we hook WM_SIZE message for this?
       dstRect.top    = 0;
       dstRect.left   = 0;
@@ -1266,21 +1277,18 @@ namespace dxvk {
     || dstRect.right  - dstRect.left != LONG(width)
     || dstRect.bottom - dstRect.top  != LONG(height);
 
-    bool recreate = 
-       m_dstRect.left   != dstRect.left
-    || m_dstRect.top    != dstRect.top
-    || m_dstRect.right  != dstRect.right
-    || m_dstRect.bottom != dstRect.bottom;
+    bool recreate =
+       m_swapchainExtent.width  != width
+    || m_swapchainExtent.height != height;
 
+    m_swapchainExtent = { width, height };
     m_dstRect = dstRect;
 
     return recreate;
   }
 
   VkExtent2D D3D9SwapChainEx::GetPresentExtent() {
-    return VkExtent2D {
-      std::max<uint32_t>(m_dstRect.right  - m_dstRect.left, 1u),
-      std::max<uint32_t>(m_dstRect.bottom - m_dstRect.top,  1u) };
+    return m_swapchainExtent;
   }
 
 

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -466,10 +466,6 @@ namespace dxvk {
     { R"(\\ToEE(a)?\.exe$)", {{
       { "d3d9.allowDiscard",                "False" },
     }} },
-    /* ZUSI 3 - Aerosoft Edition                  */
-    { R"(\\ZusiSim(\.64)?\.exe$)", {{
-      { "d3d9.noExplicitFrontBuffer",       "True" },
-    }} },
     /* GTA IV (NVAPI)                             */
     /* Also thinks we're always on Intel          *
      * and will report/use bad amounts of VRAM.
@@ -546,10 +542,6 @@ namespace dxvk {
     { R"(\\SineMoraEX\.exe$)", {{
       { "d3d9.maxFrameRate",                "60" },
     }} },
-    /* Fantasy Grounds                           */
-    { R"(\\FantasyGrounds\.exe$)", {{
-      { "d3d9.noExplicitFrontBuffer",       "True" },
-    }} },
     /* Red Orchestra 2                           */
     { R"(\\ROGame\.exe$)", {{
       { "d3d9.floatEmulation",              "Strict" },
@@ -589,17 +581,6 @@ namespace dxvk {
     /* Limbo                                    */
     { R"(\\limbo\.exe$)", {{
       { "d3d9.maxFrameRate",                "60" },
-    }} },
-    /* Warhammer: Return of Reckoning Launcher
-       Forcing SM1 fixes a black window otherwise caused by
-       the lack of support for partial presentation */
-    { R"(\\RoRLauncher\.exe$)", {{
-      { "d3d9.shaderModel",                 "1" },
-    }} },
-    /* Halo CE SPV3 launcher
-       Same issue as Warhammer: RoR above       */
-    { R"(\\spv3\.exe$)", {{
-      { "d3d9.shaderModel",                 "1" },
     }} },
     /* Escape from Tarkov launcher
        Same issue as Warhammer: RoR above       */


### PR DESCRIPTION
- Do GDI blit for SWAPEFFECT_COPY_VSYNC too (which is missing from the mingw headers on my system)
- Dont swap buffers when using SWAPEFFECT_COPY

~~- Blit the backbuffer contents into the frontbuffer, so GetFrontBufferData returns the expected data~~
~~- Replace `noExplicitFrontBuffer` with that frontbuffer blit (this needs testing)~~

- Dont create an additional front buffer for SWAPEFFECT_COPY and windowed SWAPEFFECT_DISCARD with 1 backbuffer. The latter behaves identical to SWAPEFFECT_COPY in my testing, it even supports partial presentation.
- In those cases, GetFrontBufferData will just return the contents of the backbuffer. That's technically wrong ofc but I don't think adding in another blit in windowed mode is worth it. It's only wrong for SWAPEFFECT_COPY and DISCARD in windowed mode. Fullscreen SWAPEFFECT_COPY is probably very rare because that kind of defeats the purpose as partial presentation doesn't work in fullscreen. GetFrontBufferData was broken in windowed mode anyway because Windows takes a screenshot of the entire screen when you call it and we just used to return the contents of the front buffer.

Fixes #2732
Fixes #2240
Fixes #2568
Fixes #3238
Fixes #1476
Fixes #1481
Fixes #2456
Fixes #2542
Fixes #3005 
Fixes #3208
Fixes #3238
Fixes #3206
Fixes #3141
Fixes #3250 
Fixes #1554
Fixes #2756
Fixes #2915

Closes #2749