### PR TITLE
[d3d11] Fix min luminance of HDR Metadata

### DIFF
--- a/src/d3d11/d3d11_swapchain.cpp
+++ b/src/d3d11/d3d11_swapchain.cpp
@@ -32,7 +32,7 @@ namespace dxvk {
   }
 
   static float ConvertMinLuminance(UINT dxgiLuminance) {
-    return float(dxgiLuminance) / 0.0001f;
+    return float(dxgiLuminance) * 0.0001f;
   }
 
   static float ConvertLevel(UINT16 dxgiLevel) {


### PR DESCRIPTION
This should be a multiply instead of a divide. Values are 1/10000th of a nit (0.0001 nit).