### PR TITLE
[meson] Only use the libdisplay-info subproject as a fallback

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -39,8 +39,12 @@ dxvk_include_dirs = [
   './include/spirv/include'
 ]
 
-proj_displayinfo = subproject('libdisplay-info')
-dep_displayinfo = proj_displayinfo.get_variable('di_dep')
+dep_displayinfo = dependency(
+  'libdisplay-info',
+  version: ['>= 0.0.0', '< 0.2.0'],
+  fallback: ['libdisplay-info', 'di_dep'],
+  default_options: ['default_library=static'],
+)
 
 if platform == 'windows'
   compiler_args += [


### PR DESCRIPTION
This makes it easier for distributors to build from the GitHub tarball, since they'll likely have libdisplay-info provided anyhow.

This is taken pretty much directly from gamescope's libdisplay-info dep.