### PR TITLE
[utils] Hide Intel Gpu for Batman Arkham Knight

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -55,6 +55,11 @@ namespace dxvk {
     /* D3D11 GAMES                                */
     /**********************************************/
 
+    /* Batman Arkham Knight - doesn't like intel vendor id 
+      (refuses to boot if vendor isn't 0x10de or 0x1002)  */
+    { R"(\\BatmanAK\.exe$)", {{
+      { "dxgi.customVendorId",              "10de" },
+    }} },
     /* Assassin's Creed Syndicate: amdags issues  */
     { R"(\\ACS\.exe$)", {{
       { "dxgi.customVendorId",              "10de" },

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -58,7 +58,7 @@ namespace dxvk {
     /* Batman Arkham Knight - doesn't like intel vendor id 
       (refuses to boot if vendor isn't 0x10de or 0x1002)  */
     { R"(\\BatmanAK\.exe$)", {{
-      { "dxgi.customVendorId",              "10de" },
+      { "dxgi.hideIntelGpu",                "True" },
     }} },
     /* Assassin's Creed Syndicate: amdags issues  */
     { R"(\\ACS\.exe$)", {{


### PR DESCRIPTION
Without this fix, Batman Arkham Knight won't boot on Intel GPUs since the code explicitly checks for vendor id `0x10DE` & `0x1002` and if the vendor id is different, the game won't boot.