### PR TITLE
[dxgi] Set BitsPerColor to 10

### DIFF
--- a/src/dxgi/dxgi_output.cpp
+++ b/src/dxgi/dxgi_output.cpp
@@ -221,7 +221,7 @@ namespace dxvk {
     pDesc->AttachedToDesktop     = 1;
     pDesc->Rotation              = DXGI_MODE_ROTATION_UNSPECIFIED;
     pDesc->Monitor               = m_monitor;
-    pDesc->BitsPerColor          = 8;
+    pDesc->BitsPerColor          = 10;
     // This should only return DXGI_COLOR_SPACE_RGB_FULL_G2084_NONE_P2020
     // (HDR) if the user has the HDR setting enabled in Windows.
     // Games can still punt into HDR mode by using CheckColorSpaceSupport


### PR DESCRIPTION
For two reasons:
1) Some apps will only enable or attempt to enable HDR if BitsPerColor is >= 10.

2) Encouraging apps to create 10-bit swapchains for use in hardware dithering on Gamescope/Steam Deck and to have more precision thru scanout color transforms