### PR TITLE
[d3d9] Handle map failure in texture initializer

### DIFF
--- a/src/d3d9/d3d9_common_texture.cpp
+++ b/src/d3d9/d3d9_common_texture.cpp
@@ -194,6 +194,8 @@ namespace dxvk {
 
     m_data.Map();
     uint8_t* ptr = reinterpret_cast<uint8_t*>(m_data.Ptr());
+    if (ptr == nullptr)
+      return nullptr;
     ptr += m_memoryOffset[Subresource];
     return ptr;
   }

--- a/src/d3d9/d3d9_initializer.cpp
+++ b/src/d3d9/d3d9_initializer.cpp
@@ -44,11 +44,21 @@ namespace dxvk {
     if (pTexture->GetMapMode() == D3D9_COMMON_TEXTURE_MAP_MODE_NONE)
       return;
 
+    void* mapPtr = nullptr;
+
+    if (pTexture->Desc()->Pool != D3DPOOL_DEFAULT) {
+      mapPtr = pTexture->GetData(0);
+      if (mapPtr == nullptr)
+        throw DxvkError("D3D9: InitTexture: map failed");
+    }
+
     if (pTexture->GetImage() != nullptr)
       InitDeviceLocalTexture(pTexture);
 
-    if (pTexture->Desc()->Pool != D3DPOOL_DEFAULT)
-      InitHostVisibleTexture(pTexture, pInitialData);
+    if (mapPtr != nullptr) {
+      InitHostVisibleTexture(pTexture, pInitialData, mapPtr);
+      pTexture->UnmapData();
+    }
   }
 
 
@@ -109,11 +119,11 @@ namespace dxvk {
 
   void D3D9Initializer::InitHostVisibleTexture(
           D3D9CommonTexture* pTexture,
-          void*              pInitialData) {
+          void*              pInitialData,
+          void*              mapPtr) {
     // If the buffer is mapped, we can write data directly
     // to the mapped memory region instead of doing it on
     // the GPU. Same goes for zero-initialization.
-    void* mapPtr = pTexture->GetData(0);
     if (pInitialData) {
       // Initial data is only supported for textures with 1 subresource
       VkExtent3D mipExtent = pTexture->GetExtentMip(0);
@@ -141,7 +151,6 @@ namespace dxvk {
         mapPtr, 0,
         pTexture->GetTotalSize());
     }
-    pTexture->UnmapData();
   }
 
 

--- a/src/d3d9/d3d9_initializer.h
+++ b/src/d3d9/d3d9_initializer.h
@@ -52,7 +52,8 @@ namespace dxvk {
 
     void InitHostVisibleTexture(
             D3D9CommonTexture* pTexture,
-            void*              pInitialData);
+            void*              pInitialData,
+            void*              mapPtr);
     
     void FlushImplicit();
     void FlushInternal();


### PR DESCRIPTION
Fixes Brigand: Oaxaca (Steam ID 652410) crashing during loading in game. Repro steps:
```
1) Launch game
2) Click Continue and then 1: Begin
3) Select any story (I did Brigand - Oaxaca)
3) Wait for crash
```

This is 32 bit game. At some moment the game tries to create a 16384x16384 texture with 15 mips, usage 0, POOL_MANAGED. That happens because it uses D3DX functions for that without verifying the status. First calls D3DXGetImageInfoFromFileA() while some files are missing (in this case the output dimensions are not intialized or zeroed with neither Wine builtin nor Windows native d3dx). Then it calls D3DXCreateTexture() with those uninitialzed on-stack variables which usually end up in huge values. D3DXCreateTexture() clamps those dimensions to device texture caps and thus ends up with 16384x16384.

During creating 16384x16384 texture it fails to map memory with MapViewOfFile() (perhaps unsurpisingly, mapping 1.4GB is rarely going to succeed in 32 bit app). Then it crashes in msvcrt.memset() called from dxvk's D3D9Initializer::InitHostVisibleTexture). Handling the map failure and letting the texture correctly failing to create fixes the issue (the game doesn't seem to have any deal to these textures corresponding to missing input files afterwards).

Checking the failure to map and failing before calling InitDeviceLocalTexture() is important here. Without that (failing after InitDeviceLocalTexture was called) what happens here on AMD is that while trying to create those textures, even after the failure, the GPU texture is still alive and not destroyed immediately on failure because they are queued for GPU init and referenced, VK memory is not freed. When those textures are created a few one after another, this consumes host memory at high rate (quicker than they are freed) and causes the whole session kill (there is 32GB memory here and it is 32 bit app). The memory allocated somewhere behind the scenes in Vulkan driver is not accounted to the game process anyhow so OOM killer, in the absence of visible RAM-consuming champion, just kills every process in the user session.