### PR TITLE
[d3d11] Lock context in KeyedMutex::ReleaseSync

### DIFF
--- a/src/d3d11/d3d11_context_imm.h
+++ b/src/d3d11/d3d11_context_imm.h
@@ -89,6 +89,10 @@ namespace dxvk {
     void SynchronizeCsThread(
             uint64_t                          SequenceNumber);
 
+    D3D10Multithread& GetMultithread() {
+        return m_multithread;
+    }
+
     D3D10DeviceLock LockContext() {
       return m_multithread.AcquireLock();
     }


### PR DESCRIPTION
WaitForResource is supposed to be externally synchronized.

Supersedes #3717

@yshui checked and the VRChat does enable D3D11Multithread. So this is an easy fix.
*If* it's legal to access the KeyedMutex from other threads without the context lock we can worry about that once we hit that case.