### PR TITLE
[util] Set numCompilerThreads to 1 for Crossout

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -833,6 +833,11 @@ namespace dxvk {
     { R"(\\SkyDrift\.exe$)" , {{
       { "d3d9.allowDirectBufferMapping",    "False" },
     }} },
+    /* Crossout                                 *
+     * Works around shader compilation crash    */
+    { R"(\\Crossout\.exe$)" , {{
+      { "dxvk.numCompilerThreads",          "1"},
+    }} },
 
     /**********************************************/
     /* D3D12 GAMES (vkd3d-proton with dxvk dxgi)  */


### PR DESCRIPTION
Unfortunately, it seems like there's no way for us to get a grip on what's causing the stack smashing problem, so I thought it would be best to work around it for now. 