### PR TITLE
[d3d9] Add a software cursor emulation config option

### DIFF
--- a/dxvk.conf
+++ b/dxvk.conf
@@ -626,6 +626,17 @@
 
 # d3d9.seamlessCubes = False
 
+# Software Cursor Emulation
+#
+# Will atempt to emulate a software cursor by using a hardware cursor. This is useful
+# for applications that rely on d3d9 API calls to create the cursor and potentially use
+# bitmap sizes in excess of 32 x 32.
+#
+# Supported values:
+# - True/False
+
+# d3d9.softwareCursorEmulation = False
+
 # Debug Utils
 #
 # Enables debug utils as this is off by default, this enables user annotations like BeginEvent()/EndEvent().

--- a/src/d3d9/d3d9_cursor.h
+++ b/src/d3d9/d3d9_cursor.h
@@ -13,6 +13,13 @@ namespace dxvk {
 
   public:
 
+#ifdef _WIN32
+    ~D3D9Cursor() {
+      if (m_hCursor != nullptr)
+        ::DestroyCursor(m_hCursor);
+    }
+#endif
+
     void UpdateCursor(int X, int Y);
 
     BOOL ShowCursor(BOOL bShow);

--- a/src/d3d9/d3d9_cursor.h
+++ b/src/d3d9/d3d9_cursor.h
@@ -9,9 +9,6 @@ namespace dxvk {
   constexpr uint32_t HardwareCursorFormatSize = 4u;
   constexpr uint32_t HardwareCursorPitch      = HardwareCursorWidth * HardwareCursorFormatSize;
 
-  // Format Size of 4 bytes (ARGB)
-  using CursorBitmap = uint8_t[HardwareCursorHeight * HardwareCursorPitch];
-
   class D3D9Cursor {
 
   public:
@@ -20,7 +17,14 @@ namespace dxvk {
 
     BOOL ShowCursor(BOOL bShow);
 
-    HRESULT SetHardwareCursor(UINT XHotSpot, UINT YHotSpot, const CursorBitmap& bitmap);
+    HRESULT SetHardwareCursor(
+            UINT                   XHotSpot,
+            UINT                   YHotSpot,
+      const std::vector<uint8_t>&  bitmap,
+            bool                   cursorEmulation,
+            UINT                   width,
+            UINT                   height,
+            HWND                   window);
 
   private:
 

--- a/src/d3d9/d3d9_options.cpp
+++ b/src/d3d9/d3d9_options.cpp
@@ -77,6 +77,7 @@ namespace dxvk {
     this->samplerLodBias                = config.getOption<float>       ("d3d9.samplerLodBias",                0.0f);
     this->clampNegativeLodBias          = config.getOption<bool>        ("d3d9.clampNegativeLodBias",          false);
     this->countLosableResources         = config.getOption<bool>        ("d3d9.countLosableResources",         true);
+    this->softwareCursorEmulation       = config.getOption<bool>        ("d3d9.softwareCursorEmulation",       false);
 
     // Clamp LOD bias so that people don't abuse this in unintended ways
     this->samplerLodBias = dxvk::fclamp(this->samplerLodBias, -2.0f, 1.0f);

--- a/src/d3d9/d3d9_options.h
+++ b/src/d3d9/d3d9_options.h
@@ -144,6 +144,9 @@ namespace dxvk {
     /// Clamps negative LOD bias
     bool clampNegativeLodBias;
 
+    /// Emulate a software cursor using a hardware cursor
+    bool softwareCursorEmulation;
+
     /// How much virtual memory will be used for textures (in MB).
     int32_t textureMemory;
 

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -889,7 +889,10 @@ namespace dxvk {
       { "d3d9.deviceLossOnFocusLoss",       "True" },
       { "d3d9.cachedDynamicBuffers",        "True" },
     }} },
-
+    /* Dungeon Siege II                        */
+    { R"(\\DungeonSiege2\.exe$)", {{
+      { "d3d9.softwareCursorEmulation",     "True" },
+    }} },
 
     /**********************************************/
     /* D3D12 GAMES (vkd3d-proton with dxvk dxgi)  */


### PR DESCRIPTION
In relation to #3020. The game tries to create a 64 x 64 cursor, which wasn't supported prior to this PR, but is otherwise happy with our existing code path catering for hardware cursors. It even happily switches cursor icons in game on hover over certain objects.

Since this isn't exactly a software cursor implementation, rather a workaround, I've created a config option for it.

As far as I know this is the only d3d9 game that actually depended on software cursor support and this PR is enough to get it working properly. I can't guarantee other games will work just as well, since I haven't done a lot of validations and exotic bitmap sizes may cause issues. But we can improve the logic a bit if that ever happens to be a problem.

I welcome any testing, but this shouldn't affect the previous hardware cursor logic (unless I messed up badly somewhere, which doesn't seem to be the case based on my tests at least :sweat_smile:).

Would also appreciate very critical pairs of eyes on my memory allocations and use of pointers, since it's not something I get to do every day (and frankly I'm getting too old for it). Or I'm open to better alternatives, if any exist.