### PR TITLE
[util] Don't spoof Nvidia on AMD GPUs in Hitman 3

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -131,8 +131,8 @@ namespace dxvk {
     { R"(\\vr\.exe$)", {{
       { "d3d11.dcSingleUseMode",            "False" },
     }} },
-    /* Hitman 2 and 3 - requires AGS library      */
-    { R"(\\HITMAN(2|3)\.exe$)", {{
+    /* Hitman 2 - requires AGS library      */
+    { R"(\\HITMAN2\.exe$)", {{
       { "dxgi.customVendorId",              "10de" },
     }} },
     /* Modern Warfare Remastered                  */
@@ -862,6 +862,10 @@ namespace dxvk {
      * optimization of that function is in Proton. */
     { R"(\\Cyberpunk2077\.exe$)", {{
       { "dxgi.useMonitorFallback",          "True" },
+    }} },
+    /* Hitman 3 - Ray Tracing                      */
+    { R"(\\HITMAN3\.exe$)", {{
+      { "dxgi.hideNvidiaGpu",              "False" },
     }} },
   }};
 


### PR DESCRIPTION
Spoofing to Nvidia prevents ray tracing enablement on AMD and the game does not crash without ags anymore.
Hitman 2 still needs ags to not crash on startup. (game doesn't support RT)