### PR TITLE
[util] Limit fps in Project: Snowblind

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -799,6 +799,10 @@ namespace dxvk {
     { R"(\\Vietnam\.exe$)", {{
       { "d3d9.maxFrameRate",                "60" },
     }} },
+    /* Project: Snowblind                      */
+    { R"(\\Snowblind(.SP|.MP|.exe)$)", {{
+      { "d3d9.maxFrameRate",                "60" },
+    }} },
     
     /**********************************************/
     /* D3D12 GAMES (vkd3d-proton with dxvk dxgi)  */


### PR DESCRIPTION
Player movement and animation can bug out at high fps like issues moving around objects and the players head detaching slightly when moving backwards. 
Seems like it also helps some crash issues.