### PR TITLE
[util] Disable supportDFFormats for Prototype

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -898,6 +898,11 @@ namespace dxvk {
     { R"(\\TS3(W)?\.exe$)", {{ 
       { "d3d9.deviceLossOnFocusLoss",       "True" },
     }} },
+    /* Prototype                                 *
+     * Incorrect shadows on AMD & Intel          */
+    { R"(\\prototypef\.exe$)", {{ 
+      { "d3d9.supportDFFormats",            "False" },
+    }} },
 
 
     /**********************************************/


### PR DESCRIPTION
Works around incorrect shadows on AMD & Intel

Closes #4008