### PR TITLE
[util] Disable countLosableResources for Inquisitor

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -1126,6 +1126,11 @@ namespace dxvk {
     { R"(\\(nations|patriots)\.exe$)", {{
       { "d3d9.deviceLossOnFocusLoss",       "True" },
     }} },
+    /* Inquisitor (2009)                          *
+     * Leaks a resource when alt-tabbing          */
+    { R"(\\Inquisitor\.exe$)", {{
+      { "d3d9.countLosableResources",      "False" },
+    }} },
   }};
 
 


### PR DESCRIPTION
Nobody expects... you to alt-tab in this game, apparently, as it leaks a surface (possibly a render target) when you do.

Otherwise unaffected by `d3d9.deviceLossOnFocusLoss`. I am inclined to believe this is a game bug, as all d3d8 ref counts are pretty much sorted now and we haven't noticed any problems elsewhere.