### PR TITLE
[util] Set hideIntegratedGraphics = True for The Talos Principle 2

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -45,6 +45,12 @@ namespace dxvk {
     { R"(\\Metro Exodus Enhanced Edition\\MetroExodus\.exe$)", {{
       { "dxvk.hideIntegratedGraphics",      "True" },
     }} },
+    /* The Talos Principle 2 picks GPU adapters
+     * by available VRAM, which causes issues on some
+     * systems with integrated graphics. */
+    { R"(\\Talos2(-Win64-Shipping)?\.exe$)", {{
+      { "dxvk.hideIntegratedGraphics",      "True" },
+    }} },
     /* Persona 3 Reload - disables vsync by default and
      * runs into severe frame latency issues on Deck. */
     { R"(\\P3R\.exe$)", {{


### PR DESCRIPTION
On my system with AMD Radeon RX 6800S and AMD Radeon 680M the game picks integrated card by default.

It is literally unplayable on 680M (like much less than 1 fps).

The hideIntegratedGraphics = True option fixes the issue.

Other users also reported the problem, for example you can read about it on Proton issue tracker: https://github.com/ValveSoftware/Proton/issues/7237#issuecomment-1798124091
