### PR TITLE
[util] Limit fps for some Tomb Raider games

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -497,6 +497,7 @@ namespace dxvk {
      * D3DUSAGE_DYNAMIC | D3DUSAGE_WRITEONLY buffer  */
     { R"(\\(trl|tra|tru)\.exe$)", {{
       { "d3d9.apitraceMode",                "True" },
+      { "d3d9.maxFrameRate",                "60" },
     }} },
     /* Everquest                                 */
     { R"(\\eqgame\.exe$)", {{


### PR DESCRIPTION
Games can bug out at higher fps, especially the physics, and sometimes in progress breaking ways.