### PR TITLE
Main

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -19,7 +19,7 @@ jobs:
       with:
         command: |
           export VERSION_NAME="${GITHUB_REF##*/}-${GITHUB_SHA##*/}"
-          ./package-release.sh ${VERSION_NAME} build --dev-build
+          ./package-release.sh ${VERSION_NAME} build --no-package
           echo "VERSION_NAME=${VERSION_NAME}" >> $GITHUB_ENV
 
     - name: Upload artifact

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -1,14 +1,17 @@
-name: Artifacts (Package)
-
-on: [push, pull_request, workflow_dispatch]
-
+name: Artifact (Package)
+on: workflow_dispatch
 jobs:
-  artifacts-mingw-w64:
-    runs-on: ubuntu-20.04
-
+  artifact-mingw-w64:
+    runs-on: ubuntu-latest
     steps:
+
+    - name: Update upgrade install
+      run: |
+        sudo apt-get update
+        sudo apt-get upgrade
+        sudo pip3 install meson
+
     - name: Checkout code
-      id: checkout-code
       uses: actions/checkout@v3
       with:
         submodules: recursive
@@ -18,7 +21,6 @@ jobs:
       uses: Joshua-Ashton/gcc-problem-matcher@v2
 
     - name: Build release
-      id: build-release
       uses: Joshua-Ashton/arch-mingw-github-action@v8
       with:
         command: |
@@ -26,41 +28,9 @@ jobs:
           ./package-release.sh ${VERSION_NAME} build --no-package
           echo "VERSION_NAME=${VERSION_NAME}" >> $GITHUB_ENV
 
-    - name: Upload artifacts
-      id: upload-artifacts
+    - name: Upload artifact
       uses: actions/upload-artifact@v3
       with:
-        name: dxvk-${{ env.VERSION_NAME }}
-        path: build/dxvk-${{ env.VERSION_NAME }}
-        if-no-files-found: error
-
-  artifacts-steamrt-sniper:
-    runs-on: ubuntu-20.04
-    container: registry.gitlab.steamos.cloud/steamrt/sniper/sdk:beta
-
-    steps:
-    - name: Checkout code
-      id: checkout-code
-      uses: actions/checkout@v3
-      with:
-        submodules: recursive
-        fetch-depth: 0
-
-    - name: Setup problem matcher
-      uses: Joshua-Ashton/gcc-problem-matcher@v2
-
-    - name: Build release
-      id: build-release
-      shell: bash
-      run: |
-        export VERSION_NAME="${GITHUB_REF##*/}-${GITHUB_SHA##*/}"
-        ./package-native.sh ${VERSION_NAME} build --no-package
-        echo "VERSION_NAME=${VERSION_NAME}" >> $GITHUB_ENV
-
-    - name: Upload artifacts
-      id: upload-artifacts
-      uses: actions/upload-artifact@v3
-      with:
-        name: dxvk-${{ env.VERSION_NAME }}
-        path: build/dxvk-native-${{ env.VERSION_NAME }}
+        name: dxvk-${{env.VERSION_NAME}}
+        path: build/dxvk-${{env.VERSION_NAME}}
         if-no-files-found: error

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -19,7 +19,7 @@ jobs:
       with:
         command: |
           export VERSION_NAME="${GITHUB_REF##*/}-${GITHUB_SHA##*/}"
-          ./package-release.sh ${VERSION_NAME} build --no-package
+          ./package-release.sh ${VERSION_NAME} build --dev-build
           echo "VERSION_NAME=${VERSION_NAME}" >> $GITHUB_ENV
 
     - name: Upload artifact

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -5,12 +5,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Update upgrade install
-      run: |
-        sudo apt-get update
-        sudo apt-get upgrade
-        sudo pip3 install meson
-
     - name: Checkout code
       uses: actions/checkout@v3
       with:

--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,4 @@
-project('dxvk', ['c', 'cpp'], version : 'v2.2', meson_version : '>= 0.49', default_options : [ 'cpp_std=c++17', 'warning_level=2' ])
+project('dxvk', ['c', 'cpp'], version : 'v2.2', meson_version : '>= 0.49', default_options : [ 'cpp_std=gnu++20', 'warning_level=2' ])
 
 cpu_family = target_machine.cpu_family()
 platform   = target_machine.system()
@@ -144,7 +144,7 @@ def_spec_ext = '.def'
 glsl_compiler = find_program('glslangValidator')
 glsl_args = [
   '--quiet',
-  '--target-env', 'vulkan1.2',
+  '--target-env', 'vulkan1.3',
   '--vn', '@BASENAME@',
   '--depfile', '@DEPFILE@',
   '@INPUT@',

--- a/package-release.sh
+++ b/package-release.sh
@@ -59,7 +59,8 @@ function build_arch {
   fi
 
   meson setup --cross-file "$DXVK_SRC_DIR/$crossfile$1.txt" \
-        --buildtype "release"                               \
+        --optimization s                                    \
+        --default-library shared                            \
         --prefix "$DXVK_BUILD_DIR"                          \
         $opt_strip                                          \
         --bindir "x$1"                                      \
@@ -79,7 +80,7 @@ function build_arch {
 
 function package {
   cd "$DXVK_BUILD_DIR/.."
-  tar -czf "$DXVK_ARCHIVE_PATH" "dxvk-$DXVK_VERSION"
+  tar -cJf "$DXVK_ARCHIVE_PATH" "dxvk-$DXVK_VERSION"
   rm -R "dxvk-$DXVK_VERSION"
 }
 


### PR DESCRIPTION
Hello, I made some changes, but only "meson.build" and "package-release.sh" could be merged without any issues.
Changing the "c++17" to "gnu++20" somehow removes the stuttering and increase with 10 FPS average on 
Unigine Heaven Benchmark 4.0.

I tested 8 times with my main PC, 6 times with test PC and 4 times with hot PC, half of the tests for each PC was with "doitsujin/dxvk" and rest half with my changes, for main PC it removes the shutters and FPS a bit of improvement but for test PC and hot PC the shutters was reduced not removed but still a bit of improvement for my rigs.

We should count any kind of PC build even if they are too old, some peoples like me can't have a High-end or even Mid-range computers, is just a dream for me to have a decent PC at least for 2020 era, by the way, the only thing good in "artifacts.yml" is by removing the "id:", they are optional and does nothing for this config, also the "runs-on: ubuntu-latest" is good to be up to date like other Linux systems for security and performance reasons.

Main PC = i5-2400, GT 1030, DDR3 8 GB, HDD 500 GB, Windows 11 Ghost Specter.
Test PC (Still good for casual gaming) = Q8400, GT 730, DDR 6 GB, HDD 250 GB, Windows 11 Ghost Specter.
Hot PC (Good for winter) = E8200, GT 220, DDR 4 GB, HDD 250 GB, Windows 10 Ghost Specter.