### PR TITLE
[util] Make frame rate limiter enablement heuristic more robust

### DIFF
--- a/src/d3d11/d3d11_swapchain.cpp
+++ b/src/d3d11/d3d11_swapchain.cpp
@@ -353,7 +353,7 @@ namespace dxvk {
     m_targetFrameRate = FrameRate;
 
     if (m_presenter != nullptr)
-      m_presenter->setFrameRateLimit(m_targetFrameRate);
+      m_presenter->setFrameRateLimit(m_targetFrameRate, GetActualFrameLatency());
   }
 
 
@@ -506,7 +506,7 @@ namespace dxvk {
     presenterDesc.fullScreenExclusive = PickFullscreenMode();
 
     m_presenter = new Presenter(m_device, m_frameLatencySignal, presenterDesc);
-    m_presenter->setFrameRateLimit(m_targetFrameRate);
+    m_presenter->setFrameRateLimit(m_targetFrameRate, GetActualFrameLatency());
   }
 
 

--- a/src/d3d9/d3d9_swapchain.cpp
+++ b/src/d3d9/d3d9_swapchain.cpp
@@ -1120,7 +1120,7 @@ namespace dxvk {
     if (SyncInterval && frameRateOption == 0.0)
       frameRate = -m_displayRefreshRate / double(SyncInterval);
 
-    m_wctx->presenter->setFrameRateLimit(frameRate);
+    m_wctx->presenter->setFrameRateLimit(frameRate, GetActualFrameLatency());
   }
 
 

--- a/src/dxvk/dxvk_presenter.cpp
+++ b/src/dxvk/dxvk_presenter.cpp
@@ -415,8 +415,8 @@ namespace dxvk {
   }
 
 
-  void Presenter::setFrameRateLimit(double frameRate) {
-    m_fpsLimiter.setTargetFrameRate(frameRate);
+  void Presenter::setFrameRateLimit(double frameRate, uint32_t maxLatency) {
+    m_fpsLimiter.setTargetFrameRate(frameRate, maxLatency);
   }
 
 

--- a/src/dxvk/dxvk_presenter.h
+++ b/src/dxvk/dxvk_presenter.h
@@ -195,7 +195,7 @@ namespace dxvk {
      * \param [in] frameRate Target frame rate. Set
      *    to 0 in order to disable the limiter.
      */
-    void setFrameRateLimit(double frameRate);
+    void setFrameRateLimit(double frameRate, uint32_t maxLatency);
 
     /**
      * \brief Checks whether a Vulkan swap chain exists

--- a/src/util/util_fps_limiter.h
+++ b/src/util/util_fps_limiter.h
@@ -28,7 +28,7 @@ namespace dxvk {
      * \brief Sets target frame rate
      * \param [in] frameRate Target frame rate
      */
-    void setTargetFrameRate(double frameRate);
+    void setTargetFrameRate(double frameRate, uint32_t maxLatency);
 
     /**
      * \brief Stalls calling thread as necessary
@@ -48,14 +48,15 @@ namespace dxvk {
 
     TimerDuration   m_targetInterval  = TimerDuration::zero();
     TimePoint       m_nextFrame       = TimePoint();
+    uint32_t        m_maxLatency      = 0;
 
     bool            m_envOverride     = false;
 
-    uint32_t                  m_heuristicFrameCount = 0;
-    std::array<TimePoint, 16> m_heuristicFrameTimes = { };
-    bool                      m_heuristicEnable = false;
+    uint32_t        m_heuristicFrameCount = 0;
+    TimePoint       m_heuristicFrameTime  = TimePoint();
+    bool            m_heuristicEnable     = false;
 
-    bool testRefreshHeuristic(TimerDuration interval, TimePoint now);
+    bool testRefreshHeuristic(TimerDuration interval, TimePoint now, uint32_t maxLatency);
 
   };
 


### PR DESCRIPTION
Might need a bit of testing to ensure it still applies where necessary.

Should fix some cases where some mixture of swapchain buffering and timing errors cause us to enable the limiter even if the game has its own or if we're running at display refresh in a non-`present_wait` environment.