### PR TITLE
[d3d9] Fix crash if device is freed with bound textures

### DIFF
--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -1358,14 +1358,16 @@ namespace dxvk {
     std::atomic<int64_t>            m_availableMemory = { 0 };
     std::atomic<int32_t>            m_samplerCount    = { 0 };
 
-    Direct3DState9                  m_state;
-
     D3D9DeviceLostState             m_deviceLostState          = D3D9DeviceLostState::Ok;
     HWND                            m_fullscreenWindow         = NULL;
 
 #ifdef D3D9_ALLOW_UNMAPPING
     lru_list<D3D9CommonTexture*>    m_mappedTextures;
 #endif
+
+    // m_state should be declared last (i.e. freed first), because it
+    // references objects that can call back into the device when freed.
+    Direct3DState9                  m_state;
 
     D3D9VkInteropDevice             m_d3d9Interop;
   };


### PR DESCRIPTION
The following code will cause a segfault (in `pDevice->Release`) in D3D9, but works fine on native:
```cpp
IDirect3DDevice9* pDevice = nullptr;
HRESULT status = pD3D9->CreateDevice(...);

IDirect3DTexture9* pTexture = nullptr;
status = pDevice->CreateTexture(256, 256, 1, 0, D3DFMT_A8R8G8B8, D3DPOOL_MANAGED, &pTexture, nullptr);

status = pDevice->SetTexture(0, pTexture);

pTexture->Release();
pDevice->Release();
```

The reason is that in the device, `m_state` is freed after `m_mappedTextures`, but if any textures are bound and don't have any refs left, they'll be freed, and the destructor for `D3D9CommonTexture` will try to remove them from the list.

https://github.com/doitsujin/dxvk/blob/bef2ef69abbf1c446de00e8b27162cef3ff386fd/src/d3d9/d3d9_common_texture.cpp#L96-L101

Changing the order so that `m_state` is declared last fixes this issue.