### PR TITLE
[d3d9] Add a modeHeightFilter config option

### DIFF
--- a/dxvk.conf
+++ b/dxvk.conf
@@ -555,6 +555,19 @@
 
 # d3d9.forceAspectRatio = ""
 
+# Mode Height Filter
+#
+# Only exposes modes with certain heights, if they are
+# also supported by the adapter. Can be used in conjunction
+# with forceAspectRatio to further restrict reported modes.
+# Useful for titles that break when too many modes are reported,
+# e.g., AquaNox, AquaNox 2: Revelation.
+#
+# Supported values:
+# - A list of mode heights, ie. "480,720,1080"
+
+# d3d9.modeHeightFilter = ""
+
 # Enumerate by Displays
 #
 # Whether we should enumerate D3D9 adapters by display (windows behaviour)

--- a/src/d3d9/d3d9_adapter.cpp
+++ b/src/d3d9/d3d9_adapter.cpp
@@ -771,6 +771,14 @@ namespace dxvk {
     uint32_t modeIndex = 0;
 
     const auto forcedRatio = Ratio<DWORD>(options.forceAspectRatio);
+        
+    if (!options.modeHeightFilter.empty() && m_forcedHeights.empty()) {
+      uint32_t forcedHeight;
+      for (auto height : str::split(options.modeHeightFilter, ",")) {
+        std::from_chars(height.data(), height.data() + height.size(), forcedHeight);
+        m_forcedHeights.emplace_back(forcedHeight);
+      }
+    }
 
     while (wsi::getDisplayMode(wsi::getDefaultMonitor(), modeIndex++, &devMode)) {
       // Skip interlaced modes altogether
@@ -782,6 +790,10 @@ namespace dxvk {
         continue;
 
       if (!forcedRatio.undefined() && Ratio<DWORD>(devMode.width, devMode.height) != forcedRatio)
+        continue;
+
+      if (!m_forcedHeights.empty() && 
+           std::find(m_forcedHeights.begin(), m_forcedHeights.end(), devMode.height) == m_forcedHeights.end())
         continue;
 
       D3DDISPLAYMODEEX mode = ConvertDisplayMode(devMode);

--- a/src/d3d9/d3d9_adapter.h
+++ b/src/d3d9/d3d9_adapter.h
@@ -107,6 +107,8 @@ namespace dxvk {
 
     const D3D9VkFormatTable       m_d3d9Formats;
 
+    std::vector<uint32_t>         m_forcedHeights;
+
   };
 
 }

--- a/src/d3d9/d3d9_options.cpp
+++ b/src/d3d9/d3d9_options.cpp
@@ -66,6 +66,7 @@ namespace dxvk {
     this->forceSwapchainMSAA            = config.getOption<int32_t>     ("d3d9.forceSwapchainMSAA",            -1);
     this->forceSampleRateShading        = config.getOption<bool>        ("d3d9.forceSampleRateShading",        false);
     this->forceAspectRatio              = config.getOption<std::string> ("d3d9.forceAspectRatio",              "");
+    this->modeHeightFilter              = config.getOption<std::string> ("d3d9.modeHeightFilter",              "");
     this->enumerateByDisplays           = config.getOption<bool>        ("d3d9.enumerateByDisplays",           true);
     this->longMad                       = config.getOption<bool>        ("d3d9.longMad",                       false);
     this->cachedDynamicBuffers          = config.getOption<bool>        ("d3d9.cachedDynamicBuffers",          false);

--- a/src/d3d9/d3d9_options.h
+++ b/src/d3d9/d3d9_options.h
@@ -103,6 +103,9 @@ namespace dxvk {
     /// Forced aspect ratio, disable other modes
     std::string forceAspectRatio;
 
+    /// Restrict modes based on height
+    std::string modeHeightFilter;
+
     /// Enable dialog mode (ie. no exclusive fullscreen)
     bool enableDialogMode;
 


### PR DESCRIPTION
I've tried to be as generic as possible about the filter, since the idea is to allow people to use it with other games in case they run across similar issues, however with the first 2 AquaNox games it's a particular pain point, because:

- The games won't start at all or crash on resolution change if too many modes are reported. *Too many* seems to be above a dozen total resolutions listed in the menu selection (unsure about how many modes that would actually translate to). Edit: It might actually work mostly fine up to 32 total resolutions (it's hard to be precise here, as it depends on the display).

- Initially we need to expose 640x480 because the games will default to that after install and also after any crashes. They are an absolute pain to get going otherwise.

- Refresh rates don't seem to matter as much here as the total number of resolutions. Based on observed behavior the game appears to pick the highest supported refresh rate for a selected resolution anyway. Also based on observed behavior, adapter formats are counted towards the limit (the games differentiate between 16 and 32 bit color depths).

What I've also tried and didn't work:
- Restricting anything below 640x480. Doesn't lower the mode count enough to matter.
- Forcing an aspect ratio kind of works, I guess. The game is designed with 4:3 in mind, but works just fine with 16:9/16:10 so it wouldn't be ideal to limit it to 4:3.

I'd also like to apologize for blaming ANV for any of the woes with these games. It wasn't ever at fault - it was the display. WineD3D also has the same problems with the games, in case anyone was wondering, so it's not a Vulkan specific issue by any means. It's just an excessive mode count that's causing issues (probably on native as well).