### PR TITLE
 [util] Hide Intel for Kena: Bridge of Spirits to skip faulty water re…  …ndering path.

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -485,6 +485,11 @@ namespace dxvk {
       { "d3d9.maxFrameRate",              "-1"      },
       { "dxgi.maxFrameRate",              "-1"      },
     }} },
+    /* Kena: Bridge of Spirits: intel water       * 
+      flickering issues                           */
+    { R"(\\Kena-Win64-Shipping\.exe$)", {{
+      { "dxgi.hideIntelGpu",                 "True" },
+    }} },
 
     /**********************************************/
     /* D3D9 GAMES                                 */


### PR DESCRIPTION
… water rendering path.