### PR TITLE
[d3d11] Always keep barrier control options set by app profile

### DIFF
--- a/src/d3d11/d3d11_context_ext.cpp
+++ b/src/d3d11/d3d11_context_ext.cpp
@@ -143,8 +143,9 @@ namespace dxvk {
   void STDMETHODCALLTYPE D3D11DeviceContextExt<ContextType>::SetBarrierControl(
           UINT                    ControlFlags) {
     D3D10DeviceLock lock = m_ctx->LockContext();
-    DxvkBarrierControlFlags flags;
-    
+    D3D11Device* parent = static_cast<D3D11Device*>(m_ctx->GetParentInterface());
+    DxvkBarrierControlFlags flags = parent->GetOptionsBarrierControlFlags();
+
     if (ControlFlags & D3D11_VK_BARRIER_CONTROL_IGNORE_WRITE_AFTER_WRITE)
       flags.set(DxvkBarrierControl::IgnoreWriteAfterWrite);
 

--- a/src/d3d11/d3d11_context_imm.cpp
+++ b/src/d3d11/d3d11_context_imm.cpp
@@ -24,20 +24,11 @@ namespace dxvk {
     m_videoContext(this, Device) {
     EmitCs([
       cDevice                 = m_device,
-      cRelaxedBarriers        = pParent->GetOptions()->relaxedBarriers,
-      cIgnoreGraphicsBarriers = pParent->GetOptions()->ignoreGraphicsBarriers
+      cBarrierControlFlags    = pParent->GetOptionsBarrierControlFlags()
     ] (DxvkContext* ctx) {
       ctx->beginRecording(cDevice->createCommandList());
 
-      DxvkBarrierControlFlags barrierControl;
-
-      if (cRelaxedBarriers)
-        barrierControl.set(DxvkBarrierControl::IgnoreWriteAfterWrite);
-
-      if (cIgnoreGraphicsBarriers)
-        barrierControl.set(DxvkBarrierControl::IgnoreGraphicsBarriers);
-
-      ctx->setBarrierControl(barrierControl);
+      ctx->setBarrierControl(cBarrierControlFlags);
     });
     
     ClearState();

--- a/src/d3d11/d3d11_device.h
+++ b/src/d3d11/d3d11_device.h
@@ -434,6 +434,18 @@ namespace dxvk {
     
     static DxvkDeviceFeatures GetDeviceFeatures(
       const Rc<DxvkAdapter>&  Adapter);
+
+    DxvkBarrierControlFlags GetOptionsBarrierControlFlags() {
+      DxvkBarrierControlFlags barrierControl;
+
+      if (m_d3d11Options.relaxedBarriers)
+        barrierControl.set(DxvkBarrierControl::IgnoreWriteAfterWrite);
+
+      if (m_d3d11Options.ignoreGraphicsBarriers)
+        barrierControl.set(DxvkBarrierControl::IgnoreGraphicsBarriers);
+
+      return barrierControl;
+    }
     
   private:
     


### PR DESCRIPTION
A fix for the performance regression with DXVK-NVAPI that we found earlier.
This isn't the nicest solution but it's a simple solution.