### PR TITLE
[d3d9] Handle sampling from DS_READONLY properly

### DIFF
--- a/src/d3d9/d3d9_common_texture.h
+++ b/src/d3d9/d3d9_common_texture.h
@@ -307,8 +307,8 @@ namespace dxvk {
       return util::computeMipLevelExtent(GetExtent(), MipLevel);
     }
 
-    bool MarkHazardous() {
-      return std::exchange(m_hazardous, true);
+    bool MarkTransitionedToHazardLayout() {
+      return std::exchange(m_transitionedToHazardLayout, true);
     }
 
     D3DRESOURCETYPE GetType() {
@@ -340,7 +340,7 @@ namespace dxvk {
     }
 
     VkImageLayout DetermineRenderTargetLayout(VkImageLayout hazardLayout) const {
-      if (unlikely(m_hazardous))
+      if (unlikely(m_transitionedToHazardLayout))
         return hazardLayout;
 
       return m_image != nullptr &&
@@ -350,18 +350,16 @@ namespace dxvk {
     }
 
     VkImageLayout DetermineDepthStencilLayout(bool write, bool hazardous, VkImageLayout hazardLayout) const {
-      VkImageLayout layout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
-
-      if (unlikely(hazardous)) {
-        layout = write
-          ? hazardLayout
-          : VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_STENCIL_ATTACHMENT_OPTIMAL;
-      }
+      if (unlikely(m_transitionedToHazardLayout))
+        return hazardLayout;
 
       if (unlikely(m_image->info().tiling != VK_IMAGE_TILING_OPTIMAL))
-        layout = VK_IMAGE_LAYOUT_GENERAL;
+        return VK_IMAGE_LAYOUT_GENERAL;
 
-      return layout;
+      if (unlikely(hazardous && !write))
+        return VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_STENCIL_ATTACHMENT_OPTIMAL;
+
+      return VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
     }
 
     Rc<DxvkImageView> CreateView(
@@ -512,7 +510,7 @@ namespace dxvk {
 
     int64_t                       m_size = 0;
 
-    bool                          m_hazardous = false;
+    bool                          m_transitionedToHazardLayout = false;
 
     D3D9ColorView                 m_sampleView;
 


### PR DESCRIPTION
Fixes #3593

Instead of an enum or read/write flags like we discussed, I took a step back and thought about what `CommonTexture::m_hazardous` was actually used for. It's used to track whether the image has been transition to the hazard layout (GENERAL or FEEDBACK_LOOP). That's it. The actual hazard tracking happens in the device.

So the image layout strategy for DS is now as follows:
- If there's a hazard with depth write enabled, we transition to LAYOUT_FEEDBACK_LOOP and keep using that, just like we do for color RTs.
- If there's a hazard with depth write disabled (so technically not a hazard), we use LAYOUT_DEPTH_READ_ONLY for the render pass and transition back to the regular layout afterwards.

Before we would transition between LAYOUT_FEEDBACK_LOOP and LAYOUT_DEPTH_READ_ONLY per render pass.