### PR TITLE
[d3d9] Add a forceModeHeights config option

### DIFF
--- a/dxvk.conf
+++ b/dxvk.conf
@@ -614,6 +614,19 @@
 
 # d3d9.forceAspectRatio = ""
 
+# Force Mode Heights
+#
+# Only exposes modes with certain heights, if they are
+# also supported by the adapter. Can be used in conjunction
+# with forceAspectRatio to further restrict reported modes.
+# Useful for titles that break when too many modes are reported,
+# e.g., AquaNox, AquaNox 2: Revelation.
+#
+# Supported values:
+# - A list of mode heights, i.e. "480,720,1080"
+
+# d3d9.forceModeHeights = ""
+
 # Enumerate by Displays
 #
 # Whether we should enumerate D3D9 adapters by display (windows behaviour)

--- a/src/d3d9/d3d9_adapter.cpp
+++ b/src/d3d9/d3d9_adapter.cpp
@@ -44,6 +44,16 @@ namespace dxvk {
     m_modeCacheFormat (D3D9Format::Unknown),
     m_d3d9Formats     (Adapter, m_parent->GetOptions()) {
     m_adapter->logAdapterInfo();
+
+    auto& options = m_parent->GetOptions();
+
+    if (!options.forceModeHeights.empty()) {
+      uint32_t forcedHeight = 0;
+      for (auto height : str::split(options.forceModeHeights, ",")) {
+        std::from_chars(height.data(), height.data() + height.size(), forcedHeight);
+        m_forcedModeHeights.emplace_back(forcedHeight);
+      }
+    }
   }
 
   template <size_t N>
@@ -814,6 +824,12 @@ namespace dxvk {
         continue;
 
       if (!forcedRatio.undefined() && Ratio<DWORD>(devMode.width, devMode.height) != forcedRatio)
+        continue;
+
+      if (!m_forcedModeHeights.empty() &&
+           std::find(m_forcedModeHeights.begin(),
+                     m_forcedModeHeights.end(),
+                     devMode.height) == m_forcedModeHeights.end())
         continue;
 
       D3DDISPLAYMODEEX mode = ConvertDisplayMode(devMode);

--- a/src/d3d9/d3d9_adapter.h
+++ b/src/d3d9/d3d9_adapter.h
@@ -107,6 +107,8 @@ namespace dxvk {
 
     const D3D9VkFormatTable       m_d3d9Formats;
 
+    std::vector<uint32_t>         m_forcedModeHeights;
+
   };
 
 }

--- a/src/d3d9/d3d9_options.cpp
+++ b/src/d3d9/d3d9_options.cpp
@@ -65,6 +65,7 @@ namespace dxvk {
     this->forceSwapchainMSAA            = config.getOption<int32_t>     ("d3d9.forceSwapchainMSAA",            -1);
     this->forceSampleRateShading        = config.getOption<bool>        ("d3d9.forceSampleRateShading",        false);
     this->forceAspectRatio              = config.getOption<std::string> ("d3d9.forceAspectRatio",              "");
+    this->forceModeHeights              = config.getOption<std::string> ("d3d9.forceModeHeights",              "");
     this->enumerateByDisplays           = config.getOption<bool>        ("d3d9.enumerateByDisplays",           true);
     this->cachedDynamicBuffers          = config.getOption<bool>        ("d3d9.cachedDynamicBuffers",          false);
     this->deviceLocalConstantBuffers    = config.getOption<bool>        ("d3d9.deviceLocalConstantBuffers",    false);

--- a/src/d3d9/d3d9_options.h
+++ b/src/d3d9/d3d9_options.h
@@ -103,6 +103,9 @@ namespace dxvk {
     /// Forced aspect ratio, disable other modes
     std::string forceAspectRatio;
 
+    /// Restrict modes based on height
+    std::string forceModeHeights;
+
     /// Always use a spec constant to determine sampler type (instead of just in PS 1.x)
     /// Works around a game bug in Halo CE where it gives cube textures to 2d/volume samplers
     bool forceSamplerTypeSpecConstants;


### PR DESCRIPTION
The emperor's new clothes, based off of #3615, with the following distinctions:
- naming
- it adds only the config option, no defaults for any game in particular
- forced mode heights parsing happens during adapter creation

This is needed with certain hardware combinations of monitors/GPUs that report an excessive amount of modes, as some games have troubles starting in such situations. In particular the [Aquanox](https://github.com/doitsujin/dxvk/issues/3255) series of games are a pain in this regard.