### PR TITLE
[util] Set deviceLossOnFocusLoss for Guild Wars

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -948,6 +948,11 @@ namespace dxvk {
     { R"(\\Dragonshard\.exe$)", {{ 
       { "d3d9.cachedDynamicBuffers",        "True" },
     }} },
+    /* Guild Wars 1 - Alt-tab black screen when  *
+     * fullscreen with non native resolution     */
+    { R"(\\Gw\.exe$)", {{ 
+      { "d3d9.deviceLossOnFocusLoss",       "True" },
+    }} },
 
 
     /**********************************************/


### PR DESCRIPTION
Works around the game black screening on alt-tab when it is set to fullscreen with a non native resolution