### PR TITLE
Add NV low latency support

### DIFF
--- a/src/d3d11/d3d11_initializer.cpp
+++ b/src/d3d11/d3d11_initializer.cpp
@@ -280,7 +280,7 @@ namespace dxvk {
 
 
   void D3D11Initializer::FlushInternal() {
-    m_context->flushCommandList(nullptr);
+    m_context->flushCommandList(nullptr, false);
     
     m_transferCommands = 0;
     m_transferMemory   = 0;

--- a/src/d3d11/d3d11_interfaces.h
+++ b/src/d3d11/d3d11_interfaces.h
@@ -16,6 +16,7 @@ enum D3D11_VK_EXTENSION : uint32_t {
   D3D11_VK_EXT_BARRIER_CONTROL            = 3,
   D3D11_VK_NVX_BINARY_IMPORT              = 4,
   D3D11_VK_NVX_IMAGE_VIEW_HANDLE          = 5,
+  D3D11_VK_NV_LOW_LATENCY_2               = 6
 };
 
 
@@ -27,6 +28,33 @@ enum D3D11_VK_BARRIER_CONTROL : uint32_t {
   D3D11_VK_BARRIER_CONTROL_IGNORE_GRAPHICS_UAV        = 1 << 1,
 };
 
+/**
+ * \brief Frame Report Info
+ */
+typedef struct D3D11_LATENCY_RESULTS
+{
+    UINT32 version;
+    struct D3D11_FRAME_REPORT {
+        UINT64 frameID;
+        UINT64 inputSampleTime;
+        UINT64 simStartTime;
+        UINT64 simEndTime;
+        UINT64 renderSubmitStartTime;
+        UINT64 renderSubmitEndTime;
+        UINT64 presentStartTime;
+        UINT64 presentEndTime;
+        UINT64 driverStartTime;
+        UINT64 driverEndTime;
+        UINT64 osRenderQueueStartTime;
+        UINT64 osRenderQueueEndTime;
+        UINT64 gpuRenderStartTime;
+        UINT64 gpuRenderEndTime;
+        UINT32 gpuActiveRenderTimeUs;
+        UINT32 gpuFrameTimeUs;
+        UINT8 rsvd[120];
+    } frame_reports[64];
+    UINT8 rsvd[32];
+} D3D11_LATENCY_RESULTS;
 
 /**
  * \brief Extended shader interface
@@ -114,6 +142,33 @@ ID3D11VkExtDevice1 : public ID3D11VkExtDevice {
           uint32_t*               pCudaTextureHandle) = 0;
 };
 
+/**
+ * \brief Extended extended D3D11 device
+ * 
+ * Introduces methods to get virtual addresses and driver
+ * handles for resources, and create and destroy objects
+ * for D3D11-Cuda interop.
+ */
+MIDL_INTERFACE("f3112584-41f9-348d-a59b-00b7e1d285d6")
+ID3DLowLatencyDevice : public IUnknown {
+    static const GUID guid;
+
+    virtual BOOL STDMETHODCALLTYPE SupportsLowLatency() = 0;
+
+    virtual HRESULT STDMETHODCALLTYPE LatencySleep() = 0;
+
+    virtual HRESULT STDMETHODCALLTYPE SetLatencySleepMode(
+        BOOL     lowLatencyMode,
+        BOOL     lowLatencyBoost,
+        uint32_t minimumIntervalUs) = 0;
+
+    virtual HRESULT STDMETHODCALLTYPE SetLatencyMarker(
+        uint64_t frameID,
+        uint32_t markerType) = 0;
+
+    virtual HRESULT STDMETHODCALLTYPE GetLatencyInfo(
+        D3D11_LATENCY_RESULTS* latencyResults) = 0;
+};
 
 /**
  * \brief Extended D3D11 context
@@ -189,4 +244,5 @@ __CRT_UUID_DECL(ID3D11VkExtDevice,         0x8a6e3c42,0xf74c,0x45b7,0x82,0x65,0x
 __CRT_UUID_DECL(ID3D11VkExtDevice1,        0xcfcf64ef,0x9586,0x46d0,0xbc,0xa4,0x97,0xcf,0x2c,0xa6,0x1b,0x06);
 __CRT_UUID_DECL(ID3D11VkExtContext,        0xfd0bca13,0x5cb6,0x4c3a,0x98,0x7e,0x47,0x50,0xde,0x2c,0xa7,0x91);
 __CRT_UUID_DECL(ID3D11VkExtContext1,       0x874b09b2,0xae0b,0x41d8,0x84,0x76,0x5f,0x3b,0x7a,0x0e,0x87,0x9d);
+__CRT_UUID_DECL(ID3DLowLatencyDevice,      0xf3112584,0x41f9,0x348d,0xa5,0x9b,0x00,0xb7,0xe1,0xd2,0x85,0xd6);
 #endif

--- a/src/d3d11/d3d11_swapchain.h
+++ b/src/d3d11/d3d11_swapchain.h
@@ -86,6 +86,22 @@ namespace dxvk {
     void STDMETHODCALLTYPE GetFrameStatistics(
             DXGI_VK_FRAME_STATISTICS* pFrameStatistics);
 
+    void SetLatencySleepMode(
+            bool lowLatencyMode,
+            bool lowLatencyBoost,
+            uint32_t minimumIntervalUs);
+
+    void LatencySleep();
+
+    void SetLatencyMarker(
+            VkLatencyMarkerNV marker,
+            uint64_t presentId);
+
+    void GetLatencyTimings(
+            std::vector<VkLatencyTimingsFrameReportNV>& frameReports);
+
+    bool LowLatencyEnabled();
+
   private:
 
     enum BindingIds : uint32_t {

--- a/src/dxvk/dxvk_adapter.cpp
+++ b/src/dxvk/dxvk_adapter.cpp
@@ -927,6 +927,9 @@ namespace dxvk {
       m_deviceFeatures.khrPresentWait.pNext = std::exchange(m_deviceFeatures.core.pNext, &m_deviceFeatures.khrPresentWait);
     }
 
+    if (m_deviceExtensions.supports(VK_NV_LOW_LATENCY_2_EXTENSION_NAME))
+      m_deviceFeatures.nvLowLatency2 = VK_TRUE;
+
     if (m_deviceExtensions.supports(VK_NVX_BINARY_IMPORT_EXTENSION_NAME))
       m_deviceFeatures.nvxBinaryImport = VK_TRUE;
 
@@ -994,6 +997,7 @@ namespace dxvk {
       &devExtensions.khrPresentWait,
       &devExtensions.khrSwapchain,
       &devExtensions.khrWin32KeyedMutex,
+      &devExtensions.nvLowLatency2,
       &devExtensions.nvxBinaryImport,
       &devExtensions.nvxImageViewHandle,
     }};
@@ -1133,8 +1137,13 @@ namespace dxvk {
       enabledFeatures.khrPresentWait.pNext = std::exchange(enabledFeatures.core.pNext, &enabledFeatures.khrPresentWait);
     }
 
-    if (devExtensions.nvxBinaryImport)
+    if (devExtensions.nvxBinaryImport) {
       enabledFeatures.nvxBinaryImport = VK_TRUE;
+    }
+
+    if (devExtensions.nvLowLatency2) {
+      enabledFeatures.nvLowLatency2 = VK_TRUE;
+    }
 
     if (devExtensions.nvxImageViewHandle)
       enabledFeatures.nvxImageViewHandle = VK_TRUE;
@@ -1279,6 +1288,8 @@ namespace dxvk {
       "\n  presentId                              : ", features.khrPresentId.presentId ? "1" : "0",
       "\n", VK_KHR_PRESENT_WAIT_EXTENSION_NAME,
       "\n  presentWait                            : ", features.khrPresentWait.presentWait ? "1" : "0",
+      "\n", VK_NV_LOW_LATENCY_2_EXTENSION_NAME,
+      "\n  extension supported                    : ", features.nvLowLatency2 ? "1" : "0",
       "\n", VK_NVX_BINARY_IMPORT_EXTENSION_NAME,
       "\n  extension supported                    : ", features.nvxBinaryImport ? "1" : "0",
       "\n", VK_NVX_IMAGE_VIEW_HANDLE_EXTENSION_NAME,

--- a/src/dxvk/dxvk_cmdlist.h
+++ b/src/dxvk/dxvk_cmdlist.h
@@ -94,7 +94,8 @@ namespace dxvk {
      */
     VkResult submit(
             DxvkDevice*           device,
-            VkQueue               queue);
+            VkQueue               queue,
+            uint64_t              frameId);
 
     /**
      * \brief Resets object
@@ -199,7 +200,7 @@ namespace dxvk {
      * \brief Submits command list
      * \returns Submission status
      */
-    VkResult submit();
+    VkResult submit(uint64_t frameId);
     
     /**
      * \brief Stat counters

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -105,9 +105,9 @@ namespace dxvk {
   }
 
 
-  void DxvkContext::flushCommandList(DxvkSubmitStatus* status) {
+  void DxvkContext::flushCommandList(DxvkSubmitStatus* status, bool enableFrameId) {
     m_device->submitCommandList(
-      this->endRecording(), status);
+      this->endRecording(), status, enableFrameId);
     
     this->beginRecording(
       m_device->createCommandList());

--- a/src/dxvk/dxvk_context.h
+++ b/src/dxvk/dxvk_context.h
@@ -65,8 +65,9 @@ namespace dxvk {
      * Transparently submits the current command
      * buffer and allocates a new one.
      * \param [out] status Submission feedback
+     * \param [in] enableFrameId Submission should include the frame id
      */
-    void flushCommandList(DxvkSubmitStatus* status);
+    void flushCommandList(DxvkSubmitStatus* status, bool enableFrameId = true);
     
     /**
      * \brief Begins generating query data

--- a/src/dxvk/dxvk_device.cpp
+++ b/src/dxvk/dxvk_device.cpp
@@ -18,6 +18,7 @@ namespace dxvk {
     m_properties        (adapter->devicePropertiesExt()),
     m_perfHints         (getPerfHints()),
     m_objects           (this),
+    m_latencyMarkers    ({}),
     m_queues            (queues),
     m_submissionQueue   (this, queueCallback) {
 
@@ -271,9 +272,12 @@ namespace dxvk {
 
   void DxvkDevice::submitCommandList(
     const Rc<DxvkCommandList>&      commandList,
-          DxvkSubmitStatus*         status) {
+          DxvkSubmitStatus*         status,
+          bool                      enableFrameId) {
     DxvkSubmitInfo submitInfo = { };
     submitInfo.cmdList = commandList;
+    submitInfo.frameId = enableFrameId ?
+      m_latencyMarkers.render : 0;
     m_submissionQueue.submit(submitInfo, status);
 
     std::lock_guard<sync::Spinlock> statLock(m_statLock);

--- a/src/dxvk/dxvk_device_info.h
+++ b/src/dxvk/dxvk_device_info.h
@@ -68,6 +68,7 @@ namespace dxvk {
     VkPhysicalDeviceMaintenance5FeaturesKHR                   khrMaintenance5;
     VkPhysicalDevicePresentIdFeaturesKHR                      khrPresentId;
     VkPhysicalDevicePresentWaitFeaturesKHR                    khrPresentWait;
+    VkBool32                                                  nvLowLatency2;
     VkBool32                                                  nvxBinaryImport;
     VkBool32                                                  nvxImageViewHandle;
     VkBool32                                                  khrWin32KeyedMutex;

--- a/src/dxvk/dxvk_extensions.h
+++ b/src/dxvk/dxvk_extensions.h
@@ -325,6 +325,7 @@ namespace dxvk {
     DxvkExt khrPresentWait                    = { VK_KHR_PRESENT_WAIT_EXTENSION_NAME,                       DxvkExtMode::Optional };
     DxvkExt khrSwapchain                      = { VK_KHR_SWAPCHAIN_EXTENSION_NAME,                          DxvkExtMode::Required };
     DxvkExt khrWin32KeyedMutex                = { VK_KHR_WIN32_KEYED_MUTEX_EXTENSION_NAME,                  DxvkExtMode::Optional };
+    DxvkExt nvLowLatency2                     = { VK_NV_LOW_LATENCY_2_EXTENSION_NAME,                       DxvkExtMode::Optional };
     DxvkExt nvxBinaryImport                   = { VK_NVX_BINARY_IMPORT_EXTENSION_NAME,                      DxvkExtMode::Disabled };
     DxvkExt nvxImageViewHandle                = { VK_NVX_IMAGE_VIEW_HANDLE_EXTENSION_NAME,                  DxvkExtMode::Disabled };
   };

--- a/src/dxvk/dxvk_presenter.h
+++ b/src/dxvk/dxvk_presenter.h
@@ -15,6 +15,7 @@
 #include "../vulkan/vulkan_loader.h"
 
 #include "dxvk_format.h"
+#include "dxvk_fence.h"
 
 namespace dxvk {
 
@@ -224,6 +225,42 @@ namespace dxvk {
      */
     void setHdrMetadata(const VkHdrMetadataEXT& hdrMetadata);
 
+    /**
+     * \brief Set the latency mode of the swapchain
+     *
+     * \param [in] enableLowLatency Determines if the low latency
+     * mode should be enabled of disabled
+     */
+    void setLatencySleepMode(bool lowLatencyMode, bool lowLatencyBoost, uint32_t minimumIntervalUs);
+
+    /**
+     * \brief Delay rendering work for lower latency
+     */
+    void latencySleep();
+
+    /**
+     * \brief Set a latency marker for the given stage
+     *
+     * \param [in] marker The stage this marker is for
+     * \param [in] presentId The presentId this marker is for
+     */
+    void setLatencyMarker(VkLatencyMarkerNV marker, uint64_t presentId);
+
+    /**
+     * \brief Get the low latency timing info
+     *
+     * \param [out] latencyInfo The structure to place
+     * the latency timings into
+     */
+    void getLatencyTimings(std::vector<VkLatencyTimingsFrameReportNV>& frameReports);
+
+    /**
+     * \brief Returns the low latency enabled state
+     */
+    bool lowLatencyEnabled() {
+      return m_lowLatencyEnabled && m_presentSupportsLowLatency;
+    }
+
   private:
 
     Rc<DxvkDevice>    m_device;
@@ -237,10 +274,17 @@ namespace dxvk {
     VkSurfaceKHR      m_surface     = VK_NULL_HANDLE;
     VkSwapchainKHR    m_swapchain   = VK_NULL_HANDLE;
 
+    DxvkFenceValuePair m_lowLatencyFence   = {};
+    bool               m_lowLatencyEnabled = false;
+    bool               m_lowLatencyBoost   = false; 
+    uint32_t           m_minimumIntervalUs = 0;
+    bool               m_presentSupportsLowLatency = false;
+
     std::vector<PresenterImage> m_images;
     std::vector<PresenterSync>  m_semaphores;
 
     std::vector<VkPresentModeKHR> m_dynamicModes;
+    std::vector<VkPresentModeKHR> m_lowLatencyModes;
 
     uint32_t          m_imageIndex = 0;
     uint32_t          m_frameIndex = 0;
@@ -250,6 +294,7 @@ namespace dxvk {
     FpsLimiter        m_fpsLimiter;
 
     dxvk::mutex                 m_frameMutex;
+    dxvk::mutex                 m_lowLatencyMutex;
     dxvk::condition_variable    m_frameCond;
     dxvk::thread                m_frameThread;
     std::queue<PresenterFrame>  m_frameQueue;

--- a/src/dxvk/dxvk_queue.cpp
+++ b/src/dxvk/dxvk_queue.cpp
@@ -126,7 +126,7 @@ namespace dxvk {
           m_callback(true);
 
         if (entry.submit.cmdList != nullptr)
-          entry.result = entry.submit.cmdList->submit();
+          entry.result = entry.submit.cmdList->submit(entry.submit.frameId);
         else if (entry.present.presenter != nullptr)
           entry.result = entry.present.presenter->presentImage(entry.present.presentMode, entry.present.frameId);
 

--- a/src/dxvk/dxvk_queue.h
+++ b/src/dxvk/dxvk_queue.h
@@ -32,6 +32,7 @@ namespace dxvk {
    */
   struct DxvkSubmitInfo {
     Rc<DxvkCommandList> cmdList;
+    uint64_t frameId;
   };
   
   

--- a/src/vulkan/vulkan_loader.h
+++ b/src/vulkan/vulkan_loader.h
@@ -452,6 +452,14 @@ namespace dxvk::vk {
     VULKAN_FN(wine_vkAcquireKeyedMutex);
     VULKAN_FN(wine_vkReleaseKeyedMutex);
     #endif
+
+    #ifdef VK_NV_LOW_LATENCY_2_EXTENSION_NAME
+    VULKAN_FN(vkSetLatencySleepModeNV);
+    VULKAN_FN(vkLatencySleepNV);
+    VULKAN_FN(vkSetLatencyMarkerNV);
+    VULKAN_FN(vkGetLatencyTimingsNV);
+    VULKAN_FN(vkQueueNotifyOutOfBandNV);
+    #endif
   };
   
 }


### PR DESCRIPTION
This pull request implements a new device interface called ID3DLowLatencyDevice using the VK_NV_low_latency2 extension. The purpose of this interface, is to give dxvk-nvapi a way to implement the nvapi Reflex interface.