### PR TITLE
[d3d9] Options parser vendorID fix and DF format support validation rework

### DIFF
--- a/src/d3d9/d3d9_format.cpp
+++ b/src/d3d9/d3d9_format.cpp
@@ -438,11 +438,7 @@ namespace dxvk {
   D3D9VkFormatTable::D3D9VkFormatTable(
     const Rc<DxvkAdapter>& adapter,
     const D3D9Options&     options) {
-
-    const auto& props = adapter->deviceProperties();
-    uint32_t vendorId  = options.customVendorId == -1 ? props.vendorID : uint32_t(options.customVendorId);
-
-    m_dfSupport = options.supportDFFormats && DxvkGpuVendor(vendorId) != DxvkGpuVendor::Nvidia;
+    m_dfSupport = options.supportDFFormats;
     m_x4r4g4b4Support = options.supportX4R4G4B4;
     m_d32supportFinal = options.supportD32;
 

--- a/src/d3d9/d3d9_options.cpp
+++ b/src/d3d9/d3d9_options.cpp
@@ -37,7 +37,7 @@ namespace dxvk {
     this->customDeviceId        = parsePciId(config.getOption<std::string>("d3d9.customDeviceId"));
     this->customDeviceDesc      =            config.getOption<std::string>("d3d9.customDeviceDesc");
 
-    const int32_t vendorId = this->customVendorId != -1
+    const uint32_t vendorId = this->customVendorId != -1
       ? this->customVendorId
       : (adapter != nullptr ? adapter->deviceProperties().vendorID : 0);
 
@@ -53,14 +53,14 @@ namespace dxvk {
     this->deferSurfaceCreation          = config.getOption<bool>        ("d3d9.deferSurfaceCreation",          false);
     this->samplerAnisotropy             = config.getOption<int32_t>     ("d3d9.samplerAnisotropy",             -1);
     this->maxAvailableMemory            = config.getOption<int32_t>     ("d3d9.maxAvailableMemory",            4096);
-    this->supportDFFormats              = config.getOption<bool>        ("d3d9.supportDFFormats",              true);
+    this->supportDFFormats              = config.getOption<bool>        ("d3d9.supportDFFormats",              vendorId != uint32_t(DxvkGpuVendor::Nvidia));
     this->supportX4R4G4B4               = config.getOption<bool>        ("d3d9.supportX4R4G4B4",               true);
     this->supportD32                    = config.getOption<bool>        ("d3d9.supportD32",                    true);
     this->useD32forD24                  = config.getOption<bool>        ("d3d9.useD32forD24",                  false);
     this->disableA8RT                   = config.getOption<bool>        ("d3d9.disableA8RT",                   false);
     this->invariantPosition             = config.getOption<bool>        ("d3d9.invariantPosition",             true);
     this->memoryTrackTest               = config.getOption<bool>        ("d3d9.memoryTrackTest",               false);
-    this->supportVCache                 = config.getOption<bool>        ("d3d9.supportVCache",                 vendorId == 0x10de);
+    this->supportVCache                 = config.getOption<bool>        ("d3d9.supportVCache",                 vendorId == uint32_t(DxvkGpuVendor::Nvidia));
     this->enableDialogMode              = config.getOption<bool>        ("d3d9.enableDialogMode",              false);
     this->forceSamplerTypeSpecConstants = config.getOption<bool>        ("d3d9.forceSamplerTypeSpecConstants", false);
     this->forceSwapchainMSAA            = config.getOption<int32_t>     ("d3d9.forceSwapchainMSAA",            -1);

--- a/src/d3d9/d3d9_options.cpp
+++ b/src/d3d9/d3d9_options.cpp
@@ -37,8 +37,8 @@ namespace dxvk {
     this->customDeviceId        = parsePciId(config.getOption<std::string>("d3d9.customDeviceId"));
     this->customDeviceDesc      =            config.getOption<std::string>("d3d9.customDeviceDesc");
 
-    const int32_t vendorId = this->customDeviceId != -1
-      ? this->customDeviceId
+    const int32_t vendorId = this->customVendorId != -1
+      ? this->customVendorId
       : (adapter != nullptr ? adapter->deviceProperties().vendorID : 0);
 
     this->maxFrameLatency               = config.getOption<int32_t>     ("d3d9.maxFrameLatency",               0);


### PR DESCRIPTION
I'm guessing the use of customDeviceId for vendorID was unintentional, right? :sweat_smile: Not that it affected much beyond VQuery support on the few titles that have Nvidia vendorID (& deviceID) overrides set in place (even then, only on AMD and Intel).

Also moved the DF Format support disabling on Nvidia during options parsing, sorry for not doing that earlier (didn't really think a vendorID check was already done there, so didn't bother to check).

