### PR TITLE
[util] Set dcSingleUseMode to false for SnowRunner

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -360,6 +360,10 @@ namespace dxvk {
     { R"(\\CrashBandicootNSaneTrilogy\.exe$)", {{
       { "dxgi.syncInterval",                "1"   },
     }} },
+    /* SnowRunner                                 */
+    { R"(\\SnowRunner\.exe$)", {{
+      { "d3d11.dcSingleUseMode",        "False"   },
+    }} },
 
     /**********************************************/
     /* D3D9 GAMES                                 */


### PR DESCRIPTION
Game already ships a `dxvk.conf` with this set, but might as well do it internally so it doesn't break if people load a different config file.