### PR TITLE
[build] Build using SSSE3/SSE4/4.1/4.2

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -11,6 +11,10 @@ compiler_args = [
   '-msse',
   '-msse2',
   '-msse3',
+  '-mssse3',
+  '-msse4',
+  '-msse4.1',
+  '-msse4.2',
   '-mfpmath=sse',
   '-Wimplicit-fallthrough',
   # gcc


### PR DESCRIPTION
Would like to start by saying I don't have a horse in the race and mostly want to raise this PR as a discussion point, however:
- We've reached the (in)glorious year 2023 AD now
- It might not impact DXVK performance by a lot, but it's free real estate that might make a difference on some newer "potato" CPUs (low end mobile and the like)
- DXVK isn't shy about bumping Vulkan requirements, so should we be lenient on (now ancient) CPUs?
- No offense, but people with a Vulkan 1.3 capable GPU and a Phenom can probably compile dxvk themselves without these flags and let the rest of us live in the present

Also, I think @Joshua-Ashton wanted to do this at some point last year but there was some objection...