### PR TITLE
MSVC and clang-cl QoL improvements

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -5,7 +5,7 @@ platform   = target_machine.system()
 
 cpp = meson.get_compiler('cpp')
 cc = meson.get_compiler('c')
-dxvk_is_msvc = cpp.get_id() == 'msvc'
+dxvk_is_msvc = cpp.get_argument_syntax() == 'msvc'
 
 compiler_args = [
   '-msse',

--- a/meson.build
+++ b/meson.build
@@ -48,28 +48,30 @@ if platform == 'windows'
     '-D_WIN32_WINNT=0xa00',
   ]
 
-  link_args += [
-    '-static',
-    '-static-libgcc',
-    '-static-libstdc++',
-    # We need to set the section alignment for debug symbols to
-    # work properly as well as avoiding a memcpy from the Wine loader.
-    '-Wl,--file-alignment=4096',
-  ]
-
-  # Wine's built-in back traces only work with dwarf4 symbols
-  if get_option('debug')
-    compiler_args += [
-      '-gdwarf-4',
-    ]
-  endif
-
-  # Enable stdcall fixup on 32-bit
-  if cpu_family == 'x86'
+  if not dxvk_is_msvc
     link_args += [
-      '-Wl,--enable-stdcall-fixup',
-      '-Wl,--kill-at',
+      '-static',
+      '-static-libgcc',
+      '-static-libstdc++',
+      # We need to set the section alignment for debug symbols to
+      # work properly as well as avoiding a memcpy from the Wine loader.
+      '-Wl,--file-alignment=4096',
     ]
+
+    # Wine's built-in back traces only work with dwarf4 symbols
+    if get_option('debug')
+      compiler_args += [
+        '-gdwarf-4',
+      ]
+    endif
+
+    # Enable stdcall fixup on 32-bit
+    if cpu_family == 'x86'
+      link_args += [
+        '-Wl,--enable-stdcall-fixup',
+        '-Wl,--kill-at',
+      ]
+    endif
   endif
 
   lib_d3d9    = cpp.find_library('d3d9')

--- a/meson.build
+++ b/meson.build
@@ -72,6 +72,10 @@ if platform == 'windows'
         '-Wl,--kill-at',
       ]
     endif
+  else
+    link_args += [
+      '/FILEALIGN:4096',
+    ]
   endif
 
   lib_d3d9    = cpp.find_library('d3d9')


### PR DESCRIPTION
I've been playing with using clang-cl in combination with https://github.com/mstorsjo/msvc-wine to cross-compile against MSVC C/C++ runtime on Linux. You can see an example of cross file [here](https://gist.github.com/ishitatsuyuki/bfa4b4764394f94b19115b182d269f4e).

Right now, the upside is smaller binary size as you don't need to link in the C/C++ runtime statically. In the future there might be other reasons to use this, such as when better STL support is wanted.

The PR is some small changes for build flags to ensure this setup works smoothly.