### PR TITLE
[dxvk] Don't use minImageCount + 1 for picking image count

### DIFF
--- a/src/dxvk/dxvk_presenter.cpp
+++ b/src/dxvk/dxvk_presenter.cpp
@@ -604,7 +604,7 @@ namespace dxvk {
           uint32_t                  minImageCount,
           uint32_t                  maxImageCount,
           uint32_t                  desired) {
-    uint32_t count = minImageCount + 1;
+    uint32_t count = minImageCount;
     
     if (count < desired)
       count = desired;


### PR DESCRIPTION
The image counts we get in X11/Wayland for FIFO are insane at like 3/4 already, we don't need to make input latency worse by bumping that to 4/5.