### PR TITLE
Small fix for the config template and the profiles

### DIFF
--- a/dxvk.conf
+++ b/dxvk.conf
@@ -709,16 +709,3 @@
 # - True/False
 
 # d3d9.countLosableResources = True
-
-# Use NVIDIA Shadow Buffers
-# 
-# Vendor behavior for GeForce3 and GeForce4 cards that allows
-# sampling depth textures with non-normalized Z coordinates
-# and applies hardware shadow filtering.
-#
-# Supported values:
-# - True/False
-
-# d3d8.useShadowBuffers = False
-
-

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -1009,11 +1009,6 @@ namespace dxvk {
     { R"(\\indy\.exe$)", {{
       { "d3d9.enableDialogMode",            "True" },
     }} },
-    /* Tom Clancy's Splinter Cell                *
-     * Supports shadow buffers                   */
-    { R"(\\splintercell\.exe$)", {{
-      { "d3d8.useShadowBuffers",            "True" },
-    }} },
     /* Anito: Defend a Land Enraged              */
     { R"(\\Anito\.exe$)", {{
       { "d3d9.memoryTrackTest",             "True" },


### PR DESCRIPTION
Like stated in the commit message, the feature was present in one of the d8vk branches at some point. But it never landed in DXVK.

For reference, I restored the feature here, rebase on top of current master: https://github.com/tobiasjakobi/dxvk/tree/d3d8-shadowbuf

However we might need some documentation of `d3d8.scaleDref` in the config template.