### PR TITLE
[d3d9] Fix a bunch of Wine test failures

### DIFF
--- a/src/d3d9/d3d9_adapter.cpp
+++ b/src/d3d9/d3d9_adapter.cpp
@@ -278,6 +278,8 @@ namespace dxvk {
 
     auto& options = m_parent->GetOptions();
 
+    const VkPhysicalDeviceLimits& limits = m_adapter->deviceProperties().limits;
+
     // TODO: Actually care about what the adapter supports here.
     // ^ For Intel and older cards most likely here.
 
@@ -538,7 +540,7 @@ namespace dxvk {
     // Max Vertex Blend Matrix Index
     pCaps->MaxVertexBlendMatrixIndex = 0;
     // Max Point Size
-    pCaps->MaxPointSize              = 256.0f;
+    pCaps->MaxPointSize              = limits.pointSizeRange[1];
     // Max Primitive Count
     pCaps->MaxPrimitiveCount         = 0x00555555;
     // Max Vertex Index

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -7767,6 +7767,8 @@ namespace dxvk {
     rs[D3DRS_CLIPPLANEENABLE] = 0;
     m_flags.set(D3D9DeviceFlag::DirtyClipPlanes);
 
+    const VkPhysicalDeviceLimits& limits = m_dxvkDevice->adapter()->deviceProperties().limits;
+
     rs[D3DRS_POINTSPRITEENABLE]          = FALSE;
     rs[D3DRS_POINTSCALEENABLE]           = FALSE;
     rs[D3DRS_POINTSCALE_A]               = bit::cast<DWORD>(1.0f);
@@ -7774,7 +7776,7 @@ namespace dxvk {
     rs[D3DRS_POINTSCALE_C]               = bit::cast<DWORD>(0.0f);
     rs[D3DRS_POINTSIZE]                  = bit::cast<DWORD>(1.0f);
     rs[D3DRS_POINTSIZE_MIN]              = bit::cast<DWORD>(1.0f);
-    rs[D3DRS_POINTSIZE_MAX]              = bit::cast<DWORD>(64.0f);
+    rs[D3DRS_POINTSIZE_MAX]              = bit::cast<DWORD>(limits.pointSizeRange[1]);
     UpdatePushConstant<D3D9RenderStateItem::PointSize>();
     UpdatePushConstant<D3D9RenderStateItem::PointSizeMin>();
     UpdatePushConstant<D3D9RenderStateItem::PointSizeMax>();

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -2953,14 +2953,19 @@ namespace dxvk {
     auto slice = dst->GetBufferSlice<D3D9_COMMON_BUFFER_TYPE_REAL>();
          slice = slice.subSlice(offset, slice.length() - offset);
 
+    D3D9CompactVertexElements elements;
+    for (const D3DVERTEXELEMENT9& element : decl->GetElements()) {
+      elements.emplace_back(element);
+    }
+
     EmitCs([this,
-      cVertexElements = decl->GetElements(),
+      cVertexElements = std::move(elements),
       cVertexCount    = VertexCount,
       cStartIndex     = SrcStartIndex,
       cInstanceCount  = GetInstanceCount(),
       cBufferSlice    = slice
     ](DxvkContext* ctx) mutable {
-      Rc<DxvkShader> shader = m_swvpEmulator.GetShaderModule(this, cVertexElements);
+      Rc<DxvkShader> shader = m_swvpEmulator.GetShaderModule(this, std::move(cVertexElements));
 
       auto drawInfo = GenerateDrawInfo(D3DPT_POINTLIST, cVertexCount, cInstanceCount);
 

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -2954,13 +2954,13 @@ namespace dxvk {
          slice = slice.subSlice(offset, slice.length() - offset);
 
     EmitCs([this,
-      cDecl          = ref(decl),
-      cVertexCount   = VertexCount,
-      cStartIndex    = SrcStartIndex,
-      cInstanceCount = GetInstanceCount(),
-      cBufferSlice   = slice
+      cVertexElements = decl->GetElements(),
+      cVertexCount    = VertexCount,
+      cStartIndex     = SrcStartIndex,
+      cInstanceCount  = GetInstanceCount(),
+      cBufferSlice    = slice
     ](DxvkContext* ctx) mutable {
-      Rc<DxvkShader> shader = m_swvpEmulator.GetShaderModule(this, cDecl);
+      Rc<DxvkShader> shader = m_swvpEmulator.GetShaderModule(this, cVertexElements);
 
       auto drawInfo = GenerateDrawInfo(D3DPT_POINTLIST, cVertexCount, cInstanceCount);
 

--- a/src/d3d9/d3d9_fixed_function.cpp
+++ b/src/d3d9/d3d9_fixed_function.cpp
@@ -1323,6 +1323,8 @@ namespace dxvk {
         uint32_t midDot = m_module.opDot(m_floatType, normal, mid);
                  midDot = m_module.opFClamp(m_floatType, midDot, m_module.constf32(0.0f), m_module.constf32(1.0f));
         uint32_t doSpec = m_module.opFOrdGreaterThan(bool_t, midDot, m_module.constf32(0.0f));
+                 doSpec = m_module.opLogicalAnd(bool_t, doSpec, m_module.opFOrdGreaterThan(m_floatType, hitDot, m_module.constf32(0.0f)));
+
         uint32_t specularness = m_module.opPow(m_floatType, midDot, m_vs.constants.materialPower);
                  specularness = m_module.opFMul(m_floatType, specularness, atten);
                  specularness = m_module.opSelect(m_floatType, doSpec, specularness, m_module.constf32(0.0f));

--- a/src/d3d9/d3d9_state.h
+++ b/src/d3d9/d3d9_state.h
@@ -169,11 +169,11 @@ namespace dxvk {
 
   constexpr D3DLIGHT9 DefaultLight = {
     D3DLIGHT_DIRECTIONAL,     // Type
-    {1.0f, 1.0f, 1.0f, 1.0f}, // Diffuse
+    {1.0f, 1.0f, 1.0f, 0.0f}, // Diffuse
     {0.0f, 0.0f, 0.0f, 0.0f}, // Specular
     {0.0f, 0.0f, 0.0f, 0.0f}, // Ambient
     {0.0f, 0.0f, 0.0f},       // Position
-    {0.0f, 0.0f, 0.0f},       // Direction
+    {0.0f, 0.0f, 1.0f},       // Direction
     0.0f,                     // Range
     0.0f,                     // Falloff
     0.0f, 0.0f, 0.0f,         // Attenuations [constant, linear, quadratic]

--- a/src/d3d9/d3d9_stateblock.cpp
+++ b/src/d3d9/d3d9_stateblock.cpp
@@ -49,7 +49,7 @@ namespace dxvk {
     if (m_captures.flags.test(D3D9CapturedStateFlag::VertexDecl))
       SetVertexDeclaration(m_deviceState->vertexDecl.ptr());
 
-    ApplyOrCapture<D3D9StateFunction::Capture>();
+    ApplyOrCapture<D3D9StateFunction::Capture, true>();
 
     return D3D_OK;
   }
@@ -61,7 +61,7 @@ namespace dxvk {
     if (m_captures.flags.test(D3D9CapturedStateFlag::VertexDecl) && m_state.vertexDecl != nullptr)
       m_parent->SetVertexDeclaration(m_state.vertexDecl.ptr());
 
-    ApplyOrCapture<D3D9StateFunction::Apply>();
+    ApplyOrCapture<D3D9StateFunction::Apply, false>();
     m_applying = false;
 
     return D3D_OK;
@@ -114,6 +114,20 @@ namespace dxvk {
     m_state.vertexBuffers[StreamNumber].vertexBuffer = pStreamData;
 
     m_state.vertexBuffers[StreamNumber].offset = OffsetInBytes;
+    m_state.vertexBuffers[StreamNumber].stride = Stride;
+
+    m_captures.flags.set(D3D9CapturedStateFlag::VertexBuffers);
+    m_captures.vertexBuffers.set(StreamNumber, true);
+    return D3D_OK;
+  }
+
+
+  HRESULT D3D9StateBlock::SetStreamSourceWithoutOffset(
+          UINT                StreamNumber,
+          D3D9VertexBuffer*   pStreamData,
+          UINT                Stride) {
+    m_state.vertexBuffers[StreamNumber].vertexBuffer = pStreamData;
+
     m_state.vertexBuffers[StreamNumber].stride = Stride;
 
     m_captures.flags.set(D3D9CapturedStateFlag::VertexBuffers);
@@ -572,8 +586,12 @@ namespace dxvk {
       m_captures.flags.set(D3D9CapturedStateFlag::Material);
     }
 
-    if (Type != D3D9StateBlockType::None)
-      this->Capture();
+    if (Type != D3D9StateBlockType::None) {
+      if (m_captures.flags.test(D3D9CapturedStateFlag::VertexDecl))
+        SetVertexDeclaration(m_deviceState->vertexDecl.ptr());
+
+      ApplyOrCapture<D3D9StateFunction::Capture, false>();
+    }
   }
 
 }

--- a/src/d3d9/d3d9_swapchain.cpp
+++ b/src/d3d9/d3d9_swapchain.cpp
@@ -172,6 +172,9 @@ namespace dxvk {
 
     m_lastDialog = m_dialog;
 
+    if (m_window == nullptr)
+      return D3D_OK;
+
 #ifdef _WIN32
     const bool useGDIFallback = m_partialCopy && !HasFrontBuffer();
     if (useGDIFallback)
@@ -994,6 +997,9 @@ namespace dxvk {
 
 
   void D3D9SwapChainEx::UpdateWindowCtx() {
+    if (m_window == nullptr)
+      return;
+
     if (!m_presenters.count(m_window)) {
       auto res = m_presenters.emplace(
         std::piecewise_construct,
@@ -1323,10 +1329,10 @@ namespace dxvk {
     || dstRect.right  - dstRect.left != LONG(width)
     || dstRect.bottom - dstRect.top  != LONG(height);
 
-    bool recreate =
-       m_wctx->presenter == nullptr
-    || m_wctx->presenter->info().imageExtent.width  != width
-    || m_wctx->presenter->info().imageExtent.height != height;
+    bool recreate = m_wctx != nullptr
+      && (m_wctx->presenter == nullptr
+      || m_wctx->presenter->info().imageExtent.width  != width
+      || m_wctx->presenter->info().imageExtent.height != height);
 
     m_swapchainExtent = { width, height };
     m_dstRect = dstRect;

--- a/src/d3d9/d3d9_swvp_emu.h
+++ b/src/d3d9/d3d9_swvp_emu.h
@@ -23,7 +23,7 @@ namespace dxvk {
 
   public:
 
-    Rc<DxvkShader> GetShaderModule(D3D9DeviceEx* pDevice, const D3D9VertexDecl* pDecl);
+    Rc<DxvkShader> GetShaderModule(D3D9DeviceEx* pDevice,  const D3D9VertexElements& elements);
 
   private:
 

--- a/src/d3d9/d3d9_swvp_emu.h
+++ b/src/d3d9/d3d9_swvp_emu.h
@@ -11,26 +11,41 @@ namespace dxvk {
   class D3D9VertexDecl;
   class D3D9DeviceEx;
 
+  struct D3D9CompactVertexElement {
+      uint16_t Stream : 4;
+      uint16_t Type : 5;
+      uint16_t Method : 3;
+      uint16_t Usage : 4;
+      uint16_t UsageIndex;
+      uint16_t Offset;
+
+      D3D9CompactVertexElement(const D3DVERTEXELEMENT9& element) 
+        : Stream(element.Stream), Type(element.Type), Method(element.Method),
+          Usage(element.Usage), UsageIndex(element.UsageIndex), Offset(element.Offset) {}
+  };
+
+  using D3D9CompactVertexElements = small_vector<D3D9CompactVertexElement, 4>;
+
   struct D3D9VertexDeclHash {
-    size_t operator () (const D3D9VertexElements& key) const;
+    size_t operator () (const D3D9CompactVertexElements& key) const;
   };
 
   struct D3D9VertexDeclEq {
-    bool operator () (const D3D9VertexElements& a, const D3D9VertexElements& b) const;
+    bool operator () (const D3D9CompactVertexElements& a, const D3D9CompactVertexElements& b) const;
   };
 
   class D3D9SWVPEmulator {
 
   public:
 
-    Rc<DxvkShader> GetShaderModule(D3D9DeviceEx* pDevice,  const D3D9VertexElements& elements);
+    Rc<DxvkShader> GetShaderModule(D3D9DeviceEx* pDevice,  D3D9CompactVertexElements&& elements);
 
   private:
 
     dxvk::mutex                               m_mutex;
 
     std::unordered_map<
-      D3D9VertexElements, Rc<DxvkShader>,
+      D3D9CompactVertexElements, Rc<DxvkShader>,
       D3D9VertexDeclHash, D3D9VertexDeclEq>   m_modules;
 
   };

--- a/src/util/util_matrix.cpp
+++ b/src/util/util_matrix.cpp
@@ -205,6 +205,10 @@ namespace dxvk {
     Vector4 dot0    = { m[0] * row0 };
     float dot1      = (dot0.x + dot0.y) + (dot0.z + dot0.w);
 
+    if (unlikely(std::abs(dot1) <= 0.000001f)) {
+      return m;
+    }
+
     return inverse * (1.0f / dot1);
   }
 

--- a/src/util/util_small_vector.h
+++ b/src/util/util_small_vector.h
@@ -13,8 +13,37 @@ namespace dxvk {
 
     small_vector() { }
 
-    small_vector             (const small_vector&) = delete;
-    small_vector& operator = (const small_vector&) = delete;
+    small_vector(const small_vector& other) {
+      reserve(other.m_size);
+      for (size_t i = 0; i < other.m_size; i++) {
+        *ptr(i) = *other.ptr(i);
+      }
+      m_size = other.m_size;
+    };
+
+    small_vector& operator = (const small_vector& other) {
+      for (size_t i = 0; i < m_size; i++)
+        ptr(i)->~T();
+
+      reserve(other.m_size);
+      for (size_t i = 0; i < other.m_size; i++) {
+        *ptr(i) = *other.ptr(i);
+      }
+      m_size = other.m_size;
+    };
+
+    small_vector(small_vector&& other) {
+      if (other.m_capacity == N) {
+        for (size_t i = 0; i < other.m_size; i++) {
+          u.m_data[i] = std::move(other.u.m_data[i]);
+        }
+      } else {
+        u.m_ptr = other.u.m_ptr;
+        other.m_capacity = N;
+      }
+      m_size = other.m_size;
+      other.m_size = 0;
+    }
 
     ~small_vector() {
       for (size_t i = 0; i < m_size; i++)
@@ -23,7 +52,7 @@ namespace dxvk {
       if (m_capacity > N)
         delete[] u.m_ptr;
     }
-    
+
     size_t size() const {
       return m_size;
     }
@@ -43,7 +72,7 @@ namespace dxvk {
 
       if (m_capacity > N)
         delete[] u.m_ptr;
-      
+
       m_capacity = n;
       u.m_ptr = data;
     }
@@ -56,7 +85,7 @@ namespace dxvk {
 
       for (size_t i = n; i < m_size; i++)
         ptr(i)->~T();
-      
+
       for (size_t i = m_size; i < n; i++)
         new (ptr(i)) T();
 


### PR DESCRIPTION
Fixes the following Wine test failures:

StretchRect, lighting, specular_lighting
```
visual.c:4451: Test failed: Test 6, got unexpected hr 0.
visual.c:4451: Test failed: Test 7, got unexpected hr 0.
visual.c:4451: Test failed: Test 8, got unexpected hr 0.
visual.c:4451: Test failed: Test 9, got unexpected hr 0.
visual.c:4451: Test failed: Test 14, got unexpected hr 0.
visual.c:4451: Test failed: Test 15, got unexpected hr 0.
visual.c:4451: Test failed: Test 16, got unexpected hr 0.
visual.c:4451: Test failed: Test 17, got unexpected hr 0.
visual.c:4451: Test failed: Test 22, got unexpected hr 0.
visual.c:4451: Test failed: Test 23, got unexpected hr 0.
visual.c:4451: Test failed: Test 24, got unexpected hr 0.
visual.c:4451: Test failed: Test 25, got unexpected hr 0.
visual.c:4451: Test failed: Test 30, got unexpected hr 0.
visual.c:4451: Test failed: Test 31, got unexpected hr 0.
visual.c:4451: Test failed: Test 32, got unexpected hr 0.
visual.c:4451: Test failed: Test 36, got unexpected hr 0.
visual.c:4451: Test failed: Test 38, got unexpected hr 0.
visual.c:4451: Test failed: Test 39, got unexpected hr 0.
visual.c:4451: Test failed: Test 40, got unexpected hr 0.
visual.c:4451: Test failed: Test 41, got unexpected hr 0.
visual.c:4451: Test failed: Test 42, got unexpected hr 0.
visual.c:4451: Test failed: Test 43, got unexpected hr 0.
visual.c:4451: Test failed: Test 44, got unexpected hr 0.
visual.c:4451: Test failed: Test 46, got unexpected hr 0.
visual.c:4451: Test failed: Test 47, got unexpected hr 0.
visual.c:4451: Test failed: Test 49, got unexpected hr 0.
visual.c:4451: Test failed: Test 51, got unexpected hr 0.
visual.c:4451: Test failed: Test 53, got unexpected hr 0.

visual.c:15446: Test failed: Got hr 0.
visual.c:15462: Test failed: Got hr 0.
visual.c:15466: Test failed: Got hr 0.
visual.c:15468: Test failed: Got hr 0.

visual.c:1126: Test failed: Expected color 0x00000000 at location (160, 120), got 0x00ffffff, case 7.
visual.c:1126: Test failed: Expected color 0x00000000 at location (320, 120), got 0x00adadad, case 7.
visual.c:1126: Test failed: Expected color 0x00000000 at location (480, 120), got 0x005a5a5a, case 7.
visual.c:1126: Test failed: Expected color 0x00000000 at location (160, 240), got 0x00ffffff, case 7.
visual.c:1126: Test failed: Expected color 0x00000000 at location (320, 240), got 0x00d1d1d1, case 7.
visual.c:1126: Test failed: Expected color 0x00000000 at location (480, 240), got 0x00636363, case 7.
visual.c:1126: Test failed: Expected color 0x00000000 at location (160, 360), got 0x00ffffff, case 7.
visual.c:1126: Test failed: Expected color 0x00000000 at location (320, 360), got 0x00adadad, case 7.
visual.c:1126: Test failed: Expected color 0x00000000 at location (480, 360), got 0x005a5a5a, case 7.
```

Actually matches the documentation here: https://learn.microsoft.com/en-us/windows/win32/api/d3d9/nf-d3d9-idirect3ddevice9-stretchrect