### PR TITLE
[d3d9] Keep reference to D3D9 module around

### DIFF
--- a/src/d3d9/d3d9_interface.cpp
+++ b/src/d3d9/d3d9_interface.cpp
@@ -12,6 +12,21 @@ namespace dxvk {
 
   Singleton<DxvkInstance> g_dxvkInstance;
 
+#ifdef _WIN32
+  HMODULE GetCurrentModule() {
+    HMODULE currentModule = nullptr;
+    // Get the module for the address of this function.
+    // Increments reference count for the module,
+    // unlike GetModuleHandle.
+    GetModuleHandleEx(
+      GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS,
+      (LPCTSTR)GetCurrentModule,
+      &currentModule);
+
+    return currentModule;
+  }
+#endif
+
   D3D9InterfaceEx::D3D9InterfaceEx(bool bExtended)
     : m_instance    ( g_dxvkInstance.acquire() )
     , m_extended    ( bExtended ) 
@@ -64,12 +79,18 @@ namespace dxvk {
       Logger::info("Process set as DPI aware");
       SetProcessDPIAware();
     }
+
+    m_d3d9Module = GetCurrentModule();
 #endif
   }
 
 
   D3D9InterfaceEx::~D3D9InterfaceEx() {
     g_dxvkInstance.release();
+
+#ifdef _WIN32
+    FreeLibrary(m_d3d9Module);
+#endif
   }
 
 

--- a/src/d3d9/d3d9_interface.h
+++ b/src/d3d9/d3d9_interface.h
@@ -148,6 +148,10 @@ namespace dxvk {
 
     D3D9VkInteropInterface        m_d3d9Interop;
 
+#ifdef _WIN32
+    HMODULE                       m_d3d9Module;
+#endif
+
   };
 
 }


### PR DESCRIPTION
Some games check if d3d9.dll is loaded in their WindowProc and use that to make decisions.

Some of these apps FreeLibrary after calling Direct3DCreate9 which is bad to start with... but ends up with them getting very confused and they constantly remake the device in the window proc we hooked causing a stack overflow.

I wonder if D3D11/DXGI should do the same here, needs testing.