### PR TITLE
Fixed GLFW exception at startup

### DIFF
--- a/src/wsi/glfw/wsi_platform_glfw.cpp
+++ b/src/wsi/glfw/wsi_platform_glfw.cpp
@@ -44,7 +44,7 @@ namespace dxvk::wsi {
     if (extensionCount == 0)
       throw DxvkError(str::format("GLFW WSI: Failed to get required instance extensions"));
 
-    std::vector<const char *> names(extensionCount);
+    std::vector<const char *> names;
     for (uint32_t i = 0; i < extensionCount; ++i) {
       names.push_back(extensionArray[i]);
     }


### PR DESCRIPTION
`GlfwWsiDriver::getInstanceExtensions` was creating an `std::vector` with a size argument in the ctor but then used `push_back` instead of filling the pre-allocated elements, leading to a bunch of nullptr entries at the start that caused an exception later on when accessed.