### PR TITLE
[util] Limit Conflict Vietnam to 60fps

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -795,6 +795,10 @@ namespace dxvk {
     { R"(\\IncPC\.exe$)", {{
       { "d3d9.maxFrameRate",                "59" },
     }} },
+    /* Conflict Vietnam                        */
+    { R"(\\Vietnam\.exe$)", {{
+      { "d3d9.maxFrameRate",                "60" },
+    }} },
     
     /**********************************************/
     /* D3D12 GAMES (vkd3d-proton with dxvk dxgi)  */


### PR DESCRIPTION
Physics can bug out at high fps making the character fly or get stuck when running up or down slopes.

Closes https://github.com/doitsujin/dxvk/issues/3485