### PR TITLE
[util] Set deferSurfaceCreation for 9th Dawn II

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -865,6 +865,12 @@ namespace dxvk {
     { R"(\\ShippingPC-SkyGame\.exe$)", {{
       { "d3d9.maxFrameRate",                "60" },
     }} },
+    /* 9th Dawn II                               *
+     * OpenGL game that also spins up d3d9       *
+     * Black screens without config              */
+    { R"(\\ninthdawnii\.exe$)", {{
+      { "d3d9.deferSurfaceCreation",        "True" },
+    }} },
 
 
     /**********************************************/


### PR DESCRIPTION
OpenGL game that also spins up d3d9. Will black screen without deferSurfaceCreation when using dxvk

fixes #3964