### PR TITLE
[d3d11] Shared texture flags handling fixes

### DIFF
--- a/src/d3d11/d3d11_device.cpp
+++ b/src/d3d11/d3d11_device.cpp
@@ -2309,6 +2309,10 @@ namespace dxvk {
     d3d11Desc.CPUAccessFlags = metadata.CPUAccessFlags;
     d3d11Desc.MiscFlags      = metadata.MiscFlags;
     d3d11Desc.TextureLayout  = metadata.TextureLayout;
+    if ((d3d11Desc.MiscFlags & D3D11_RESOURCE_MISC_SHARED_NTHANDLE) && !(d3d11Desc.MiscFlags & (D3D11_RESOURCE_MISC_SHARED | D3D11_RESOURCE_MISC_SHARED_KEYEDMUTEX))) {
+      Logger::warn("Fixing up wrong MiscFlags");
+      d3d11Desc.MiscFlags |= D3D11_RESOURCE_MISC_SHARED;
+    }
 
     // Only 2D textures may be shared
     try {

--- a/src/d3d11/d3d11_texture.cpp
+++ b/src/d3d11/d3d11_texture.cpp
@@ -48,7 +48,16 @@ namespace dxvk {
     if (hSharedHandle == nullptr)
       hSharedHandle = INVALID_HANDLE_VALUE;
 
-    if (m_desc.MiscFlags & (D3D11_RESOURCE_MISC_SHARED|D3D11_RESOURCE_MISC_SHARED_NTHANDLE)) {
+    const auto sharingFlags = D3D11_RESOURCE_MISC_SHARED|D3D11_RESOURCE_MISC_SHARED_NTHANDLE|D3D11_RESOURCE_MISC_SHARED_KEYEDMUTEX;
+
+    if (m_desc.MiscFlags & sharingFlags) {
+      if (pDevice->GetFeatureLevel() < D3D_FEATURE_LEVEL_10_0 ||
+          (m_desc.MiscFlags & (D3D11_RESOURCE_MISC_SHARED|D3D11_RESOURCE_MISC_SHARED_KEYEDMUTEX)) == (D3D11_RESOURCE_MISC_SHARED|D3D11_RESOURCE_MISC_SHARED_KEYEDMUTEX) ||
+          (m_desc.MiscFlags & sharingFlags) == D3D11_RESOURCE_MISC_SHARED_NTHANDLE)
+        throw DxvkError(str::format("D3D11: Cannot create shared texture:",
+          "\n  MiscFlags:  ", m_desc.MiscFlags,
+          "\n  FeatureLevel:  ", pDevice->GetFeatureLevel()));
+
       if (m_desc.MiscFlags & D3D11_RESOURCE_MISC_SHARED_KEYEDMUTEX)
         Logger::warn("D3D11_RESOURCE_MISC_SHARED_KEYEDMUTEX: not supported.");
 

--- a/src/d3d11/d3d11_texture.cpp
+++ b/src/d3d11/d3d11_texture.cpp
@@ -719,7 +719,7 @@ namespace dxvk {
       Logger::warn("D3D11: Failed to write shared resource info for a texture");
     }
 
-    if ((m_desc.MiscFlags & D3D11_RESOURCE_MISC_SHARED) && hSharedHandle != INVALID_HANDLE_VALUE)
+    if (hSharedHandle != INVALID_HANDLE_VALUE)
       CloseHandle(hSharedHandle);
   }
   

--- a/src/d3d11/d3d11_texture.cpp
+++ b/src/d3d11/d3d11_texture.cpp
@@ -54,9 +54,9 @@ namespace dxvk {
 
       imageInfo.shared = true;
       imageInfo.sharing.mode = hSharedHandle == INVALID_HANDLE_VALUE ? DxvkSharedHandleMode::Export : DxvkSharedHandleMode::Import;
-      imageInfo.sharing.type = (m_desc.MiscFlags & D3D11_RESOURCE_MISC_SHARED)
-        ? VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_KMT_BIT
-        : VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT;
+      imageInfo.sharing.type = (m_desc.MiscFlags & D3D11_RESOURCE_MISC_SHARED_NTHANDLE)
+        ? VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT
+        : VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_KMT_BIT;
       imageInfo.sharing.handle = hSharedHandle;
     }
 
@@ -696,10 +696,10 @@ namespace dxvk {
   void D3D11CommonTexture::ExportImageInfo() {
     HANDLE hSharedHandle;
 
-    if (m_desc.MiscFlags & D3D11_RESOURCE_MISC_SHARED)
-      hSharedHandle = openKmtHandle( m_image->sharedHandle() );
-    else
+    if (m_desc.MiscFlags & D3D11_RESOURCE_MISC_SHARED_NTHANDLE)
       hSharedHandle = m_image->sharedHandle();
+    else
+      hSharedHandle = openKmtHandle( m_image->sharedHandle() );
 
     DxvkSharedTextureMetadata metadata;
 


### PR DESCRIPTION
Fixes Night Security (steam id 2367230) crash upon reaching 2nd floor during the first mission (soon after beginning of the game, at "1F" to "2F" level transition). The crash is due to shared texture import failure which is due to the mess between handle types (wrongly determined from flags). The texture is created with (D3D11_RESOURCE_MISC_SHARED | D3D11_RESOURCE_MISC_SHARED_NTHANDLE) which looks confusing from the point of view of currently present logic but actually this is the only way one can create a texture with NT shared handle without using D3D11_RESOURCE_MISC_SHARED_KEYEDMUTEX (see below).

Only patch 2 is strictly need for the game, while patch 1 fixes handle (and the shared memory under it) possible leak and the rest are straightening the thing up by adding validations (also covered by the tests) and giving some sense to the changed flag handling.

Here is the test I made which covers all of this behaviour: https://gitlab.winehq.org/wine/wine/-/merge_requests/3247
Attached is the diff on top of the referenced MR with the test which removes fixed todo's (and adds one for NT kernel object name), as well as leaving only the related test to run.

To summarize the test essentials (for some reason not clearly covered in MS docs) for easier understanding what the patches do:
- D3D11_RESOURCE_MISC_SHARED_NTHANDLE can't be used alone, it is actually modifier to D3D11_RESOURCE_MISC_SHARED or D3D11_RESOURCE_MISC_SHARED_KEYEDMUTEX;
- D3D11_RESOURCE_MISC_SHARED and D3D11_RESOURCE_MISC_SHARED_KEYEDMUTEX can't be used together;
- D3D11_RESOURCE_MISC_SHARED or D3D11_RESOURCE_MISC_SHARED_KEYEDMUTEX alone means KMT handle is used, D3D11_RESOURCE_MISC_SHARED_NTHANDLE modifier means NT handle is used;
- IDXGIResource::OpenSharedHandle can only open KMT handle, IDXGIResource1::CreateSharedHandle can only return NT handle (using those with texture with non-matching MiscFlags results in a error);
- Similarly, ID3D11Device_OpenSharedResource can only open KMT handle, ID3D11Device1::OpenSharedResource1 can only open NT handle (this part was already working correctly).

There are some returned value fixes which are not strictly related, but since I tested that anyway...

[test.txt](https://github.com/doitsujin/dxvk/files/11962977/test.txt)
