### PR TITLE
[d3d9] Default to Strict floatEmulation for amdvlk 2024.Q3.1

### DIFF
--- a/src/d3d9/d3d9_options.cpp
+++ b/src/d3d9/d3d9_options.cpp
@@ -95,7 +95,8 @@ namespace dxvk {
     } else {
       bool hasMulz = adapter != nullptr
                   && (adapter->matchesDriver(VK_DRIVER_ID_MESA_RADV)
-                   || adapter->matchesDriver(VK_DRIVER_ID_MESA_NVK));
+                   || adapter->matchesDriver(VK_DRIVER_ID_MESA_NVK)
+                   || adapter->matchesDriver(VK_DRIVER_ID_AMD_OPEN_SOURCE, Version(2, 0, 316), Version()));
       d3d9FloatEmulation = hasMulz ? D3D9FloatEmulation::Strict : D3D9FloatEmulation::Enabled;
     }
 


### PR DESCRIPTION
AMD's Linux open source driver now optimizes for the Strict floatEmulation path.