### PR TITLE
D3D9: Make windowed GetFrontBufferData more accurate

### DIFF
--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -1083,7 +1083,12 @@ namespace dxvk {
     if (unlikely(iSwapChain != 0))
       return D3DERR_INVALIDCALL;
 
-    return m_implicitSwapchain->GetFrontBufferData(pDestSurface);
+    D3D9DeviceLock lock = LockDevice();
+
+    // In windowed mode, GetFrontBufferData takes a screenshot of the entire screen.
+    // We use the last used swapchain as a workaround.
+    // Total War: Medieval 2 relies on this.
+    return m_mostRecentlyUsedSwapchain->GetFrontBufferData(pDestSurface);
   }
 
 
@@ -7813,6 +7818,7 @@ namespace dxvk {
     }
     else
       m_implicitSwapchain = new D3D9SwapChainEx(this, pPresentationParameters, pFullscreenDisplayMode);
+      m_mostRecentlyUsedSwapchain = m_implicitSwapchain.ptr();
 
     if (pPresentationParameters->EnableAutoDepthStencil) {
       D3D9_COMMON_TEXTURE_DESC desc;

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -1241,6 +1241,34 @@ namespace dxvk {
 
     uint64_t GetCurrentSequenceNumber();
 
+    /**
+     * @brief Get the swapchain that was used the most recently for presenting
+     * Has to be externally synchronized.
+     * 
+     * @return D3D9SwapChainEx* Swapchain
+     */
+    D3D9SwapChainEx* GetMostRecentlyUsedSwapchain() {
+      return m_mostRecentlyUsedSwapchain;
+    }
+
+    /**
+     * @brief Set the swapchain that was used the most recently for presenting
+     * Has to be externally synchronized.
+     * 
+     * @param swapchain Swapchain
+     */
+    void SetMostRecentlyUsedSwapchain(D3D9SwapChainEx* swapchain) {
+      m_mostRecentlyUsedSwapchain = swapchain;
+    }
+
+    /**
+     * @brief Reset the most recently swapchain back to the implicit one
+     * Has to be externally synchronized.
+     */
+    void ResetMostRecentlyUsedSwapchain() {
+      m_mostRecentlyUsedSwapchain = m_implicitSwapchain.ptr();
+    }
+
     Com<D3D9InterfaceEx>            m_parent;
     D3DDEVTYPE                      m_deviceType;
     HWND                            m_window;
@@ -1402,6 +1430,8 @@ namespace dxvk {
     D3D9DeviceLostState             m_deviceLostState          = D3D9DeviceLostState::Ok;
     HWND                            m_fullscreenWindow         = NULL;
     std::atomic<uint32_t>           m_losableResourceCounter   = { 0 };
+
+    D3D9SwapChainEx*                m_mostRecentlyUsedSwapchain = nullptr;
 
 #ifdef D3D9_ALLOW_UNMAPPING
     lru_list<D3D9CommonTexture*>    m_mappedTextures;

--- a/src/d3d9/d3d9_swapchain.cpp
+++ b/src/d3d9/d3d9_swapchain.cpp
@@ -382,6 +382,20 @@ namespace dxvk {
       blitInfo.srcOffsets[0] = VkOffset3D{ 0, 0, 0 };
       blitInfo.srcOffsets[1] = VkOffset3D{ int32_t(srcExtent.width),  int32_t(srcExtent.height),  1 };
 
+#ifdef _WIN32
+      if (m_presentParams.Windowed) {
+        // In windowed mode, GetFrontBufferData takes a screenshot of the entire screen.
+        // So place the copy of the front buffer at the position of the window.
+        POINT point = { 0, 0 };
+        if (ClientToScreen(m_window, &point) != 0) {
+          blitInfo.dstOffsets[0].x = point.x;
+          blitInfo.dstOffsets[0].y = point.y;
+          blitInfo.dstOffsets[1].x += point.x;
+          blitInfo.dstOffsets[1].y += point.y;
+        }
+      }
+#endif
+
       m_parent->EmitCs([
         cDstImage = blittedSrc,
         cDstMap   = dstTexInfo->GetMapping().Swizzle,


### PR DESCRIPTION
Fixes #3724

Total War Medieval 2 uses GetFrontBufferData to take a screenshot and then copies that screenshot to a texture which is used to render the background of the loading screen.

In windowed mode, GetFrontbufferData will in fact take a screenshot of the entire screen. We don't implement it that way in DXVK, we always blit the most recent front buffer.

There's two problems with our implementations in Medieval 2:
- The image is positioned incorrectly. The game retrieves the window client rect and copies those parts of the GetFrontBufferData destination surface. DXVK always puts the screenshot at 0,0.
- The game uses additional swapchains (on the same window no less) and presents using one of those. DXVK always blits the implicit swapchain.

So to solve this without having to implement GetFrontBufferData properly (taking a screenshot of the entire screen), I propose that we:
- Query the position of the window and blit the screenshot to that location. (easy)
- Track the swapchain that was the most recently used for presenting and forward GetFrontBufferData calls to that swapchain instead of the implicit one. That's obviously a hack but it works for Medieval 2 and should be fine for most other games, as very few games use additional swapchains and even fewer of those use them together with GetFrontBufferData.