### PR TITLE
[util] Set cachedDynamicResources for Guild Wars 2

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -431,6 +431,11 @@ namespace dxvk {
       { "d3d11.exposeDriverCommandLists",   "False" },
       { "dxgi.hideNvidiaGpu",               "False" },
     }} },
+    /* Guild Wars 2                                   *
+     * Helps CPU bound performance on some setups     */
+    { R"(\\Gw2-64\.exe$)", {{
+      { "d3d11.cachedDynamicResources",     "vc" },
+    }} },
 
     /**********************************************/
     /* D3D9 GAMES                                 */


### PR DESCRIPTION
Helps the games CPU bound performance on some setups so it gets closer to Windows.

See example comparison without and with below. Screenshots are taken by @LankyFranky89
<details>
  <summary>Screenshots</summary>
  
![image](https://github.com/doitsujin/dxvk/assets/47954800/6e4c576c-1b3b-45f6-ba33-9ffe6bb48601)
![image](https://github.com/doitsujin/dxvk/assets/47954800/bea78ee0-82b3-4d84-8d1d-6d5a76c72369)
</details>