### PR TITLE
[dxgi] unchain DxgiFactory::CreateSwapChain and CreateSwapChainForHwnd

### DIFF
--- a/src/dxgi/dxgi_factory.cpp
+++ b/src/dxgi/dxgi_factory.cpp
@@ -230,7 +230,7 @@ namespace dxvk {
     descFs.Windowed         = pDesc->Windowed;
     
     IDXGISwapChain1* swapChain = nullptr;
-    HRESULT hr = CreateSwapChainForHwnd(
+    HRESULT hr = CreateSwapChainForHwndBase(
       pDevice, pDesc->OutputWindow,
       &desc, &descFs, nullptr,
       &swapChain);
@@ -241,6 +241,19 @@ namespace dxvk {
   
   
   HRESULT STDMETHODCALLTYPE DxgiFactory::CreateSwapChainForHwnd(
+          IUnknown*             pDevice,
+          HWND                  hWnd,
+    const DXGI_SWAP_CHAIN_DESC1* pDesc,
+    const DXGI_SWAP_CHAIN_FULLSCREEN_DESC* pFullscreenDesc,
+          IDXGIOutput*          pRestrictToOutput,
+          IDXGISwapChain1**     ppSwapChain) {
+    return CreateSwapChainForHwndBase(
+      pDevice, hWnd,
+      pDesc, pFullscreenDesc, pRestrictToOutput,
+      ppSwapChain);
+  }
+
+  HRESULT STDMETHODCALLTYPE DxgiFactory::CreateSwapChainForHwndBase(
           IUnknown*             pDevice,
           HWND                  hWnd,
     const DXGI_SWAP_CHAIN_DESC1* pDesc,

--- a/src/dxgi/dxgi_factory.h
+++ b/src/dxgi/dxgi_factory.h
@@ -200,6 +200,14 @@ namespace dxvk {
     UINT             m_flags;
     BOOL             m_monitorFallback;
       
+
+    HRESULT STDMETHODCALLTYPE CreateSwapChainForHwndBase(
+            IUnknown*             pDevice,
+            HWND                  hWnd,
+      const DXGI_SWAP_CHAIN_DESC1* pDesc,
+      const DXGI_SWAP_CHAIN_FULLSCREEN_DESC* pFullscreenDesc,
+            IDXGIOutput*          pRestrictToOutput,
+            IDXGISwapChain1**     ppSwapChain);
   };
   
 }


### PR DESCRIPTION
similar to https://github.com/doitsujin/dxvk/pull/3966, avoid chaining so that dxgi tools attempting to wrap swapchains don't end up double wrapping

ref: https://github.com/SpecialKO/SpecialK/issues/168