### PR TITLE
[d3d9] Add R16 and AL16 as known unsupported formats + some cleanup

### DIFF
--- a/src/d3d9/d3d9_format.cpp
+++ b/src/d3d9/d3d9_format.cpp
@@ -429,6 +429,10 @@ namespace dxvk {
 
       case D3D9Format::RAWZ: return {}; // Unsupported
 
+      case D3D9Format::R16:  return {}; // Unsupported
+
+      case D3D9Format::AL16: return {}; // Unsupported
+
       default:
         Logger::warn(str::format("ConvertFormat: Unknown format encountered: ", Format));
         return {}; // Unsupported

--- a/src/d3d9/d3d9_format.cpp
+++ b/src/d3d9/d3d9_format.cpp
@@ -509,9 +509,6 @@ namespace dxvk {
     static const DxvkFormatInfo a8r3g3b2    = { 2, VK_IMAGE_ASPECT_COLOR_BIT };
     static const DxvkFormatInfo a8p8        = { 2, VK_IMAGE_ASPECT_COLOR_BIT };
     static const DxvkFormatInfo p8          = { 1, VK_IMAGE_ASPECT_COLOR_BIT };
-    static const DxvkFormatInfo l6v5u5      = { 2, VK_IMAGE_ASPECT_COLOR_BIT };
-    static const DxvkFormatInfo x8l8v8u8    = { 4, VK_IMAGE_ASPECT_COLOR_BIT };
-    static const DxvkFormatInfo a2w10v10u10 = { 4, VK_IMAGE_ASPECT_COLOR_BIT };
     static const DxvkFormatInfo cxv8u8      = { 2, VK_IMAGE_ASPECT_COLOR_BIT };
     static const DxvkFormatInfo unknown     = {};
 
@@ -530,15 +527,6 @@ namespace dxvk {
 
       case D3D9Format::P8:
         return &p8;
-
-      case D3D9Format::L6V5U5:
-        return &l6v5u5;
-
-      case D3D9Format::X8L8V8U8:
-        return &x8l8v8u8;
-
-      case D3D9Format::A2W10V10U10:
-        return &a2w10v10u10;
 
       // MULTI2_ARGB8 -> Don't have a clue what this is.
 


### PR DESCRIPTION
Some games will use these two formats (excessively even) with CreateOffscreenPlainSurface (d3d9) / CreateImageSurface (d3d8), which won't fail even for known unsupported formats. We've had the same problem with P8 on d3d8 side in the past.

WineD3D supports both R16 and AL16 along these lines, but not with CreateTexture (nor does it advertise them as supported formats). This PR brings us on par and is also meant to silence a lot of `ConvertFormat: Unknown format encountered` warnings we've seen in logs for these two formats in particular.

I've also cleaned up some supported formats from GetUnsupportedFormatInfo, for good measure (I'm assuming nobody bothered to remove them from there once support was added). 

Draft for now as I still have to:
- test the behavior on native WinXP
- see if any other dubious formats need inclusion based on above