### PR TITLE
[util] Set cachedDynamicBuffers for Battle for Middle-Earth 2

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -953,6 +953,11 @@ namespace dxvk {
     { R"(\\Gw\.exe$)", {{ 
       { "d3d9.deviceLossOnFocusLoss",       "True" },
     }} },
+    /* Battle for Middle-earth 2 and expansion   *
+     * Slowdowns in certain scenarios            */
+    { R"(\\(The Battle for Middle-earth (\(tm\))? II( Demo)?|The Lord of the Rings, The Rise of the Witch-king)\\game\.dat$)", {{
+      { "d3d9.cachedDynamicBuffers",        "True" },
+    }} },
 
 
     /**********************************************/


### PR DESCRIPTION
Helps slowdowns below 30fps in certain scenarios like when moving the camera over heavy vegetation areas among others.
Yes the exe is named `game.dat`

Closes #3950