### PR TITLE
[util] Add folder to Beyond Good and Evil config

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -739,7 +739,7 @@ namespace dxvk {
     }} },
     /* Beyond Good And Evil                     *
      * UI breaks at high fps                     */
-    { R"(\\BGE\.exe$)", {{
+    { R"(\\Beyond Good and Evil\\BGE\.exe$)", {{
       { "dxvk.maxFrameRate",                "60" },
     }} },
     /* King Of Fighters XIII                     *


### PR DESCRIPTION
So the frame limit doesn't apply to the new remaster.

I checked that both the Steam and Gog version of the original is `Beyond Good and Evil` by default. For the remaster the Steam folder is `Beyond Good and Evil - 20th Anniversary Edition`