### PR TITLE
[util] Enable apitrace mode for Tomb Raider Anniversary

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -487,8 +487,11 @@ namespace dxvk {
     { R"(\\SpellForce2.*\.exe$)", {{
       { "d3d9.forceSamplerTypeSpecConstants", "True" },
     }} },
-    /* Tomb Raider: Legend                       */
-    { R"(\\trl\.exe$)", {{
+    /* Tomb Raider: Legend, Anniversary, Underworld  *
+     * Read from a buffer created with:              *
+     * D3DPOOL_DEFAULT,                              *
+     * D3DUSAGE_DYNAMIC | D3DUSAGE_WRITEONLY buffer  */
+    { R"(\\(trl|tra|tru)\.exe$)", {{
       { "d3d9.apitraceMode",                "True" },
     }} },
     /* Everquest                                 */


### PR DESCRIPTION
Fixes  #3438

We know that both Legend and Anniversary do it, so I figured we might as well enable it for Underworld too just to be safe.