### PR TITLE
[util] Disable direct buffer mapping for Max Payne 1

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -1129,6 +1129,10 @@ namespace dxvk {
     { R"(\\Art of Murder - FBI Confidential\\game\.exe$)", {{
       { "d3d9.cachedDynamicBuffers",       "True" },
     }} },
+    /* Max Payne 1 - Stalls waiting for an index buffer */
+    { R"(\\MaxPayne\.exe$)", {{
+      { "d3d9.allowDirectBufferMapping",    "False" },
+    }} },
   }};
 
 


### PR DESCRIPTION
Improves performance by avoiding stalls.

The game locks an index buffer multiple times per frame.

warn:  Waiting for resource: Lock Buffer
- Pool: D3DPOOL_DEFAULT
- Usage: D3DUSAGE_WRITEONLY
- OriginalFlags: 0
- Flags: 0
- OffsetToLock: 0
- SizeToLock: 240
- Type: INDEXBUFFER
- Total buffer Size: 240
- Map Mode: DIRECT
