### PR TITLE
[util] Reorder config options by API

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -17,6 +17,44 @@ namespace dxvk {
 
 
   const static ProfileList g_profiles = {{
+    /**********************************************/
+    /* D3D12 GAMES (vkd3d-proton with dxvk dxgi)  */
+    /**********************************************/
+
+    /* Diablo 4 - Will complain about missing  *
+     * GPU unless dxgi Id match actual GPU Id  */
+    { R"(\\Diablo IV\.exe$)", {{
+      { "dxgi.hideNvidiaGpu",               "False"  },
+    }} },
+    /* WILD HEARTS™️                            *
+     * D3D12 title using D3D11 device for      *
+     * media texture creation, whereby a large *
+     * chunk size only slows down media        *
+     * initialization                          */
+    { R"(\\WILD HEARTS(_Trial)?\.exe$)", {{
+      { "dxvk.maxChunkSize",                 "4" },
+    }} },
+    /* Ratchet & Clank: Rift Apart - does not allow
+     * enabling ray tracing if it sees an AMD GPU. */
+    { R"(\\RiftApart\.exe$)", {{
+      { "dxgi.hideNvidiaGpu",               "False" },
+    }} },
+    /* Metro Exodus Enhanced Edition picks GPU adapters
+     * by available VRAM, which causes issues on some
+     * systems with integrated graphics. */
+    { R"(\\Metro Exodus Enhanced Edition\\MetroExodus\.exe$)", {{
+      { "dxvk.hideIntegratedGraphics",      "True" },
+    }} },
+    /* Persona 3 Reload - disables vsync by default and
+     * runs into severe frame latency issues on Deck. */
+    { R"(\\P3R\.exe$)", {{
+      { "dxgi.syncInterval",                "1" },
+    }} },
+
+    /**********************************************/
+    /* D3D11 GAMES                                */
+    /**********************************************/
+
     /* Assassin's Creed Syndicate: amdags issues  */
     { R"(\\ACS\.exe$)", {{
       { "dxgi.customVendorId",              "10de" },
@@ -949,47 +987,13 @@ namespace dxvk {
     }} },
     /* Battle for Middle-earth 2 and expansion   *
      * Slowdowns in certain scenarios            */
-    { R"(\\(The Battle for Middle-earth (\(tm\))? II( Demo)?|The Lord of the Rings, The Rise of the Witch-king)\\game\.dat$)", {{
+    { R"(\\(The Battle for Middle-earth( \(tm\))? II( Demo)?)"
+      R"(|The Lord of the Rings, The Rise of the Witch-king)\\game\.dat$)", {{
       { "d3d9.cachedDynamicBuffers",        "True" },
     }} },
     /* WRC4 - Audio breaks above 60fps */
     { R"(\\WRC4\.exe$)", {{
       { "d3d9.maxFrameRate",                "60" },
-    }} },
-
-
-    /**********************************************/
-    /* D3D12 GAMES (vkd3d-proton with dxvk dxgi)  */
-    /**********************************************/
-
-    /* Diablo 4 - Will complain about missing  *
-     * GPU unless dxgi Id match actual GPU Id  */
-    { R"(\\Diablo IV\.exe$)", {{
-      { "dxgi.hideNvidiaGpu",               "False"  },
-    }} },
-    /* WILD HEARTS™️                            *
-     * D3D12 title using D3D11 device for      *
-     * media texture creation, whereby a large *
-     * chunk size only slows down media        *
-     * initialization                          */
-    { R"(\\WILD HEARTS(_Trial)?\.exe$)", {{
-      { "dxvk.maxChunkSize",                 "4" },
-    }} },
-    /* Ratchet & Clank: Rift Apart - does not allow
-     * enabling ray tracing if it sees an AMD GPU. */
-    { R"(\\RiftApart\.exe$)", {{
-      { "dxgi.hideNvidiaGpu",               "False" },
-    }} },
-    /* Metro Exodus Enhanced Edition picks GPU adapters
-     * by available VRAM, which causes issues on some
-     * systems with integrated graphics. */
-    { R"(\\Metro Exodus Enhanced Edition\\MetroExodus\.exe$)", {{
-      { "dxvk.hideIntegratedGraphics",      "True" },
-    }} },
-    /* Persona 3 Reload - disables vsync by default and
-     * runs into severe frame latency issues on Deck. */
-    { R"(\\P3R\.exe$)", {{
-      { "dxgi.syncInterval",                "1" },
     }} },
 
     /**********************************************/


### PR DESCRIPTION
Suggested by @Blisto91. Makes more sense to order them this way, now that d3d8 is part of the picture. I'll let @Blisto91 follow up if he also wants to order them alphabetically :wink: .

I've also checked if we missed to transition any d3d8 games from the d3d9 section, but it all looks good as is.