### PR TITLE
[util] Set maxChunkSize to 1 for the Rockstar launcher and social club

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -364,6 +364,14 @@ namespace dxvk {
     { R"(\\SnowRunner\.exe$)", {{
       { "d3d11.dcSingleUseMode",        "False"   },
     }} },
+    /* Rockstar Games Launcher                    */
+    { R"(\\Rockstar Games\\Launcher\\Launcher\.exe$)", {{
+      { "dxvk.maxChunkSize",                "1"   },
+    }} },
+    /* Rockstar Social Club                       */
+    { R"(\\Rockstar Games\\Social Club\\SocialClubHelper\.exe$)", {{
+      { "dxvk.maxChunkSize",                "1"   },
+    }} },
 
     /**********************************************/
     /* D3D9 GAMES                                 */


### PR DESCRIPTION
Currently when Red Dead Redemption 2 is running the Rockstar launcher, and social club each use over 600MB of VRAM. The root cause of this is DXVK creating two memory pools of 256MB for read, and read/write resources. Reducing the max chunk size to 1MB reduces the memory usage of each to around 40MB.