### PR TITLE
[d3d9] Add a device compatibility mode for d3d8

### DIFF
--- a/src/d3d9/d3d9_bridge.cpp
+++ b/src/d3d9/d3d9_bridge.cpp
@@ -32,6 +32,10 @@ namespace dxvk {
     m_device->m_implicitSwapchain->SetApiName(name);
   }
 
+  void DxvkD3D8Bridge::SetD3D8CompatibilityMode(const bool compatMode) {
+    m_device->SetD3D8CompatibilityMode(compatMode);
+  }
+
   HRESULT DxvkD3D8Bridge::UpdateTextureFromBuffer(
         IDirect3DSurface9*  pDestSurface,
         IDirect3DSurface9*  pSrcSurface,

--- a/src/d3d9/d3d9_bridge.h
+++ b/src/d3d9/d3d9_bridge.h
@@ -31,6 +31,13 @@ IDxvkD3D8Bridge : public IUnknown {
   virtual void SetAPIName(const char* name) = 0;
 
   /**
+   * \brief Enables or disables D3D9-specific device features and validations
+   * 
+   * \param [in] compatibility state
+   */
+  virtual void SetD3D8CompatibilityMode(const bool compatMode) = 0;
+
+  /**
    * \brief Updates a D3D9 surface from a D3D9 buffer
    * 
    * \param [in] pDestSurface Destination surface (typically in VRAM)
@@ -83,6 +90,7 @@ namespace dxvk {
             void** ppvObject);
 
     void SetAPIName(const char* name);
+    void SetD3D8CompatibilityMode(const bool compatMode);
 
     HRESULT UpdateTextureFromBuffer(
         IDirect3DSurface9*        pDestSurface,

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -2360,7 +2360,8 @@ namespace dxvk {
     try {
       const Com<D3D9StateBlock> sb = new D3D9StateBlock(this, ConvertStateBlockType(Type));
       *ppSB = sb.ref();
-      m_losableResourceCounter++;
+      if (!m_isD3D8Compatible)
+        m_losableResourceCounter++;
 
       return D3D_OK;
     }
@@ -2392,7 +2393,8 @@ namespace dxvk {
       return D3DERR_INVALIDCALL;
 
     *ppSB = m_recorder.ref();
-    m_losableResourceCounter++;
+    if (!m_isD3D8Compatible)
+      m_losableResourceCounter++;
     m_recorder = nullptr;
 
     return D3D_OK;

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -970,6 +970,17 @@ namespace dxvk {
     void TouchMappedTexture(D3D9CommonTexture* pTexture);
     void RemoveMappedTexture(D3D9CommonTexture* pTexture);
 
+    bool IsD3D8Compatible() const {
+      return m_isD3D8Compatible;
+    }
+
+    void SetD3D8CompatibilityMode(bool compatMode) {
+      if (compatMode)
+        Logger::info("The D3D9 device is now operating in D3D8 compatibility mode.");
+
+      m_isD3D8Compatible = compatMode;
+    }
+
     // Device Lost
     bool IsDeviceLost() const {
       return m_deviceLostState != D3D9DeviceLostState::Ok;
@@ -1318,9 +1329,10 @@ namespace dxvk {
     D3D9ShaderMasks                 m_psShaderMasks = FixedFunctionMask;
 
     bool                            m_isSWVP;
-    bool                            m_amdATOC         = false;
-    bool                            m_nvATOC          = false;
-    bool                            m_ffZTest         = false;
+    bool                            m_isD3D8Compatible = false;
+    bool                            m_amdATOC          = false;
+    bool                            m_nvATOC           = false;
+    bool                            m_ffZTest          = false;
     
     VkImageLayout                   m_hazardLayout = VK_IMAGE_LAYOUT_GENERAL;
 

--- a/src/d3d9/d3d9_stateblock.cpp
+++ b/src/d3d9/d3d9_stateblock.cpp
@@ -18,7 +18,8 @@ namespace dxvk {
   }
 
   D3D9StateBlock::~D3D9StateBlock() {
-    m_parent->DecrementLosableCounter();
+    if (!m_parent->IsD3D8Compatible())
+      m_parent->DecrementLosableCounter();
   }
 
   HRESULT STDMETHODCALLTYPE D3D9StateBlock::QueryInterface(


### PR DESCRIPTION
Long story short, the behavior of losable resource validation on device Reset() differs slightly between d3d9 and d3d8 in the sense that d3d8 state blocks survive Reset() calls and shouldn't be considered losable. 

D3D8 games like AIM 2: Clan Wars and others depend on this to work properly. Quick tests have also confirmed WineD3D ignores D3D8 state blocks on calls to device Reset().

At @K0bin's suggestion I've given a broader meaning to the member variable, since we might end up using it to toggle other d3d8-specific behavior in the future.

