### PR TITLE
[d3d8] Add an option to respect DISCARD only for dynamic write-only buffers

### DIFF
--- a/src/d3d8/d3d8_buffer.h
+++ b/src/d3d8/d3d8_buffer.h
@@ -18,6 +18,7 @@ namespace dxvk {
       : D3D8Resource<D3D9, D3D8> (pDevice, std::move(pBuffer))
       , m_pool                   (Pool)
       , m_usage                  (Usage) {
+      m_options = this->GetParent()->GetOptions();
     }
 
     HRESULT STDMETHODCALLTYPE Lock(
@@ -25,6 +26,13 @@ namespace dxvk {
             UINT   SizeToLock,
             BYTE** ppbData,
             DWORD  Flags) {
+
+      if (m_options->forceLegacyDiscard &&
+          (Flags & D3DLOCK_DISCARD) &&
+         !((m_usage & D3DUSAGE_DYNAMIC) &&
+           (m_usage & D3DUSAGE_WRITEONLY)))
+          Flags &= ~D3DLOCK_DISCARD;
+
       return this->GetD3D9()->Lock(
         OffsetToLock,
         SizeToLock,
@@ -41,8 +49,9 @@ namespace dxvk {
     }
 
   protected:
-    const D3DPOOL m_pool;
-    const DWORD   m_usage;
+    const D3D8Options* m_options;
+    const D3DPOOL      m_pool;
+    const DWORD        m_usage;
   };
 
 

--- a/src/d3d8/d3d8_device.h
+++ b/src/d3d8/d3d8_device.h
@@ -357,6 +357,10 @@ namespace dxvk {
 
   public: // Internal Methods //
 
+    const D3D8Options* GetOptions() const {
+      return &m_d3d8Options;
+    }
+
     inline bool ShouldRecord() { return m_recorder != nullptr; }
     inline bool ShouldBatch()  { return m_batcher  != nullptr; }
 

--- a/src/d3d8/d3d8_options.h
+++ b/src/d3d8/d3d8_options.h
@@ -34,11 +34,19 @@ namespace dxvk {
     /// and above. Most likely ATI/AMD drivers never supported P8 in the first place.
     bool placeP8InScratch = false;
 
+    /// Rayman 3 relies on D3DLOCK_DISCARD being ignored for everything except D3DUSAGE_DYNAMIC +
+    /// D3DUSAGE_WRITEONLY buffers, however this approach incurs a performance penalty.
+    ///
+    /// Some titles might abuse this early D3D8 quirk, however at some point in its history
+    /// it was brought in line with standard D3D9 behavior.
+    bool forceLegacyDiscard = false;
+
     D3D8Options() {}
     D3D8Options(const Config& config) {
       auto forceVsDeclStr     = config.getOption<std::string>("d3d8.forceVsDecl",            "");
       batching                = config.getOption<bool>       ("d3d8.batching",               batching);
       placeP8InScratch        = config.getOption<bool>       ("d3d8.placeP8InScratch",       placeP8InScratch);
+      forceLegacyDiscard      = config.getOption<bool>       ("d3d8.forceLegacyDiscard",     forceLegacyDiscard);
 
       parseVsDecl(forceVsDeclStr);
     }

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -1121,6 +1121,13 @@ namespace dxvk {
     { R"(\\Chrome(Single|Net)\.exe$)", {{
       { "d3d9.maxFrameRate",                  "60" },
     }} },
+    /* Rayman 3: Hoodlum Havoc                    *
+     * Missing geometry and textures without      *
+     * legacy DISCARD behavior                    */
+    { R"(\\Rayman3\.exe$)", {{
+      { "d3d9.allowDirectBufferMapping",   "False" },
+      { "d3d8.forceLegacyDiscard",          "True" },
+    }} },
   }};
 
 


### PR DESCRIPTION
Fixes missing textures in Rayman 3, a problem that based on online testimonies started to occur with the transition to Windows 7.

Test on Windows XP have shown that the game renders properly, so native behavior on age-accurate systems seem to differ from d3d9, as in D3DLOCK_DISCARD appears to be respected only for D3DUSAGE_DYNAMIC + D3DUSAGE_WRITEONLY.

Making it a draft for now, as it would need more testing to ensure there are no regressions in other titles.