### PR TITLE
[dxgi] Enumerate all monitors if only one unique GPU is present

### DIFF
--- a/src/dxgi/dxgi_adapter.cpp
+++ b/src/dxgi/dxgi_adapter.cpp
@@ -162,7 +162,7 @@ namespace dxvk {
 
     auto linkedAdapter = m_adapter->linkedIGPUAdapter();
 
-    /* If either LUID is not valid enumerate all monitors. */
+    // If either LUID is not valid, enumerate all monitors.
     if (numLUIDs && linkedAdapter != nullptr) {
       const auto& deviceId = linkedAdapter->devicePropertiesExt().vk11;
 
@@ -171,6 +171,10 @@ namespace dxvk {
       else
         numLUIDs = 0;
     }
+
+    // Enumerate all monitors if the robustness fallback is active.
+    if (m_factory->UseMonitorFallback())
+      numLUIDs = 0;
 
     HMONITOR monitor = wsi::enumMonitors(adapterLUIDs.data(), numLUIDs, Output);
 

--- a/src/dxgi/dxgi_factory.h
+++ b/src/dxgi/dxgi_factory.h
@@ -158,6 +158,10 @@ namespace dxvk {
     HRESULT STDMETHODCALLTYPE UnregisterAdaptersChangedEvent(
             DWORD                 Cookie);
 
+    BOOL UseMonitorFallback() const {
+      return m_monitorFallback;
+    }
+
     Rc<DxvkInstance> GetDXVKInstance() const {
       return m_instance;
     }
@@ -177,6 +181,7 @@ namespace dxvk {
     DxgiOptions      m_options;
     DxgiMonitorInfo  m_monitorInfo;
     UINT             m_flags;
+    BOOL             m_monitorFallback;
     
     HWND m_associatedWindow = nullptr;
     


### PR DESCRIPTION
TL;DR if users set something like `DXVK_DEVICE_FILTER` or various Vulkan-related environment variables to select a specific device, our current logic may end up reporting zero monitors for the DXGI adapter, which may cause all sorts of problems such as Assassin's Creed Valhalla being forced into a resolution of 1280x720. This should (hopefully) work around that.

@gofman