### PR TITLE
[dxvk] Always use LoadLibrary in OpenXR extension provider

### DIFF
--- a/src/dxvk/dxvk_openvr.cpp
+++ b/src/dxvk/dxvk_openvr.cpp
@@ -305,11 +305,14 @@ namespace dxvk {
 
 
   HMODULE VrInstance::loadLibrary() {
-    HMODULE handle = nullptr;
-    if (!(handle = ::GetModuleHandle("openvr_api.dll"))) {
+    HMODULE handle;
+
+    // Use openvr_api.dll only if already loaded in the process (and reference it which GetModuleHandleEx does without
+    // GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT flag).
+    if (!::GetModuleHandleEx(0, "openvr_api.dll", &handle))
       handle = ::LoadLibrary("openvr_api_dxvk.dll");
-      m_loadedOvrApi = handle != nullptr;
-    }
+
+    m_loadedOvrApi = handle != nullptr;
     return handle;
   }
 

--- a/src/dxvk/dxvk_openxr.cpp
+++ b/src/dxvk/dxvk_openxr.cpp
@@ -147,11 +147,9 @@ namespace dxvk {
 
 
   HMODULE DxvkXrProvider::loadLibrary() {
-    HMODULE handle = nullptr;
-    if (!(handle = ::GetModuleHandle("wineopenxr.dll"))) {
-      handle = ::LoadLibrary("wineopenxr.dll");
-      m_loadedOxrApi = handle != nullptr;
-    }
+    HMODULE handle = ::LoadLibrary("wineopenxr.dll");
+
+    m_loadedOxrApi = handle != nullptr;
     return handle;
   }
 


### PR DESCRIPTION
Fixes GTA V randomly crashing on start after recent update.

The crash is due to DxvkXrProvider::queryDeviceExtensions() calls wineopenxr functions while openxr is already unloaded. The logic with GetModuleHandle() can only work correctly if DxvkXrProvider class is a process global singleton. This is not the case during GTA V startup as different instances of the object are present in both dxgi.dll and d3d9.dll and that races resulting in premature library unloading.