### PR TITLE
[d3d9] Initialize m_mapFlags to 0

### DIFF
--- a/src/d3d9/d3d9_common_buffer.h
+++ b/src/d3d9/d3d9_common_buffer.h
@@ -225,7 +225,7 @@ namespace dxvk {
 
     D3D9DeviceEx*               m_parent;
     const D3D9_BUFFER_DESC      m_desc;
-    DWORD                       m_mapFlags;
+    DWORD                       m_mapFlags = 0;
     bool                        m_needsReadback = false;
     D3D9_COMMON_BUFFER_MAP_MODE m_mapMode;
 


### PR DESCRIPTION
Part of #3411

I have found in debugging games with d8vk you could sometimes get weird default values for m_mapFlags