### PR TITLE
[util] Limit fps in The Incredibles

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -788,6 +788,10 @@ namespace dxvk {
     { R"(\\SG_ELITE\\Game\.exe$)", {{
       { "d3d9.maxFrameRate",                "60" },
     }} },
+    /* The Incredibles                         */
+    { R"(\\IncPC\.exe$)", {{
+      { "d3d9.maxFrameRate",                "59" },
+    }} },
     
     /**********************************************/
     /* D3D12 GAMES (vkd3d-proton with dxvk dxgi)  */


### PR DESCRIPTION
The higher uneven framerates [can bug the game out](https://www.pcgamingwiki.com/wiki/The_Incredibles#Dash_Glitch). The horrible frame timings is allegedly because even though it appears uncapped besides vsync it will try to reach for 60fps. Even then it has some frame time issues, so opted to cap it just below.

<details>
  <summary>Screenshots</summary>
  
uncapped
![1](https://github.com/doitsujin/dxvk/assets/47954800/68144c08-c424-42b9-8baa-e0d2be20db84)

60
![2](https://github.com/doitsujin/dxvk/assets/47954800/b9d2cd53-1f00-42af-839f-c102f05b52d0)

59
![3](https://github.com/doitsujin/dxvk/assets/47954800/852c1c16-98a6-48ff-997a-0321f0ba8893)
</details>