### PR TITLE
[d3d11] Add stub IDXGIKeyedMutex interface.

### DIFF
--- a/src/d3d11/d3d11_resource.h
+++ b/src/d3d11/d3d11_resource.h
@@ -23,6 +23,62 @@ namespace dxvk {
   
 
   /**
+   * \brief IDXGIKeyedMutex implementation
+   */
+  class D3D11DXGIKeyedMutex : public IDXGIKeyedMutex {
+
+  public:
+
+    D3D11DXGIKeyedMutex(
+            ID3D11Resource*         pResource);
+
+    ~D3D11DXGIKeyedMutex();
+
+    ULONG STDMETHODCALLTYPE AddRef();
+
+    ULONG STDMETHODCALLTYPE Release();
+
+    HRESULT STDMETHODCALLTYPE QueryInterface(
+            REFIID                  riid,
+            void**                  ppvObject);
+
+    HRESULT STDMETHODCALLTYPE GetPrivateData(
+            REFGUID                 Name,
+            UINT*                   pDataSize,
+            void*                   pData);
+
+    HRESULT STDMETHODCALLTYPE SetPrivateData(
+            REFGUID                 Name,
+            UINT                    DataSize,
+      const void*                   pData);
+
+    HRESULT STDMETHODCALLTYPE SetPrivateDataInterface(
+            REFGUID                 Name,
+      const IUnknown*               pUnknown);
+
+    HRESULT STDMETHODCALLTYPE GetParent(
+            REFIID                  riid,
+            void**                  ppParent);
+
+    HRESULT STDMETHODCALLTYPE GetDevice(
+            REFIID                  riid,
+            void**                  ppDevice);
+
+    HRESULT STDMETHODCALLTYPE AcquireSync(
+            UINT64                  Key,
+            DWORD                   dwMilliseconds);
+
+    HRESULT STDMETHODCALLTYPE ReleaseSync(
+            UINT64                  Key);
+
+  private:
+
+    ID3D11Resource* m_resource;
+    bool m_warned = false;
+  };
+
+
+  /**
    * \brief IDXGIResource implementation for D3D11 resources
    */
   class D3D11DXGIResource : public IDXGIResource1 {
@@ -86,9 +142,12 @@ namespace dxvk {
             UINT                    index,
             IDXGISurface2**         ppSurface);
 
+    HRESULT GetKeyedMutex(void **ppvObject);
+
   private:
 
     ID3D11Resource* m_resource;
+    D3D11DXGIKeyedMutex m_keyedMutex;
 
   };
 

--- a/src/d3d11/d3d11_texture.cpp
+++ b/src/d3d11/d3d11_texture.cpp
@@ -1146,7 +1146,10 @@ namespace dxvk {
        *ppvObject = ref(&m_resource);
        return S_OK;
     }
-    
+
+    if (riid == __uuidof(IDXGIKeyedMutex))
+      return m_resource.GetKeyedMutex(ppvObject);
+
     if (riid == __uuidof(IDXGIVkInteropSurface)) {
       *ppvObject = ref(&m_interop);
       return S_OK;
@@ -1307,6 +1310,9 @@ namespace dxvk {
        *ppvObject = ref(&m_resource);
        return S_OK;
     }
+
+    if (riid == __uuidof(IDXGIKeyedMutex))
+      return m_resource.GetKeyedMutex(ppvObject);
     
     if (riid == __uuidof(IDXGIVkInteropSurface)) {
       *ppvObject = ref(&m_interop);
@@ -1418,7 +1424,10 @@ namespace dxvk {
        *ppvObject = ref(&m_resource);
        return S_OK;
     }
-    
+
+    if (riid == __uuidof(IDXGIKeyedMutex))
+      return m_resource.GetKeyedMutex(ppvObject);
+
     if (riid == __uuidof(IDXGIVkInteropSurface)) {
       *ppvObject = ref(&m_interop);
       return S_OK;


### PR DESCRIPTION
Partially based on a patch by Derek Lesho.

I am planning on implementing the real support for that (in Proton's winevulkan first), although I guess it should be nothing wrong in having a stub meanwhile. Worst case I think some games will have videos starting showing up but still flickering. The stub already helps some games to properly show videos.

I tested that if the shared resource is created without D3D11_RESOURCE_MISC_SHARED_KEYEDMUTEX, QueryInterface indeed returns E_NOINTERFACE on Windows. It also seems to me that keyed mutex implementation belongs to DXGI resource (like other shared resources stuff) rather than to D3D11 textures of specific types.