### PR TITLE
Add option to explicitly emit long dot products

### DIFF
--- a/dxvk.conf
+++ b/dxvk.conf
@@ -529,6 +529,17 @@
 # d3d11.longMad = False
 # d3d9.longMad = False
 
+
+# Long Dot
+#
+# Whether to emit dot products as an FMA chain or as a plain SPIR-V dot product.
+#
+# Supported values:
+# - True/False
+
+# d3d11.longDot = False
+
+
 # Device Local Constant Buffers
 #
 # Enables using device local, host accessible memory for constant buffers in D3D9.

--- a/src/d3d11/d3d11_options.cpp
+++ b/src/d3d11/d3d11_options.cpp
@@ -32,6 +32,7 @@ namespace dxvk {
     this->maxFrameLatency       = config.getOption<int32_t>("dxgi.maxFrameLatency", 0);
     this->exposeDriverCommandLists = config.getOption<bool>("d3d11.exposeDriverCommandLists", true);
     this->longMad               = config.getOption<bool>("d3d11.longMad", false);
+    this->longDot               = config.getOption<bool>("d3d11.longDot", false);
     this->reproducibleCommandStream = config.getOption<bool>("d3d11.reproducibleCommandStream", false);
 
     // Clamp LOD bias so that people don't abuse this in unintended ways

--- a/src/d3d11/d3d11_options.h
+++ b/src/d3d11/d3d11_options.h
@@ -118,8 +118,11 @@ namespace dxvk {
     /// Shader dump path
     std::string shaderDumpPath;
 
-    /// Should we make our Mads a FFma or do it the long way with an FMul and an FAdd?
+    /// Translate Mad/Dfma to separate FMul+FAdd
     bool longMad;
+
+    /// Translate DpX to a precise FMul+FFma chain
+    bool longDot;
 
     /// Ensure that for the same D3D commands the output VK commands
     /// don't change between runs. Useful for comparative benchmarking,

--- a/src/dxbc/dxbc_options.cpp
+++ b/src/dxbc/dxbc_options.cpp
@@ -39,6 +39,7 @@ namespace dxvk {
     forceSampleRateShading   = options.forceSampleRateShading;
     enableSampleShadingInterlock = device->features().extFragmentShaderInterlock.fragmentShaderSampleInterlock;
     longMad                  = options.longMad;
+    longDot                  = options.longDot;
 
     // Figure out float control flags to match D3D11 rules
     if (options.floatControls) {

--- a/src/dxbc/dxbc_options.h
+++ b/src/dxbc/dxbc_options.h
@@ -55,8 +55,11 @@ namespace dxvk {
     /// Minimum storage buffer alignment
     VkDeviceSize minSsboAlignment = 0;
 
-    /// Should we make our Mads a FFma or do it the long way with an FMul and an FAdd?
+    /// Translate Mad/Dfma to separate FMul+FAdd
     bool longMad;
+
+    /// Translate DpX to a precise FMul+FFma chain
+    bool longDot;
   };
   
 }

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -457,6 +457,10 @@ namespace dxvk {
       { "d3d9.maxFrameRate",              "-1"      },
       { "dxgi.maxFrameRate",              "-1"      },
     }} },
+    /* Kuro no Kiseki - Broken water on NV        */
+    { R"(\\(kuro|ed9)\.exe$)", {{
+      { "d3d11.longDot",                  "True"    },
+    }} },
 
     /**********************************************/
     /* D3D9 GAMES                                 */


### PR DESCRIPTION
The intention here is to do this by default and remove the option as soon as we flip on longMad as well, only made this an option for now for a) testing purposes and b) not screwing with fossilize DBs too much. Not sure if we should do this for D3D9 too.

Fixes #4162.