### PR TITLE
[d3d9] Fix std::hex in D3D9CommonTexture

### DIFF
--- a/src/d3d9/d3d9_common_texture.cpp
+++ b/src/d3d9/d3d9_common_texture.cpp
@@ -367,7 +367,7 @@ namespace dxvk {
     if (!CheckImageSupport(&imageInfo, imageInfo.tiling)) {
       throw DxvkError(str::format(
         "D3D9: Cannot create texture:",
-        "\n  Type:    ", std::hex, ResourceType,
+        "\n  Type:    0x", std::hex, ResourceType, std::dec,
         "\n  Format:  ", m_desc.Format,
         "\n  Extent:  ", m_desc.Width,
                     "x", m_desc.Height,
@@ -375,8 +375,8 @@ namespace dxvk {
         "\n  Samples: ", m_desc.MultiSample,
         "\n  Layers:  ", m_desc.ArraySize,
         "\n  Levels:  ", m_desc.MipLevels,
-        "\n  Usage:   ", std::hex, m_desc.Usage,
-        "\n  Pool:    ", std::hex, m_desc.Pool));
+        "\n  Usage:   0x", std::hex, m_desc.Usage, std::dec,
+        "\n  Pool:    0x", std::hex, m_desc.Pool, std::dec));
     }
 
     return m_device->GetDXVKDevice()->createImage(imageInfo, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);


### PR DESCRIPTION
It was broken.