### PR TITLE
[meta] Add per-app DXVK_CONFIG example

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,9 @@ The following environment variables can be used for **debugging** purposes.
 - `DXVK_LOG_PATH=/some/directory` Changes path where log files are stored. Set to `none` to disable log file creation entirely, without disabling logging.
 - `DXVK_DEBUG=markers|validation` Enables use of the `VK_EXT_debug_utils` extension for translating performance event markers, or to enable Vulkan validation, respecticely.
 - `DXVK_CONFIG_FILE=/xxx/dxvk.conf` Sets path to the configuration file.
-- `DXVK_CONFIG="dxgi.hideAmdGpu = True; dxgi.syncInterval = 0"` Can be used to set config variables through the environment instead of a configuration file using the same syntax. `;` is used as a seperator.
+- `DXVK_CONFIG="dxgi.hideAmdGpu = True; dxgi.syncInterval = 0"` Can be used to set config variables through the environment instead of a configuration file using the same syntax. `;` is used as a seperator.<br>
+  `DXVK_CONFIG="[launcher.exe];dxvk.maxChunkSize=1;[game.exe];d3d9.presentInterval=0"` Per-app configuration feature example. Can be useful in cases where dxvk option only required for specific executable in chain.
+  
 
 ## Troubleshooting
 DXVK requires threading support from your mingw-w64 build environment. If you


### PR DESCRIPTION
Almost forgot about this feature.
Remembered when running dxvk-tests with single config file. Wanted to change something only for one of the triangle tests.
e.g. `DXVK_CONFIG="[d3d9-triangle.exe];d3d9.presentInterval=0"`