### PR TITLE
[d3d9] Check depth bounds test when deciding to bind DSV

### DIFF
--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -2308,6 +2308,9 @@ namespace dxvk {
         case D3DRS_ADAPTIVETESS_W:
           if (states[D3DRS_ADAPTIVETESS_X] == uint32_t(D3D9Format::NVDB) || oldNVDB) {
             m_flags.set(D3D9DeviceFlag::DirtyDepthBounds);
+
+            if (m_state.depthStencil != nullptr && m_state.renderStates[D3DRS_ZENABLE])
+              m_flags.set(D3D9DeviceFlag::DirtyFramebuffer);
             break;
           }
         [[fallthrough]];
@@ -5882,7 +5885,8 @@ namespace dxvk {
     if (m_state.depthStencil != nullptr &&
       (m_state.renderStates[D3DRS_ZENABLE]
         || m_state.renderStates[D3DRS_ZWRITEENABLE]
-        || m_state.renderStates[D3DRS_STENCILENABLE])) {
+        || m_state.renderStates[D3DRS_STENCILENABLE]
+        || m_state.renderStates[D3DRS_ADAPTIVETESS_X] == uint32_t(D3D9Format::NVDB))) {
       const DxvkImageCreateInfo& dsImageInfo = m_state.depthStencil->GetCommonTexture()->GetImage()->info();
       const bool depthWrite = m_state.renderStates[D3DRS_ZWRITEENABLE];
 


### PR DESCRIPTION
Fixes a regression in PSO2 spotted by @CME42 

![image](https://github.com/doitsujin/dxvk/assets/1131720/fcfdc987-51ad-42eb-bed2-731cf63b772b)
