### PR TITLE
Fix issues with CheckDeviceFormat & CheckDeviceFormatConversion

### DIFF
--- a/src/d3d9/d3d9_adapter.cpp
+++ b/src/d3d9/d3d9_adapter.cpp
@@ -251,7 +251,8 @@ namespace dxvk {
           D3D9Format SourceFormat,
           D3D9Format TargetFormat) {
     bool sourceSupported = SourceFormat != D3D9Format::Unknown
-                        && IsSupportedBackBufferFormat(SourceFormat);
+                        && (IsSupportedBackBufferFormat(SourceFormat)
+                        || (IsFourCCFormat(SourceFormat) && !IsVendorFormat(SourceFormat)));
     bool targetSupported = TargetFormat == D3D9Format::X1R5G5B5
                         || TargetFormat == D3D9Format::A1R5G5B5
                         || TargetFormat == D3D9Format::R5G6B5

--- a/src/d3d9/d3d9_adapter.cpp
+++ b/src/d3d9/d3d9_adapter.cpp
@@ -169,7 +169,11 @@ namespace dxvk {
       return D3D_OK;
 
     // Let's actually ask Vulkan now that we got some quirks out the way!
-    return CheckDeviceVkFormat(mapping.FormatColor, Usage, RType);
+    VkFormat format = mapping.FormatColor;
+    if (unlikely(mapping.ConversionFormatInfo.FormatColor != VK_FORMAT_UNDEFINED)) {
+      format = mapping.ConversionFormatInfo.FormatColor;
+    }
+    return CheckDeviceVkFormat(format, Usage, RType);
   }
 
 

--- a/src/d3d9/d3d9_format.h
+++ b/src/d3d9/d3d9_format.h
@@ -230,6 +230,7 @@ namespace dxvk {
       && format != D3D9Format::MULTI2_ARGB8
       && format != D3D9Format::UYVY
       && format != D3D9Format::R8G8_B8G8
+      && format != D3D9Format::YUY2
       && format != D3D9Format::G8R8_G8B8
       && format != D3D9Format::DXT1
       && format != D3D9Format::DXT2


### PR DESCRIPTION
Fixes #4158

Serious Sam 2 has 3 ways of uploading video frames:

- Lock XRGB texture and write XRGB data to that texture.
That happens when: YUY2 **textures** are supported in `CheckDeviceFormat`. DXVK master hits this code path on Nvidia GPUs because we check for sampling support on `VK_FORMAT_G8B8G8R8_422_UNORM` and Nvidia supports that.
- Lock YUY2 offscreen surface and write YUY2 data to that surface. Copy it to a XRGB texture afterwards using `StretchRect`.
That happens when: YUY2 **textures** are **un**supported but YUY2 **surfaces** are supported in `CheckDeviceFormat`. Additionally YUY2 is supported as a source format in `CheckDeviceFormatConversion`.
- Lock XRGB texture and write YUY2 data to that texture.
That happens when:
    - either YUY2 **textures** are **un**supported in `CheckDeviceFormat` but YUY2 **surfaces** are supported in `CheckDeviceFormat`. At the same time YUY2 is **not** supported as a source format in `CheckDeviceFormatConversion`.
    - neither YUY2 **textures** nor **surfaces** are supported in `CheckDeviceFormat`. This is what happens with DXVK master on RADV because it does **not** support `VK_FORMAT_G8B8G8R8_422_UNORM` images.

Given that it also manages to get writing to the XRGB texture right in one of the cases, I'm pretty sure this is a game bug because no actual hardware hits that.
I do not know why support for YUY2 textures makes it use the code path where it writes XRGB data.

The case that YUY2 surfaces are supported in `CheckDeviceFormat` but not as a source format in `CheckDeviceFormatConversion` is almost certainly wrong anyway.

The first commit is pretty straightforward and should be clear.

The second one is because `CheckDeviceFormatConversion` also decides whether or not a format is supported in `StretchRect`. We do support YUY2 there.

The docs say (emphasis mine):

> CheckDeviceFormatConversion can also be used to determine which combinations of source surface formats and destination surface formats are permissible in calls to [StretchRect](https://learn.microsoft.com/en-us/windows/desktop/api/d3d9helper/nf-d3d9helper-idirect3ddevice9-stretchrect).
[...]
The source format must be **a FOURCC format** or a valid back buffer format.