### PR TITLE
[Util] two more executables to workaround Warhammer Online

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -568,7 +568,7 @@ namespace dxvk {
       { "d3d9.customDeviceId",              "0402" },
     }} },
     /* Warhammer: Online                         */
-    { R"(\\WAR(-64)?\.exe$)", {{
+    { R"(\\(WAR(-64)?|WARTEST(-64)?)\.exe$)", {{
       { "d3d9.customVendorId",              "1002" },
     }} },
     /* Dragon Nest                               */


### PR DESCRIPTION
Test server executables need the same VendorID to work around the rendering issues.