### PR TITLE
[d3d9] Respect vertex buffer offset when dynamically uploading geometry

### DIFF
--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -5246,7 +5246,7 @@ namespace dxvk {
         auto* vbo = GetCommonBuffer(m_state.vertexBuffers[i].vertexBuffer);
 
         const uint32_t vertexStride = m_state.vertexDecl->GetSize(i);
-        uint32_t offset = (BaseVertexIndex + FirstVertexIndex) * vertexStride;
+        uint32_t offset = (BaseVertexIndex + FirstVertexIndex) * vertexStride + m_state.vertexBuffers[i].offset;
 
         uint8_t* data = reinterpret_cast<uint8_t*>(upSlice.mapPtr) + vboUPBufferOffsets[i];
         uint8_t* src = reinterpret_cast<uint8_t*>(vbo->GetMappedSlice().mapPtr) + offset;


### PR DESCRIPTION
Fixes #3888 

Before anyone asks: You cannot specify an offset when binding the index buffer so we don't have to do the same thing there.