### PR TITLE
[d3d9] Do not enable support for DF formats on Nvidia

### DIFF
--- a/dxvk.conf
+++ b/dxvk.conf
@@ -515,7 +515,9 @@
 
 # Support DF formats
 #
-# Support the vendor extension DF floating point depth formats
+# Support the vendor extension DF floating point depth formats on AMD and Intel.
+# Note that this config is ignored and disabled by default on Nvidia, or when
+# spoofing a Nvidia GPU, as it does not support these formats natively.
 #
 # Supported values:
 # - True/False

--- a/src/d3d9/d3d9_format.cpp
+++ b/src/d3d9/d3d9_format.cpp
@@ -438,7 +438,11 @@ namespace dxvk {
   D3D9VkFormatTable::D3D9VkFormatTable(
     const Rc<DxvkAdapter>& adapter,
     const D3D9Options&     options) {
-    m_dfSupport = options.supportDFFormats;
+
+    const auto& props = adapter->deviceProperties();
+    uint32_t vendorId  = options.customVendorId == -1 ? props.vendorID : uint32_t(options.customVendorId);
+
+    m_dfSupport = options.supportDFFormats && DxvkGpuVendor(vendorId) != DxvkGpuVendor::Nvidia;
     m_x4r4g4b4Support = options.supportX4R4G4B4;
     m_d32supportFinal = options.supportD32;
 


### PR DESCRIPTION
Should get #4008 shadows working properly on Nvidia and provide a saner default behavior for some games. Since native Nvidia d3d9 drivers don't support DF16 or DF24 it makes little sense to expose them IMHO.

The game in question would still need a config option for AMD and Intel, since it seems to be broken in regards to shadows in general.

Alternatively, we could allow it only for AMD and Intel (more historically accurate), rather than disabling it only on Nvidia, since this would also disable it for more exotic vendors. Let me know what you think.