### PR TITLE
[d3d9] Allow changing API name for d3d8

### DIFF
--- a/src/d3d9/d3d9_bridge.cpp
+++ b/src/d3d9/d3d9_bridge.cpp
@@ -28,6 +28,10 @@ namespace dxvk {
     return m_device->QueryInterface(riid, ppvObject);
   }
 
+  void DxvkD3D8Bridge::SetAPIName(const char* name) {
+    m_device->m_implicitSwapchain->SetApiName(name);
+  }
+
   HRESULT DxvkD3D8Bridge::UpdateTextureFromBuffer(
         IDirect3DSurface9*  pDestSurface,
         IDirect3DSurface9*  pSrcSurface,

--- a/src/d3d9/d3d9_bridge.h
+++ b/src/d3d9/d3d9_bridge.h
@@ -24,6 +24,13 @@ IDxvkD3D8Bridge : public IUnknown {
   #endif
 
   /**
+   * \brief Changes the API name displayed on the HUD
+   * 
+   * \param [in] name The new API name 
+   */
+  virtual void SetAPIName(const char* name) = 0;
+
+  /**
    * \brief Updates a D3D9 surface from a D3D9 buffer
    * 
    * \param [in] pDestSurface Destination surface (typically in VRAM)
@@ -45,6 +52,7 @@ MIDL_INTERFACE("D3D9D3D8-A407-773E-18E9-CAFEBEEF3000")
 IDxvkD3D8InterfaceBridge : public IUnknown {
   /**
    * \brief Retrieves the DXVK configuration
+   * 
    * \returns The DXVK Config object
    */
   virtual const dxvk::Config* GetConfig() const = 0;
@@ -73,6 +81,8 @@ namespace dxvk {
     HRESULT STDMETHODCALLTYPE QueryInterface(
             REFIID  riid,
             void** ppvObject);
+
+    void SetAPIName(const char* name);
 
     HRESULT UpdateTextureFromBuffer(
         IDirect3DSurface9*        pDestSurface,

--- a/src/d3d9/d3d9_swapchain.cpp
+++ b/src/d3d9/d3d9_swapchain.cpp
@@ -1068,6 +1068,10 @@ namespace dxvk {
     m_frameLatencySignal->wait(m_frameId - GetActualFrameLatency());
   }
 
+  void D3D9SwapChainEx::SetApiName(const char* name) {
+    m_apiName = name;
+    CreateHud();
+  }
 
   uint32_t D3D9SwapChainEx::GetActualFrameLatency() {
     uint32_t maxFrameLatency = m_parent->GetFrameLatency();
@@ -1298,7 +1302,11 @@ namespace dxvk {
 
 
   std::string D3D9SwapChainEx::GetApiName() {
-    return this->GetParent()->IsExtended() ? "D3D9Ex" : "D3D9";
+    if (m_apiName == nullptr) {
+      return this->GetParent()->IsExtended() ? "D3D9Ex" : "D3D9";
+    } else {
+      return m_apiName;
+    }
   }
 
   D3D9VkExtSwapchain::D3D9VkExtSwapchain(D3D9SwapChainEx *pSwapChain)

--- a/src/d3d9/d3d9_swapchain.h
+++ b/src/d3d9/d3d9_swapchain.h
@@ -122,6 +122,8 @@ namespace dxvk {
 
     void DestroyBackBuffers();
 
+    void SetApiName(const char* name);
+
   private:
 
     enum BindingIds : uint32_t {
@@ -166,6 +168,8 @@ namespace dxvk {
     wsi::DxvkWindowState      m_windowState;
 
     double                    m_displayRefreshRate = 0.0;
+
+    const char*               m_apiName  = nullptr;
 
     bool                      m_warnedAboutGDIFallback = false;
 


### PR DESCRIPTION
Adds a method to D3D8Bridge to change the API displayed on the HUD.