### PR TITLE
package-native.sh should force libdisplay-info subproject

### DIFF
--- a/package-native.sh
+++ b/package-native.sh
@@ -56,13 +56,14 @@ function build_arch {
     opt_strip=--strip
   fi
 
-  CC="$CC -m$1" CXX="$CXX -m$1" meson setup \
-        --buildtype "release"               \
-        --prefix "$DXVK_BUILD_DIR/usr"      \
-        $opt_strip                          \
-        --bindir "$2"                       \
-        --libdir "$2"                       \
-        -Dbuild_id=$opt_buildid             \
+  CC="$CC -m$1" CXX="$CXX -m$1" meson setup  \
+        --buildtype "release"                \
+        --prefix "$DXVK_BUILD_DIR/usr"       \
+        $opt_strip                           \
+        --bindir "$2"                        \
+        --libdir "$2"                        \
+        -Dbuild_id=$opt_buildid              \
+        --force-fallback-for=libdisplay-info \
         "$DXVK_BUILD_DIR/build.$1"
 
   cd "$DXVK_BUILD_DIR/build.$1"


### PR DESCRIPTION
This ensures that the script produces a build similar to the default steamrt build, even if libdisplay-info is available on the build system root.

Fixes #3833