### PR TITLE
[d3d9] Only set initial NeedsUpload for D3DPOOL_MANAGED textures

### DIFF
--- a/src/d3d9/d3d9_common_texture.cpp
+++ b/src/d3d9/d3d9_common_texture.cpp
@@ -31,11 +31,12 @@ namespace dxvk {
       AddDirtyBox(nullptr, i);
     }
 
-    if (m_desc.Pool != D3DPOOL_DEFAULT) {
+    if (m_desc.Pool != D3DPOOL_DEFAULT && pSharedHandle) {
+      throw DxvkError("D3D9: Incompatible pool type for texture sharing.");
+    }
+
+    if (IsPoolManaged(m_desc.Pool)) {
       SetAllNeedUpload();
-      if (pSharedHandle) {
-        throw DxvkError("D3D9: Incompatible pool type for texture sharing.");
-      }
     }
 
     m_mapping = pDevice->LookupFormat(m_desc.Format);


### PR DESCRIPTION
IMO this is the better fix for #3662.

Right now, binding a system mem / scratch texture will make us call FlushImage for that texture which crashes because there is no image. On top of that, we may end up uploading recently created D3DPOOL_DEFAULT textures which means we basically clear it again.