### PR TITLE
[util] Enable cachedDynamicBuffers for Battlestations Midway

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -819,6 +819,10 @@ namespace dxvk {
     { R"(\\AoK HD\.exe$)", {{
       { "d3d9.maxFrameLatency",             "1" },
     }} },
+    /* Battlestations Midway                   */
+    { R"(\\Battlestationsmidway\.exe$)", {{
+      { "d3d9.cachedDynamicBuffers",     "True" },
+    }} },
 
     /**********************************************/
     /* D3D12 GAMES (vkd3d-proton with dxvk dxgi)  */


### PR DESCRIPTION
Helps performance dips that can happen in some areas

<details>
  <summary>Screenshots</summary>
  
![Screenshot_20231002_212831](https://github.com/doitsujin/dxvk/assets/47954800/8f500e84-e575-4188-9b7f-67d4b3e35f84)
![Screenshot_20231002_213112](https://github.com/doitsujin/dxvk/assets/47954800/c9c598ce-e368-482d-a14d-fdd099fec963)
</details>

I'm leaving Battlestations Pacific out of this PR as even when i seem to get past the Games For Windows Live related crashes i still crash sitting in the main menu before i can get in game and test if it would benefit the same.