### PR TITLE
build: Disable stdcall alias-ing and use kill-at

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -68,8 +68,8 @@ if platform == 'windows'
   if cpu_family == 'x86'
     link_args += [
       '-Wl,--enable-stdcall-fixup',
-      '-Wl,--add-stdcall-alias',
-  ]
+      '-Wl,--kill-at',
+    ]
   endif
 
   lib_d3d9    = cpp.find_library('d3d9')

--- a/src/d3d10/meson.build
+++ b/src/d3d10/meson.build
@@ -7,14 +7,17 @@ d3d10_core_src = [
 d3d10_core_ld_args      = []
 d3d10_core_link_depends = []
 
-if platform != 'windows'
+if platform == 'windows'
+  d3d10_d3d11_dep = lib_d3d11
+else
   d3d10_core_ld_args      += [ '-Wl,--version-script', join_paths(meson.current_source_dir(), 'd3d10core.sym') ]
   d3d10_core_link_depends += files('d3d10core.sym')
+  d3d10_d3d11_dep = d3d11_dep
 endif
 
 d3d10_core_dll = shared_library('d3d10core'+dll_ext, d3d10_core_src, d3d10_core_res,
   name_prefix         : dxvk_name_prefix,
-  dependencies        : [ d3d11_dep ],
+  dependencies        : [ d3d10_d3d11_dep ],
   include_directories : dxvk_include_path,
   install             : true,
   vs_module_defs      : 'd3d10core'+def_spec_ext,

--- a/src/d3d11/meson.build
+++ b/src/d3d11/meson.build
@@ -69,15 +69,18 @@ d3d11_shaders = files([
 d3d11_ld_args      = []
 d3d11_link_depends = []
 
-if platform != 'windows'
+if platform == 'windows'
+  d3d11_dxgi_dep = lib_dxgi
+else
   d3d11_ld_args      += [ '-Wl,--version-script', join_paths(meson.current_source_dir(), 'd3d11.sym') ]
   d3d11_link_depends += files('d3d11.sym')
+  d3d11_dxgi_dep = dxgi_dep
 endif
 
 d3d11_dll = shared_library('d3d11'+dll_ext, dxgi_common_src + d3d11_src + d3d10_src,
     glsl_generator.process(d3d11_shaders), d3d11_res,
   name_prefix         : dxvk_name_prefix,
-  dependencies        : [ dxgi_dep, dxbc_dep, dxvk_dep ],
+  dependencies        : [ d3d11_dxgi_dep, dxbc_dep, dxvk_dep ],
   include_directories : dxvk_include_path,
   install             : true,
   vs_module_defs      : 'd3d11'+def_spec_ext,

--- a/src/d3d9/d3d9_include.h
+++ b/src/d3d9/d3d9_include.h
@@ -12,9 +12,9 @@
 
 //for some reason we need to specify __declspec(dllexport) for MinGW
 #if defined(__WINE__) || !defined(_WIN32)
-#define DLLEXPORT __attribute__((visibility("default")))
+  #define DLLEXPORT __attribute__((visibility("default")))
 #else
-#define DLLEXPORT
+  #define DLLEXPORT
 #endif
 
 

--- a/src/dxgi/dxgi_include.h
+++ b/src/dxgi/dxgi_include.h
@@ -3,10 +3,8 @@
 //for some reason we need to specify __declspec(dllexport) for MinGW
 #if defined(__WINE__) || !defined(_WIN32)
   #define DLLEXPORT __attribute__((visibility("default")))
-#elif defined(_MSC_VER)
-  #define DLLEXPORT
 #else
-  #define DLLEXPORT __declspec(dllexport)
+  #define DLLEXPORT
 #endif
 
 #include "../util/com/com_guid.h"


### PR DESCRIPTION
Disable stdcall aliasing and enable kill-at to ensure our exported functions don't have the @8, @40, etc suffixes.

This still keeps `--enable-stdcall-fixup` as otherwise the linker can get confused trying to find exports from the .def. This does not result in aliases being added, just for them to be found to add to the export table.

This also switches d3d11 to use the MinGW provided dxgi.lib for linking and d3d10 to use the MinGW provided d3d11.lib for linking. Unfortunately the .a's we output seem to still have the @blah that we killed so we cannot use them for internal linkage since using kill-at.

Tested that what we get out of MinGW now is what we want with dllexp.

Supercedes: #3590

Exports

```
➜  build git:(master) ✗ winedump -j export src/dxgi/dxgi.dll
Contents of src/dxgi/dxgi.dll: 129505860 bytes


  Name:            DXGI.DLL
  Characteristics: 00000000
  TimeDateStamp:   64C97A2D Tue Aug  1 22:33:33 2023
  Version:         0.00
  Ordinal base:    9
  # of functions:  9
  # of Names:      5
Addresses of functions: 00423028
Addresses of name ordinals: 00423060
Addresses of names: 0042304C

  Entry Pt  Ordn  Name
  00007C17     9 CreateDXGIFactory
  00007BF3    10 CreateDXGIFactory1
  00007B62    11 CreateDXGIFactory2
  00007C3B    16 DXGIDeclareAdapterRemovalSupport
  00007CD8    17 DXGIGetDebugInterface1

Done dumping src/dxgi/dxgi.dll
```

```
➜  build git:(fix-stdcall-32-bit) winedump -j export src/d3d11/d3d11.dll
Contents of src/d3d11/d3d11.dll: 263021637 bytes


  Name:            D3D11.DLL
  Characteristics: 00000000
  TimeDateStamp:   64C97A2E Tue Aug  1 22:33:34 2023
  Version:         0.00
  Ordinal base:    18
  # of functions:  7
  # of Names:      4
Addresses of functions: 005E3028
Addresses of name ordinals: 005E3054
Addresses of names: 005E3044

  Entry Pt  Ordn  Name
  00020045    18 D3D11CoreCreateDevice
  000200AA    22 D3D11CreateDevice
  0002010E    23 D3D11CreateDeviceAndSwapChain
  0002025F    24 D3D11On12CreateDevice

Done dumping src/d3d11/d3d11.dll
```

Import of DXGI in D3D11

```
  offset 005e1014 dxgi.dll
  Hint/Name Table: 005E408C
  TimeDateStamp:   00000000 (Thu Jan  1 01:00:00 1970)
  ForwarderChain:  00000000
  First thunk RVA: 005E4300
   Thunk    Ordn  Name
  005e4300     4  CreateDXGIFactory1
```