### PR TITLE
[util] Solve Swapchain Error for Time Leap Paradise

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -661,6 +661,10 @@ namespace dxvk {
     { R"(\\k2\.exe$)", {{
       { "d3d9.memoryTrackTest",             "True" },
     }} },
+    /* Time Leap Paradise SUPER LIVE             */
+    { R"(\\tlpsl\.exe$)", {{
+      { "d3d9.deferSurfaceCreation",        "True" },
+    }} },
     /* Ninja Gaiden Sigma 1/2                    */
     { R"(\\NINJA GAIDEN SIGMA(2)?\.exe$)", {{
       { "d3d9.deferSurfaceCreation",        "True" },


### PR DESCRIPTION
Solve this error `err:   D3D9SwapChainEx: Failed to recreate swap chain: VK_ERROR_NATIVE_WINDOW_IN_USE_KHR`
![image](https://github.com/user-attachments/assets/3d2843fd-6eb4-4d63-894c-98e1186fdc7f)

After fix it works
![20240818142222_1](https://github.com/user-attachments/assets/63d96317-d6c4-4c0a-9aa2-9e9326a40064)



PS: if run under 4K, LAA patch is suggested to avoid crash
