### PR TITLE
[util] Set cachedDynamicBuffers for The Sims 2 and friends

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -502,6 +502,7 @@ namespace dxvk {
       { "d3d9.supportX4R4G4B4",             "False" },
       { "d3d9.maxAvailableMemory",          "2048" },
       { "d3d9.memoryTrackTest",             "True" },
+      { "d3d9.cachedDynamicBuffers",        "True" },
     }} },
     /* Dead Space uses the a NULL render target instead
        of a 1x1 one if DF24 is NOT supported


### PR DESCRIPTION
Helps very low CPU bound performance especially in Castaway Stories.

https://github.com/doitsujin/dxvk/issues/4066 is kept open since even though this helps a bunch the performance is still oddly low. 
I haven't been able to compare to Windows since it crashes for me before i get ingame without dxvk and so far the game doesn't agree with apitrace.