### PR TITLE
Support building for ARM64EC

### DIFF
--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -5325,7 +5325,7 @@ namespace dxvk {
 
     // Round to nearest
     _controlfp(_RC_NEAR, _MCW_RC);
-#elif (defined(__GNUC__) || defined(__MINGW32__)) && (defined(__i386__) || defined(__x86_64__) || defined(__ia64))
+#elif (defined(__GNUC__) || defined(__MINGW32__)) && (defined(__i386__) || (defined(__x86_64__) && !defined(__arm64ec__)) || defined(__ia64))
     // For GCC/MinGW we can use inline asm to set it.
     // This only works for x86 and x64 processors however.
 

--- a/src/util/util_bit.h
+++ b/src/util/util_bit.h
@@ -1,11 +1,12 @@
 #pragma once
 
-#if defined(__x86_64__) || defined(_M_X64) || defined(__i386__) || defined(_M_IX86) || defined(__e2k__)
+#if (defined(__x86_64__) && !defined(__arm64ec__)) || (defined(_M_X64) && !defined(_M_ARM64EC)) \
+    || defined(__i386__) || defined(_M_IX86) || defined(__e2k__)
   #define DXVK_ARCH_X86
   #if defined(__x86_64__) || defined(_M_X64) || defined(__e2k__)
     #define DXVK_ARCH_X86_64
   #endif
-#elif defined(__aarch64__) || defined(_M_ARM64)
+#elif defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
   #define DXVK_ARCH_ARM64
 #else
 #error "Unknown CPU Architecture"


### PR DESCRIPTION
When targeting ARM64EC, both __x86_64__ and _M_X64 are defined but not all x86 intrinsics are present, treat EC as regular ARM64 so the native intrinsics are used instead.