### PR TITLE
[d3d9] Tweak VCache query results

### DIFF
--- a/src/d3d9/d3d9_query.cpp
+++ b/src/d3d9/d3d9_query.cpp
@@ -217,12 +217,10 @@ namespace dxvk {
 
       switch (m_queryType) {
         case D3DQUERYTYPE_VCACHE:
-          // Don't know what the hell any of this means.
-          // Nor do I care. This just makes games work.
-          m_dataCache.VCache.Pattern     = MAKEFOURCC('H', 'C', 'A', 'C');
+          m_dataCache.VCache.Pattern     = MAKEFOURCC('C', 'A', 'C', 'H');
           m_dataCache.VCache.OptMethod   = 1;
-          m_dataCache.VCache.CacheSize   = 24;
-          m_dataCache.VCache.MagicNumber = 20;
+          m_dataCache.VCache.CacheSize   = 16;
+          m_dataCache.VCache.MagicNumber = 7;
           break;
 
         case D3DQUERYTYPE_OCCLUSION:


### PR DESCRIPTION
I'm not entirely sure which games relied on this being exposed anyway, but here's a bit more insight into how this obscure query is supposed to work: https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/d3d9types/ns-d3d9types-_d3ddevinfo_vcache

Also this is what you get with native 45.23 Nvidia drivers, on Windows XP, with a GeForce 4:

```
Listing VCache query result:
  ~ vCache Pattern: CACH
  ~ vCache OptMethod: 1
  ~ vCache CacheSize: 16
  ~ vCache MagicNumber: 7
```

dxvk currently does:

```
Listing VCache query result:
  ~ vCache Pattern: HCAC
  ~ vCache OptMethod: 1
  ~ vCache CacheSize: 24
  ~ vCache MagicNumber: 20
```

Since I'm guessing CacheSize refers to the number of internal cached buffers the driver holds, it's probably safe to assume a d3d9-era card reported somewhat higher numbers (hence the doubling in this PR).

As for the :magic_wand: number, allegedly:

> Typically, the best values are near CacheSize/2

... whatever that means. So copied over native behavior of `CacheSize/2 - 1` here.

As far as I can tell, at least with d3d8, the results are entirely static, so this should be good enough. WineD3D actually just returns a bunch of gibberish.

I'll undraft this once I figure out what native drivers report these days.