### PR TITLE
Add Graphics Pipeline Library readme section and cleanup example config

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ cp x32/*.dll $WINEPREFIX/drive_c/windows/system32
 winecfg
 ```
 
-Verify that your application uses DXVK instead of wined3d by by enabling the HUD (see notes below).
+Verify that your application uses DXVK instead of wined3d by enabling the HUD (see notes below).
 
 In order to remove DXVK from a prefix, remove the DLLs and DLL overrides, and run `wineboot -u` to restore the original DLL files.
 
@@ -116,6 +116,15 @@ Some applications do not provide a method to select a different GPU. In that cas
 
 **Note:** If the device filter is configured incorrectly, it may filter out all devices and applications will be unable to create a D3D device.
 
+### Graphics Pipeline Library
+On drivers which support `VK_EXT_graphics_pipeline_library` Vulkan shaders will be compiled at the time the game loads its D3D shaders, rather than at draw time. This reduces or eliminates shader compile stutter in many games when compared to the previous system.
+
+In games that load their shaders during loading screens or in the menu, this can lead to prolonged periods of very high CPU utilization, especially on weaker CPUs. For affected games it is recommended to wait for shader compilation to finish before starting the game to avoid stutter and low performance. Shader compiler activity can be monitored with `DXVK_HUD=compiler`.
+
+This feature largely replaces the state cache.
+
+**Note:** Games which only load their D3D shaders at draw time (e.g. most Unreal Engine games) will still exhibit some stutter, although it should still be less severe than without this feature.
+
 ### State cache
 DXVK caches pipeline state by default, so that shaders can be recompiled ahead of time on subsequent runs of an application, even if the driver's own shader cache got invalidated in the meantime. This cache is enabled by default, and generally reduces stuttering.
 
@@ -124,6 +133,8 @@ The following environment variables can be used to control the cache:
   - `disable`: Disables the cache entirely.
   - `reset`: Clears the cache file.
 - `DXVK_STATE_CACHE_PATH=/some/directory` Specifies a directory where to put the cache files. Defaults to the current working directory of the application.
+
+This feature is mostly only relevant on systems without support for `VK_EXT_graphics_pipeline_library`
 
 ### Debugging
 The following environment variables can be used for **debugging** purposes.

--- a/dxvk.conf
+++ b/dxvk.conf
@@ -475,15 +475,6 @@
 
 # d3d9.deviceLocalConstantBuffers = False
 
-# No Explicit Front Buffer
-#
-# Disables the front buffer
-#
-# Supported values:
-# - True/False
-
-# d3d9.noExplicitFrontBuffer = False
-
 # Support DF formats
 #
 # Support the vendor extension DF floating point depth formats
@@ -575,7 +566,7 @@
 
 # d3d9.enumerateByDisplays = True
 
-# APITrace Mode
+# Cached Dynamic Buffers
 #
 # Allocates dynamic resources in D3DPOOL_DEFAULT in
 # cached system memory rather than uncached memory or host-visible


### PR DESCRIPTION
Adds a Graphics Pipeline Library section to the readme and removes a dead option from example config while renaming another.

The new readme section is mostly copy pasted from the dxvk 2.0 release notes with some minor changes.