### PR TITLE
[dxvk] Replace deprecated Vulkan macros

### DIFF
--- a/src/dxvk/dxvk_adapter.cpp
+++ b/src/dxvk/dxvk_adapter.cpp
@@ -415,7 +415,7 @@ namespace dxvk {
       m_deviceFeatures.khrPresentWait.presentWait;
 
     // Unless we're on an Nvidia driver where these extensions are known to be broken
-    if (matchesDriver(VK_DRIVER_ID_NVIDIA_PROPRIETARY, 0, VK_MAKE_VERSION(535, 0, 0))) {
+    if (matchesDriver(VK_DRIVER_ID_NVIDIA_PROPRIETARY, 0, VK_MAKE_API_VERSION(0, 535, 0, 0))) {
       enabledFeatures.khrPresentId.presentId = VK_FALSE;
       enabledFeatures.khrPresentWait.presentWait = VK_FALSE;
     }
@@ -431,9 +431,9 @@ namespace dxvk {
     Logger::info(str::format("Device properties:"
       "\n  Device : ", m_deviceInfo.core.properties.deviceName,
       "\n  Driver : ", m_deviceInfo.vk12.driverName, " ",
-      VK_VERSION_MAJOR(m_deviceInfo.core.properties.driverVersion), ".",
-      VK_VERSION_MINOR(m_deviceInfo.core.properties.driverVersion), ".",
-      VK_VERSION_PATCH(m_deviceInfo.core.properties.driverVersion)));
+      VK_API_VERSION_MAJOR(m_deviceInfo.core.properties.driverVersion), ".",
+      VK_API_VERSION_MINOR(m_deviceInfo.core.properties.driverVersion), ".",
+      VK_API_VERSION_PATCH(m_deviceInfo.core.properties.driverVersion)));
 
     Logger::info("Enabled device extensions:");
     this->logNameList(extensionNameList);
@@ -631,9 +631,9 @@ namespace dxvk {
     Logger::info(str::format("Device properties:"
       "\n  Device name: ", m_deviceInfo.core.properties.deviceName,
       "\n  Driver:      ", m_deviceInfo.vk12.driverName, " ",
-      VK_VERSION_MAJOR(m_deviceInfo.core.properties.driverVersion), ".",
-      VK_VERSION_MINOR(m_deviceInfo.core.properties.driverVersion), ".",
-      VK_VERSION_PATCH(m_deviceInfo.core.properties.driverVersion)));
+      VK_API_VERSION_MAJOR(m_deviceInfo.core.properties.driverVersion), ".",
+      VK_API_VERSION_MINOR(m_deviceInfo.core.properties.driverVersion), ".",
+      VK_API_VERSION_PATCH(m_deviceInfo.core.properties.driverVersion)));
 
     Logger::info("Enabled device extensions:");
     this->logNameList(extensionNameList);
@@ -686,9 +686,9 @@ namespace dxvk {
     
     Logger::info(str::format(deviceInfo.core.properties.deviceName, ":",
       "\n  Driver : ", deviceInfo.vk12.driverName, " ",
-      VK_VERSION_MAJOR(deviceInfo.core.properties.driverVersion), ".",
-      VK_VERSION_MINOR(deviceInfo.core.properties.driverVersion), ".",
-      VK_VERSION_PATCH(deviceInfo.core.properties.driverVersion)));
+      VK_API_VERSION_MAJOR(deviceInfo.core.properties.driverVersion), ".",
+      VK_API_VERSION_MINOR(deviceInfo.core.properties.driverVersion), ".",
+      VK_API_VERSION_PATCH(deviceInfo.core.properties.driverVersion)));
 
     for (uint32_t i = 0; i < memoryInfo.memoryHeapCount; i++) {
       constexpr VkDeviceSize mib = 1024 * 1024;
@@ -792,14 +792,14 @@ namespace dxvk {
     // Some drivers reports the driver version in a slightly different format
     switch (m_deviceInfo.vk12.driverID) {
       case VK_DRIVER_ID_NVIDIA_PROPRIETARY:
-        m_deviceInfo.core.properties.driverVersion = VK_MAKE_VERSION(
+        m_deviceInfo.core.properties.driverVersion = VK_MAKE_API_VERSION(0,
           (m_deviceInfo.core.properties.driverVersion >> 22) & 0x3ff,
           (m_deviceInfo.core.properties.driverVersion >> 14) & 0x0ff,
           (m_deviceInfo.core.properties.driverVersion >>  6) & 0x0ff);
         break;
 
       case VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS:
-        m_deviceInfo.core.properties.driverVersion = VK_MAKE_VERSION(
+        m_deviceInfo.core.properties.driverVersion = VK_MAKE_API_VERSION(0,
           m_deviceInfo.core.properties.driverVersion >> 14,
           m_deviceInfo.core.properties.driverVersion & 0x3fff, 0);
         break;

--- a/src/dxvk/dxvk_device_filter.cpp
+++ b/src/dxvk/dxvk_device_filter.cpp
@@ -17,10 +17,10 @@ namespace dxvk {
   
   
   bool DxvkDeviceFilter::testAdapter(const VkPhysicalDeviceProperties& properties) const {
-    if (properties.apiVersion < VK_MAKE_VERSION(1, 3, 0)) {
+    if (properties.apiVersion < VK_MAKE_API_VERSION(0, 1, 3, 0)) {
       Logger::warn(str::format("Skipping Vulkan ",
-        VK_VERSION_MAJOR(properties.apiVersion), ".",
-        VK_VERSION_MINOR(properties.apiVersion), " adapter: ",
+        VK_API_VERSION_MAJOR(properties.apiVersion), ".",
+        VK_API_VERSION_MINOR(properties.apiVersion), " adapter: ",
         properties.deviceName));
       return false;
     }

--- a/src/dxvk/dxvk_instance.cpp
+++ b/src/dxvk/dxvk_instance.cpp
@@ -182,8 +182,8 @@ namespace dxvk {
       appInfo.pApplicationName      = appName.c_str();
       appInfo.applicationVersion    = flags.raw();
       appInfo.pEngineName           = "DXVK";
-      appInfo.engineVersion         = VK_MAKE_VERSION(2, 3, 2);
-      appInfo.apiVersion            = VK_MAKE_VERSION(1, 3, 0);
+      appInfo.engineVersion         = VK_MAKE_API_VERSION(0, 2, 3, 2);
+      appInfo.apiVersion            = VK_MAKE_API_VERSION(0, 1, 3, 0);
 
       VkInstanceCreateInfo info = { VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO };
       info.pApplicationInfo         = &appInfo;

--- a/src/dxvk/hud/dxvk_hud_item.cpp
+++ b/src/dxvk/hud/dxvk_hud_item.cpp
@@ -131,9 +131,9 @@ namespace dxvk::hud {
 
     if (driverInfo.empty()) {
       driverInfo = str::format(
-        VK_VERSION_MAJOR(props.core.properties.driverVersion), ".",
-        VK_VERSION_MINOR(props.core.properties.driverVersion), ".",
-        VK_VERSION_PATCH(props.core.properties.driverVersion));
+        VK_API_VERSION_MAJOR(props.core.properties.driverVersion), ".",
+        VK_API_VERSION_MINOR(props.core.properties.driverVersion), ".",
+        VK_API_VERSION_PATCH(props.core.properties.driverVersion));
     }
 
     m_deviceName = props.core.properties.deviceName;


### PR DESCRIPTION
Replace deprecated Vulkan macros with their new equivalents 