### PR TITLE
Use custom driver version helper

### DIFF
--- a/src/d3d9/d3d9_options.cpp
+++ b/src/d3d9/d3d9_options.cpp
@@ -90,8 +90,8 @@ namespace dxvk {
       d3d9FloatEmulation = D3D9FloatEmulation::Enabled;
     } else {
       bool hasMulz = adapter != nullptr
-                  && (adapter->matchesDriver(VK_DRIVER_ID_MESA_RADV, 0, 0)
-                   || adapter->matchesDriver(VK_DRIVER_ID_MESA_NVK, 0, 0));
+                  && (adapter->matchesDriver(VK_DRIVER_ID_MESA_RADV)
+                   || adapter->matchesDriver(VK_DRIVER_ID_MESA_NVK));
       d3d9FloatEmulation = hasMulz ? D3D9FloatEmulation::Strict : D3D9FloatEmulation::Enabled;
     }
 

--- a/src/dxvk/dxvk_adapter.h
+++ b/src/dxvk/dxvk_adapter.h
@@ -255,8 +255,17 @@ namespace dxvk {
      */
     bool matchesDriver(
             VkDriverIdKHR       driver,
-            uint32_t            minVer,
-            uint32_t            maxVer) const;
+            Version             minVer,
+            Version             maxVer) const;
+
+    /**
+     * \brief Tests if the driver matches certain criteria
+     *
+     * \param [in] driver Driver ID
+     * \returns \c True if the driver matches these criteria
+     */
+    bool matchesDriver(
+            VkDriverIdKHR       driver) const;
     
     /**
      * \brief Logs DXVK adapter info
@@ -343,6 +352,8 @@ namespace dxvk {
     static void logFeatures(const DxvkDeviceFeatures& features);
     static void logQueueFamilies(const DxvkAdapterQueueIndices& queues);
     
+    static Version decodeDriverVersion(VkDriverId driverId, uint32_t version);
+
   };
   
 }

--- a/src/dxvk/dxvk_device.cpp
+++ b/src/dxvk/dxvk_device.cpp
@@ -82,7 +82,7 @@ namespace dxvk {
 
         // Disable lifetime tracking for drivers that do not have any
         // significant issues with 32-bit address space to begin with
-        if (m_adapter->matchesDriver(VK_DRIVER_ID_MESA_RADV_KHR, 0, 0))
+        if (m_adapter->matchesDriver(VK_DRIVER_ID_MESA_RADV_KHR))
           return false;
 
         return true;
@@ -325,12 +325,12 @@ namespace dxvk {
   DxvkDevicePerfHints DxvkDevice::getPerfHints() {
     DxvkDevicePerfHints hints;
     hints.preferFbDepthStencilCopy = m_features.extShaderStencilExport
-      && (m_adapter->matchesDriver(VK_DRIVER_ID_MESA_RADV_KHR, 0, 0)
-       || m_adapter->matchesDriver(VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR, 0, 0)
-       || m_adapter->matchesDriver(VK_DRIVER_ID_AMD_PROPRIETARY_KHR, 0, 0));
+      && (m_adapter->matchesDriver(VK_DRIVER_ID_MESA_RADV_KHR)
+       || m_adapter->matchesDriver(VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR)
+       || m_adapter->matchesDriver(VK_DRIVER_ID_AMD_PROPRIETARY_KHR));
     hints.preferFbResolve = m_features.amdShaderFragmentMask
-      && (m_adapter->matchesDriver(VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR, 0, 0)
-       || m_adapter->matchesDriver(VK_DRIVER_ID_AMD_PROPRIETARY_KHR, 0, 0));
+      && (m_adapter->matchesDriver(VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR)
+       || m_adapter->matchesDriver(VK_DRIVER_ID_AMD_PROPRIETARY_KHR));
     return hints;
   }
 

--- a/src/dxvk/dxvk_device_filter.cpp
+++ b/src/dxvk/dxvk_device_filter.cpp
@@ -17,10 +17,10 @@ namespace dxvk {
   
   
   bool DxvkDeviceFilter::testAdapter(const VkPhysicalDeviceProperties& properties) const {
-    if (properties.apiVersion < VK_MAKE_VERSION(1, 3, 0)) {
+    if (properties.apiVersion < VK_MAKE_API_VERSION(0, 1, 3, 0)) {
       Logger::warn(str::format("Skipping Vulkan ",
-        VK_VERSION_MAJOR(properties.apiVersion), ".",
-        VK_VERSION_MINOR(properties.apiVersion), " adapter: ",
+        VK_API_VERSION_MAJOR(properties.apiVersion), ".",
+        VK_API_VERSION_MINOR(properties.apiVersion), " adapter: ",
         properties.deviceName));
       return false;
     }

--- a/src/dxvk/dxvk_device_info.h
+++ b/src/dxvk/dxvk_device_info.h
@@ -2,6 +2,8 @@
 
 #include "dxvk_include.h"
 
+#include "../util/util_version.h"
+
 namespace dxvk {
 
   /**
@@ -13,6 +15,7 @@ namespace dxvk {
    * so before using them, check whether they are supported.
    */
   struct DxvkDeviceInfo {
+    Version                                                   driverVersion;
     VkPhysicalDeviceProperties2                               core;
     VkPhysicalDeviceVulkan11Properties                        vk11;
     VkPhysicalDeviceVulkan12Properties                        vk12;

--- a/src/dxvk/dxvk_instance.cpp
+++ b/src/dxvk/dxvk_instance.cpp
@@ -182,8 +182,8 @@ namespace dxvk {
       appInfo.pApplicationName      = appName.c_str();
       appInfo.applicationVersion    = flags.raw();
       appInfo.pEngineName           = "DXVK";
-      appInfo.engineVersion         = VK_MAKE_VERSION(2, 3, 2);
-      appInfo.apiVersion            = VK_MAKE_VERSION(1, 3, 0);
+      appInfo.engineVersion         = VK_MAKE_API_VERSION(0, 2, 3, 2);
+      appInfo.apiVersion            = VK_MAKE_API_VERSION(0, 1, 3, 0);
 
       VkInstanceCreateInfo info = { VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO };
       info.pApplicationInfo         = &appInfo;

--- a/src/dxvk/hud/dxvk_hud_item.cpp
+++ b/src/dxvk/hud/dxvk_hud_item.cpp
@@ -129,12 +129,8 @@ namespace dxvk::hud {
 
     std::string driverInfo = props.vk12.driverInfo;
 
-    if (driverInfo.empty()) {
-      driverInfo = str::format(
-        VK_VERSION_MAJOR(props.core.properties.driverVersion), ".",
-        VK_VERSION_MINOR(props.core.properties.driverVersion), ".",
-        VK_VERSION_PATCH(props.core.properties.driverVersion));
-    }
+    if (driverInfo.empty())
+      driverInfo = props.driverVersion.toString();
 
     m_deviceName = props.core.properties.deviceName;
     m_driverName = str::format("Driver:  ", props.vk12.driverName);

--- a/src/util/util_version.h
+++ b/src/util/util_version.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <cstdint>
+
+#include "../vulkan/vulkan_loader.h"
+
+#include "util_string.h"
+
+namespace dxvk {
+
+  /**
+   * \brief Decoded driver version
+   */
+  class Version {
+
+  public:
+
+    Version() = default;
+
+    Version(uint32_t major, uint32_t minor, uint32_t patch)
+    : m_raw((uint64_t(major) << 48) | (uint64_t(minor) << 24) | uint64_t(patch)) { }
+
+    uint32_t major() const { return uint32_t(m_raw >> 48); }
+    uint32_t minor() const { return uint32_t(m_raw >> 24) & 0xffffffu; }
+    uint32_t patch() const { return uint32_t(m_raw) & 0xffffffu; }
+
+    bool operator == (const Version& other) const { return m_raw == other.m_raw; }
+    bool operator != (const Version& other) const { return m_raw != other.m_raw; }
+    bool operator >= (const Version& other) const { return m_raw >= other.m_raw; }
+    bool operator <= (const Version& other) const { return m_raw <= other.m_raw; }
+    bool operator >  (const Version& other) const { return m_raw >  other.m_raw; }
+    bool operator <  (const Version& other) const { return m_raw <  other.m_raw; }
+
+    std::string toString() const {
+      return str::format(major(), ".", minor(), ".", patch());
+    }
+
+    explicit operator bool () const {
+      return m_raw != 0;
+    }
+
+  private:
+
+    uint64_t m_raw = 0;
+
+  };
+
+}


### PR DESCRIPTION
And stop misusing deprecated `VK_VERSION` macros.

Supercedes #4001.

@Blisto91 