### PR TITLE
[util] Disable Crysis 1 refresh rate fps limiter

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -451,6 +451,11 @@ namespace dxvk {
     { R"(\\watch_dogs\.exe$)", {{
       { "d3d11.longMad",                  "True"    },
     }} },
+    /* Crysis 1/Warhead - Game bug in d3d10 makes *
+     * it select lowest supported refresh rate    */
+    { R"(\\Crysis(64)?\.exe$)", {{
+      { "dxvk.maxFrameRate",              "-1"      },
+    }} },
 
     /**********************************************/
     /* D3D9 GAMES                                 */


### PR DESCRIPTION
Depends on https://github.com/doitsujin/dxvk/pull/4056

Game bug in its d3d10 mode where it selects the lowest supported refresh rate.