### PR TITLE
[d3d9] Rework FF texcoord processing

### DIFF
--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -7273,6 +7273,7 @@ namespace dxvk {
         key.Data.Contents.TransformFlags  |= transformFlags << (i * 3);
         key.Data.Contents.TexcoordFlags   |= indexFlags     << (i * 3);
         key.Data.Contents.TexcoordIndices |= index          << (i * 3);
+        key.Data.Contents.Projected       |= ((m_state.textureStages[i][DXVK_TSS_TEXTURETRANSFORMFLAGS] & D3DTTFF_PROJECTED) == D3DTTFF_PROJECTED) << i;
       }
 
       key.Data.Contents.TexcoordDeclMask = m_state.vertexDecl != nullptr ? m_state.vertexDecl->GetTexcoordMask() : 0;

--- a/src/d3d9/d3d9_fixed_function.h
+++ b/src/d3d9/d3d9_fixed_function.h
@@ -133,9 +133,11 @@ namespace dxvk {
         uint32_t VertexBlendCount   : 3;
 
         uint32_t VertexClipping     : 1;
+
+        uint32_t Projected : 8;
       } Contents;
 
-      uint32_t Primitive[4];
+      uint32_t Primitive[5];
     };
   };
 


### PR DESCRIPTION
Fixes #4035
Fixes #4087 

We need to apply the count **after** transforming the texcoord.

Passes my tests here: https://gitlab.winehq.org/K0bin/wine/-/blob/ff-texcoord-tests/dlls/d3d9/tests/visual.c#L28402-29023