### PR TITLE
Fixes for D3D8 Total War Rome

### DIFF
--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -5307,11 +5307,13 @@ namespace dxvk {
       m_flags.set(D3D9DeviceFlag::DirtyVertexBuffers);
     }
 
-    // Change the draw call parameters to reflect the changed vertex buffers
-    if (NumIndices != 0) {
-      BaseVertexIndex = -FirstVertexIndex;
-    } else {
-      FirstVertexIndex = 0;
+    if (dynamicSysmemVBOs) {
+      // Change the draw call parameters to reflect the changed vertex buffers
+      if (NumIndices != 0) {
+        BaseVertexIndex = -FirstVertexIndex;
+      } else {
+        FirstVertexIndex = 0;
+      }
     }
 
     if (dynamicSysmemIBO) {


### PR DESCRIPTION
Fixes #4083

The game also suffers from a broken shadow which is fixed by #4036