### PR TITLE
[util] Add config for Tom Clancy's The Division.

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -127,6 +127,10 @@ namespace dxvk {
       { "dxgi.maxFrameRate",                "60"   },
       { "d3d11.cachedDynamicResources",     "vi"   },
     }} },
+    /* Tom Clancy's The Division                  */
+    { R"(\\TheDivision\.exe)", {{
+      { "dxgi.syncInterval",                "1"    },
+    }} },
     /* SteamVR performance test                   */
     { R"(\\vr\.exe$)", {{
       { "d3d11.dcSingleUseMode",            "False" },


### PR DESCRIPTION
During some cinematics the game calls Present() frequently switching between SyncInterval 0 and 1. At each change the Vulkan swapchain must be rebuilt. This can cause some stuttering, which is fixed by overriding SyncInterval to 1.