### PR TITLE
[util] Set maxChunkSize to 1 for Battle.net

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -387,6 +387,10 @@ namespace dxvk {
     { R"(\\Fallout76\.exe$)", {{
       { "dxgi.syncInterval",              "1" },
     }} },
+    /* Blizzard Entertainment Battle.net          */
+    { R"(\\Battle.net\.exe$)", {{
+      { "dxvk.maxChunkSize",                "1"   },
+    }} },
 
     /**********************************************/
     /* D3D9 GAMES                                 */


### PR DESCRIPTION
Currently when Diablo 4 is running the Battle.net launcher it uses around 600MB of VRAM. Reducing the max chunk size to 1MB reduces the memory usage to around 150MB.

---
Tested with `dxvk.conf`
```
[Battle.net.exe]
dxvk.maxChunkSize = 1
```
`DXVK_CONFIG_FILE=/mnt/games/battlenet/Battle.net/dxvk.conf %command%`

and current Proton Experimental.

### before
```
$ nvidia-smi
Thu Jun 15 01:26:11 2023
+---------------------------------------------------------------------------------------+
| NVIDIA-SMI 530.41.03              Driver Version: 530.41.03    CUDA Version: 12.1     |
|-----------------------------------------+----------------------+----------------------+
| GPU  Name                  Persistence-M| Bus-Id        Disp.A | Volatile Uncorr. ECC |
| Fan  Temp  Perf            Pwr:Usage/Cap|         Memory-Usage | GPU-Util  Compute M. |
|                                         |                      |               MIG M. |
|=========================================+======================+======================|
|   0  NVIDIA GeForce RTX 2060 S...    Off| 00000000:2D:00.0  On |                  N/A |
| 57%   63C    P0               54W / 175W|   7790MiB /  8192MiB |     22%      Default |
|                                         |                      |                  N/A |
+-----------------------------------------+----------------------+----------------------+

+---------------------------------------------------------------------------------------+
| Processes:                                                                            |
|  GPU   GI   CI        PID   Type   Process name                            GPU Memory |
|        ID   ID                                                             Usage      |
|=======================================================================================|
|    0   N/A  N/A     93736      G   /usr/bin/X                                  725MiB |
|    0   N/A  N/A     93771      G   /usr/x86_64-pc-linux-gnu/bin/kwalletd5        2MiB |
|    0   N/A  N/A     93832      G   /usr/x86_64-pc-linux-gnu/bin/ksmserver        2MiB |
|    0   N/A  N/A     93834      G   /usr/x86_64-pc-linux-gnu/bin/kded5            2MiB |
|    0   N/A  N/A     93835      G   /usr/x86_64-pc-linux-gnu/bin/kwin_x11        65MiB |
|    0   N/A  N/A     93882      G   ...x86_64-pc-linux-gnu/bin/plasmashell       29MiB |
|    0   N/A  N/A     93899      G   ...c/polkit-kde-authentication-agent-1        2MiB |
|    0   N/A  N/A     93901      G   ...-gnu/libexec/xdg-desktop-portal-kde        2MiB |
|    0   N/A  N/A     93982      G   ...64-pc-linux-gnu/libexec/kdeconnectd        2MiB |
|    0   N/A  N/A     93988      G   /usr/host/bin/kaccess                         2MiB |
|    0   N/A  N/A     94167      G   /usr/host/bin/konsole                         2MiB |
|    0   N/A  N/A    700889      G   ...14710040,2067270321329485247,262144       29MiB |
|    0   N/A  N/A    706915      G   ...local/share/Steam/ubuntu12_32/steam        3MiB |
|    0   N/A  N/A    706919      G   ...re/Steam/ubuntu12_64/steamwebhelper       16MiB |
|    0   N/A  N/A    707800      G   ...eam/logs/cef_log.txt --shared-files       13MiB |
|    0   N/A  N/A    711998      G   /usr/host/bin/dolphin                         2MiB |
|    0   N/A  N/A    720652    C+G   ...battlenet\Battle.net\Battle.net.exe      589MiB |
|    0   N/A  N/A    720979    C+G   ...s/battlenet/Diablo IV/Diablo IV.exe     6245MiB |
+---------------------------------------------------------------------------------------+
```

### after
```
$ nvidia-smi
Wed Jun 14 23:15:40 2023
+---------------------------------------------------------------------------------------+
| NVIDIA-SMI 530.41.03              Driver Version: 530.41.03    CUDA Version: 12.1     |
|-----------------------------------------+----------------------+----------------------+
| GPU  Name                  Persistence-M| Bus-Id        Disp.A | Volatile Uncorr. ECC |
| Fan  Temp  Perf            Pwr:Usage/Cap|         Memory-Usage | GPU-Util  Compute M. |
|                                         |                      |               MIG M. |
|=========================================+======================+======================|
|   0  NVIDIA GeForce RTX 2060 S...    Off| 00000000:2D:00.0  On |                  N/A |
| 51%   52C    P5               23W / 175W|   7953MiB /  8192MiB |     35%      Default |
|                                         |                      |                  N/A |
+-----------------------------------------+----------------------+----------------------+

+---------------------------------------------------------------------------------------+
| Processes:                                                                            |
|  GPU   GI   CI        PID   Type   Process name                            GPU Memory |
|        ID   ID                                                             Usage      |
|=======================================================================================|
|    0   N/A  N/A     93736      G   /usr/bin/X                                  675MiB |
|    0   N/A  N/A     93771      G   /usr/x86_64-pc-linux-gnu/bin/kwalletd5        2MiB |
|    0   N/A  N/A     93832      G   /usr/x86_64-pc-linux-gnu/bin/ksmserver        2MiB |
|    0   N/A  N/A     93834      G   /usr/x86_64-pc-linux-gnu/bin/kded5            2MiB |
|    0   N/A  N/A     93835      G   /usr/x86_64-pc-linux-gnu/bin/kwin_x11        18MiB |
|    0   N/A  N/A     93882      G   ...x86_64-pc-linux-gnu/bin/plasmashell       29MiB |
|    0   N/A  N/A     93899      G   ...c/polkit-kde-authentication-agent-1        2MiB |
|    0   N/A  N/A     93901      G   ...-gnu/libexec/xdg-desktop-portal-kde        2MiB |
|    0   N/A  N/A     93982      G   ...64-pc-linux-gnu/libexec/kdeconnectd        2MiB |
|    0   N/A  N/A     93988      G   /usr/host/bin/kaccess                         2MiB |
|    0   N/A  N/A     94167      G   /usr/host/bin/konsole                         2MiB |
|    0   N/A  N/A    700889      G   ...14710040,2067270321329485247,262144       77MiB |
|    0   N/A  N/A    706915      G   ...local/share/Steam/ubuntu12_32/steam        3MiB |
|    0   N/A  N/A    706919      G   ...re/Steam/ubuntu12_64/steamwebhelper       16MiB |
|    0   N/A  N/A    707800      G   ...eam/logs/cef_log.txt --shared-files       13MiB |
|    0   N/A  N/A    711998      G   /usr/host/bin/dolphin                         2MiB |
|    0   N/A  N/A    716490    C+G   ...battlenet\Battle.net\Battle.net.exe      133MiB |
|    0   N/A  N/A    717044    C+G   ...s/battlenet/Diablo IV/Diablo IV.exe     6918MiB |
+---------------------------------------------------------------------------------------+
```