### PR TITLE
[util] Enable useMonitorFallback for Holocure

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -417,6 +417,11 @@ namespace dxvk {
     { R"(\\RidersRepublic(_BE)?\.exe$)", {{
       { "dxgi.hideAmdGpu",                "True"   },
     }} },
+    /* HoloCure - Save the Fans!
+       Same as Cyberpunk 2077                     */
+    { R"(\\HoloCure\.exe$)", {{
+      { "dxgi.useMonitorFallback",          "True" },
+    }} },
 
     /**********************************************/
     /* D3D9 GAMES                                 */


### PR DESCRIPTION
Temporary performance drop workaround until QueryDisplayConfig optimization is in Proton Wine.