### PR TITLE
[d3d11] Pass device directly to D3D11DXGIKeyedMutex

### DIFF
--- a/src/d3d11/d3d11_buffer.cpp
+++ b/src/d3d11/d3d11_buffer.cpp
@@ -12,7 +12,7 @@ namespace dxvk {
     const D3D11_ON_12_RESOURCE_INFO*  p11on12Info)
   : D3D11DeviceChild<ID3D11Buffer>(pDevice),
     m_desc        (*pDesc),
-    m_resource    (this),
+    m_resource    (this, pDevice),
     m_d3d10       (this) {
     DxvkBufferCreateInfo info;
     info.flags  = 0;

--- a/src/d3d11/d3d11_resource.cpp
+++ b/src/d3d11/d3d11_resource.cpp
@@ -9,11 +9,10 @@
 namespace dxvk {
 
   D3D11DXGIKeyedMutex::D3D11DXGIKeyedMutex(
-          ID3D11Resource* pResource)
-  : m_resource(pResource) {
-    Com<ID3D11Device> device;
-    m_resource->GetDevice(&device);
-    m_device = static_cast<D3D11Device*>(device.ptr());
+          ID3D11Resource* pResource,
+          D3D11Device*    pDevice)
+  : m_resource(pResource),
+    m_device(pDevice) {
 
     m_supported = m_device->GetDXVKDevice()->features().khrWin32KeyedMutex
                && m_device->GetDXVKDevice()->vkd()->wine_vkAcquireKeyedMutex != nullptr
@@ -120,9 +119,10 @@ namespace dxvk {
   }
 
   D3D11DXGIResource::D3D11DXGIResource(
-          ID3D11Resource*         pResource)
+          ID3D11Resource*         pResource,
+          D3D11Device*            pDevice)
   : m_resource(pResource),
-    m_keyedMutex(pResource) {
+    m_keyedMutex(pResource, pDevice) {
 
   }
 

--- a/src/d3d11/d3d11_resource.h
+++ b/src/d3d11/d3d11_resource.h
@@ -30,7 +30,8 @@ namespace dxvk {
   public:
 
     D3D11DXGIKeyedMutex(
-            ID3D11Resource*         pResource);
+            ID3D11Resource*         pResource,
+            D3D11Device*            pDevice);
 
     ~D3D11DXGIKeyedMutex();
 
@@ -88,7 +89,8 @@ namespace dxvk {
   public:
     
     D3D11DXGIResource(
-            ID3D11Resource*         pResource);
+            ID3D11Resource*         pResource,
+            D3D11Device*            pDevice);
 
     ~D3D11DXGIResource();
 

--- a/src/d3d11/d3d11_texture.cpp
+++ b/src/d3d11/d3d11_texture.cpp
@@ -1099,7 +1099,7 @@ namespace dxvk {
     m_texture (this, pDevice, pDesc, p11on12Info, D3D11_RESOURCE_DIMENSION_TEXTURE1D, 0, VK_NULL_HANDLE, nullptr),
     m_interop (this, &m_texture),
     m_surface (this, &m_texture),
-    m_resource(this),
+    m_resource(this, pDevice),
     m_d3d10   (this) {
     
   }
@@ -1205,7 +1205,7 @@ namespace dxvk {
     m_texture   (this, pDevice, pDesc, p11on12Info, D3D11_RESOURCE_DIMENSION_TEXTURE2D, 0, VK_NULL_HANDLE, hSharedHandle),
     m_interop   (this, &m_texture),
     m_surface   (this, &m_texture),
-    m_resource  (this),
+    m_resource  (this, pDevice),
     m_d3d10     (this),
     m_swapChain (nullptr) {
   }
@@ -1220,7 +1220,7 @@ namespace dxvk {
     m_texture   (this, pDevice, pDesc, nullptr, D3D11_RESOURCE_DIMENSION_TEXTURE2D, DxgiUsage, vkImage, nullptr),
     m_interop   (this, &m_texture),
     m_surface   (this, &m_texture),
-    m_resource  (this),
+    m_resource  (this, pDevice),
     m_d3d10     (this),
     m_swapChain (nullptr) {
     
@@ -1236,7 +1236,7 @@ namespace dxvk {
     m_texture   (this, pDevice, pDesc, nullptr, D3D11_RESOURCE_DIMENSION_TEXTURE2D, DxgiUsage, VK_NULL_HANDLE, nullptr),
     m_interop   (this, &m_texture),
     m_surface   (this, &m_texture),
-    m_resource  (this),
+    m_resource  (this, pDevice),
     m_d3d10     (this),
     m_swapChain (pSwapChain) {
     
@@ -1384,7 +1384,7 @@ namespace dxvk {
   : D3D11DeviceChild<ID3D11Texture3D1>(pDevice),
     m_texture (this, pDevice, pDesc, p11on12Info, D3D11_RESOURCE_DIMENSION_TEXTURE3D, 0, VK_NULL_HANDLE, nullptr),
     m_interop (this, &m_texture),
-    m_resource(this),
+    m_resource(this, pDevice),
     m_d3d10   (this) {
     
   }


### PR DESCRIPTION
Fixes a crash with reshade mod (https://github.com/ValveSoftware/Proton/issues/3977#issuecomment-1716597154).

The mod modifies GetDevice function pointer in resource's vtable, and that triggers the crash in D3D11DXGIKeyedMutex::D3D11DXGIKeyedMutex(). Calling public interface to get dxvk device there was a bad idea.