### PR TITLE
[d3d9] Various vendor formats adjustments

### DIFF
--- a/dxvk.conf
+++ b/dxvk.conf
@@ -569,15 +569,6 @@
 
 # d3d9.supportX4R4G4B4 = True
 
-# Support D32
-#
-# Support the D32 format.
-#
-# Supported values:
-# - True/False
-
-# d3d9.supportD32 = True
-
 # Disable A8 as a Render Target
 #
 # Disable support for A8 format render targets

--- a/dxvk.conf
+++ b/dxvk.conf
@@ -569,6 +569,17 @@
 
 # d3d9.supportX4R4G4B4 = True
 
+# Support D16_LOCKABLE
+#
+# Support the D16_LOCKABLE format.
+# Always enabled on AMD, or when spoofing an AMD GPU
+# via customVendorId, disabled by default on Nvidia and Intel.
+#
+# Supported values:
+# - True/False
+
+# d3d9.supportD16Lockable = False
+
 # Disable A8 as a Render Target
 #
 # Disable support for A8 format render targets

--- a/src/d3d9/d3d9_adapter.cpp
+++ b/src/d3d9/d3d9_adapter.cpp
@@ -227,14 +227,14 @@ namespace dxvk {
     if (!IsDepthFormat(DepthStencilFormat))
       return D3DERR_NOTAVAILABLE;
 
-    auto dsfMapping = ConvertFormatUnfixed(DepthStencilFormat);
+    auto dsfMapping = GetFormatMapping(DepthStencilFormat);
     if (dsfMapping.FormatColor == VK_FORMAT_UNDEFINED)
       return D3DERR_NOTAVAILABLE;
 
     if (RenderTargetFormat == dxvk::D3D9Format::NULL_FORMAT)
       return D3D_OK;
 
-    auto rtfMapping = ConvertFormatUnfixed(RenderTargetFormat);
+    auto rtfMapping = GetFormatMapping(RenderTargetFormat);
     if (rtfMapping.FormatColor == VK_FORMAT_UNDEFINED)
       return D3DERR_NOTAVAILABLE;
 

--- a/src/d3d9/d3d9_format.cpp
+++ b/src/d3d9/d3d9_format.cpp
@@ -440,7 +440,6 @@ namespace dxvk {
     const D3D9Options&     options) {
     m_dfSupport = options.supportDFFormats;
     m_x4r4g4b4Support = options.supportX4R4G4B4;
-    m_d32supportFinal = options.supportD32;
 
     // AMD do not support 24-bit depth buffers on Vulkan,
     // so we have to fall back to a 32-bit depth format.
@@ -477,9 +476,6 @@ namespace dxvk {
       return D3D9_VK_FORMAT_MAPPING();
 
     if (Format == D3D9Format::DF24 && !m_dfSupport)
-      return D3D9_VK_FORMAT_MAPPING();
-
-    if (Format == D3D9Format::D32 && !m_d32supportFinal)
       return D3D9_VK_FORMAT_MAPPING();
     
     if (!m_d24s8Support && mapping.FormatColor == VK_FORMAT_D24_UNORM_S8_UINT)

--- a/src/d3d9/d3d9_format.cpp
+++ b/src/d3d9/d3d9_format.cpp
@@ -442,7 +442,8 @@ namespace dxvk {
     const auto& props = adapter->deviceProperties();
     uint32_t vendorId  = options.customVendorId == -1 ? props.vendorID : uint32_t(options.customVendorId);
 
-    m_dfSupport = options.supportDFFormats;
+    // NVIDIA does not natively support any DF formats
+    m_dfSupport = vendorId == uint32_t(DxvkGpuVendor::Nvidia) ? false : options.supportDFFormats;
     m_x4r4g4b4Support = options.supportX4R4G4B4;
     // Only AMD supports D16_LOCKABLE natively
     m_d16lockableSupport = vendorId == uint32_t(DxvkGpuVendor::Amd) ? true : options.supportD16Lockable;

--- a/src/d3d9/d3d9_format.h
+++ b/src/d3d9/d3d9_format.h
@@ -217,6 +217,7 @@ namespace dxvk {
 
     bool m_dfSupport;
     bool m_x4r4g4b4Support;
+    bool m_d16lockableSupport;
   };
 
   inline bool IsFourCCFormat(D3D9Format format) {

--- a/src/d3d9/d3d9_format.h
+++ b/src/d3d9/d3d9_format.h
@@ -217,7 +217,6 @@ namespace dxvk {
 
     bool m_dfSupport;
     bool m_x4r4g4b4Support;
-    bool m_d32supportFinal;
   };
 
   inline bool IsFourCCFormat(D3D9Format format) {

--- a/src/d3d9/d3d9_options.cpp
+++ b/src/d3d9/d3d9_options.cpp
@@ -55,7 +55,6 @@ namespace dxvk {
     this->maxAvailableMemory            = config.getOption<int32_t>     ("d3d9.maxAvailableMemory",            4096);
     this->supportDFFormats              = config.getOption<bool>        ("d3d9.supportDFFormats",              vendorId != uint32_t(DxvkGpuVendor::Nvidia));
     this->supportX4R4G4B4               = config.getOption<bool>        ("d3d9.supportX4R4G4B4",               true);
-    this->supportD32                    = config.getOption<bool>        ("d3d9.supportD32",                    true);
     this->useD32forD24                  = config.getOption<bool>        ("d3d9.useD32forD24",                  false);
     this->disableA8RT                   = config.getOption<bool>        ("d3d9.disableA8RT",                   false);
     this->invariantPosition             = config.getOption<bool>        ("d3d9.invariantPosition",             true);

--- a/src/d3d9/d3d9_options.cpp
+++ b/src/d3d9/d3d9_options.cpp
@@ -55,6 +55,7 @@ namespace dxvk {
     this->maxAvailableMemory            = config.getOption<int32_t>     ("d3d9.maxAvailableMemory",            4096);
     this->supportDFFormats              = config.getOption<bool>        ("d3d9.supportDFFormats",              vendorId != uint32_t(DxvkGpuVendor::Nvidia));
     this->supportX4R4G4B4               = config.getOption<bool>        ("d3d9.supportX4R4G4B4",               true);
+    this->supportD16Lockable            = config.getOption<bool>        ("d3d9.supportD16Lockable",            false);
     this->useD32forD24                  = config.getOption<bool>        ("d3d9.useD32forD24",                  false);
     this->disableA8RT                   = config.getOption<bool>        ("d3d9.disableA8RT",                   false);
     this->invariantPosition             = config.getOption<bool>        ("d3d9.invariantPosition",             true);

--- a/src/d3d9/d3d9_options.cpp
+++ b/src/d3d9/d3d9_options.cpp
@@ -53,7 +53,7 @@ namespace dxvk {
     this->deferSurfaceCreation          = config.getOption<bool>        ("d3d9.deferSurfaceCreation",          false);
     this->samplerAnisotropy             = config.getOption<int32_t>     ("d3d9.samplerAnisotropy",             -1);
     this->maxAvailableMemory            = config.getOption<int32_t>     ("d3d9.maxAvailableMemory",            4096);
-    this->supportDFFormats              = config.getOption<bool>        ("d3d9.supportDFFormats",              vendorId != uint32_t(DxvkGpuVendor::Nvidia));
+    this->supportDFFormats              = config.getOption<bool>        ("d3d9.supportDFFormats",              true);
     this->supportX4R4G4B4               = config.getOption<bool>        ("d3d9.supportX4R4G4B4",               true);
     this->supportD16Lockable            = config.getOption<bool>        ("d3d9.supportD16Lockable",            false);
     this->useD32forD24                  = config.getOption<bool>        ("d3d9.useD32forD24",                  false);

--- a/src/d3d9/d3d9_options.h
+++ b/src/d3d9/d3d9_options.h
@@ -78,9 +78,6 @@ namespace dxvk {
     /// Support X4R4G4B4
     bool supportX4R4G4B4;
 
-    /// Support D32
-    bool supportD32;
-
     /// Use D32f for D24
     bool useD32forD24;
 

--- a/src/d3d9/d3d9_options.h
+++ b/src/d3d9/d3d9_options.h
@@ -78,6 +78,9 @@ namespace dxvk {
     /// Support X4R4G4B4
     bool supportX4R4G4B4;
 
+    /// Support D16_LOCKABLE
+    bool supportD16Lockable;
+
     /// Use D32f for D24
     bool useD32forD24;
 

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -554,10 +554,6 @@ namespace dxvk {
     { R"(\\SKShinoviVersus\.exe$)", {{
       { "d3d9.forceAspectRatio",            "16:9" },
     }} },
-    /* Metal Slug X                               */
-    { R"(\\mslugx\.exe$)", {{
-      { "d3d9.supportD32",                  "False" },
-    }} },
     /* Skyrim (NVAPI)                             */
     { R"(\\TESV\.exe$)", {{
       { "d3d9.customVendorId",              "1002" },


### PR DESCRIPTION
Fixes #4098.

Tests of both modern and d3d8/d3d9 era drivers show that D16_LOCKABLE is and was only ever supported on AMD.

P.S.: [Reference outputs here](https://drive.proton.me/urls/1WHHKT8P0C#cbJ6R2bTCCF8).

I've also taken the liberty to clean up the D32 configs and what was left of the validation logic, since we've removed support for it globally quite some time ago.