### PR TITLE
[dxgi] Treat R16G16B16A16_FLOAT as 32bpp for display

### DIFF
--- a/src/dxgi/dxgi_monitor.cpp
+++ b/src/dxgi/dxgi_monitor.cpp
@@ -107,7 +107,11 @@ namespace dxvk {
         return 32;
       
       case DXGI_FORMAT_R16G16B16A16_FLOAT:
-        return 64;
+        // Floating point output doesn't really make sense.
+        // This seemingly works on Windows, and based on FindClosestMode etc documentaton,
+        // this seems required to work for any format that scanout it supported for.
+        // Treat as 10-bit -> 32.
+        return 32;
       
       default:
         Logger::warn(str::format(


### PR DESCRIPTION
HDR in Control (a patch released by a developer post-launch, not actually in the game sadly) tries to set a video mode with DXGI_FORMAT_R16G16B16A16_FLOAT.

This seemingly works on Windows, and based on FindClosestMode etc documentaton, this seems required to work for any format that scanout it supported for.

It's really not like the bpp is meaningful on Windows with the distinction of 8bit and 10bit not working in GDI modes at all. Nor does it end up actually setting anything on Linux/Deck where modesets are emulated.

So, treat DXGI_FORMAT_R16G16B16A16_FLOAT as 32bpp so the FindClosestMatchingMode and EnterFullscreenMode calls succeed.