### PR TITLE
build: Switch symbols to DWARF 4

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -57,11 +57,10 @@ if platform == 'windows'
     '-Wl,--file-alignment=4096',
   ]
 
-  # Wine's built-in back traces only work with dwarf2 symbols
+  # Wine's built-in back traces only work with dwarf4 symbols
   if get_option('debug')
     compiler_args += [
-      '-gstrict-dwarf',
-      '-gdwarf-2',
+      '-gdwarf-4',
     ]
   endif
 


### PR DESCRIPTION
Since [1], Wine's supports and uses DWARF 4 as default. Make use of it, which should fix inlined stacks and some other small details.

[1]: https://www.winehq.org/pipermail/wine-devel/2021-November/201333.html