### PR TITLE
[util] Dead Space 2 - Limit to 60 FPS and enable vsync

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -511,6 +511,14 @@ namespace dxvk {
       { "dxvk.maxFrameRate",                     "60" },
       { "d3d9.presentInterval",                  "1" },
     }} },
+    /* Dead Space 2
+       Physics issues above 60 FPS
+       Built-in Vsync Locks the game to 30 FPS
+    */
+    { R"(\\deadspace2\.exe$)", {{
+      { "dxvk.maxFrameRate",                     "60" },
+      { "d3d9.presentInterval",                  "1" },
+    }} },
     /* Halo CE/HaloPC                             */
     { R"(\\halo(ce)?\.exe$)", {{
       // Game enables minor decal layering fixes


### PR DESCRIPTION
Similar to the first game it has a poor vsync implementation (limits to 30 fps) and physics issues when the frame rate is unlocked.

Limiting to 60 FPS and enabling vsync externally provides a better experience after the ingame vsync is disabled.