### PR TITLE
[d3d8] Mimic native token allocations

### DIFF
--- a/src/d3d8/d3d8_device.h
+++ b/src/d3d8/d3d8_device.h
@@ -417,7 +417,7 @@ namespace dxvk {
     D3DPRESENT_PARAMETERS m_presentParams;
 
     D3D8StateBlock*                            m_recorder = nullptr;
-    DWORD                                      m_recorderToken = -1;
+    DWORD                                      m_recorderToken = 0;
     DWORD                                      m_token    = 0;
     std::unordered_map<DWORD, D3D8StateBlock>  m_stateBlocks;
     D3D8Batcher*                               m_batcher  = nullptr;


### PR DESCRIPTION
Wrote some more extensive tests against native and it looks like:
- tokens actually start at 1
- tokens decrease if the most recent token is the one being deleted

Perhaps there are some additional corner cases I've missed, but since ultimately the token values are purely cosmetic, I'm going to call this close enough.