### PR TITLE
[d3d9] Allow querying ID3D9VkInteropTexture from surfaces

### DIFF
--- a/src/d3d9/d3d9_surface.cpp
+++ b/src/d3d9/d3d9_surface.cpp
@@ -74,6 +74,11 @@ namespace dxvk {
       return S_OK;
     }
 
+    if (riid == __uuidof(ID3D9VkInteropTexture)) {
+      *ppvObject = ref(m_texture->GetVkInterop());
+      return S_OK;
+    }
+
     if (logQueryInterfaceError(__uuidof(IDirect3DSurface9), riid)) {
       Logger::warn("D3D9Surface::QueryInterface: Unknown interface query");
       Logger::warn(str::format(riid));


### PR DESCRIPTION
This allows people using interop to use `GetVulkanImageInfo` on surfaces like render targets and the backbuffer in addition to textures.