### PR TITLE
[util] cachedDynamicBuffers for Codename Panzers Phase One/Two

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -791,9 +791,11 @@ namespace dxvk {
       { "d3d9.maxFrameRate",                "60" },
     }} },
     /* Codename Panzers Phase One/Two          *
-     * Main menu won't render after intros     */
+     * Main menu won't render after intros     *
+     * and CPU bound performance               */
     { R"(\\(PANZERS|PANZERS_Phase_2)\.exe$)", {{
       { "d3d9.enableDialogMode",            "True"   },
+      { "d3d9.cachedDynamicBuffers",        "True"   },
     }} },
     /* DC Universe Online                      *
      * Freezes after alt tabbing               */


### PR DESCRIPTION
Helps CPU bound performance

<details>
  <summary>Phase One</summary>
 
Without
![phaseone-without](https://github.com/doitsujin/dxvk/assets/47954800/3676a3f5-51ee-4037-ae50-19cfd4d799c0)

With
![phaseone-with](https://github.com/doitsujin/dxvk/assets/47954800/9835f9ae-2c5d-4b13-ac53-e3f68e044ea0)
</details>

<details>
  <summary>Phase Two</summary>
 
Without
![phasetwo-without](https://github.com/doitsujin/dxvk/assets/47954800/5c0d812f-6187-4904-b8dc-6c1f8f4a1155)

With
![phasetwo-with](https://github.com/doitsujin/dxvk/assets/47954800/099502cd-3422-4d04-9e4c-8c373f082e0d)
</details>