### PR TITLE
Initialize UMD version quad to a max signed int64

### DIFF
--- a/src/dxgi/dxgi_adapter.cpp
+++ b/src/dxgi/dxgi_adapter.cpp
@@ -130,7 +130,7 @@ namespace dxvk {
     // We can't really reconstruct the version numbers
     // returned by Windows drivers from Vulkan data
     if (SUCCEEDED(hr) && pUMDVersion)
-      pUMDVersion->QuadPart = LLONG_MAX;
+      pUMDVersion->QuadPart = INT64_MAX;
 
     if (FAILED(hr)) {
       Logger::err("DXGI: CheckInterfaceSupport: Unsupported interface");

--- a/src/dxgi/dxgi_adapter.cpp
+++ b/src/dxgi/dxgi_adapter.cpp
@@ -130,7 +130,7 @@ namespace dxvk {
     // We can't really reconstruct the version numbers
     // returned by Windows drivers from Vulkan data
     if (SUCCEEDED(hr) && pUMDVersion)
-      pUMDVersion->QuadPart = ~0ull;
+      pUMDVersion->QuadPart = LLONG_MAX;
 
     if (FAILED(hr)) {
       Logger::err("DXGI: CheckInterfaceSupport: Unsupported interface");


### PR DESCRIPTION
Set to max signed integer and prevent sign bit from being set to negative.

Resolves https://github.com/doitsujin/dxvk/issues/3983