### PR TITLE
[util] Set longMad for Watch_Dogs

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -447,6 +447,10 @@ namespace dxvk {
     { R"(\\ghost\.exe$)", {{
       { "d3d11.longMad",                  "True"    },
     }} },
+    /* Watch_Dogs - Some objects flicker without  */
+    { R"(\\watch_dogs\.exe$)", {{
+      { "d3d11.longMad",                  "True"    },
+    }} },
 
     /**********************************************/
     /* D3D9 GAMES                                 */


### PR DESCRIPTION
Works around flickering on some objects such as the blue light arrow on lowering gates