### PR TITLE
[util] Add configs for Splinter Cell Conviction

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -996,9 +996,17 @@ namespace dxvk {
       R"(|The Lord of the Rings, The Rise of the Witch-king)\\game\.dat$)", {{
       { "d3d9.cachedDynamicBuffers",        "True" },
     }} },
-    /* WRC4 - Audio breaks above 60fps */
+    /* WRC4 - Audio breaks above 60fps           */
     { R"(\\WRC4\.exe$)", {{
       { "d3d9.maxFrameRate",                "60" },
+    }} },
+    /* Splinter Cell Conviction - Alt-tab black  *
+     * screen and unsupported GPU complaint      */
+    { R"(\\conviction_game\.exe$)", {{
+      { "d3d9.deviceLossOnFocusLoss",       "True" },
+      { "dxgi.customVendorId",              "10de" },
+      { "dxgi.customDeviceId",              "05e0" },
+      { "dxgi.customDeviceDesc",            "GeForce GTX 295" },
     }} },
 
     /**********************************************/


### PR DESCRIPTION
The game will sometimes black screen upon alt-tab without deviceLossOnFocusLoss. 
Spoofing the GPU through dxgi to a known one from its list prevents the System Detection tool from complaining that it is unsupported on some setups.

The reason for the spoof being dxgi and not d3d9 is that it is what is used during system validation. Deleting systemdetection.dll will make the game not load dxgi.dll at all (besides via the ubisoft overlay).
The game itself uses d3d9 to determine vendor for e.g. if Nvapi should be loaded or not.