### PR TITLE
WRC4 Added

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -959,7 +959,7 @@ namespace dxvk {
     { R"(\\(The Battle for Middle-earth (\(tm\))? II( Demo)?|The Lord of the Rings, The Rise of the Witch-king)\\game\.dat$)", {{
       { "d3d9.cachedDynamicBuffers",        "True" },
     }} },
-    /* WRC4 - Audio brakes above 60fps */
+    /* WRC4 - Audio breaks above 60fps */
     { R"(\\WRC4\.exe$)", {{
       { "d3d9.maxFrameRate",                "60" },
     }} },

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -407,6 +407,10 @@ namespace dxvk {
     { R"(\\BLADESTORM Nightmare\\Launch_(EA|JP)\.exe$)", {{
       { "dxgi.maxFrameRate",                "60"  },
     }} },
+    /* WRC4 - Audio brakes above 60fps */
+    { R"(\\WRC4\.exe$)", {{
+      { "dxgi.maxFrameRate",                "60" },
+    }} },
     /* Ghost Recon Wildlands                      */
     { R"(\\GRW\.exe$)", {{
       { "d3d11.dcSingleUseMode",            "False" },

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -407,10 +407,6 @@ namespace dxvk {
     { R"(\\BLADESTORM Nightmare\\Launch_(EA|JP)\.exe$)", {{
       { "dxgi.maxFrameRate",                "60"  },
     }} },
-    /* WRC4 - Audio brakes above 60fps */
-    { R"(\\WRC4\.exe$)", {{
-      { "dxgi.maxFrameRate",                "60" },
-    }} },
     /* Ghost Recon Wildlands                      */
     { R"(\\GRW\.exe$)", {{
       { "d3d11.dcSingleUseMode",            "False" },
@@ -962,6 +958,10 @@ namespace dxvk {
      * Slowdowns in certain scenarios            */
     { R"(\\(The Battle for Middle-earth (\(tm\))? II( Demo)?|The Lord of the Rings, The Rise of the Witch-king)\\game\.dat$)", {{
       { "d3d9.cachedDynamicBuffers",        "True" },
+    }} },
+    /* WRC4 - Audio brakes above 60fps */
+    { R"(\\WRC4\.exe$)", {{
+      { "d3d9.maxFrameRate",                "60" },
     }} },
 
 


### PR DESCRIPTION
There is a game engine bug where playing above 60fps, causes audio to brake when switching maps. It would be nice to lock the framerate to avoid that issue.