### PR TITLE
[util] Set float emulation to Strict for UK Truck Simulator 1

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -845,6 +845,11 @@ namespace dxvk {
     { R"(\\soniccd\.exe$)", {{
       { "d3d9.maxFrameRate",                "60" },
     }} },
+    /* UK Truck Simulator 1                    */
+    { R"(\\UK Truck Simulator\\bin\\win_x86\\game\.exe$)", {{
+      { "d3d9.floatEmulation",              "Strict" },
+    }} },
+    
 
     /**********************************************/
     /* D3D12 GAMES (vkd3d-proton with dxvk dxgi)  */


### PR DESCRIPTION
Fixes #3780 