### PR TITLE
[util] Add DXVK_CONFIG to define additional options

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -1090,6 +1090,7 @@ namespace dxvk {
 
     // Load either $DXVK_CONFIG_FILE or $PWD/dxvk.conf
     std::string filePath = env::getEnvVar("DXVK_CONFIG_FILE");
+    std::string confLine = env::getEnvVar("DXVK_CONFIG");
 
     if (filePath == "")
       filePath = "dxvk.conf";
@@ -1097,23 +1098,34 @@ namespace dxvk {
     // Open the file if it exists
     std::ifstream stream(str::topath(filePath.c_str()).c_str());
 
-    if (!stream)
+    if (!stream && confLine.empty())
       return config;
-    
-    // Inform the user that we loaded a file, might
-    // help when debugging configuration issues
-    Logger::info(str::format("Found config file: ", filePath));
 
     // Initialize parser context
     ConfigContext ctx;
     ctx.active = true;
 
-    // Parse the file line by line
-    std::string line;
+    if (stream) {
+      // Inform the user that we loaded a file, might
+      // help when debugging configuration issues
+      Logger::info(str::format("Found config file: ", filePath));
 
-    while (std::getline(stream, line))
-      parseUserConfigLine(config, ctx, line);
-    
+      // Parse the file line by line
+      std::string line;
+
+      while (std::getline(stream, line))
+        parseUserConfigLine(config, ctx, line);
+    }
+
+    if (!confLine.empty()) {
+      // Inform the user that we parsing config from environment, might
+      // help when debugging configuration issues
+      Logger::info(str::format("Found config env: ", confLine));
+
+      for(auto l : str::split(confLine, "#"))
+        parseUserConfigLine(config, ctx, std::string(l.data(), l.size()));
+    }
+
     return config;
   }
 

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -1122,7 +1122,7 @@ namespace dxvk {
       // help when debugging configuration issues
       Logger::info(str::format("Found config env: ", confLine));
 
-      for(auto l : str::split(confLine, "#"))
+      for(auto l : str::split(confLine, ";"))
         parseUserConfigLine(config, ctx, std::string(l.data(), l.size()));
     }
 


### PR DESCRIPTION
Lazy-ass implementation

* <s>`#` used as separator</s>
* `;` used as separator
* options will override/extend those in dxvk.conf file
* <s>`DXVK_CONFIG="dxvk.hud=full#dxvk.blah = blah;blah:blah,#"`</s>
* `DXVK_CONFIG="dxvk.hud = full; dxvk.blah=blah"`

Note:
* `DXVK_HUD` variable still have higher priority than `dxvk.conf` and `DXVK_CONFIG`
* `#` act as comment now (same as in `dxvk.conf`)
     e.g. `DXVK_CONFIG="#Show compiler; dxvk.hud = compiler; #dxvk.blah=blah"`
    Lets call it feature.

Closes: #2894
