### PR TITLE
[d3d9] Don't show/hide a software cursor

### DIFF
--- a/src/d3d9/d3d9_cursor.cpp
+++ b/src/d3d9/d3d9_cursor.cpp
@@ -16,7 +16,11 @@ namespace dxvk {
 
 
   BOOL D3D9Cursor::ShowCursor(BOOL bShow) {
-    ::SetCursor(bShow ? m_hCursor : nullptr);
+    if (likely(m_hCursor != nullptr))
+      ::SetCursor(bShow ? m_hCursor : nullptr);
+    else
+      Logger::debug("D3D9Cursor::ShowCursor: Software cursor not implemented.");
+    
     return std::exchange(m_visible, bShow);
   }
 


### PR DESCRIPTION
Since dxvk doesn't implement a software cursor, don't attempt to change its visibility. 

Not 100% certain if this is the right behavior vs native, but I'm trying to fix [...] https://github.com/AlpyneDreams/d8vk/issues/59 , and WineD3D simply seems to ignore the game's calls to `D3D8Device::ShowCursor(FALSE)`, which get forwarded to `D3D9DeviceEx::ShowCursor(FALSE)` with d8vk, as the game's software cursor remains visible even after these calls. This is the right, or at least expected, behavior in this case.

I can hypothesize Cossacks 2 is actually trying to hide a mythical and undefined hardware cursor perhaps, although it doesn't explicitly call `SetCursorProperties()` at all, only `D3D8Device::ShowCursor(FALSE)` after loading the main menu or starting a new game, which is a rather odd behavior...

Age of Mythology also tries to hide/show a software cursor created with Win32, and we end up setting it as nullptr on `D3D8Device::ShowCursor(TRUE)` at the moment, which clearly isn't right. This was causing the missing cursor on the game's main menu.