### PR TITLE
[util] Disable hideNvidiaGpu for The Finals

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -927,6 +927,11 @@ namespace dxvk {
     { R"(\\P3R\.exe$)", {{
       { "dxgi.syncInterval",                "1" },
     }} },
+    /* The Finals - Prevents a crash on Nvidia    *
+     * when XeSS is selected in the graphics menu */
+    { R"(\\Discovery\.exe$)", {{
+      { "dxgi.hideNvidiaGpu",              "False" },
+    }} },
   }};
 
 


### PR DESCRIPTION
Prevents a crash on Nvidia when XeSS is selected in the graphics menu.
Probably some kind of mismatch when vendor Id's doesn't match causing trouble as it could also be worked around in Proton Wine with `WINE_HIDE_NVIDIA_GPU=1`. Besides just enabling Nvapi that is.