### PR TITLE
[util] Set maxChunkSize to 1 for EA App

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -372,6 +372,10 @@ namespace dxvk {
     { R"(\\Rockstar Games\\Social Club\\SocialClubHelper\.exe$)", {{
       { "dxvk.maxChunkSize",                "1"   },
     }} },
+    /* EA Desktop App                             */
+    { R"(\\EADesktop.exe\.exe$)", {{
+      { "dxvk.maxChunkSize",                "1"   },
+    }} },
     /* Fallout 76
      * Game tries to be too "smart" and changes sync
      * interval based on performance (in fullscreen)


### PR DESCRIPTION
Reduces GPU VRAM usage of EADesktop.exe from 162MB to 6MB

Before
![image](https://github.com/doitsujin/dxvk/assets/3117355/84d4c01c-6cd3-431d-aa4e-c4a51a0d29d3)
After
![image](https://github.com/doitsujin/dxvk/assets/3117355/29bcfaed-b616-4967-baea-b3df367177c9)
