### PR TITLE
[util] Enable cachedDynamicBuffers for Art of Murder

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -1143,6 +1143,10 @@ namespace dxvk {
     { R"(\\Inquisitor\.exe$)", {{
       { "d3d9.countLosableResources",      "False" },
     }} },
+    /* Art of Murder FBI Confidential - CPU perf  */
+    { R"(\\Art of Murder - FBI Confidential\\game\.exe$)", {{
+      { "d3d9.cachedDynamicBuffers",       "True" },
+    }} },
   }};
 
 


### PR DESCRIPTION
Think the screenshots speak for themselves


<details>
  <summary>Screenshots</summary>
  
Without
![image](https://github.com/user-attachments/assets/273c1f86-0160-4910-8161-5b18f46106db)

With (+ vsync forced off)
![image](https://github.com/user-attachments/assets/4ae49790-5a47-4414-ade1-4c87b3ae6876)
</details>