### PR TITLE
[d3d11] Implement video processor source rect and tweak filtering.

### DIFF
--- a/src/d3d11/d3d11_video.cpp
+++ b/src/d3d11/d3d11_video.cpp
@@ -1262,12 +1262,29 @@ namespace dxvk {
         viewport.height = float(cStreamState.dstRect.bottom) - viewport.y;
       }
 
+      VkExtent3D viewExtent = cViews[0]->mipLevelExtent(0);
+      VkViewport srcViewport;
+
+      if (cStreamState.srcRectEnabled) {
+        srcViewport.x      = float(cStreamState.srcRect.left);
+        srcViewport.y      = float(cStreamState.srcRect.top);
+        srcViewport.width  = float(cStreamState.srcRect.right) - srcViewport.x;
+        srcViewport.height = float(cStreamState.srcRect.bottom) - srcViewport.y;
+      } else {
+        srcViewport.x      = 0.0f;
+        srcViewport.y      = 0.0f;
+        srcViewport.width  = float(viewExtent.width);
+        srcViewport.height = float(viewExtent.height);
+      }
+
       UboData uboData = { };
       uboData.colorMatrix[0][0] = 1.0f;
       uboData.colorMatrix[1][1] = 1.0f;
       uboData.colorMatrix[2][2] = 1.0f;
-      uboData.coordMatrix[0][0] = 1.0f;
-      uboData.coordMatrix[1][1] = 1.0f;
+      uboData.coordMatrix[0][0] = srcViewport.width / float(viewExtent.width);
+      uboData.coordMatrix[1][1] = srcViewport.height / float(viewExtent.height);
+      uboData.coordMatrix[2][0] = srcViewport.x / float(viewExtent.width);
+      uboData.coordMatrix[2][1] = srcViewport.y / float(viewExtent.height);
       uboData.yMin = 0.0f;
       uboData.yMax = 1.0f;
       uboData.isPlanar = cViews[1] != nullptr;

--- a/src/d3d11/d3d11_video.cpp
+++ b/src/d3d11/d3d11_video.cpp
@@ -1334,7 +1334,7 @@ namespace dxvk {
 
   void D3D11VideoContext::CreateSampler() {
     DxvkSamplerCreateInfo samplerInfo;
-    samplerInfo.magFilter       = VK_FILTER_LINEAR;
+    samplerInfo.magFilter       = VK_FILTER_NEAREST;
     samplerInfo.minFilter       = VK_FILTER_LINEAR;
     samplerInfo.mipmapMode      = VK_SAMPLER_MIPMAP_MODE_NEAREST;
     samplerInfo.mipmapLodBias   = 0.0f;


### PR DESCRIPTION
The use case is the implementation of Media Foundation video processing to convert YUV to RGB D3D buffers.

Media Foundation decoders only support YUV format output, and have some specific behavior where they align their YUV planes on 16 bytes (most common case is 1920x1080 video being padded to 1920x1088, with padding at the end of the Y plane). For some games, we need to be able to convert these aligned YUV buffers to RGB buffers while at the same time cropping or keeping the alignment-induced padding (this depends on the video processor MFT media type attributes).

In short, I'm implementing it like this:

```C
    if (FAILED(hr = IMFMediaType_GetUINT64(processor->input_type, &MF_MT_FRAME_SIZE, &input_desc.frame_size))
            || FAILED(hr = IMFMediaType_GetGUID(processor->input_type, &MF_MT_SUBTYPE, &input_desc.subtype))
            || FAILED(hr = IMFMediaType_GetUINT64(processor->output_type, &MF_MT_FRAME_SIZE, &output_desc.frame_size))
            || FAILED(hr = IMFMediaType_GetGUID(processor->output_type, &MF_MT_SUBTYPE, &output_desc.subtype)))
        return hr;

    /* ... */

    streams.Enable = TRUE;
    streams.OutputIndex = 0;
    streams.InputFrameOrField = 0;
    streams.PastFrames = 0;
    streams.FutureFrames = 0;
    streams.pInputSurface = input_view;

    if (SUCCEEDED(IMFMediaType_GetBlob(processor->input_type, &MF_MT_MINIMUM_DISPLAY_APERTURE, (BYTE *)&aperture, sizeof(aperture), NULL)))
        SetRect(&rect, aperture.OffsetX.value, aperture.OffsetY.value, aperture.OffsetX.value + aperture.Area.cx,
                aperture.OffsetY.value + aperture.Area.cy);
    else
        SetRect(&rect, 0, 0, input_desc.frame_size >> 32, (UINT32)input_desc.frame_size);
    ID3D11VideoContext_VideoProcessorSetStreamSourceRect(video_context, video_processor, 0, TRUE, &rect);

    if (SUCCEEDED(IMFMediaType_GetBlob(processor->output_type, &MF_MT_MINIMUM_DISPLAY_APERTURE, (BYTE *)&aperture, sizeof(aperture), NULL)))
        SetRect(&rect, aperture.OffsetX.value, aperture.OffsetY.value, aperture.OffsetX.value + aperture.Area.cx,
                aperture.OffsetY.value + aperture.Area.cy);
    else
        SetRect(&rect, 0, 0, output_desc.frame_size >> 32, (UINT32)output_desc.frame_size);
    ID3D11VideoContext_VideoProcessorSetStreamDestRect(video_context, video_processor, 0, TRUE, &rect);

    ID3D11VideoContext_VideoProcessorBlt(video_context, video_processor, output_view, 0, 1, &streams);
```

Currently, as `VideoProcessorSetStreamSourceRect` does nothing, this ends up scaling the entire input frame into the output rect, which causes the YUV padding to be converted to RGB, causing a green band to be visible (from the Y padding).

Then, when input/output rects are properly scaled onto each other, there's still some color bleed from the padding as linear filtering is used, and a single pixel green line is still visible. Using nearest filtering fixes that. I'm not completely sure what's best here, maybe we can create two (linear + nearest) samplers, and use either one or the other depending on whether the rects dimensions perfectly match.