### PR TITLE
[d3d9] Only unbind in EndScene if the game cleared the binding

### DIFF
--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -1616,15 +1616,22 @@ namespace dxvk {
 
     m_flags.clr(D3D9DeviceFlag::InScene);
 
-    // D3D9 resets the internally bound vertex buffers and index buffer in EndScene.
+    // D3D9 resets the internally bound vertex buffers and index buffer in EndScene if they were unbound in the meantime.
     // We have to ignore unbinding those buffers because of Operation Flashpoint Red River,
     // so we should also clear the bindings here, to avoid leaks.
-    EmitCs([](DxvkContext* ctx) {
-      ctx->bindIndexBuffer(DxvkBufferSlice(), VK_INDEX_TYPE_UINT32);
-      for (uint32_t i = 0; i < DxvkLimits::MaxNumVertexBindings; i++) {
-        ctx->bindVertexBuffer(i, DxvkBufferSlice(), 0);
+    if (m_state.indices == nullptr) {
+      EmitCs([](DxvkContext* ctx) {
+        ctx->bindIndexBuffer(DxvkBufferSlice(), VK_INDEX_TYPE_UINT32);
+      });
+    }
+    
+    for (uint32_t i = 0; i < DxvkLimits::MaxNumVertexBindings; i++) {
+      if (m_state.vertexBuffers[i].vertexBuffer == nullptr) {
+        EmitCs([cIndex = i](DxvkContext* ctx) {
+          ctx->bindVertexBuffer(cIndex, DxvkBufferSlice(), 0);
+        });
       }
-    });
+    }
 
     return D3D_OK;
   }


### PR DESCRIPTION
Fixes a regression in Dragon Age Origins, Carries Order Up and Mount & Blade.

Fixes #3891
Fixes #3892