### PR TITLE
Add dxvk.maxChunkSize 1 to Origin

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -370,6 +370,10 @@ namespace dxvk {
     { R"(\\EADesktop\.exe$)", {{
       { "dxvk.maxChunkSize",                "1"   },
     }} },
+    /* Origin app (legacy EA Desktop)             */
+    { R"(\\Origin\.exe$)", {{
+      { "dxvk.maxChunkSize",                "1"   },
+    }} },
     /* GOG Galaxy                                 */
     { R"(\\GalaxyClient\.exe$)", {{
       { "dxvk.maxChunkSize",                "1"   },


### PR DESCRIPTION
Closes #4034.
@K0bin 

Here's a screenshot of which processes stay open with the game (tested with Battlefield 4):
![image_1](https://github.com/doitsujin/dxvk/assets/30274161/b6952878-d986-4cb0-972a-2fce73fbcb5d)
