### PR TITLE
[util] BLADESTORM: Nightmare - Game speed increases when above 60 FPS

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -399,6 +399,12 @@ namespace dxvk {
     { R"(\\Battle.net\.exe$)", {{
       { "dxvk.maxChunkSize",                "1"   },
     }} },
+    /* Bladestorm Nightmare                       *
+     * Game speed increases when above 60 fps in  *
+     * the tavern area                            */
+    { R"(\\BLADESTORM Nightmare\\Launch_(EA|JP)\.exe$)", {{
+      { "dxgi.maxFrameRate",                "60"  },
+    }} },
 
     /**********************************************/
     /* D3D9 GAMES                                 */


### PR DESCRIPTION
The game has 3 v-sync options but doesn't explain what they do. 
0 = 60 FPS
1 = Monitor Refresh Rate
2 = 30 FPS

Framerate is capped at 60 in missions and then up to monitor refresh in the main menu and tavern area

This PR would provide a better default experience for people using option 1 with high refresh displays