### PR TITLE
[util] Disable allowDirectBufferMapping for SkyDrift

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -828,6 +828,11 @@ namespace dxvk {
     { R"(\\Battlestationsmidway\.exe$)", {{
       { "d3d9.cachedDynamicBuffers",     "True" },
     }} },
+    /* SkyDrift                                 *
+     * Works around alt tab OOM crash           */
+    { R"(\\SkyDrift\.exe$)" , {{
+      { "d3d9.allowDirectBufferMapping",    "False" },
+    }} },
 
     /**********************************************/
     /* D3D12 GAMES (vkd3d-proton with dxvk dxgi)  */


### PR DESCRIPTION
Works around a alt tab OOM crash.

https://github.com/doitsujin/dxvk/issues/3639 is kept open for a deeper root cause look when there is time.