### PR TITLE
[d3d9] Validate D3DCREATE_PUREDEVICE usage

### DIFF
--- a/src/d3d9/d3d9_interface.cpp
+++ b/src/d3d9/d3d9_interface.cpp
@@ -354,6 +354,12 @@ namespace dxvk {
     || pPresentationParameters    == nullptr)
       return D3DERR_INVALIDCALL;
 
+    // creating a device with D3DCREATE_PUREDEVICE only works in conjunction
+    // with D3DCREATE_HARDWARE_VERTEXPROCESSING on native drivers
+    if (BehaviorFlags & D3DCREATE_PUREDEVICE &&
+    !(BehaviorFlags & D3DCREATE_HARDWARE_VERTEXPROCESSING))
+      return D3DERR_INVALIDCALL;
+
     auto* adapter = GetAdapter(Adapter);
 
     if (adapter == nullptr)


### PR DESCRIPTION
Probably not all that relevant, however native drivers apparently enforce it. There are games out there that make use of D3DCREATE_PUREDEVICE, so it doesn't hurt to make sure we don't end up in weird situations. 

To be fair, I fail to see how this flag would ever have made any sense outside of HWVP (and maaaaaybe mixed VP), but there's nothing explicitly mentioned in the spec as far as limitations go, so this was based purely on observed behavior.