### PR TITLE
[dxgi] Add useMonitorFallback option

### DIFF
--- a/dxvk.conf
+++ b/dxvk.conf
@@ -623,3 +623,14 @@
 # DO NOT CHANGE THIS UNLESS YOU HAVE A VERY GOOD REASON.
 
 # d3d9.textureMemory = 100
+
+# Always enumerate all monitors on each dxgi output
+#
+# Used to avoid performance degradation in some games
+# (will be deprecated once QueryDisplayConfig optimization
+# is in Proton Wine).
+#
+# Supported values:
+# - True/False
+
+# dxgi.useMonitorFallback = False

--- a/src/dxgi/dxgi_factory.cpp
+++ b/src/dxgi/dxgi_factory.cpp
@@ -124,10 +124,13 @@ namespace dxvk {
       }
     }
 
+
     // If any monitors are left on the list, enable the
     // fallback to always enumerate all monitors.
     if ((m_monitorFallback = !monitors.empty()))
       Logger::warn("DXGI: Found monitors not associated with any adapter, using fallback");
+    else
+      m_monitorFallback = m_options.useMonitorFallback;
   }
   
   

--- a/src/dxgi/dxgi_options.cpp
+++ b/src/dxgi/dxgi_options.cpp
@@ -101,6 +101,10 @@ namespace dxvk {
       Logger::info("HDR was configured to be enabled, but has been force disabled as a UE4 DX11 game was detected.");
       this->enableHDR = false;
     }
+
+    this->useMonitorFallback = config.getOption<bool>("dxgi.useMonitorFallback", env::getEnvVar("DXVK_MONITOR_FALLBACK") == "1");
+    if (this->useMonitorFallback)
+      Logger::info("Enabled useMonitorFallback option");
   }
   
 }

--- a/src/dxgi/dxgi_options.h
+++ b/src/dxgi/dxgi_options.h
@@ -44,6 +44,9 @@ namespace dxvk {
 
     /// Enable HDR
     bool enableHDR;
+
+    /// Use monitor fallback to enumerating all monitors per output
+    bool useMonitorFallback;
   };
   
 }

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -846,6 +846,13 @@ namespace dxvk {
     { R"(\\RiftApart\.exe$)", {{
       { "dxgi.hideNvidiaGpu",               "False" },
     }} },
+    /* CP2077 enumerates display outputs each frame.
+     * Avoid using QueryDisplayConfig to avoid
+     * performance degradation until the
+     * optimization of that function is in Proton. */
+    { R"(\\Cyberpunk2077\.exe$)", {{
+      { "dxgi.useMonitorFallback",          "True" },
+    }} },
   }};
 
 


### PR DESCRIPTION
And enable it for CP2077.
It is supposed to be dropped once QueryDisplayConfig optimization is in Proton Wine.