### PR TITLE
A few more WinDef types in windows_base.h

### DIFF
--- a/include/native/windows/windows_base.h
+++ b/include/native/windows/windows_base.h
@@ -48,7 +48,6 @@ typedef const void* LPCVOID;
 typedef size_t SIZE_T;
 
 typedef int8_t INT8;
-
 typedef uint8_t UINT8;
 typedef uint8_t BYTE;
 
@@ -56,9 +55,13 @@ typedef int16_t SHORT;
 typedef uint16_t USHORT;
 
 typedef int64_t LONGLONG;
+typedef int64_t INT64;
+
 typedef uint64_t ULONGLONG;
+typedef uint64_t UINT64;
 
 typedef intptr_t LONG_PTR;
+typedef uintptr_t ULONG_PTR;
 
 typedef float FLOAT;
 


### PR DESCRIPTION
These specific ones are used in MS's d3dx12 headers