### PR TITLE
Fix MiscFlags check in GetDescFromResource

### DIFF
--- a/src/d3d11/d3d11_view_srv.cpp
+++ b/src/d3d11/d3d11_view_srv.cpp
@@ -298,7 +298,7 @@ namespace dxvk {
         D3D11_BUFFER_DESC bufferDesc;
         static_cast<D3D11Buffer*>(pResource)->GetDesc(&bufferDesc);
         
-        if (bufferDesc.MiscFlags == D3D11_RESOURCE_MISC_BUFFER_STRUCTURED) {
+        if (bufferDesc.MiscFlags & D3D11_RESOURCE_MISC_BUFFER_STRUCTURED) {
           pDesc->Format              = DXGI_FORMAT_UNKNOWN;
           pDesc->ViewDimension       = D3D11_SRV_DIMENSION_BUFFER;
           pDesc->Buffer.FirstElement = 0;

--- a/src/d3d11/d3d11_view_uav.cpp
+++ b/src/d3d11/d3d11_view_uav.cpp
@@ -214,7 +214,7 @@ namespace dxvk {
         D3D11_BUFFER_DESC bufferDesc;
         static_cast<D3D11Buffer*>(pResource)->GetDesc(&bufferDesc);
         
-        if (bufferDesc.MiscFlags == D3D11_RESOURCE_MISC_BUFFER_STRUCTURED) {
+        if (bufferDesc.MiscFlags & D3D11_RESOURCE_MISC_BUFFER_STRUCTURED) {
           pDesc->Format              = DXGI_FORMAT_UNKNOWN;
           pDesc->ViewDimension       = D3D11_UAV_DIMENSION_BUFFER;
           pDesc->Buffer.FirstElement = 0;


### PR DESCRIPTION
Noticed this bug while messing around with running OVRServer (Oculus Runtime) in Wine, as its MiscFlags was set to `D3D11_RESOURCE_MISC_SHARED (0x2), D3D11_RESOURCE_MISC_BUFFER_STRUCTURED (0x40)` (0x42), GetDescFromResource would fail due to it not being exactly 0x40.

I don't know if the direct MiscFlags comparison was intended behavior, but changing it to a `&` like a proper flag comparison worked fine in my testing.

Please let me know if this is correct or if there is any changes I should make.