### PR TITLE
[d3d9] Only enable ATOC when rendering to MS RT

### DIFF
--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -816,7 +816,7 @@ namespace dxvk {
     inline bool IsAlphaToCoverageEnabled() {
       const bool alphaTest = m_state.renderStates[D3DRS_ALPHATESTENABLE] != 0;
 
-      return m_amdATOC || (m_nvATOC && alphaTest);
+      return (m_amdATOC || (m_nvATOC && alphaTest)) && m_flags.test(D3D9DeviceFlag::ValidSampleMask);
     }
 
     inline bool IsDepthBiasEnabled() {


### PR DESCRIPTION
Fixes #3798
Fixes #3617

Observed using this test: https://github.com/K0bin/D3D9Garbage/blob/master/D3D9Garbage/ATIATOC.cpp