### PR TITLE
[util] Set deviceLossOnFocusLoss for Assassin's Creed 2

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -836,6 +836,11 @@ namespace dxvk {
     { R"(\\SkyDrift\.exe$)" , {{
       { "d3d9.allowDirectBufferMapping",    "False" },
     }} },
+     /* Assassin's Creed 2                      *
+     *  Helps alt tab crash on Linux            */
+    { R"(\\AssassinsCreedIIGame\.exe$)" , {{
+      { "d3d9.deviceLossOnFocusLoss",       "True" },
+    }} },
 
     /**********************************************/
     /* D3D12 GAMES (vkd3d-proton with dxvk dxgi)  */


### PR DESCRIPTION
Makes it not crash on alt tab when using at least Proton on Linux. Was unable to test regular Wine or Staging as Ubisoft Connect doesn't work there currently.
See [issue description](https://github.com/doitsujin/dxvk/issues/3653) for behavior on Windows.

Closes #3653