### PR TITLE
[d3d9] use strict float emulation for nvk

### DIFF
--- a/src/d3d9/d3d9_options.cpp
+++ b/src/d3d9/d3d9_options.cpp
@@ -89,7 +89,8 @@ namespace dxvk {
       d3d9FloatEmulation = D3D9FloatEmulation::Enabled;
     } else {
       bool hasMulz = adapter != nullptr
-                  && adapter->matchesDriver(VK_DRIVER_ID_MESA_RADV, 0, 0);
+                  && (adapter->matchesDriver(VK_DRIVER_ID_MESA_RADV, 0, 0)
+                   || adapter->matchesDriver(VK_DRIVER_ID_MESA_NVK, 0, 0));
       d3d9FloatEmulation = hasMulz ? D3D9FloatEmulation::Strict : D3D9FloatEmulation::Enabled;
     }
 


### PR DESCRIPTION
nvk supports nir_op_fmulz/ffmaz