### PR TITLE
[d3d11] Remove missed Shared Keyedmutex warning

### DIFF
--- a/src/d3d11/d3d11_texture.cpp
+++ b/src/d3d11/d3d11_texture.cpp
@@ -58,9 +58,6 @@ namespace dxvk {
           "\n  MiscFlags:  ", m_desc.MiscFlags,
           "\n  FeatureLevel:  ", pDevice->GetFeatureLevel()));
 
-      if (m_desc.MiscFlags & D3D11_RESOURCE_MISC_SHARED_KEYEDMUTEX)
-        Logger::warn("D3D11_RESOURCE_MISC_SHARED_KEYEDMUTEX: not supported.");
-
       imageInfo.shared = true;
       imageInfo.sharing.mode = hSharedHandle == INVALID_HANDLE_VALUE ? DxvkSharedHandleMode::Export : DxvkSharedHandleMode::Import;
       imageInfo.sharing.type = (m_desc.MiscFlags & D3D11_RESOURCE_MISC_SHARED_NTHANDLE)


### PR DESCRIPTION
D3D11_RESOURCE_MISC_SHARED_KEYEDMUTEX is implemented.