### PR TITLE
Add some WAs for UE4 games

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -303,9 +303,11 @@ namespace dxvk {
     }} },
     /* Stray - writes to the same UAV every draw, *
      * presumably for culling, which doesn't play *
-     * nicely with D3D11 without vendor libraries */
+     * nicely with D3D11 without vendor libraries 
+     * Also, need the NVAPI hack for Intel GPUs   */
     { R"(\\Stray-Win64-Shipping\.exe$)", {{
       { "d3d11.ignoreGraphicsBarriers",     "True" },
+      { "dxgi.customVendorId",              "1002" },
     }} },
     /* Metal Gear Solid V: Ground Zeroes          *
      * Texture quality can break at high vram     */

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -309,6 +309,11 @@ namespace dxvk {
       { "d3d11.ignoreGraphicsBarriers",     "True" },
       { "dxgi.customVendorId",              "1002" },
     }} },
+    /* System Shock (2023) - NVAPI hack for
+     * Intel GPUs                                 */
+    { R"(\\SystemReShock-Win64-Shipping\.exe$)", {{
+      { "dxgi.customVendorId",              "1002" },
+    }} },
     /* Metal Gear Solid V: Ground Zeroes          *
      * Texture quality can break at high vram     */
     { R"(\\MgsGroundZeroes\.exe$)", {{


### PR DESCRIPTION
These games use UE4 and, without customVendorId, they don't run on Intel GPUs due to NVAPI.