### PR TITLE
[util] replaceNaN: Use unaligned SIMD _mm_loadu_ps

### DIFF
--- a/src/util/util_vector.h
+++ b/src/util/util_vector.h
@@ -153,7 +153,7 @@ namespace dxvk {
   inline Vector4 replaceNaN(Vector4 a) {
     #ifdef DXVK_ARCH_X86
     Vector4 result;
-    __m128 value = _mm_load_ps(a.data);
+    __m128 value = _mm_loadu_ps(a.data);
     __m128 mask  = _mm_cmpeq_ps(value, value);
            value = _mm_and_ps(value, mask);
     _mm_store_ps(result.data, value);


### PR DESCRIPTION
There is no good reason to expect games will have aligned the data they're passing in.