### PR TITLE
[Build/CI] Build PDBs for MSVC builds + upload MSVC build artifacts.

### DIFF
--- a/.github/workflows/test-build-windows.yml
+++ b/.github/workflows/test-build-windows.yml
@@ -38,6 +38,12 @@ jobs:
         Invoke-WebRequest -URI https://raw.githubusercontent.com/NovaRain/DXSDK_Collection/master/DXSDK_Aug2007/Include/d3d8.h -OutFile include/d3d8.h
         Invoke-WebRequest -URI https://raw.githubusercontent.com/NovaRain/DXSDK_Collection/master/DXSDK_Aug2007/Include/d3d8types.h -OutFile include/d3d8types.h
         Invoke-WebRequest -URI https://raw.githubusercontent.com/NovaRain/DXSDK_Collection/master/DXSDK_Aug2007/Include/d3d8caps.h -OutFile include/d3d8caps.h
+        
+    - name: Get version
+      id: get-version
+      shell: bash
+      run: |
+        echo "VERSION_NAME=${GITHUB_REF##*/}-${GITHUB_SHA##*/}" >> $GITHUB_ENV
 
     - name: Build MSVC x86
       shell: pwsh
@@ -49,9 +55,9 @@ jobs:
         msbuild -m build-msvc-x86/dxvk.sln
 
     - name: Upload artifacts (x86)
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
-        name: msvc_x86_output
+        name: dxvk-${{ env.VERSION_NAME }}-msvc-x86-output
         path: |
           build-msvc-x86\**\*.pdb
           build-msvc-x86\**\*.dll
@@ -66,9 +72,9 @@ jobs:
         msbuild -m build-msvc-x64/dxvk.sln
 
     - name: Upload artifacts (x64)
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
-        name: msvc_amd64_output
+        name: dxvk-${{ env.VERSION_NAME }}-msvc-amd64-output
         path: |
           build-msvc-x64\**\*.pdb
           build-msvc-x64\**\*.dll

--- a/.github/workflows/test-build-windows.yml
+++ b/.github/workflows/test-build-windows.yml
@@ -48,6 +48,14 @@ jobs:
         meson --buildtype release --backend vs2022 build-msvc-x86
         msbuild -m build-msvc-x86/dxvk.sln
 
+    - name: Upload artifacts (x86)
+      uses: actions/upload-artifact@v3
+      with:
+        name: msvc_x86_output
+        path: |
+          build-msvc-x86\**\*.pdb
+          build-msvc-x86\**\*.dll
+
     - name: Build MSVC x64
       shell: pwsh
       run: |
@@ -56,3 +64,11 @@ jobs:
           | % { [System.Environment]::SetEnvironmentVariable($_[0], $_[1]) }
         meson --buildtype release --backend vs2022 build-msvc-x64
         msbuild -m build-msvc-x64/dxvk.sln
+
+    - name: Upload artifacts (x64)
+      uses: actions/upload-artifact@v3
+      with:
+        name: msvc_amd64_output
+        path: |
+          build-msvc-x64\**\*.pdb
+          build-msvc-x64\**\*.dll

--- a/meson.build
+++ b/meson.build
@@ -87,8 +87,14 @@ if platform == 'windows'
       ]
     endif
   else
+    # setup file alignment + enable PDB output for MSVC builds
+    # PDBs are useful for Windows consumers of DXVK 
+    compiler_args += [
+	  '/Z7'
+	]
     link_args += [
       '/FILEALIGN:4096',
+      '/DEBUG:FULL'
     ]
   endif
 


### PR DESCRIPTION
While DXVK seems mostly meant for usage with Wine, a lot of people end up using it anyways as a D3D9 replacement on Windows due to native driver support getting worse or being dropped altogether and replaced with D3D9on12.

Generating PDBs for MSVC builds makes debugging DXVK issues a lot easier on Windows, especially when porting legacy D3D9/D3D8 code to use it. I believe PDB symbols would have been generated anyways for debug builds, but testing with release builds is sometimes required. 

Not sure if uploading the artifacts for the MSVC builds is a good idea, I presume there might have been a reason those weren't uploaded before. If those builds are not intended for anything other than testing, I could look into whatever PDB generation is possible under `mingw` without breaking anything but I don't have (much) experience with cross compiling for Windows, and it seems there are some special considerations for symbol generation when Wine is involved.