### PR TITLE
[util] Enable cached vertex buffers for Kenshi

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -425,6 +425,11 @@ namespace dxvk {
     { R"(\\HoloCure\.exe$)", {{
       { "dxgi.useMonitorFallback",          "True" },
     }} },
+    /* Kenshi                                     *
+     * Helps CPU bound performance                */
+    { R"(\\kenshi_x64\.exe$)", {{
+      { "d3d11.cachedDynamicResources",     "v"    },
+    }} },
 
     /**********************************************/
     /* D3D9 GAMES                                 */


### PR DESCRIPTION
Improves the games performance when CPU bound.
Tested on a Radeon RX 6800 and Ryzen 7950x

<details>
  <summary>Screenshots</summary>
  
Without
![Screenshot_20231229_221337](https://github.com/doitsujin/dxvk/assets/47954800/bcc4e3b8-9f68-4b5e-92aa-2baa7010ed04)

With
![Screenshot_20231229_221745-1](https://github.com/doitsujin/dxvk/assets/47954800/97e76565-bfdc-49d4-8a86-7ec58188fab1)
</details>