### PR TITLE
[util] Allow switching log file at runtime

### DIFF
--- a/src/util/log/log.h
+++ b/src/util/log/log.h
@@ -32,6 +32,8 @@ namespace dxvk {
     
     Logger(const std::string& file_name);
     ~Logger();
+
+    static void setLogFile(const std::string& file_name);
     
     static void trace(const std::string& message);
     static void debug(const std::string& message);
@@ -49,11 +51,12 @@ namespace dxvk {
     static Logger     s_instance;
     
     const LogLevel    m_minLevel;
-    const std::string m_fileName;
     
-    dxvk::mutex       m_mutex;
-    std::ofstream     m_fileStream;
+    dxvk::mutex   m_mutex;
+    std::ofstream m_fileStream;
 
+    std::string   m_fileName;
+    
     bool              m_initialized = false;
     PFN_wineLogOutput m_wineLogOutput = nullptr;
 
@@ -63,6 +66,8 @@ namespace dxvk {
       const std::string& base);
 
     static LogLevel getMinLogLevel();
+
+    static inline bool s_initialized = false;
 
   };
   


### PR DESCRIPTION
Part of #3411

Required since d3d8 is a single DLL, but links d3d9 as a static library, so we need a way to override the initialization-time log filename.