### PR TITLE
[d3d9] Mark presenter for recreation on device reset with deferSurfaceCreation

### DIFF
--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -482,6 +482,9 @@ namespace dxvk {
     Flush();
     SynchronizeCsThread(DxvkCsThread::SynchronizeAll);
 
+    if (m_d3d9Options.deferSurfaceCreation)
+      m_deviceHasBeenReset = true;
+
     return D3D_OK;
   }
 

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -1022,6 +1022,12 @@ namespace dxvk {
     bool CanSWVP() const {
       return m_behaviorFlags & (D3DCREATE_MIXED_VERTEXPROCESSING | D3DCREATE_SOFTWARE_VERTEXPROCESSING);
     }
+
+    // Device Reset detection for D3D9SwapChainEx::Present
+    bool IsDeviceReset() {
+      return std::exchange(m_deviceHasBeenReset, false);
+    }
+
     void DetermineConstantLayouts(bool canSWVP);
 
     D3D9BufferSlice AllocUPBuffer(VkDeviceSize size);
@@ -1325,6 +1331,7 @@ namespace dxvk {
     VkImageLayout                   m_hazardLayout = VK_IMAGE_LAYOUT_GENERAL;
 
     bool                            m_usingGraphicsPipelines = false;
+    bool                            m_deviceHasBeenReset = false;
 
     DxvkDepthBiasRepresentation     m_depthBiasRepresentation = { VK_DEPTH_BIAS_REPRESENTATION_LEAST_REPRESENTABLE_VALUE_FORMAT_EXT, false };
     float                           m_depthBiasScale  = 0.0f;

--- a/src/d3d9/d3d9_swapchain.cpp
+++ b/src/d3d9/d3d9_swapchain.cpp
@@ -147,6 +147,8 @@ namespace dxvk {
     bool recreate = false;
     recreate   |= m_wctx->presenter == nullptr;
     recreate   |= m_dialog != m_lastDialog;
+    if (options->deferSurfaceCreation)
+      recreate |= m_parent->IsDeviceReset();
 
     if (m_wctx->presenter != nullptr) {
       m_dirty  |= m_wctx->presenter->setSyncInterval(presentInterval) != VK_SUCCESS;


### PR DESCRIPTION
I don't particularly like having to do this either, so I've hid it under deferSurfaceCreation for now, as it seems to work around the same sort of problem, albeit at later stages in a swapchain's lifecycle.

Fixes Scrapland (Remastered), which apart from the intro video plays videos using ddraw (or maybe d3d7, haven't *really* checked, but it's not d3d8) when starting a new game or in between some levels, which will end up in a black screen with d8vk/dxvk unless we mark the presenter for recreation. Latest WineD3D somehow handles this sort of multiple swapchains on the same window situation just fine, although Scrapland was broken for a while there too with the same behavior (black screen after video playblack apart from the intro).

The first d3d8 thing the game calls after it's done with playing videos is a device Reset(), which is what gave me this rather awful, but working idea.