### PR TITLE
meson: Check for bundled Vulkan/SPIR-V headers

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,8 @@
-project('dxvk', ['c', 'cpp'], version : 'v2.3', meson_version : '>= 0.49', default_options : [ 'cpp_std=c++17', 'warning_level=2' ])
+project('dxvk', ['c', 'cpp'], version : 'v2.3', meson_version : '>= 0.58', default_options : [ 'cpp_std=c++17', 'warning_level=2' ])
 
 cpu_family = target_machine.cpu_family()
 platform   = target_machine.system()
+fs = import('fs')
 
 cpp = meson.get_compiler('cpp')
 cc = meson.get_compiler('c')
@@ -33,11 +34,17 @@ if get_option('build_id')
   ]
 endif
 
-dxvk_include_dirs = [
-  './include',
-  './include/vulkan/include',
-  './include/spirv/include'
-]
+dxvk_include_dirs = ['./include']
+if fs.is_dir('./include/vulkan/include')
+  dxvk_include_dirs += ['./include/vulkan/include']
+elif not cpp.check_header('vulkan/vulkan.h')
+  error('Missing Vulkan-Headers')
+endif
+if fs.is_dir('./include/spirv/include')
+  dxvk_include_dirs += ['./include/spirv/include']
+elif not cpp.check_header('spirv/unified1/spirv.hpp')
+  error('Missing SPIRV-Headers')
+endif
 
 dep_displayinfo = dependency(
   'libdisplay-info',


### PR DESCRIPTION
This is at least enough to use the system headers when building from the tarball, but doesn't check for any version requirements. While imperfect, it's an improvement on the current solution which is to `sed -i` meson.build, which is sort of overkill...

Partially fixes #3322