### PR TITLE
Remove unused DxvkResource::waitIdle

### DIFF
--- a/src/dxvk/dxvk_resource.h
+++ b/src/dxvk/dxvk_resource.h
@@ -103,19 +103,6 @@ namespace dxvk {
       return bool(m_useCount.load() & mask);
     }
     
-    /**
-     * \brief Waits for resource to become unused
-     *
-     * Blocks calling thread until the GPU finishes
-     * using the resource with the given access type.
-     * \param [in] access Access type to check for
-     */
-    void waitIdle(DxvkAccess access = DxvkAccess::Read) const {
-      sync::spin(50000, [this, access] {
-        return !isInUse(access);
-      });
-    }
-    
   private:
     
     std::atomic<uint64_t> m_useCount;


### PR DESCRIPTION
Spinning-based wait idle is no longer used.