### PR TITLE
[util] Enable deviceLossOnFocusLoss for BF2 and BF2142

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -545,9 +545,15 @@ namespace dxvk {
       { "d3d9.supportDFFormats",            "False" },
       { "d3d9.deviceLossOnFocusLoss",       "True" },
     }} },
-    /* Battlefield 2 (bad z-pass)                 */
+    /* Battlefield 2                              *
+     * Bad z-pass and ingame GUI loss on alt tab  */
     { R"(\\BF2\.exe$)", {{
-      { "d3d9.longMad",                     "True" },
+      { "d3d9.longMad",                     "True" },  
+      { "d3d9.deviceLossOnFocusLoss",       "True" },
+    }} },
+    /* Battlefield 2142 - Same GUI issue as BF2   */
+    { R"(\\BF2142\.exe$)", {{ 
+      { "d3d9.deviceLossOnFocusLoss",       "True" },
     }} },
     /* SpellForce 2 Series                        */
     { R"(\\SpellForce2.*\.exe$)", {{


### PR DESCRIPTION
By total coincidence i stumbled upon https://github.com/doitsujin/dxvk/issues/3651 while i was doing a random test of Battlefield 2142 with Proton. The issue shows when you alt tab out and in of the game. 
When i had tested BF2 originally for the issue i think i did it in regular Wine where i had to enable virtual desktop for it to not just show a black screen which then makes the behavior not show. Proton doesn't have this issue and so i reproduced immediate there when alt tabbing in BF2142 and then went back to check BF2 again.

Fixes #3651 