### PR TITLE
[util] Enable deviceLossOnFocusLoss for The Force Unleased

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -933,6 +933,11 @@ namespace dxvk {
     { R"(\\prototypef\.exe$)", {{ 
       { "d3d9.supportDFFormats",            "False" },
     }} },
+    /* STAR WARS: The Force Unleashed            *
+     * Prevents black screen on each alt-tab     */
+    { R"(\\SWTFU\.exe$)", {{ 
+      { "d3d9.deviceLossOnFocusLoss",       "True" },
+    }} },
 
 
     /**********************************************/


### PR DESCRIPTION
Prevents the game from black screening on each alt-tab