### PR TITLE
[util] Enable longMad for Watch_Dogs 2 and Legion

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -447,8 +447,8 @@ namespace dxvk {
     { R"(\\ghost\.exe$)", {{
       { "d3d11.longMad",                  "True"    },
     }} },
-    /* Watch_Dogs - Some objects flicker without  */
-    { R"(\\watch_dogs\.exe$)", {{
+    /* Watch_Dogs series - Some objects flicker  */
+    { R"(\\watch(_)?dogs(2|Legion)?\.exe$)", {{
       { "d3d11.longMad",                  "True"    },
     }} },
     /* Crysis 1/Warhead - Game bug in d3d10 makes *


### PR DESCRIPTION
Works around flickering on characters when a outline or highlight effect is showing.

Closes #4090 