### PR TITLE
[util] Re-add TRAHA Global config

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -331,6 +331,11 @@ namespace dxvk {
     { R"(\\SonicFrontiers\.exe$)", {{
       { "dxgi.maxFrameLatency",             "1" },
     }} },
+    /* TRAHA Global                               *
+     * Shadow issues when it sees AMD/Nvidia      */
+    { R"(\\RapaNui-Win64-Shipping\.exe$)", {{
+      { "dxgi.customVendorId",              "8086" },
+    }} },
     /* SpellForce 3 Reforced & expansions         *
      * Greatly improves CPU bound performance     */
     { R"(\\SF3ClientFinal\.exe$)", {{


### PR DESCRIPTION
Although not likely, it is possible the game could come back (either officially or through private servers)

If we maintain an archive of all old and dead games, then they can be brought back to life with DXVK taking care of compatibility. Especially old games can benefit from DXVK even on Windows (we use it by default in Deus Ex Randomizer).

If the game is brought back through unofficial means, it could become legally difficult to explain why we added back their config code for an unofficial release. But if we decide to be an archive and keep these configs forever, then there's no legal concern because we're just acting as an archive/historical reserve.

discussion here https://github.com/doitsujin/dxvk/commit/855b2746b61ad944759ae9e31bbb4ad7562e6912#commitcomment-140395860