### PR TITLE
[d3d9] workaround for EDG frontend based compilers

### DIFF
--- a/src/d3d9/d3d9_state.h
+++ b/src/d3d9/d3d9_state.h
@@ -303,7 +303,8 @@ namespace dxvk {
         }
         else {
           for (UINT i = 0; i < Count; i++)
-            set->fConsts[StartRegister + i] = replaceNaN(pConstantData + (i * 4));
+            // The (float*) cast is a workaround for a bug in the EDG compiler frontend
+            set->fConsts[StartRegister + i] = replaceNaN((float*)pConstantData + (i * 4));
         }
       }
       else if constexpr (ConstantType == D3D9ConstantType::Int) {


### PR DESCRIPTION
EDG frontend based compilers can't find suitable constructor to convert from "const int *"

```
lcc: "../src/d3d9/d3d9_state.h", line 306: error #415: no suitable constructor
          exists to convert from "const int *" to "dxvk::Vector4Base<float>"
              set->fConsts[StartRegister + i] = replaceNaN(pConstantData + (i * 4));
                                                           ^
          detected during:
            instantiation of
                      "HRESULT dxvk::UpdateStateConstants<ProgramType,ConstantType,T,StateType>(StateType *, UINT, const T *, UINT, bool) [with ProgramType=dxvk::DxsoProgramTypes::VertexShader, ConstantType=dxvk::D3D9ConstantType::Int, T=int, StateType=dxvk::D3D9CapturableState]"
                      at line 374 of "../src/d3d9/d3d9_stateblock.h"
            instantiation of
                      "HRESULT dxvk::D3D9StateBlock::SetShaderConstants<ProgramType,ConstantType,T>(UINT, const T *, UINT) [with ProgramType=dxvk::DxsoProgramTypes::VertexShader, ConstantType=dxvk::D3D9ConstantType::Int, T=int]"
                      at line 6871 of "../src/d3d9/d3d9_device.cpp"
            instantiation of
                      "HRESULT dxvk::D3D9DeviceEx::SetShaderConstants<ProgramType,ConstantType,T>(UINT, const T *, UINT) [with ProgramType=dxvk::DxsoProgramTypes::VertexShader, ConstantType=dxvk::D3D9ConstantType::Int, T=int]"
                      at line 3143 of "../src/d3d9/d3d9_device.cpp"

1 error detected in the compilation of "../src/d3d9/d3d9_device.cpp".
```

Added workaround for this case.