### PR TITLE
[util] Match on the GOG version of KoF XIII as well

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -661,7 +661,7 @@ namespace dxvk {
     }} },
     /* King Of Fighters XIII                     *
      * In-game speed increases on high FPS       */
-    { R"(\\kofxiii\.exe$)", {{
+    { R"(\\kof(xiii|13_win32_Release)\.exe$)", {{
       { "d3d9.maxFrameRate",                "60" },
     }} },
     /* YS Origin                                *


### PR DESCRIPTION
I'm not entirely sure how many people have the game on GOG, but the executable name is different than the one on Steam.

It's a good idea to leverage the game's builtin framerate limiter flag, but in case users are not aware of its existence this ensures they won't think the game is broken with dxvk.