### PR TITLE
[util] Add dxvk.maxChunkSize 1 for Origin Web Helper Service and Ubisoft Connect (UPlay)

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -359,11 +359,11 @@ namespace dxvk {
       { "d3d11.dcSingleUseMode",            "False" },
     }} },
     /* Rockstar Games Launcher                    */
-    { R"(\\Rockstar Games\\Launcher\.exe$)", {{
+    { R"(\\Rockstar Games\\Launcher\\Launcher\.exe$)", {{
       { "dxvk.maxChunkSize",                "1"   },
     }} },
     /* Rockstar Social Club                       */
-    { R"(\\Rockstar Games\\SocialClub\\SocialClubHelper\.exe$)", {{
+    { R"(\\Rockstar Games\\Social Club\\SocialClubHelper\.exe$)", {{
       { "dxvk.maxChunkSize",                "1"   },
     }} },
     /* EA Desktop App                             */
@@ -371,11 +371,11 @@ namespace dxvk {
       { "dxvk.maxChunkSize",                "1"   },
     }} },
     /* Origin app (legacy EA Desktop)             */
-    { R"(\\Origin\\OriginWebHelperService\.exe$)", {{
+    { R"(\\Origin\\(Origin|OriginWebHelperService)\.exe$)", {{
       { "dxvk.maxChunkSize",                "1"   },
     }} },
     /* Ubisoft Connect (UPlay)                    */
-    { R"(\\UbisoftConnect\\upc\.exe$)", {{
+    { R"(\\Ubisoft\\Ubisoft Game Launcher\\(UbisoftConnect|upc)\.exe$)", {{
       { "dxvk.maxChunkSize",                "1"   },
     }} },
     /* GOG Galaxy                                 */

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -359,11 +359,11 @@ namespace dxvk {
       { "d3d11.dcSingleUseMode",            "False" },
     }} },
     /* Rockstar Games Launcher                    */
-    { R"(\\Rockstar Games\\Launcher\\Launcher\.exe$)", {{
+    { R"(\\Rockstar Games\\Launcher\.exe$)", {{
       { "dxvk.maxChunkSize",                "1"   },
     }} },
     /* Rockstar Social Club                       */
-    { R"(\\Rockstar Games\\Social Club\\SocialClubHelper\.exe$)", {{
+    { R"(\\Rockstar Games\\SocialClub\\SocialClubHelper\.exe$)", {{
       { "dxvk.maxChunkSize",                "1"   },
     }} },
     /* EA Desktop App                             */
@@ -371,7 +371,7 @@ namespace dxvk {
       { "dxvk.maxChunkSize",                "1"   },
     }} },
     /* Origin app (legacy EA Desktop)             */
-    { R"(\\Origin\.exe$)", {{
+    { R"(\\Origin\\OriginWebHelperService\.exe$)", {{
       { "dxvk.maxChunkSize",                "1"   },
     }} },
     /* Ubisoft Connect (UPlay)                    */

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -374,6 +374,10 @@ namespace dxvk {
     { R"(\\Origin\.exe$)", {{
       { "dxvk.maxChunkSize",                "1"   },
     }} },
+    /* Ubisoft Connect (UPlay)                    */
+    { R"(\\UbisoftConnect\\upc\.exe$)", {{
+      { "dxvk.maxChunkSize",                "1"   },
+    }} },
     /* GOG Galaxy                                 */
     { R"(\\GalaxyClient\.exe$)", {{
       { "dxvk.maxChunkSize",                "1"   },


### PR DESCRIPTION
A follow-up to #4037.

Tested by exiting Steam completely, then launching with `DXVK_CONFIG="dxvk.maxChunkSize = 1" steam` and playing Watch Dogs 1 for about 5 minutes. Haven't experienced any problems.

Below are the processes that stay open with the game in the background:
![ubisoft](https://github.com/doitsujin/dxvk/assets/30274161/3269d458-a676-42e4-8272-04dc6040116d)

`UbisoftConnect.exe` is the main process, which doesn't stay open, but I'm adding it for extra safety. `upc.exe` seems to be what really matters here (I guess it means "UPlay Core").

We also have these ones in the Ubisoft Game Launcher installation folder:

- `UbisoftGameLauncher64.exe` and `UbisoftGameLauncher.exe` (opens temporarily during Steam game launch; maybe a proxy service for Steam-Ubisoft?)
- `UplayCrashReporter.exe` (I don't think this one needs maxchunksize)
- `UplayWebCore.exe` (probably related to the overlay, but the UPlay overlay causes issues on Linux and Lutris even disables it by editing a config. file)
- `UbisoftExtension.exe` and `UplayService.exe` (I have no idea, but they do not stay open with the game)

Feel free to add maxchunksize for any process mentioned before that I haven't added if you have a better reasoning.

To be clear, Ubisoft does not support its legacy launcher anymore, and forces the new one onto its users, so there's no point to add UPlay-exclusive-related process names here.

Thank you for your attention.