### PR TITLE
[d3d11,d3d9,util] Add a config option for reproducible VK output

### DIFF
--- a/dxvk.conf
+++ b/dxvk.conf
@@ -312,6 +312,20 @@
 # d3d11.exposeDriverCommandLists = True
 
 
+# Reproducible Command Stream
+#
+# Ensure that for the same D3D commands the output VK commands
+# don't change between runs. Useful for comparative benchmarking,
+# can negatively affect performance and can break some games
+# that don't use queries correctly.
+#
+# Supported values:
+# - True/False
+
+# d3d11.reproducibleCommandStream = False
+# d3d9.reproducibleCommandStream = False
+
+
 # Sets number of pipeline compiler threads.
 # 
 # If the graphics pipeline library feature is enabled, the given

--- a/src/d3d11/d3d11_context_imm.cpp
+++ b/src/d3d11/d3d11_context_imm.cpp
@@ -19,6 +19,7 @@ namespace dxvk {
     m_csThread(Device, Device->createContext(DxvkContextType::Primary)),
     m_maxImplicitDiscardSize(pParent->GetOptions()->maxImplicitDiscardSize),
     m_submissionFence(new sync::CallbackFence()),
+    m_flushTracker(pParent->GetOptions()->reproducibleCommandStream),
     m_multithread(this, false, pParent->GetOptions()->enableContextLock),
     m_videoContext(this, Device) {
     EmitCs([

--- a/src/d3d11/d3d11_options.cpp
+++ b/src/d3d11/d3d11_options.cpp
@@ -33,6 +33,7 @@ namespace dxvk {
     this->maxFrameRate          = config.getOption<int32_t>("dxgi.maxFrameRate", 0);
     this->exposeDriverCommandLists = config.getOption<bool>("d3d11.exposeDriverCommandLists", true);
     this->longMad               = config.getOption<bool>("d3d11.longMad", false);
+    this->reproducibleCommandStream = config.getOption<bool>("d3d11.reproducibleCommandStream", false);
 
     // Clamp LOD bias so that people don't abuse this in unintended ways
     this->samplerLodBias = dxvk::fclamp(this->samplerLodBias, -2.0f, 1.0f);

--- a/src/d3d11/d3d11_options.h
+++ b/src/d3d11/d3d11_options.h
@@ -123,6 +123,11 @@ namespace dxvk {
 
     /// Should we make our Mads a FFma or do it the long way with an FMul and an FAdd?
     bool longMad;
+
+    /// Ensure that for the same D3D commands the output VK commands
+    /// don't change between runs. Useful for comparative benchmarking,
+    /// can negatively affect performance.
+    bool reproducibleCommandStream;
   };
   
 }

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -56,6 +56,7 @@ namespace dxvk {
     , m_csThread        ( dxvkDevice, dxvkDevice->createContext(DxvkContextType::Primary) )
     , m_csChunk         ( AllocCsChunk() )
     , m_submissionFence (new sync::Fence())
+    , m_flushTracker    (m_d3d9Options.reproducibleCommandStream)
     , m_d3d9Interop     ( this )
     , m_d3d9On12        ( this )
     , m_d3d8Bridge      ( this ) {

--- a/src/d3d9/d3d9_options.cpp
+++ b/src/d3d9/d3d9_options.cpp
@@ -77,6 +77,7 @@ namespace dxvk {
     this->samplerLodBias                = config.getOption<float>       ("d3d9.samplerLodBias",                0.0f);
     this->clampNegativeLodBias          = config.getOption<bool>        ("d3d9.clampNegativeLodBias",          false);
     this->countLosableResources         = config.getOption<bool>        ("d3d9.countLosableResources",         true);
+    this->reproducibleCommandStream     = config.getOption<bool>        ("d3d9.reproducibleCommandStream",     false);
 
     // Clamp LOD bias so that people don't abuse this in unintended ways
     this->samplerLodBias = dxvk::fclamp(this->samplerLodBias, -2.0f, 1.0f);

--- a/src/d3d9/d3d9_options.h
+++ b/src/d3d9/d3d9_options.h
@@ -155,6 +155,11 @@ namespace dxvk {
 
     /// Disable counting losable resources and rejecting calls to Reset() if any are still alive
     bool countLosableResources;
+
+    /// Ensure that for the same D3D commands the output VK commands
+    /// don't change between runs. Useful for comparative benchmarking,
+    /// can negatively affect performance.
+    bool reproducibleCommandStream;
   };
 
 }

--- a/src/util/util_flush.cpp
+++ b/src/util/util_flush.cpp
@@ -2,6 +2,12 @@
 
 namespace dxvk {
 
+  GpuFlushTracker::GpuFlushTracker(
+          bool ensureReproducibleHeuristic)
+  : m_ensureReproducibleHeuristic(ensureReproducibleHeuristic) {
+
+  }
+
   bool GpuFlushTracker::considerFlush(
           GpuFlushType          flushType,
           uint64_t              chunkId,
@@ -15,6 +21,9 @@ namespace dxvk {
     uint32_t chunkCount = uint32_t(chunkId - m_lastFlushChunkId);
 
     if (!chunkCount)
+      return false;
+
+    if (m_ensureReproducibleHeuristic && flushType != GpuFlushType::ExplicitFlush)
       return false;
 
     // Take any earlier missed flush with a stronger hint into account, so

--- a/src/util/util_flush.h
+++ b/src/util/util_flush.h
@@ -34,6 +34,8 @@ namespace dxvk {
 
   public:
 
+    GpuFlushTracker(bool ensureReproducibleHeuristic);
+
     /**
      * \brief Checks whether a context flush should be performed
      *
@@ -60,6 +62,8 @@ namespace dxvk {
             uint64_t              submissionId);
 
   private:
+
+    bool          m_ensureReproducibleHeuristic;
 
     GpuFlushType  m_lastMissedType        = GpuFlushType::ImplicitWeakHint;
 


### PR DESCRIPTION
It ensures that for the same D3D commands the output VK commands don't change between runs.

Useful for comparative benchmarking, can negatively affect performance.

---

To fully test it I'd need to disable all threading and compare runs with api dump layer. For now, what was compared are renderpasses after d3d11 translation - they are the same between runs.

When `reproducibleCommandStream` is not set the number of draw calls in renderpass and even the number of renderpasses may vary, which makes hard to make comparisons between runs, especially on GPUs where renderpasses do matter.