### PR TITLE
Fix incorrect comparison in sparse, convert all operator bool to explicit

### DIFF
--- a/src/d3d11/d3d11_features.cpp
+++ b/src/d3d11/d3d11_features.cpp
@@ -107,7 +107,7 @@ namespace dxvk {
     m_gpuVirtualAddress.MaxGPUVirtualAddressBitsPerProcess = 40;
 
     // Marker support only depends on the debug utils extension
-    m_marker.Profile = Instance->extensions().extDebugUtils;
+    m_marker.Profile = static_cast<bool>(Instance->extensions().extDebugUtils);
 
     // DXVK will keep all shaders in memory once created, and all Vulkan
     // drivers that we know of that can run DXVK have an on-disk cache.

--- a/src/d3d9/d3d9_mem.h
+++ b/src/d3d9/d3d9_mem.h
@@ -81,7 +81,7 @@ namespace dxvk {
       D3D9Memory             (D3D9Memory&& other);
       D3D9Memory& operator = (D3D9Memory&& other);
 
-      operator bool() const { return m_chunk != nullptr; }
+      explicit operator bool() const { return m_chunk != nullptr; }
 
       void Map();
       void Unmap();
@@ -139,7 +139,7 @@ namespace dxvk {
       D3D9Memory             (D3D9Memory&& other);
       D3D9Memory& operator = (D3D9Memory&& other);
 
-      operator bool() const { return m_ptr != nullptr; }
+      explicit operator bool() const { return m_ptr != nullptr; }
 
       void Map() {}
       void Unmap() {}

--- a/src/d3d9/d3d9_state.h
+++ b/src/d3d9/d3d9_state.h
@@ -195,7 +195,7 @@ namespace dxvk {
     const T* operator & () const { ensure(); return m_data.get(); }
           T* operator & ()       { ensure(); return m_data.get(); }
 
-    operator bool() { return m_data != nullptr; }
+    explicit operator bool() const { return m_data != nullptr; }
     operator T() { ensure(); return *m_data; }
 
     void ensure() const { if (!m_data) m_data = std::make_unique<T>(); }
@@ -213,7 +213,7 @@ namespace dxvk {
 
     T& operator=(const T& x) { m_data = x; return m_data; }
 
-    operator bool() { return true; }
+    explicit operator bool() const { return true; }
     operator T() { return m_data; }
 
     const T* operator -> () const { return &m_data; }

--- a/src/dxbc/dxbc_decoder.h
+++ b/src/dxbc/dxbc_decoder.h
@@ -196,7 +196,7 @@ namespace dxvk {
       return out;
     }
 
-    operator bool () const {
+    explicit operator bool () const {
       return m_mask != 0;
     }
     

--- a/src/dxvk/dxvk_cs.h
+++ b/src/dxvk/dxvk_cs.h
@@ -350,7 +350,7 @@ namespace dxvk {
       return m_chunk;
     }
     
-    operator bool () const {
+    explicit operator bool () const {
       return m_chunk != nullptr;
     }
     

--- a/src/dxvk/dxvk_extensions.h
+++ b/src/dxvk/dxvk_extensions.h
@@ -61,7 +61,7 @@ namespace dxvk {
      * provided by the extension can be used.
      * \returns \c true if the extension is enabled
      */
-    operator bool () const {
+    explicit operator bool () const {
       return m_revision != 0;
     }
 

--- a/src/dxvk/dxvk_memory.h
+++ b/src/dxvk/dxvk_memory.h
@@ -158,7 +158,7 @@ namespace dxvk {
      * \returns \c true if this slice points to actual device
      *          memory, and \c false if it is undefined.
      */
-    operator bool () const {
+    explicit operator bool () const {
       return m_memory != VK_NULL_HANDLE;
     }
     

--- a/src/dxvk/dxvk_sparse.cpp
+++ b/src/dxvk/dxvk_sparse.cpp
@@ -410,7 +410,7 @@ namespace dxvk {
           DxvkCommandList*        cmd,
           uint32_t                page,
           DxvkSparseMapping&&     mapping) {
-    if (m_mappings[page] != page) {
+    if (m_mappings[page] != mapping) {
       if (m_mappings[page])
         cmd->trackResource<DxvkAccess::None>(m_mappings[page].m_page);
 

--- a/src/dxvk/dxvk_sparse.h
+++ b/src/dxvk/dxvk_sparse.h
@@ -239,7 +239,7 @@ namespace dxvk {
       return m_page != other.m_page;
     }
 
-    operator bool () const {
+    explicit operator bool () const {
       return m_page != nullptr;
     }
 
@@ -341,7 +341,7 @@ namespace dxvk {
      * \brief Checks whether page table is defined
      * \returns \c true if the page table is defined
      */
-    operator bool () const {
+    explicit operator bool () const {
       return m_buffer || m_image;
     }
 


### PR DESCRIPTION
@mastercoms found an incorrectly coded comparison logic in sparse. The first commit fixes it.

The reason type checker let this through was because some surprising implicit conversion done by operator bool. Mark all operator bool as explicit to prevent any similar bug from happening in the future.