### PR TITLE
[d3d9/d3d11] add samplerLodBias to d3d9 and clampNegativeLodBias for both d3d9 and d3d11

### DIFF
--- a/dxvk.conf
+++ b/dxvk.conf
@@ -197,6 +197,7 @@
 #
 # Supported values: True, False
 
+# d3d11.clampNegativeLodBias = False
 # d3d9.clampNegativeLodBias = False
 
 

--- a/dxvk.conf
+++ b/dxvk.conf
@@ -189,7 +189,7 @@
 # Supported values: Any number between -2.0 and 1.0
 
 # d3d11.samplerLodBias = 0.0
-
+# d3d9.samplerLodBias = 0.0
 
 # Declares vertex positions as invariant in order to solve
 # potential Z-fighting issues at a small performance cost.

--- a/dxvk.conf
+++ b/dxvk.conf
@@ -191,6 +191,15 @@
 # d3d11.samplerLodBias = 0.0
 # d3d9.samplerLodBias = 0.0
 
+
+# Clamps any negative LOD bias to 0. Applies after samplerLodBias has been
+# applied. May help with games that use a high negative LOD bias by default.
+#
+# Supported values: True, False
+
+# d3d9.clampNegativeLodBias = False
+
+
 # Declares vertex positions as invariant in order to solve
 # potential Z-fighting issues at a small performance cost.
 #

--- a/src/d3d11/d3d11_options.cpp
+++ b/src/d3d11/d3d11_options.cpp
@@ -21,6 +21,7 @@ namespace dxvk {
     this->maxTessFactor         = config.getOption<int32_t>("d3d11.maxTessFactor", 0);
     this->samplerAnisotropy     = config.getOption<int32_t>("d3d11.samplerAnisotropy", -1);
     this->samplerLodBias        = config.getOption<float>("d3d11.samplerLodBias", 0.0f);
+    this->clampNegativeLodBias  = config.getOption<bool>("d3d11.clampNegativeLodBias", false);
     this->invariantPosition     = config.getOption<bool>("d3d11.invariantPosition", true);
     this->floatControls         = config.getOption<bool>("d3d11.floatControls", true);
     this->forceSampleRateShading = config.getOption<bool>("d3d11.forceSampleRateShading", false);

--- a/src/d3d11/d3d11_options.h
+++ b/src/d3d11/d3d11_options.h
@@ -63,6 +63,9 @@ namespace dxvk {
     /// Enforces the given LOD bias for all samplers.
     float samplerLodBias;
 
+    /// Clamps negative LOD bias
+    bool clampNegativeLodBias;
+
     /// Declare vertex positions in shaders as invariant
     bool invariantPosition;
 

--- a/src/d3d11/d3d11_sampler.cpp
+++ b/src/d3d11/d3d11_sampler.cpp
@@ -47,8 +47,12 @@ namespace dxvk {
     if (desc.MaxAnisotropy > 16) info.maxAnisotropy = 16.0f;
     
     // Enforce LOD bias specified in the device options
-    if (info.minFilter == VK_FILTER_LINEAR && info.magFilter == VK_FILTER_LINEAR)
+    if (info.minFilter == VK_FILTER_LINEAR && info.magFilter == VK_FILTER_LINEAR) {
       info.mipmapLodBias += device->GetOptions()->samplerLodBias;
+
+      if (device->GetOptions()->clampNegativeLodBias)
+        info.mipmapLodBias = std::max(info.mipmapLodBias, 0.0f);
+    }
 
     // Enforce anisotropy specified in the device options
     int32_t samplerAnisotropyOption = device->GetOptions()->samplerAnisotropy;

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -6243,7 +6243,11 @@ namespace dxvk {
       info.mipmapMode     = mipFilter.MipFilter;
       info.maxAnisotropy  = float(cKey.MaxAnisotropy);
       info.useAnisotropy  = cKey.MaxAnisotropy > 1;
+
       info.mipmapLodBias  = cKey.MipmapLodBias + m_d3d9Options.samplerLodBias;
+      if (m_d3d9Options.clampNegativeLodBias)
+        info.mipmapLodBias = std::max(info.mipmapLodBias, 0.0f);
+
       info.mipmapLodMin   = mipFilter.MipsEnabled ? float(cKey.MaxMipLevel) : 0;
       info.mipmapLodMax   = mipFilter.MipsEnabled ? FLT_MAX                 : 0;
       info.reductionMode  = VK_SAMPLER_REDUCTION_MODE_WEIGHTED_AVERAGE;

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -6243,7 +6243,7 @@ namespace dxvk {
       info.mipmapMode     = mipFilter.MipFilter;
       info.maxAnisotropy  = float(cKey.MaxAnisotropy);
       info.useAnisotropy  = cKey.MaxAnisotropy > 1;
-      info.mipmapLodBias  = cKey.MipmapLodBias;
+      info.mipmapLodBias  = cKey.MipmapLodBias + m_d3d9Options.samplerLodBias;
       info.mipmapLodMin   = mipFilter.MipsEnabled ? float(cKey.MaxMipLevel) : 0;
       info.mipmapLodMax   = mipFilter.MipsEnabled ? FLT_MAX                 : 0;
       info.reductionMode  = VK_SAMPLER_REDUCTION_MODE_WEIGHTED_AVERAGE;

--- a/src/d3d9/d3d9_options.cpp
+++ b/src/d3d9/d3d9_options.cpp
@@ -1,3 +1,5 @@
+#include "../util/util_math.h"
+
 #include "d3d9_options.h"
 
 #include "d3d9_caps.h"
@@ -72,6 +74,10 @@ namespace dxvk {
     this->seamlessCubes                 = config.getOption<bool>        ("d3d9.seamlessCubes",                 false);
     this->textureMemory                 = config.getOption<int32_t>     ("d3d9.textureMemory",                 100) << 20;
     this->deviceLossOnFocusLoss         = config.getOption<bool>        ("d3d9.deviceLossOnFocusLoss",         false);
+    this->samplerLodBias                = config.getOption<float>       ("d3d9.samplerLodBias",                0.0f);
+
+    // Clamp LOD bias so that people don't abuse this in unintended ways
+    this->samplerLodBias = dxvk::fclamp(this->samplerLodBias, -2.0f, 1.0f);
 
     std::string floatEmulation = Config::toLower(config.getOption<std::string>("d3d9.floatEmulation", "auto"));
     if (floatEmulation == "strict") {

--- a/src/d3d9/d3d9_options.cpp
+++ b/src/d3d9/d3d9_options.cpp
@@ -75,6 +75,7 @@ namespace dxvk {
     this->textureMemory                 = config.getOption<int32_t>     ("d3d9.textureMemory",                 100) << 20;
     this->deviceLossOnFocusLoss         = config.getOption<bool>        ("d3d9.deviceLossOnFocusLoss",         false);
     this->samplerLodBias                = config.getOption<float>       ("d3d9.samplerLodBias",                0.0f);
+    this->clampNegativeLodBias          = config.getOption<bool>        ("d3d9.clampNegativeLodBias",          false);
 
     // Clamp LOD bias so that people don't abuse this in unintended ways
     this->samplerLodBias = dxvk::fclamp(this->samplerLodBias, -2.0f, 1.0f);

--- a/src/d3d9/d3d9_options.h
+++ b/src/d3d9/d3d9_options.h
@@ -136,6 +136,11 @@ namespace dxvk {
     /// Don't use non seamless cube maps
     bool seamlessCubes;
 
+    /// Mipmap LOD bias
+    ///
+    /// Enforces the given LOD bias for all samplers.
+    float samplerLodBias;
+
     /// How much virtual memory will be used for textures (in MB).
     int32_t textureMemory;
 

--- a/src/d3d9/d3d9_options.h
+++ b/src/d3d9/d3d9_options.h
@@ -141,6 +141,9 @@ namespace dxvk {
     /// Enforces the given LOD bias for all samplers.
     float samplerLodBias;
 
+    /// Clamps negative LOD bias
+    bool clampNegativeLodBias;
+
     /// How much virtual memory will be used for textures (in MB).
     int32_t textureMemory;
 


### PR DESCRIPTION
`d3d9.clampNegativeLodBias` addresses https://github.com/doitsujin/dxvk/issues/2779

a negative lod bias can help for some d3d9 games to look better
while clamping the negative load bias can also help some other games too 😄

Thanks to [@Kaldaien](https://github.com/Kaldaien) for giving me the code for clamping in D3D9!