### PR TITLE
[d3d9] Properly expose the MaxVertexBlendMatrixIndex capability

### DIFF
--- a/src/d3d9/d3d9_adapter.cpp
+++ b/src/d3d9/d3d9_adapter.cpp
@@ -529,7 +529,7 @@ namespace dxvk {
     // Max Vertex Blend Matrices
     pCaps->MaxVertexBlendMatrices    = 4;
     // Max Vertex Blend Matrix Index
-    pCaps->MaxVertexBlendMatrixIndex = 8;
+    pCaps->MaxVertexBlendMatrixIndex = 0;
     // Max Point Size
     pCaps->MaxPointSize              = 256.0f;
     // Max Primitive Count

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -268,7 +268,15 @@ namespace dxvk {
 
 
   HRESULT STDMETHODCALLTYPE D3D9DeviceEx::GetDeviceCaps(D3DCAPS9* pCaps) {
-    return m_adapter->GetDeviceCaps(m_deviceType, pCaps);
+    if (pCaps == nullptr)
+      return D3DERR_INVALIDCALL;
+
+    m_adapter->GetDeviceCaps(m_deviceType, pCaps);
+
+    // When in SWVP mode, 256 matrices can be used for indexed vertex blending
+    pCaps->MaxVertexBlendMatrixIndex = m_isSWVP ? 255 : 8;
+
+    return D3D_OK;
   }
 
 


### PR DESCRIPTION
The behavior on both native AMD (thanks @Blisto91) and WineD3D is as follows:

- if IDirect3D8/9::GetDeviceCaps() is called, MaxVertexBlendMatrixIndex is set to 0
- if IDirect3DDevice8/9::GetDeviceCaps() is called in HWVP mode, MaxVertexBlendMatrixIndex is set to 8
- if IDirect3DDevice8/9::GetDeviceCaps() is called in SWVP mode, MaxVertexBlendMatrixIndex is set to 255

The last bit seems to be in line with what the docs state:

> DWORD value that specifies the maximum matrix index that can be indexed into using the per-vertex indices. The number of matrices is MaxVertexBlendMatrixIndex + 1, which is the size of the matrix palette. If normals are present in the vertex data that needs to be blended for lighting, then the number of matrices is half the number specified by this capability flag. If MaxVertexBlendMatrixIndex is set to zero, the driver does not support indexed vertex blending. If this value is not zero then the valid range of indices is zero through MaxVertexBlendMatrixIndex.
> 
> A zero value for MaxVertexBlendMatrixIndex indicates that the driver does not support indexed matrices.
> 
> When software vertex processing is used, 256 matrices could be used for indexed vertex blending, with or without normal blending.
> 
> For a given physical device, this capability may vary across Direct3D devices depending on the parameters supplied to [CreateDevice](https://learn.microsoft.com/en-us/windows/desktop/api/d3d9/nf-d3d9-idirect3d9-createdevice).

Initially I thought this won't affect anything, but it fixes #2956, so here we are. It's probably best to replicate native behavior either way (even if this hadn't fixed anything in d3d9), because SWVP use in d3d8 is far more common.