### PR TITLE
[util] Cap Dark Void to 60fps

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -873,6 +873,10 @@ namespace dxvk {
     { R"(\\RedRiver\.exe$)", {{
       { "d3d9.floatEmulation",              "Strict" },
     }} },
+    /* Dark Void - Crashes above 60fps in places */
+    { R"(\\ShippingPC-SkyGame\.exe$)", {{
+      { "d3d9.maxFrameRate",                "60" },
+    }} },
 
 
     /**********************************************/


### PR DESCRIPTION
Game crashes in certain places like specific cutscenes unless capped at 60fps.