### PR TITLE
[dxgi] Under-report iGPU memory if dGPUs are present

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -39,12 +39,6 @@ namespace dxvk {
     { R"(\\RiftApart\.exe$)", {{
       { "dxgi.hideNvidiaGpu",               "False" },
     }} },
-    /* Metro Exodus Enhanced Edition picks GPU adapters
-     * by available VRAM, which causes issues on some
-     * systems with integrated graphics. */
-    { R"(\\Metro Exodus Enhanced Edition\\MetroExodus\.exe$)", {{
-      { "dxvk.hideIntegratedGraphics",      "True" },
-    }} },
     /* Persona 3 Reload - disables vsync by default and
      * runs into severe frame latency issues on Deck. */
     { R"(\\P3R\.exe$)", {{


### PR DESCRIPTION
Should help games pick the correct GPU on setups with integrated graphics.

Supercedes #4192.