### PR TITLE
[d3d9] Don't resolve an image with 1 sample

### DIFF
--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -4536,9 +4536,12 @@ namespace dxvk {
       if (pResource->GetImage() != nullptr) {
         Rc<DxvkImage> resourceImage = pResource->GetImage();
 
-        Rc<DxvkImage> mappedImage = resourceImage->info().sampleCount != 1
-          ? pResource->GetResolveImage()
-          : std::move(resourceImage);
+        Rc<DxvkImage> mappedImage;
+        if (resourceImage->info().sampleCount != 1) {
+            mappedImage = pResource->GetResolveImage();
+        } else {
+            mappedImage = std::move(resourceImage);
+        }
 
         // When using any map mode which requires the image contents
         // to be preserved, and if the GPU has write access to the


### PR DESCRIPTION
Fixes the following validation errors in Spider Man Shattered Dimensions:

> err:   Validation Error: [ VUID-VkResolveImageInfo2-srcImage-00257 ] Object 0: handle = 0x2820ecf0430, type = VK_OBJECT_TYPE_COMMAND_BUFFER; | MessageID = 0x24e35931 | vkCmdResolveImage2: srcImage sample count is VK_SAMPLE_COUNT_1_BIT. The Vulkan spec states: srcImage must have a sample count equal to any valid sample count value other than VK_SAMPLE_COUNT_1_BIT (https://vulkan.lunarg.com/doc/view/1.3.250.1/windows/1.3-extensions/vkspec.html#VUID-VkResolveImageInfo2-srcImage-00257)

> err:   Validation Error: [ VUID-VkResolveImageInfo2-dstImageLayout-00262 ] Object 0: handle = 0x2820ecf0430, type = VK_OBJECT_TYPE_COMMAND_BUFFER; | MessageID = 0xb2b816de | vkCmdResolveImage2: Cannot use VkImage 0xf3215e0000001a22[] (layer=0 mip=0) with specific layout VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL that doesn't match the previous known layout VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL. The Vulkan spec states: dstImageLayout must specify the layout of the image subresources of dstImage specified in pRegions at the time this command is executed on a VkDevice (https://vulkan.lunarg.com/doc/view/1.3.250.1/windows/1.3-extensions/vkspec.html#VUID-VkResolveImageInfo2-dstImageLayout-00262)

The ternary ends up making a copy instead of moving, so `resourceImage` is never null afterwards.