### PR TITLE
[util] Remove framerate limiter for Nier Replicant

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -122,8 +122,6 @@ namespace dxvk {
     }} },
     /* NieR Replicant                             */
     { R"(\\NieR Replicant ver\.1\.22474487139\.exe)", {{
-      { "dxgi.syncInterval",                "1"    },
-      { "dxgi.maxFrameRate",                "60"   },
       { "d3d11.cachedDynamicResources",     "vi"   },
     }} },
     /* SteamVR performance test                   */


### PR DESCRIPTION
### Context

Without mods, Nier Replicant runs faster when going above 60 FPS.
The game had an official patch that implemented a framerate limiter to prevent this. This limiter is terrible, because it's not a stable 60 FPS, but a weird 57-58 FPS. There's no way to disable this in-game, it has to be done by editing a config file or through a mod.

### So, why remove the default frame limiter from DXVK?

- In the default case (a user plays the game as it is), it does nothing, since 57-58 is lower than 60.
- If a user is going out of their way to edit the config file, why would they assume that DXVK already provides a frame limiter? [Guides](https://www.pcgamingwiki.com/wiki/NieR_Replicant#Framerate_limited_to_57.7E58_FPS) already tell the user to set up a frame limiter.
- They are using [Special K in order to use a mod to play at high refresh rates at normal speed](https://wiki.special-k.info/SpecialK/Custom/Replicant). In this case, DXVK's default limiter is harmful, since it is not documented that it's there by default.

Since this default limiter is useless in the first two cases and harmful in the third, I think it should be removed.
The alternative would be to document this (e.g. in PCGamingWiki), but this would bloat the instructions to the point that nothing is being simplified...
- "If you want a stable 60 FPS, [...], then set up a frame limiter, but don't do the last step if you are using DXVK/Proton, because in that case it's already there"
- "To play at higher framerates at normal speed, install Special K [...], and if are using DXVK/Proton, also do these things to disable its default 60 FPS cap: [...]"

Especially because that the game isn't broken in the default case, I don't think DXVK should tamper with these things in a way that requires documentation to revert: default settings should be there only when they are only an advantage, not when they are opinionated.
I say opinionated because this is basically an undocumented half-mod M that works only if a user does A (with guides already telling the user to do M), and causes conflicts when a user does B.

And considering that the only advantage to having this default in DXVK is not having to set manually `DXVK_FRAME_RATE=60`, I think the cons outweigh the pros.

Tested Special K's mod to play at higher refresh rates on Linux.