### PR TITLE
[util] Set maxChunkSize to 1 for GOG and fix EA App exe name

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -373,7 +373,11 @@ namespace dxvk {
       { "dxvk.maxChunkSize",                "1"   },
     }} },
     /* EA Desktop App                             */
-    { R"(\\EADesktop.exe\.exe$)", {{
+    { R"(\\EADesktop\.exe$)", {{
+      { "dxvk.maxChunkSize",                "1"   },
+    }} },
+    /* GOG Galaxy                                 */
+    { R"(\\GalaxyClient\.exe$)", {{
       { "dxvk.maxChunkSize",                "1"   },
     }} },
     /* Fallout 76


### PR DESCRIPTION
Similar to the other launchers the VRAM goes 600MB+ to 100MB+

Triple checked this time