### PR TITLE
[d3d8+9] Relax certain StretchRect restrictions

### DIFF
--- a/src/d3d9/d3d9_bridge.h
+++ b/src/d3d9/d3d9_bridge.h
@@ -3,8 +3,6 @@
 #include <windows.h>
 #include "../util/config/config.h"
 
-#include "../vulkan/vulkan_loader.h"
-
 /**
  * The D3D9 bridge allows D3D8 to access DXVK internals.
  * For Vulkan interop without needing DXVK internals, see d3d9_interop.h.
@@ -111,7 +109,7 @@ namespace dxvk {
             void** ppvObject);
 
     const Config* GetConfig() const;
-    
+
   protected:
     D3D9InterfaceEx* m_interface;
   };

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -1264,7 +1264,7 @@ namespace dxvk {
       // - both destination and source are depth stencil surfaces
       // - both destination and source are offscreen plain surfaces.
       // The only way to get a surface with resource type D3DRTYPE_SURFACE without USAGE_RT or USAGE_DS is CreateOffscreenPlainSurface.
-      if (unlikely(!dstHasRTUsage && (!dstIsSurface || !srcIsSurface || srcHasRTUsage)))
+      if (unlikely((!dstHasRTUsage && (!dstIsSurface || !srcIsSurface || srcHasRTUsage)) && !m_isD3D8Compatible))
         return D3DERR_INVALIDCALL;
     }
 

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -1245,6 +1245,7 @@ namespace dxvk {
     bool stretch = srcCopyExtent != dstCopyExtent;
 
     bool dstHasRTUsage = (dstTextureInfo->Desc()->Usage & (D3DUSAGE_RENDERTARGET | D3DUSAGE_DEPTHSTENCIL)) != 0;
+    bool dstIsSurface = dstTextureInfo->GetType() == D3DRTYPE_SURFACE;
     if (stretch) {
       if (unlikely(pSourceSurface == pDestSurface))
         return D3DERR_INVALIDCALL;
@@ -1252,12 +1253,13 @@ namespace dxvk {
       if (unlikely(dstIsDepth))
         return D3DERR_INVALIDCALL;
 
-      // Stretching is only allowed if the destination is either a render target surface or a render target texture
-      if (unlikely(!dstHasRTUsage))
+      // The docs say that stretching is only allowed if the destination is either a render target surface or a render target texture.
+      // However in practice, using an offscreen plain surface in D3DPOOL_DEFAULT as the destination works fine.
+      // Using a texture without USAGE_RENDERTARGET as destination however does not.
+      if (unlikely(!dstIsSurface && !dstHasRTUsage))
         return D3DERR_INVALIDCALL;
     } else {
       bool srcIsSurface = srcTextureInfo->GetType() == D3DRTYPE_SURFACE;
-      bool dstIsSurface = dstTextureInfo->GetType() == D3DRTYPE_SURFACE;
       bool srcHasRTUsage = (srcTextureInfo->Desc()->Usage & (D3DUSAGE_RENDERTARGET | D3DUSAGE_DEPTHSTENCIL)) != 0;
       // Non-stretching copies are only allowed if:
       // - the destination is either a render target surface or a render target texture


### PR DESCRIPTION
Fixes #4119
Fixes #4122

I did some cleanup to CopyRects and put the StretchRect internals into a separate function that allows disabling specific checks.

cc
@WinterSnowfall 
@Joshua-Ashton 