### PR TITLE
[util] Clarify maxDeviceMemory and maxSharedMemory

### DIFF
--- a/dxvk.conf
+++ b/dxvk.conf
@@ -90,6 +90,7 @@
 # Override maximum amount of device memory and shared system memory
 # reported to the application. This may fix texture streaming issues
 # in games that do not support cards with large amounts of VRAM.
+# This is not a hard cap and applications can choose to ignore it.
 #
 # Supported values: Any number in Megabytes.
 


### PR DESCRIPTION
Minor clarification in the example config comment as this option often leads to confusion because people expect applications to honor the reported number.