### PR TITLE
[d3d9] Handle remaining edge cases of Discard & Lockable

### DIFF
--- a/src/d3d9/d3d9_adapter.cpp
+++ b/src/d3d9/d3d9_adapter.cpp
@@ -134,7 +134,7 @@ namespace dxvk {
     if (rt && CheckFormat == D3D9Format::A8 && m_parent->GetOptions().disableA8RT)
       return D3DERR_NOTAVAILABLE;
 
-    if (ds && !IsDepthFormat(CheckFormat))
+    if (ds && !IsDepthStencilFormat(CheckFormat))
       return D3DERR_NOTAVAILABLE;
 
     if (rt && CheckFormat == D3D9Format::NULL_FORMAT && twoDimensional)
@@ -228,7 +228,7 @@ namespace dxvk {
           D3D9Format AdapterFormat,
           D3D9Format RenderTargetFormat,
           D3D9Format DepthStencilFormat) {
-    if (!IsDepthFormat(DepthStencilFormat))
+    if (!IsDepthStencilFormat(DepthStencilFormat))
       return D3DERR_NOTAVAILABLE;
 
     auto dsfMapping = GetFormatMapping(DepthStencilFormat);

--- a/src/d3d9/d3d9_common_texture.cpp
+++ b/src/d3d9/d3d9_common_texture.cpp
@@ -184,6 +184,17 @@ namespace dxvk {
     if (pDesc->MipLevels == 0 || pDesc->MipLevels > maxMipLevelCount)
       pDesc->MipLevels = maxMipLevelCount;
 
+    if (unlikely(pDesc->Discard)) {
+      if (!IsDepthStencilFormat(pDesc->Format))
+        return D3DERR_INVALIDCALL;
+
+      if (pDesc->Format == D3D9Format::D32_LOCKABLE
+        || pDesc->Format == D3D9Format::D32F_LOCKABLE
+        || pDesc->Format == D3D9Format::D16_LOCKABLE
+        || pDesc->Format == D3D9Format::S8_LOCKABLE)
+        return D3DERR_INVALIDCALL;
+    }
+
     return D3D_OK;
   }
 

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -3891,7 +3891,7 @@ namespace dxvk {
     desc.MultiSample        = D3DMULTISAMPLE_NONE;
     desc.MultisampleQuality = 0;
     desc.IsBackBuffer       = FALSE;
-    desc.IsAttachmentOnly   = Pool == D3DPOOL_DEFAULT;
+    desc.IsAttachmentOnly   = TRUE;
     // Docs: Off-screen plain surfaces are always lockable, regardless of their pool types.
     desc.IsLockable         = TRUE;
 

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -1141,9 +1141,6 @@ namespace dxvk {
     const VkImageSubresource dstSubresource = dstTextureInfo->GetSubresourceFromIndex(dstFormatInfo->aspectMask, dst->GetSubresource());
     const VkImageSubresource srcSubresource = srcTextureInfo->GetSubresourceFromIndex(srcFormatInfo->aspectMask, src->GetSubresource());
 
-    if (unlikely((srcSubresource.aspectMask & (VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT)) && m_flags.test(D3D9DeviceFlag::InScene)))
-      return D3DERR_INVALIDCALL;
-
     if (unlikely(Filter != D3DTEXF_NONE && Filter != D3DTEXF_LINEAR && Filter != D3DTEXF_POINT))
       return D3DERR_INVALIDCALL;
 

--- a/src/d3d9/d3d9_swapchain.cpp
+++ b/src/d3d9/d3d9_swapchain.cpp
@@ -45,7 +45,7 @@ namespace dxvk {
         RecreateSwapChain();
     }
 
-    if (FAILED(CreateBackBuffers(m_presentParams.BackBufferCount)))
+    if (FAILED(CreateBackBuffers(m_presentParams.BackBufferCount, m_presentParams.Flags)))
       throw DxvkError("D3D9: Failed to create swapchain backbuffers");
 
     CreateBlitter();
@@ -627,7 +627,7 @@ namespace dxvk {
     if (changeFullscreen)
       SetGammaRamp(0, &m_ramp);
 
-    hr = CreateBackBuffers(m_presentParams.BackBufferCount);
+    hr = CreateBackBuffers(m_presentParams.BackBufferCount, m_presentParams.Flags);
     if (FAILED(hr))
       return hr;
 
@@ -1013,7 +1013,7 @@ namespace dxvk {
   }
 
 
-  HRESULT D3D9SwapChainEx::CreateBackBuffers(uint32_t NumBackBuffers) {
+  HRESULT D3D9SwapChainEx::CreateBackBuffers(uint32_t NumBackBuffers, DWORD Flags) {
     // Explicitly destroy current swap image before
     // creating a new one to free up resources
     DestroyBackBuffers();
@@ -1038,8 +1038,7 @@ namespace dxvk {
     desc.Discard            = FALSE;
     desc.IsBackBuffer       = TRUE;
     desc.IsAttachmentOnly   = FALSE;
-    // Docs: Also note that - unlike textures - swap chain back buffers, render targets [..] can be locked
-    desc.IsLockable         = TRUE;
+    desc.IsLockable         = (Flags & D3DPRESENTFLAG_LOCKABLE_BACKBUFFER) != 0;
 
     for (uint32_t i = 0; i < NumBuffers; i++) {
       D3D9Surface* surface;

--- a/src/d3d9/d3d9_swapchain.h
+++ b/src/d3d9/d3d9_swapchain.h
@@ -205,7 +205,8 @@ namespace dxvk {
     void CreateRenderTargetViews();
 
     HRESULT CreateBackBuffers(
-            uint32_t            NumBackBuffers);
+            uint32_t            NumBackBuffers,
+            DWORD               Flags);
 
     void CreateBlitter();
 

--- a/src/d3d9/d3d9_util.cpp
+++ b/src/d3d9/d3d9_util.cpp
@@ -420,4 +420,15 @@ namespace dxvk {
         || Format == D3D9Format::INTZ;
   }
 
+  bool IsDepthStencilFormat(D3D9Format Format) {
+    return IsDepthFormat(Format) || Format == D3D9Format::S8_LOCKABLE;
+  }
+
+  bool IsLockableDepthStencilFormat(D3D9Format Format) {
+    return Format == D3D9Format::S8_LOCKABLE
+        || Format == D3D9Format::D16_LOCKABLE
+        || Format == D3D9Format::D32_LOCKABLE
+        || Format == D3D9Format::D32F_LOCKABLE;
+  }
+
 }

--- a/src/d3d9/d3d9_util.h
+++ b/src/d3d9/d3d9_util.h
@@ -204,6 +204,11 @@ namespace dxvk {
 
   bool IsDepthFormat(D3D9Format Format);
 
+  bool IsDepthStencilFormat(D3D9Format Format);
+
+  bool IsLockableDepthStencilFormat(D3D9Format Format);
+
+
   inline bool IsPoolManaged(D3DPOOL Pool) {
     return Pool == D3DPOOL_MANAGED || Pool == D3DPOOL_MANAGED_EX;
   }


### PR DESCRIPTION
A bunch of edge cases we weren't handling properly.
This is gonna need some testing.

In theory we could also use VK_STORE_OP_DONT_CARE for discardable depth stencil surfaces but I don't think that's worth the additional complexity. Tracking the load op is already a bit of a mess. Games don't really use discardable depth stencil surfaces all that much and it would only help tilers anyway as far as I know.