### PR TITLE
[util] Add str::split

### DIFF
--- a/src/util/util_string.h
+++ b/src/util/util_string.h
@@ -212,5 +212,31 @@ namespace dxvk::str {
       dst[count - 1] = '\0';
     }
   }
-  
+
+  /**
+   * \brief Split string at one or more delimiters characters
+   * 
+   * \param [in] string String to split
+   * \param [in] delims Delimiter characters
+   * \returns Vector of substring views
+  */
+  inline std::vector<std::string_view> split(std::string_view string, std::string_view delims = " ") {
+    std::vector<std::string_view> tokens;
+
+    for (size_t start = 0; start < string.size(); ) {
+      // Find first delimiter
+      const auto end = string.find_first_of(delims, start);
+
+      // Add non-empty tokens
+      if (start != end)
+        tokens.emplace_back(string.substr(start, end-start));
+
+      // Break at the end of string
+      if (end == std::string_view::npos)
+        break;
+
+      start = end + 1;
+    }
+    return tokens;
+  }
 }


### PR DESCRIPTION
Part of #3411

Used by d3d8 to parse a complex config option (`forceVsDecl`)