### PR TITLE
[dxgi] Remove useMonitorFallback option

### DIFF
--- a/dxvk.conf
+++ b/dxvk.conf
@@ -644,18 +644,6 @@
 
 # d3d9.textureMemory = 100
 
-# Always enumerate all monitors on each dxgi output
-#
-# Used to avoid performance degradation in some games
-# (will be deprecated once QueryDisplayConfig optimization
-# is in Proton Wine).
-#
-# Supported values:
-# - True/False
-
-# dxgi.useMonitorFallback = False
-
-
 # Hide integrated graphics from applications
 #
 # Only has an effect when dedicated GPUs are present on the system. It is

--- a/src/dxgi/dxgi_factory.cpp
+++ b/src/dxgi/dxgi_factory.cpp
@@ -124,13 +124,10 @@ namespace dxvk {
       }
     }
 
-
     // If any monitors are left on the list, enable the
     // fallback to always enumerate all monitors.
     if ((m_monitorFallback = !monitors.empty()))
       Logger::warn("DXGI: Found monitors not associated with any adapter, using fallback");
-    else
-      m_monitorFallback = m_options.useMonitorFallback;
   }
   
   

--- a/src/dxgi/dxgi_options.cpp
+++ b/src/dxgi/dxgi_options.cpp
@@ -100,10 +100,6 @@ namespace dxvk {
       Logger::info("HDR was configured to be enabled, but has been force disabled as a UE4 DX11 game was detected.");
       this->enableHDR = false;
     }
-
-    this->useMonitorFallback = config.getOption<bool>("dxgi.useMonitorFallback", env::getEnvVar("DXVK_MONITOR_FALLBACK") == "1");
-    if (this->useMonitorFallback)
-      Logger::info("Enabled useMonitorFallback option");
   }
   
 }

--- a/src/dxgi/dxgi_options.h
+++ b/src/dxgi/dxgi_options.h
@@ -49,9 +49,6 @@ namespace dxvk {
     /// Enable HDR
     bool enableHDR;
 
-    /// Use monitor fallback to enumerating all monitors per output
-    bool useMonitorFallback;
-
     /// Sync interval. Overrides the value
     /// passed to IDXGISwapChain::Present.
     int32_t syncInterval;

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -411,11 +411,6 @@ namespace dxvk {
     { R"(\\RidersRepublic(_BE)?\.exe$)", {{
       { "dxgi.hideAmdGpu",                "True"   },
     }} },
-    /* HoloCure - Save the Fans!
-       Same as Cyberpunk 2077                     */
-    { R"(\\HoloCure\.exe$)", {{
-      { "dxgi.useMonitorFallback",          "True" },
-    }} },
     /* Kenshi                                     *
      * Helps CPU bound performance                */
     { R"(\\kenshi_x64\.exe$)", {{
@@ -900,13 +895,6 @@ namespace dxvk {
      * enabling ray tracing if it sees an AMD GPU. */
     { R"(\\RiftApart\.exe$)", {{
       { "dxgi.hideNvidiaGpu",               "False" },
-    }} },
-    /* CP2077 enumerates display outputs each frame.
-     * Avoid using QueryDisplayConfig to avoid
-     * performance degradation until the
-     * optimization of that function is in Proton. */
-    { R"(\\Cyberpunk2077\.exe$)", {{
-      { "dxgi.useMonitorFallback",          "True" },
     }} },
     /* Metro Exodus Enhanced Edition picks GPU adapters
      * by available VRAM, which causes issues on some


### PR DESCRIPTION
The QueryDisplayConfig optimization is now in Proton 9 Wine which is the proper fix.

Closes https://github.com/doitsujin/dxvk/issues/3632