### PR TITLE
[util] Add config for Halo Online ( massive performance increase )

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -785,6 +785,7 @@ namespace dxvk {
      * Black textures                          */
     { R"(\\eldorado\.exe$)", {{
       { "d3d9.floatEmulation",              "Strict"   },
+      { "d3d9.allowDirectBufferMapping",    "False" },
     }} },
     /* Injustice: Gods Among Us                *
      * Locks a buffer that's still in use      */


### PR DESCRIPTION
Insane Performance increase With d3d9.allowDirectBufferMapping To false
oddly enough seems like the performance issue only apply's to AMD card since Radeon HD 4000 To current RX card,
I was wondering If I can also get this command to work without using the Vulkan graphic api as The majority playersbase in
eldewrito (Halo online) uses Radeon GPU that doesn't support Vulkan. It would be nice if its possible.

Here are some proof that using the commands makes the game run faster
https://www.youtube.com/watch?v=vRG7wRrptiY