### PR TITLE
Add config for C&C Generals ZH (solve crashing + performance increase )

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -837,7 +837,6 @@ namespace dxvk {
      * solve loading saved and replay missions  *
      * crash due to limited memory              */
     { R"(\\generals\.exe$)" , {{
-      { "d3d9.maxAvailableMemory",          "6144" },
       { "d3d9.memoryTrackTest",             "True" },
       { "d3d9.textureMemory",               "2048" },
     }} },

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -833,6 +833,14 @@ namespace dxvk {
     { R"(\\SkyDrift\.exe$)" , {{
       { "d3d9.allowDirectBufferMapping",    "False" },
     }} },
+    /* C&C Generals                             *
+     * solve loading saved and replay missions  *
+     * crash due to limited memory              */
+    { R"(\\generals\.exe$)" , {{
+      { "d3d9.maxAvailableMemory",          "6144" },
+      { "d3d9.memoryTrackTest",             "True" },
+      { "d3d9.textureMemory",               "2048" },
+    }} },
 
     /**********************************************/
     /* D3D12 GAMES (vkd3d-proton with dxvk dxgi)  */


### PR DESCRIPTION
Solved the problem of the game crashing when it starts loading saved missions or skirmish, especially for Mods
+ Huge performance increase.
+ Solve Alt tab crashing.