### PR TITLE
[util] Set textureMemory to 0 for Operation Racoon City

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -1008,6 +1008,10 @@ namespace dxvk {
       { "dxgi.customDeviceId",              "05e0" },
       { "dxgi.customDeviceDesc",            "GeForce GTX 295" },
     }} },
+    /* Resident Evil: Operation Raccoon City     */
+    { R"(\\RaccoonCity\.exe$)", {{
+      { "d3d9.textureMemory",               "0" },
+    }} },
 
     /**********************************************/
     /* D3D8 GAMES                                 */


### PR DESCRIPTION
See issue https://github.com/doitsujin/dxvk/issues/4172. 
Does not close it as it is just a work-around and not a proper fix.