### PR TITLE
[build] Use new glslang name with fallback

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -140,7 +140,7 @@ exe_ext = ''
 dll_ext = ''
 def_spec_ext = '.def'
 
-glsl_compiler = find_program('glslangValidator')
+glsl_compiler = find_program('glslang', 'glslangValidator')
 glsl_args = [
   '--quiet',
   '--target-env', 'vulkan1.2',


### PR DESCRIPTION
Fixes the CI failing with the name change even though the changelog says the old name should have a symlink. https://github.com/KhronosGroup/glslang/releases/tag/12.3.0
Even though that is a bug it seems fine to change the name anyway and have a fallback.

Edit: Symlink now fixed on Arch with glslang 12.3.1-2