### PR TITLE
[util] Limit STEINS;GATE ELITE to 60 fps

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -778,6 +778,10 @@ namespace dxvk {
     { R"(\\injustice\.exe$)", {{
       { "d3d9.allowDirectBufferMapping",    "False" },
     }} },
+    /* STEINS;GATE ELITE                       */
+    { R"(\\SG_ELITE\\Game\.exe$)", {{
+      { "d3d9.maxFrameRate",                "60" },
+    }} },
     
     /**********************************************/
     /* D3D12 GAMES (vkd3d-proton with dxvk dxgi)  */


### PR DESCRIPTION
Intros, menu and ui animations are playing way too fast, also causing input issues.

---
Executable name `Game.exe` is unfortunately a bit vague but:

![image](https://github.com/doitsujin/dxvk/assets/414984/a4335b4b-0bc7-4cdc-8cba-4789f2b0920f)

Tested with

```
[Game.exe]
d3d9.maxFrameRate = 60
```
and running the game via steam with `DXVK_CONFIG_FILE=/mnt/games/dxvk-temp/dxvk-steinsgate.conf %command%`.