### PR TITLE
[d3d8] Implement monotonic state block tokens

### DIFF
--- a/src/d3d8/d3d8_device.cpp
+++ b/src/d3d8/d3d8_device.cpp
@@ -63,11 +63,6 @@ namespace dxvk {
   D3D8Device::~D3D8Device() {
     if (m_batcher)
       delete m_batcher;
-    
-    // Delete any remaining state blocks.
-    for (D3D8StateBlock* block : m_stateBlocks) {
-      delete block;
-    }
   }
 
   HRESULT STDMETHODCALLTYPE D3D8Device::GetInfo(DWORD DevInfoID, void* pDevInfoStruct, DWORD DevInfoStructSize) {
@@ -993,21 +988,37 @@ namespace dxvk {
     Com<d3d9::IDirect3DStateBlock9> pStateBlock9;
     HRESULT res = GetD3D9()->CreateStateBlock(d3d9::D3DSTATEBLOCKTYPE(Type), &pStateBlock9);
 
-    D3D8StateBlock* pStateBlock = new D3D8StateBlock(this, Type, pStateBlock9.ref());
-    m_stateBlocks.insert(pStateBlock);
-
-    *pToken = DWORD(reinterpret_cast<uintptr_t>(pStateBlock));
+    m_stateBlocks.emplace(std::piecewise_construct,
+                          std::forward_as_tuple(m_token),
+                          std::forward_as_tuple(this, Type, pStateBlock9.ref()));
+    *pToken = m_token;
+    m_token++;
 
     return res;
   }
 
   HRESULT STDMETHODCALLTYPE D3D8Device::CaptureStateBlock(DWORD Token) {
-    return reinterpret_cast<D3D8StateBlock*>(Token)->Capture();
+    auto stateBlockIter = m_stateBlocks.find(Token);
+
+    if (unlikely(stateBlockIter == m_stateBlocks.end())) {
+      Logger::err("Invalid token passed to CaptureStateBlock");
+      return D3DERR_INVALIDCALL;
+    }
+
+    return stateBlockIter->second.Capture();
   }
 
   HRESULT STDMETHODCALLTYPE D3D8Device::ApplyStateBlock(DWORD Token) {
     StateChange();
-    return reinterpret_cast<D3D8StateBlock*>(Token)->Apply();
+
+    auto stateBlockIter = m_stateBlocks.find(Token);
+
+    if (unlikely(stateBlockIter == m_stateBlocks.end())) {
+      Logger::err("Invalid token passed to ApplyStateBlock");
+      return D3DERR_INVALIDCALL;
+    }
+
+    return stateBlockIter->second.Apply();
   }
 
   HRESULT STDMETHODCALLTYPE D3D8Device::DeleteStateBlock(DWORD Token) {
@@ -1015,9 +1026,14 @@ namespace dxvk {
     if (unlikely(ShouldRecord()))
       return D3DERR_INVALIDCALL;
 
-    D3D8StateBlock* block = reinterpret_cast<D3D8StateBlock*>(Token);
-    m_stateBlocks.erase(block);
-    delete block;
+    auto stateBlockIter = m_stateBlocks.find(Token);
+
+    if (unlikely(stateBlockIter == m_stateBlocks.end())) {
+      Logger::err("Invalid token passed to DeleteStateBlock");
+      return D3DERR_INVALIDCALL;
+    }
+
+    m_stateBlocks.erase(stateBlockIter);
 
     return D3D_OK;
   }
@@ -1026,8 +1042,12 @@ namespace dxvk {
     if (unlikely(m_recorder != nullptr))
       return D3DERR_INVALIDCALL;
 
-    m_recorder = new D3D8StateBlock(this);
-    m_stateBlocks.insert(m_recorder);
+    auto stateBlockIterPair = m_stateBlocks.emplace(std::piecewise_construct,
+                                                    std::forward_as_tuple(m_token),
+                                                    std::forward_as_tuple(this));
+    m_recorder = &stateBlockIterPair.first->second;
+    m_recorderToken = m_token;
+    m_token++;
 
     return GetD3D9()->BeginStateBlock();
   }
@@ -1041,9 +1061,10 @@ namespace dxvk {
 
     m_recorder->SetD3D9(std::move(pStateBlock));
 
-    *pToken = DWORD(reinterpret_cast<uintptr_t>(m_recorder));
+    *pToken = m_recorderToken;
 
     m_recorder = nullptr;
+    m_recorderToken = -1;
 
     return res;
   }

--- a/src/d3d8/d3d8_device.h
+++ b/src/d3d8/d3d8_device.h
@@ -14,7 +14,7 @@
 #include <array>
 #include <vector>
 #include <type_traits>
-#include <unordered_set>
+#include <unordered_map>
 
 namespace dxvk {
 
@@ -416,9 +416,11 @@ namespace dxvk {
 
     D3DPRESENT_PARAMETERS m_presentParams;
 
-    D3D8StateBlock*                      m_recorder = nullptr;
-    std::unordered_set<D3D8StateBlock*>  m_stateBlocks;
-    D3D8Batcher*                         m_batcher  = nullptr;
+    D3D8StateBlock*                            m_recorder = nullptr;
+    DWORD                                      m_recorderToken = -1;
+    DWORD                                      m_token    = 0;
+    std::unordered_map<DWORD, D3D8StateBlock>  m_stateBlocks;
+    D3D8Batcher*                               m_batcher  = nullptr;
 
     struct D3D8VBO {
       Com<D3D8VertexBuffer, false>   buffer = nullptr;


### PR DESCRIPTION
Would need feedback from @AlpyneDreams .

The idea is to get rid of reinterpret casts and stick with what native does, namely a monotonically increasing counter that is passed back as the token whenever new state blocks are created. Tests have shown there's no token reuse, not even between device resets.

I also don't think we should worry about the address space being exhausted, because I did some quick math and if let's say a game creates 8 state blocks per frame @ 60 fps, it will take about 100+ days to overflow a DWORD. That's "let's not worry about it" territory in my book... but I can in theory implement a check to see if a token is already taken before allocating it.