### PR TITLE
[dxgi] Force vendor ID change when XeSS is detected on an Intel GPU

### DIFF
--- a/src/dxgi/dxgi_options.cpp
+++ b/src/dxgi/dxgi_options.cpp
@@ -26,6 +26,21 @@ namespace dxvk {
     return id;
   }
 
+  /* First generation XeSS causes crash on proton for Intel due to missing
+   * Intel interface. Avoid crash by pretending to be non-Intel if the
+   * libxess.dll module is loaded by an application.
+   */
+  static bool isXessUsed() {
+#ifdef _WIN32
+      if (GetModuleHandleA("libxess") != nullptr ||
+          GetModuleHandleA("libxess_dx11") != nullptr)
+        return true;
+      else
+        return false;
+#else
+      return false;
+#endif
+  }
 
   static bool isNvapiEnabled() {
     return env::getEnvVar("DXVK_ENABLE_NVAPI") == "1";
@@ -94,6 +109,12 @@ namespace dxvk {
     // logic to Nvidia later, if necessary.
     this->hideAmdGpu = config.getOption<Tristate>("dxgi.hideAmdGpu", Tristate::Auto) == Tristate::True;
     this->hideIntelGpu = config.getOption<Tristate>("dxgi.hideIntelGpu", Tristate::Auto) == Tristate::True;
+
+    /* Force vendor ID to non-Intel ID when XeSS is in use */
+    if (isXessUsed()) {
+      Logger::info(str::format("Detected XeSS usage, hiding Intel GPU Vendor"));
+      this->hideIntelGpu = true;
+    }
 
     this->enableHDR = config.getOption<bool>("dxgi.enableHDR", env::getEnvVar("DXVK_HDR") == "1");
     if (this->enableHDR && isHDRDisallowed()) {


### PR DESCRIPTION
Games using libxess.dll or wrapper modules will crash. To work around this, the vendor ID is set to -1 to avoid using the XeSS module.

This change was tested with various XeSS titles, including Shadow of the Tomb Raider, Hitman 3, Dying Light 2, and Diablo IV (I ensured the relevant driconf changes were made so that the mesa driver isn't the one setting the vendor ID to '-1').

Note that Dying Light 2 created its own DX11 wrapper module, libxess_dx11.dll, which uses some functionality from the libxess.dll module and consequently causes a hang. I don't anticipate many titles doing this, so it's included in the module check.