### PR TITLE
[d3d9] Validate DS format support during CheckDepthStencilMatch

### DIFF
--- a/src/d3d9/d3d9_adapter.cpp
+++ b/src/d3d9/d3d9_adapter.cpp
@@ -224,11 +224,15 @@ namespace dxvk {
     if (!IsDepthFormat(DepthStencilFormat))
       return D3DERR_NOTAVAILABLE;
 
+    auto dsfMapping = ConvertFormatUnfixed(DepthStencilFormat);
+    if (dsfMapping.FormatColor == VK_FORMAT_UNDEFINED)
+      return D3DERR_NOTAVAILABLE;
+
     if (RenderTargetFormat == dxvk::D3D9Format::NULL_FORMAT)
       return D3D_OK;
 
-    auto mapping = ConvertFormatUnfixed(RenderTargetFormat);
-    if (mapping.FormatColor == VK_FORMAT_UNDEFINED)
+    auto rtfMapping = ConvertFormatUnfixed(RenderTargetFormat);
+    if (rtfMapping.FormatColor == VK_FORMAT_UNDEFINED)
       return D3DERR_NOTAVAILABLE;
 
     return D3D_OK;


### PR DESCRIPTION
Fixes #3938. Adds a check against passed DS formats during calls to `CheckDepthStencilMatch()`. Should prevent games from using D32, D15S1 and D24X4S4 going forward.

We had to do [a similar check for DS formats in d8vk](https://github.com/AlpyneDreams/d8vk/blob/1a039a4729b9a8f0440739eec4cedf59e79a3aa0/src/d3d8/d3d8_format.h#L18) for what it's worth, so this makes sense.