### PR TITLE
[d3d9] Fixed function fix a bunch of wine tests with FF texture coord…

### DIFF
--- a/src/d3d9/d3d9_constant_buffer.cpp
+++ b/src/d3d9/d3d9_constant_buffer.cpp
@@ -13,7 +13,7 @@ namespace dxvk {
           DxsoProgramType       ShaderStage,
           DxsoConstantBuffers   BufferType,
           VkDeviceSize          Size)
-  : D3D9ConstantBuffer(pDevice, getBufferUsage(pDevice, ShaderStage, BufferType), GetShaderStage(ShaderStage),
+  : D3D9ConstantBuffer(pDevice, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT | VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, GetShaderStage(ShaderStage),
       computeResourceSlotId(ShaderStage, DxsoBindingType::ConstantBuffer, BufferType),
       Size) {
 
@@ -133,23 +133,6 @@ namespace dxvk {
       device->properties().core.properties.limits.minUniformBufferOffsetAlignment,
       device->properties().core.properties.limits.minStorageBufferOffsetAlignment),
       device->properties().extRobustness2.robustUniformBufferAccessSizeAlignment);
-  }
-
-
-  VkBufferUsageFlags D3D9ConstantBuffer::getBufferUsage(
-          D3D9DeviceEx*         pDevice,
-          DxsoProgramType       ShaderStage,
-          DxsoConstantBuffers   BufferType) {
-    VkBufferUsageFlags result = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
-
-    // We won't always need this, but the only buffer that
-    // this applies to is so large that it will not matter.
-    if (pDevice->CanSWVP()
-     && ShaderStage == DxsoProgramType::VertexShader
-     && BufferType == DxsoConstantBuffers::VSConstantBuffer)
-      result |= VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
-
-    return result;
   }
 
 }

--- a/src/d3d9/d3d9_constant_buffer.h
+++ b/src/d3d9/d3d9_constant_buffer.h
@@ -80,11 +80,6 @@ namespace dxvk {
 
     VkDeviceSize getAlignment(const Rc<DxvkDevice>& device) const;
 
-    static VkBufferUsageFlags getBufferUsage(
-            D3D9DeviceEx*         pDevice,
-            DxsoProgramType       ShaderStage,
-            DxsoConstantBuffers   BufferType);
-
   };
 
 }

--- a/src/d3d9/d3d9_fixed_function.cpp
+++ b/src/d3d9/d3d9_fixed_function.cpp
@@ -1111,6 +1111,17 @@ namespace dxvk {
       const uint32_t wIndex = 3;
 
       uint32_t flags = (m_vsKey.Data.Contents.TransformFlags >> (i * 3)) & 0b111;
+
+      if (flags == D3DTTFF_COUNT1) {
+        // D3DTTFF_COUNT1 behaves like D3DTTFF_DISABLE on NV and like D3DTTFF_COUNT2 on AMD.
+        // The Nvidia behavior is easier to implement.
+        flags = D3DTTFF_DISABLE;
+      }
+
+      // Passing 0xffffffff results in it getting clamped to the dimensions of the texture coords and getting treated as PROJECTED
+      // but D3D9 does not apply the transformation matrix.
+      bool applyTransform = flags >= D3DTTFF_COUNT1 && flags <= D3DTTFF_COUNT4;
+
       uint32_t count;
       switch (inputFlags) {
         default:
@@ -1121,11 +1132,14 @@ namespace dxvk {
           count = flags;
           if (texcoordCount) {
             // Clamp by the number of elements in the texcoord input.
-            if (!count || count > texcoordCount)
+            if (!count || count > texcoordCount) {
               count = texcoordCount;
-          }
-          else
+            }
+          } else {
+            count = 0;
             flags = D3DTTFF_DISABLE;
+            applyTransform = false;
+          }
           break;
 
         case (DXVK_TSS_TCI_CAMERASPACENORMAL >> TCIOffset):
@@ -1141,7 +1155,7 @@ namespace dxvk {
         case (DXVK_TSS_TCI_CAMERASPACEREFLECTIONVECTOR >> TCIOffset): {
           uint32_t vtx3 = m_module.opVectorShuffle(m_vec3Type, vtx, vtx, 3, indices.data());
           vtx3 = m_module.opNormalize(m_vec3Type, vtx3);
-          
+
           uint32_t reflection = m_module.opReflect(m_vec3Type, vtx3, normal);
 
           std::array<uint32_t, 4> transformIndices;
@@ -1179,9 +1193,8 @@ namespace dxvk {
         }
       }
 
-      uint32_t type = flags;
-      if (type != D3DTTFF_DISABLE) {
-        if (!m_vsKey.Data.Contents.HasPositionT) {
+      if (applyTransform || (count != 4 && count != 0)) {
+        if (applyTransform && !m_vsKey.Data.Contents.HasPositionT) {
           for (uint32_t j = count; j < 4; j++) {
             // If we're outside the component count of the vertex decl for this texcoord then we pad with zeroes.
             // Otherwise, pad with ones.
@@ -1198,8 +1211,8 @@ namespace dxvk {
         }
 
         // Pad the unused section of it with the value for projection.
-        uint32_t lastIdx = count - 1;
-        uint32_t projValue = m_module.opCompositeExtract(m_floatType, transformed, 1, &lastIdx);
+        uint32_t projIdx = std::max(2u, count - 1);
+        uint32_t projValue = m_module.opCompositeExtract(m_floatType, transformed, 1, &projIdx);
 
         for (uint32_t j = count; j < 4; j++)
           transformed = m_module.opCompositeInsert(m_vec4Type, projValue, transformed, 1, &j);
@@ -1808,21 +1821,16 @@ namespace dxvk {
           texcoord = m_module.opVectorShuffle(texcoord_t,
             texcoord, texcoord, texcoordCnt, indices.data());
 
-          uint32_t projIdx = m_fsKey.Stages[i].Contents.ProjectedCount;
-          if (projIdx == 0 || projIdx > texcoordCnt) {
-            projIdx = 4; // Always use w if ProjectedCount is 0.
-          }
-          --projIdx;
-
+          bool shouldProject = m_fsKey.Stages[i].Contents.Projected;
           uint32_t projValue = 0;
 
-          if (m_fsKey.Stages[i].Contents.Projected) {
+          if (shouldProject) {
+            // Always use w, the vertex shader puts the correct value there.
+            const uint32_t projIdx = 3;
             projValue = m_module.opCompositeExtract(m_floatType, m_ps.in.TEXCOORD[i], 1, &projIdx);
             uint32_t insertIdx = texcoordCnt - 1;
             texcoord = m_module.opCompositeInsert(texcoord_t, projValue, texcoord, 1, &insertIdx);
           }
-
-          bool shouldProject = m_fsKey.Stages[i].Contents.Projected;
 
           if (i != 0 && (
             m_fsKey.Stages[i - 1].Contents.ColorOp == D3DTOP_BUMPENVMAP ||


### PR DESCRIPTION
Fixes #3117

Master:

> visual.c:28422: Driver string: "nvd3dum.dll"
visual.c:28423: Description string: "NVIDIA GeForce RTX 3090"
visual.c:28426: Device name string: "\\.\DISPLAY1"
visual.c:28428: Driver version 32767.65535.65535.65535
visual.c:5709: Test failed: quad 4 has color 00000000, expected 0x0033cc00
visual.c:5375: Test failed: D3DTTFF_COUNT3 | D3DTTFF_PROJECTED (draws non-projected) - top right: pixel (341, 211) has color ff000000, expected ffffffff.
visual.c:5375: Test failed: D3DTTFF_COUNT3 | D3DTTFF_PROJECTED (draws non-projected) - top right: pixel (341, 224) has color ff000000, expected ffffffff.
visual.c:5375: Test failed: D3DTTFF_COUNT3 | D3DTTFF_PROJECTED (draws non-projected) - top right: pixel (359, 211) has color ff000000, expected ffffffff.
visual.c:5375: Test failed: D3DTTFF_COUNT3 | D3DTTFF_PROJECTED (draws non-projected) - top right: pixel (359, 224) has color ff000000, expected ffffffff.
visual.c:5375: Test failed: D3DTTFF_PROJECTED (like COUNT3 | PROJECTED, texcoord has only 3 components) - bottom right: pixel (401, 361) has color ff000000, expected ffffffff.
visual.c:5375: Test failed: D3DTTFF_PROJECTED (like COUNT3 | PROJECTED, texcoord has only 3 components) - bottom right: pixel (401, 419) has color ff000000, expected ffffffff.
visual.c:5375: Test failed: D3DTTFF_PROJECTED (like COUNT3 | PROJECTED, texcoord has only 3 components) - bottom right: pixel (479, 361) has color ff000000, expected ffffffff.
visual.c:5375: Test failed: D3DTTFF_PROJECTED (like COUNT3 | PROJECTED, texcoord has only 3 components) - bottom right: pixel (479, 419) has color ff000000, expected ffffffff.
visual.c:5375: Test failed: D3DTTFF_COUNT1 (draws non-projected) - top right: pixel (341, 209) has color ffffffff, expected ff000000.
visual.c:5375: Test failed: D3DTTFF_COUNT1 (draws non-projected) - top right: pixel (341, 226) has color ffffffff, expected ff000000.
visual.c:5375: Test failed: D3DTTFF_COUNT1 (draws non-projected) - top right: pixel (359, 209) has color ffffffff, expected ff000000.
visual.c:5375: Test failed: D3DTTFF_COUNT1 (draws non-projected) - top right: pixel (359, 226) has color ffffffff, expected ff000000.
visual.c:5979: Test failed: quad 3 has color 00000000, expected 0x000000ff
visual.c:5981: Test failed: quad 4 has color 00000000, expected 0x00ffffff
visual.c:6068: Test failed: quad 3 has color 00ffffff, expected 0x00ff0000
45d4:visual: 460 tests executed (0 marked as todo, 0 as flaky, 16 failures), 0 skipped.

PR:

> visual.c:28422: Driver string: "nvd3dum.dll"
visual.c:28423: Description string: "NVIDIA GeForce RTX 3090"
visual.c:28426: Device name string: "\\.\DISPLAY1"
visual.c:28428: Driver version 32767.65535.65535.65535
a4d0:visual: 460 tests executed (0 marked as todo, 0 as flaky, 0 failures), 0 skipped.

I'd appreciate testing for regressions with:
~~#3293 (maybe @mrdeathjr28)~~ I still had the Apitrace of Coldfear and that is fine with the PR.
~~#3628 (@Blisto91)~~ I still had the Project Snowblind Apitrace and that also renders fine with the PR.
and Sims 2 (maybe @tannisroot)