### PR TITLE
[d3d9] Adjust the MaxActiveLights capability

### DIFF
--- a/src/d3d9/d3d9_adapter.cpp
+++ b/src/d3d9/d3d9_adapter.cpp
@@ -523,7 +523,7 @@ namespace dxvk {
                                      | D3DVTXPCAPS_TEXGEN_SPHEREMAP
                                   /* | D3DVTXPCAPS_NO_TEXGEN_NONLOCALVIEWER*/;
     // Max Active Lights
-    pCaps->MaxActiveLights           = caps::MaxEnabledLights;
+    pCaps->MaxActiveLights           = 8;
     // Max User Clip Planes
     pCaps->MaxUserClipPlanes         = MaxClipPlanes;
     // Max Vertex Blend Matrices

--- a/src/d3d9/d3d9_caps.h
+++ b/src/d3d9/d3d9_caps.h
@@ -27,7 +27,7 @@ namespace dxvk::caps {
 
   constexpr uint32_t TextureStageCount           = MaxSimultaneousTextures;
 
-  constexpr uint32_t MaxEnabledLights             = 8;
+  constexpr uint32_t MaxEnabledLights             = 255;
 
   constexpr uint32_t MaxTexturesVS                = 4;
   constexpr uint32_t MaxTexturesPS                = 16;

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -298,6 +298,8 @@ namespace dxvk {
 
     m_adapter->GetDeviceCaps(m_deviceType, pCaps);
 
+    // Native drivers report either 255 or UINT_MAX when doing SWVP
+    pCaps->MaxActiveLights           = m_isSWVP ? caps::MaxEnabledLights : 10;
     // When in SWVP mode, 256 matrices can be used for indexed vertex blending
     pCaps->MaxVertexBlendMatrixIndex = m_isSWVP ? 255 : 8;
 


### PR DESCRIPTION
Probably won't affect much, but in practice the number of SWVP active lights shouldn't be limited to 8, and native drivers report either 255 or UINT_MAX here. Also bumped the HWVP value to 10 while at it, as it's what both native Nvidia and AMD report.

Native Nvidia:
`  ~ MaxActiveLights: 8 (I*), 255 (SWVP), 10 (HWVP)`

Native AMD:
`  ~ MaxActiveLights: 8 (I*), 4294967295 (SWVP), 10 (HWVP)`

\* I is what IDirect3D->GetDeviceCaps() reports, while SWVP/HWVP values are reported on IDirect3DDevice->GetDeviceCaps()

There might be some games that end up using less lights then they would on native because of the current status quo, but that's really hard to pin down (dxvk isn't actively enforcing any of these limits anyway, so it's up to game code). 

Also, d8vk is far more likely to be impacted due to the increased prevalence of SWVP.