### PR TITLE
[util] Document "d3d9.allowDirectBufferMapping" in dxvk.conf

### DIFF
--- a/dxvk.conf
+++ b/dxvk.conf
@@ -688,3 +688,13 @@
 # - True/False
 
 # d3d9.countLosableResources = True
+
+# Allow direct buffer mapping
+#
+# Allow applications to access direct buffer mapping.
+# Disabling can fix crashes related to
+# address space and buffers.
+#
+# Supported values: True, False
+#
+# d3d9.allowDirectBufferMapping = True


### PR DESCRIPTION
I'm not sure if the description of the option is correct; I described it as best I could interpret it from past commits and current usage.