### PR TITLE
[d3d8] Add NVIDIA shadow filtering vendor hack for d3d8

### DIFF
--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -7144,6 +7144,11 @@ namespace dxvk {
 
         stage.Projected      = (ttff & D3DTTFF_PROJECTED) ? 1      : 0;
         stage.ProjectedCount = (ttff & D3DTTFF_PROJECTED) ? count  : 0;
+
+        // [D3D8] Only use Dref sampling for games that could
+        // bind depth textures to fixed function shaders.
+        if (m_dxsoOptions.drefScaling || m_dxsoOptions.shadowFilter)
+          stage.SampleDref = (m_depthTextures & (1 << idx)) != 0;
       }
 
       auto& stage0 = key.Stages[0].Contents;

--- a/src/d3d9/d3d9_fixed_function.cpp
+++ b/src/d3d9/d3d9_fixed_function.cpp
@@ -16,6 +16,7 @@ namespace dxvk {
     invariantPosition = options->invariantPosition;
     forceSampleRateShading = options->forceSampleRateShading;
     drefScaling = options->drefScaling;
+    shadowFilter = options->shadowFilter;
   }
 
   uint32_t DoFixedFunctionFog(D3D9ShaderSpecConstantManager& spec, SpirvModule& spvModule, const D3D9FogContext& fogCtx) {

--- a/src/d3d9/d3d9_fixed_function.cpp
+++ b/src/d3d9/d3d9_fixed_function.cpp
@@ -15,6 +15,7 @@ namespace dxvk {
   D3D9FixedFunctionOptions::D3D9FixedFunctionOptions(const D3D9Options* options) {
     invariantPosition = options->invariantPosition;
     forceSampleRateShading = options->forceSampleRateShading;
+    drefScaling = options->drefScaling;
   }
 
   uint32_t DoFixedFunctionFog(D3D9ShaderSpecConstantManager& spec, SpirvModule& spvModule, const D3D9FogContext& fogCtx) {

--- a/src/d3d9/d3d9_fixed_function.cpp
+++ b/src/d3d9/d3d9_fixed_function.cpp
@@ -1834,6 +1834,11 @@ namespace dxvk {
         return coords;
       };
 
+      auto ScalarReplicate = [&](uint32_t reg) {
+        std::array<uint32_t, 4> replicant = { reg, reg, reg, reg };
+        return m_module.opCompositeConstruct(m_vec4Type, replicant.size(), replicant.data());
+      };
+
       auto GetTexture = [&]() {
         if (!processedTexture) {
           SpirvImageOperands imageOperands;
@@ -1881,10 +1886,28 @@ namespace dxvk {
             shouldProject = false;
           }
 
-          if (shouldProject)
+          if (unlikely(stage.SampleDref)) {
+            uint32_t component = 2;
+            uint32_t reference = m_module.opCompositeExtract(m_floatType, texcoord, 1, &component);
+
+            // [D3D8] Scale Dref to [0..(2^N - 1)] for D24S8 and D16 if Dref scaling is enabled
+            if (m_options.drefScaling) {
+              uint32_t maxDref = m_module.constf32(1.0f / (float(1 << m_options.drefScaling) - 1.0f));
+              reference        = m_module.opFMul(m_floatType, reference, maxDref);
+            }
+
+            texture = m_module.opImageSampleDrefImplicitLod(m_floatType, imageVarId, texcoord, reference, imageOperands);
+
+            if (m_options.shadowFilter) {
+              texture = DoFixedFunctionShadowFilter(m_module, texture, imageVarId, texcoord, reference, imageOperands);
+            }
+
+            texture = ScalarReplicate(texture);
+          } else if (shouldProject) {
             texture = m_module.opImageSampleProjImplicitLod(m_vec4Type, imageVarId, texcoord, imageOperands);
-          else
+          } else {
             texture = m_module.opImageSampleImplicitLod(m_vec4Type, imageVarId, texcoord, imageOperands);
+          }
 
           if (i != 0 && m_fsKey.Stages[i - 1].Contents.ColorOp == D3DTOP_BUMPENVMAPLUMINANCE) {
             uint32_t index = m_module.constu32(D3D9SharedPSStages_Count * (i - 1) + D3D9SharedPSStages_BumpEnvLScale);
@@ -1910,11 +1933,6 @@ namespace dxvk {
         processedTexture = true;
 
         return texture;
-      };
-
-      auto ScalarReplicate = [&](uint32_t reg) {
-        std::array<uint32_t, 4> replicant = { reg, reg, reg, reg };
-        return m_module.opCompositeConstruct(m_vec4Type, replicant.size(), replicant.data());
       };
 
       auto AlphaReplicate = [&](uint32_t reg) {
@@ -2313,6 +2331,11 @@ namespace dxvk {
           dimensionality = spv::Dim2D;
           sampler.texcoordCnt = 2;
           viewType       = VK_IMAGE_VIEW_TYPE_2D;
+
+          // Z coordinate for Dref sampling
+          if (m_fsKey.Stages[i].Contents.SampleDref)
+            sampler.texcoordCnt++;
+
           break;
         case D3DRTYPE_CUBETEXTURE:
           dimensionality = spv::DimCube;

--- a/src/d3d9/d3d9_fixed_function.h
+++ b/src/d3d9/d3d9_fixed_function.h
@@ -51,6 +51,7 @@ namespace dxvk {
     bool    invariantPosition;
     bool    forceSampleRateShading;
     int32_t drefScaling;
+    bool    shadowFilter;
   };
 
   // Returns new oFog if VS

--- a/src/d3d9/d3d9_fixed_function.h
+++ b/src/d3d9/d3d9_fixed_function.h
@@ -54,6 +54,10 @@ namespace dxvk {
     bool    shadowFilter;
   };
 
+  constexpr float GetDrefScaleFactor(int32_t bitDepth) {
+    return 1.0f / (float(1 << bitDepth) - 1.0f);
+  }
+
   // Returns new oFog if VS
   // Returns new oColor if PS
   uint32_t DoFixedFunctionFog(D3D9ShaderSpecConstantManager& spec, SpirvModule& spvModule, const D3D9FogContext& fogCtx);

--- a/src/d3d9/d3d9_fixed_function.h
+++ b/src/d3d9/d3d9_fixed_function.h
@@ -48,8 +48,9 @@ namespace dxvk {
   struct D3D9FixedFunctionOptions {
     D3D9FixedFunctionOptions(const D3D9Options* options);
 
-    bool invariantPosition;
-    bool forceSampleRateShading;
+    bool    invariantPosition;
+    bool    forceSampleRateShading;
+    int32_t drefScaling;
   };
 
   // Returns new oFog if VS

--- a/src/d3d9/d3d9_fixed_function.h
+++ b/src/d3d9/d3d9_fixed_function.h
@@ -64,6 +64,14 @@ namespace dxvk {
 
   void DoFixedFunctionAlphaTest(SpirvModule& spvModule, const D3D9AlphaTestContext& ctx);
 
+  uint32_t DoFixedFunctionShadowFilter(
+        SpirvModule&            module,
+        uint32_t                inSample,
+        uint32_t                sampledImage,
+        uint32_t                coordinates,
+        uint32_t                reference,
+  const SpirvImageOperands&     operands);
+
   // Returns a render state block
   uint32_t SetupRenderStateBlock(SpirvModule& spvModule, uint32_t count);
 

--- a/src/d3d9/d3d9_fixed_function.h
+++ b/src/d3d9/d3d9_fixed_function.h
@@ -177,6 +177,7 @@ namespace dxvk {
         uint32_t     Projected    : 1;
 
         uint32_t     ProjectedCount : 3;
+        uint32_t     SampleDref     : 1;
 
         uint32_t     TextureBound : 1;
 

--- a/src/d3d9/d3d9_options.cpp
+++ b/src/d3d9/d3d9_options.cpp
@@ -77,6 +77,9 @@ namespace dxvk {
     this->samplerLodBias                = config.getOption<float>       ("d3d9.samplerLodBias",                0.0f);
     this->clampNegativeLodBias          = config.getOption<bool>        ("d3d9.clampNegativeLodBias",          false);
 
+    // D3D8 options
+    this->drefScaling                   = config.getOption<int32_t>     ("d3d8.scaleDref",                     0);
+
     // Clamp LOD bias so that people don't abuse this in unintended ways
     this->samplerLodBias = dxvk::fclamp(this->samplerLodBias, -2.0f, 1.0f);
 

--- a/src/d3d9/d3d9_options.cpp
+++ b/src/d3d9/d3d9_options.cpp
@@ -79,6 +79,7 @@ namespace dxvk {
 
     // D3D8 options
     this->drefScaling                   = config.getOption<int32_t>     ("d3d8.scaleDref",                     0);
+    this->shadowFilter                  = config.getOption<bool>        ("d3d8.shadowFilter",                  false);
 
     // Clamp LOD bias so that people don't abuse this in unintended ways
     this->samplerLodBias = dxvk::fclamp(this->samplerLodBias, -2.0f, 1.0f);

--- a/src/d3d9/d3d9_options.h
+++ b/src/d3d9/d3d9_options.h
@@ -152,6 +152,9 @@ namespace dxvk {
 
     /// Enable emulation of device loss when a fullscreen app loses focus
     bool deviceLossOnFocusLoss;
+
+    /// [D3D8] Enable depth texcoord Z (Dref) scaling for games that expect it 
+    int32_t drefScaling;
   };
 
 }

--- a/src/d3d9/d3d9_options.h
+++ b/src/d3d9/d3d9_options.h
@@ -155,6 +155,9 @@ namespace dxvk {
 
     /// [D3D8] Enable depth texcoord Z (Dref) scaling for games that expect it 
     int32_t drefScaling;
+
+    /// [D3D8] Enable hardware shadow filtering emulation for games that expect it
+    bool shadowFilter;
   };
 
 }

--- a/src/dxso/dxso_compiler.cpp
+++ b/src/dxso/dxso_compiler.cpp
@@ -2929,6 +2929,12 @@ void DxsoCompiler::emitControlFlowGenericLoop(
         fetch4,
         imageOperands);
 
+      // [D3D8] Emulate hardware shadow filtering for 2D depth texture lookups.
+      if (depth && m_moduleInfo.options.shadowFilter && samplerType == SamplerTypeTexture2D) {
+        const uint32_t sampledImage = m_module.opLoad(sampler.typeId, sampler.varId);
+        result.id = DoFixedFunctionShadowFilter(m_module, result.id, sampledImage, texcoordVar.id, reference, imageOperands);
+      }
+
       // If we are sampling depth we've already specc'ed this!
       // This path is always size 4 because it only hits on color.
       if (isNull != 0) {

--- a/src/dxso/dxso_compiler.cpp
+++ b/src/dxso/dxso_compiler.cpp
@@ -2896,6 +2896,14 @@ void DxsoCompiler::emitControlFlowGenericLoop(
         uint32_t component = sampler.dimensions;
         reference = m_module.opCompositeExtract(
           fType, texcoordVar.id, 1, &component);
+
+        // [D3D8] Scale Dref from [0..(2^N - 1)] for D24S8 and D16 if Dref scaling is enabled
+        if (m_moduleInfo.options.drefScaling) {
+          uint32_t drefScale       = m_module.constf32(GetDrefScaleFactor(m_moduleInfo.options.drefScaling));
+          reference                = m_module.opFMul(fType, reference, drefScale);
+        }
+
+        // Clamp Dref to [0..1] for D32F emulating UNORM textures 
         uint32_t clampDref = m_spec.get(m_module, m_specUbo, SpecDrefClamp, samplerIdx, 1);
         clampDref = m_module.opINotEqual(bool_t, clampDref, m_module.constu32(0));
         uint32_t clampedDref = m_module.opFClamp(fType, reference, m_module.constf32(0.0f), m_module.constf32(1.0f));

--- a/src/dxso/dxso_options.cpp
+++ b/src/dxso/dxso_options.cpp
@@ -33,6 +33,7 @@ namespace dxvk {
     robustness2Supported = devFeatures.extRobustness2.robustBufferAccess2;
 
     drefScaling         = options.drefScaling;
+    shadowFilter        = options.shadowFilter;
   }
 
 }

--- a/src/dxso/dxso_options.cpp
+++ b/src/dxso/dxso_options.cpp
@@ -31,6 +31,8 @@ namespace dxvk {
 
     longMad = options.longMad;
     robustness2Supported = devFeatures.extRobustness2.robustBufferAccess2;
+
+    drefScaling         = options.drefScaling;
   }
 
 }

--- a/src/dxso/dxso_options.h
+++ b/src/dxso/dxso_options.h
@@ -49,6 +49,12 @@ namespace dxvk {
 
     /// Whether or not we can rely on robustness2 to handle oob constant access
     bool robustness2Supported;
+
+    /// Whether runtime to apply Dref scaling for depth textures of specified bit depth
+    /// (24: D24S8, 16: D16, 0: Disabled). This allows compatability with games
+    /// that expect a different depth test range, which was typically a D3D8 quirk on
+    /// early NVIDIA hardware.
+    int32_t drefScaling = 0;
   };
 
 }

--- a/src/dxso/dxso_options.h
+++ b/src/dxso/dxso_options.h
@@ -55,6 +55,11 @@ namespace dxvk {
     /// that expect a different depth test range, which was typically a D3D8 quirk on
     /// early NVIDIA hardware.
     int32_t drefScaling = 0;
+
+    /// Whether to perform 2x2 PCF when linearly sampling certain depth texture formats,
+    /// as done by early NVIDIA GPUs. The possibility of this behavior is also implied by
+    /// the spec for GL_ARB_shadow and various NVIDIA publications. 
+    bool shadowFilter = false;
   };
 
 }


### PR DESCRIPTION
Part of #3411, but not a requirement for #3411 to merge.

Features:
- Some early D3D8 games expect Dref to be on the range of [0..2^bitDepth - 1], so this adds a config option for DXSO and D3D9 fixed function to scale it back down to [0..1]. [Source](http://www.jiri-dvorak.cz/scellpt/)
- Certain D3D8 games expect hardware to perform shadow filtering when they sample depth textures. This PR adds another config option to enable a basic 2x2 PCF to emulate hardware shadow filtering.

More info:
- http://www.jiri-dvorak.cz/scellpt/
- AlpyneDreams/d8vk#65
- AlpyneDreams/d8vk#69