### PR TITLE
[meta, native] Add DXVK Native readme section and change DXVK_WSIDRIVER name

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,3 +163,22 @@ For non debian based distros, make sure that your mingw-w64-gcc cross compiler
 does have `--enable-threads=posix` enabled during configure. If your distro does
 ship its mingw-w64-gcc binary with `--enable-threads=win32` you might have to
 recompile locally or open a bug at your distro's bugtracker to ask for it. 
+
+# DXVK Native
+
+DXVK Native is a version of DXVK which allows it to be used natively without Wine.
+
+This is primarily useful for game and application ports to either avoid having to write another rendering backend, or to help with port bringup during development.
+
+[Release builds](https://github.com/doitsujin/dxvk/releases) are built using the Steam Runtime.
+
+### How does it work?
+
+DXVK Native replaces certain Windows-isms with a platform and framework-agnostic replacement, for example, `HWND`s can become `SDL_Window*`s, etc.
+All it takes to do that is to add another WSI backend.
+
+**Note:** DXVK Native requires a backend to be explicitly set via the `DXVK_WSI_DRIVER` environment variable. The current built-in options are `SDL2` and `GLFW`.
+
+DXVK Native comes with a slim set of Windows header definitions required for D3D9/11 and the MinGW headers for D3D9/11.
+In most cases, it will end up being plug and play with your renderer, but there may be certain teething issues such as:
+- `__uuidof(type)` is supported, but `__uuidof(variable)` is not supported. Use `__uuidof_var(variable)` instead.

--- a/src/wsi/wsi_platform.cpp
+++ b/src/wsi/wsi_platform.cpp
@@ -24,14 +24,14 @@ namespace dxvk::wsi {
     if (s_refcount++ > 0)
       return;
 
-    std::string hint = dxvk::env::getEnvVar("DXVK_WSIDRIVER");
+    std::string hint = dxvk::env::getEnvVar("DXVK_WSI_DRIVER");
     if (hint == "") {
         // At least for Windows, it is reasonable to fall back to a default;
         // for other platforms however we _need_ to know which WSI to use!
 #if defined(DXVK_WSI_WIN32)
         hint = "Win32";
 #else
-        throw DxvkError("DXVK_WSIDRIVER environment variable unset");
+        throw DxvkError("DXVK_WSI_DRIVER environment variable unset");
 #endif
     }
 


### PR DESCRIPTION
A modified port of the top section of the [dxvk-native](https://github.com/Joshua-Ashton/dxvk-native) readme.
Rendered version at https://github.com/Blisto91/dxvk/blob/native-readme/README.md

CC: @flibitijibibo It was shortly discussed after the merge that there was a preference to change `DXVK_WSIDRIVER` to `DXVK_WSI_DRIVER`