### PR TITLE
Update shouldSubmit to correctly handle descriptorPoolOverallocation

### DIFF
--- a/src/dxvk/dxvk_descriptor.cpp
+++ b/src/dxvk/dxvk_descriptor.cpp
@@ -72,7 +72,9 @@ namespace dxvk {
     // memory bloat. This may be necessary for off-screen
     // rendering applications, or in situations where games
     // pre-render a lot of images without presenting in between.
-    return m_descriptorPools.size() > MaxDesiredPoolCount;
+    return m_device->features().nvDescriptorPoolOverallocation.descriptorPoolOverallocation ?
+      m_setsAllocated > MaxDesiredPoolCount * m_manager->getMaxSetCount() :
+      m_descriptorPools.size() > MaxDesiredPoolCount;
   }
 
 


### PR DESCRIPTION
Currently shouldSubmit will force the dxvk context to be flushed when too many descriptor pools have been allocated. This heuristic does not work when VK_NV_descriptor_pool_overallocation is in use because there will only ever be a single pool.

This change updates the heuristic to use the number of allocated sets when VK_NV_descriptor_pool_overallocation is in use.

Resolves the issue described in https://github.com/ValveSoftware/Proton/issues/7862