### PR TITLE
Add FreeBSD support

### DIFF
--- a/package-native.sh
+++ b/package-native.sh
@@ -25,6 +25,8 @@ shift 2
 opt_nopackage=0
 opt_devbuild=0
 opt_buildid=false
+opt_64_only=0
+opt_32_only=0
 
 CC=${CC:="gcc"}
 CXX=${CXX:="g++"}
@@ -40,6 +42,12 @@ while [ $# -gt 0 ]; do
     ;;
   "--build-id")
     opt_buildid=true
+    ;;
+  "--64-only")
+    opt_64_only=1
+    ;;
+  "--32-only")
+    opt_32_only=1
     ;;
   *)
     echo "Unrecognized option: $1" >&2
@@ -81,8 +89,12 @@ function package {
   rm -R "dxvk-native-$DXVK_VERSION"
 }
 
-build_arch 64 lib
-build_arch 32 lib32
+if [ $opt_32_only -eq 0 ]; then
+  build_arch 64 lib
+fi
+if [ $opt_64_only -eq 0 ]; then
+  build_arch 32 lib32
+fi
 
 if [ $opt_nopackage -eq 0 ]; then
   package

--- a/src/util/thread.h
+++ b/src/util/thread.h
@@ -316,7 +316,11 @@ namespace dxvk {
       switch (priority) {
         default:
         case ThreadPriority::Normal: policy = SCHED_OTHER; break;
+#ifndef __linux__
+        case ThreadPriority::Lowest: policy = SCHED_OTHER; break;
+#else
         case ThreadPriority::Lowest: policy = SCHED_IDLE;  break;
+#endif
       }
       ::pthread_setschedparam(this->native_handle(), policy, &param);
     }

--- a/src/util/util_env.cpp
+++ b/src/util/util_env.cpp
@@ -6,6 +6,10 @@
 #ifdef __linux__
 #include <unistd.h>
 #include <limits.h>
+#elif defined(__FreeBSD__)
+#include <sys/sysctl.h>
+#include <unistd.h>
+#include <limits.h>
 #endif
 
 #include "util_env.h"
@@ -85,6 +89,17 @@ namespace dxvk::env {
     size_t count = readlink("/proc/self/exe", exePath.data(), exePath.size());
 
     return std::string(exePath.begin(), exePath.begin() + count);
+#elif defined(__FreeBSD__)
+    int mib[4] = {CTL_KERN, KERN_PROC, KERN_PROC_PATHNAME, getpid()};
+    char exePath[PATH_MAX] = {};
+    size_t size = PATH_MAX;
+
+    if (sysctl(mib, 4, exePath, &size, NULL, 0) != 0) {
+        // throw error here?
+        return "";
+    }
+
+    return std::string(exePath);
 #endif
   }
   

--- a/src/util/util_win32_compat.h
+++ b/src/util/util_win32_compat.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#if defined(__linux__)
+#if defined(__unix__)
 
 #include <windows.h>
 #include <dlfcn.h>


### PR DESCRIPTION
This pull request adds initial FreeBSD operating system support.

To build: `env CC=cc CXX=c++ ./package_native.sh <other args here> --64-only` (for 64-bit system)
~~(gcc13 is currently not working)~~