### PR TITLE
[d3d8] Clamp BaseVertexIndex to INT_MAX during use

### DIFF
--- a/src/d3d8/d3d8_device.cpp
+++ b/src/d3d8/d3d8_device.cpp
@@ -1168,7 +1168,7 @@ namespace dxvk {
           UINT             PrimitiveCount) {
     return GetD3D9()->DrawIndexedPrimitive(
       d3d9::D3DPRIMITIVETYPE(PrimitiveType),
-      m_baseVertexIndex, // set by SetIndices
+      static_cast<INT>(std::min(m_baseVertexIndex, static_cast<UINT>(INT_MAX))), // set by SetIndices
       MinVertexIndex,
       NumVertices,
       StartIndex,
@@ -1292,8 +1292,11 @@ namespace dxvk {
     if (unlikely(ShouldRecord()))
       return m_recorder->SetIndices(pIndexData, BaseVertexIndex);
 
+    if (unlikely(BaseVertexIndex > INT_MAX))
+      Logger::warn("BaseVertexIndex exceeds INT_MAX and will be clamped on use.");
+
     // used by DrawIndexedPrimitive
-    m_baseVertexIndex = static_cast<INT>(BaseVertexIndex);
+    m_baseVertexIndex = BaseVertexIndex;
 
     D3D8IndexBuffer* buffer = static_cast<D3D8IndexBuffer*>(pIndexData);
 

--- a/src/d3d8/d3d8_device.h
+++ b/src/d3d8/d3d8_device.h
@@ -432,7 +432,7 @@ namespace dxvk {
     std::array<D3D8VBO, d8caps::MAX_STREAMS>                           m_streams;
 
     Com<D3D8IndexBuffer, false>        m_indices;
-    INT                                m_baseVertexIndex = 0;
+    UINT                               m_baseVertexIndex = 0;
 
     // TODO: Which of these should be a private ref
     std::vector<Com<D3D8Surface, false>> m_backBuffers;


### PR DESCRIPTION
There's a minor type difference between BaseVertexIndex in d3d8 (UINT set by SetIndices) and in d3d9 (INT as input parameter for DrawIndexedPrimitive). The values are, I expect, too high to ever be hit, however if that happens we shouldn't overflow into a negative value with d3d9.

Clamping is perhaps not ideal, but in order to simulate native d3d8 behavior we technically have to accept the full range of UINT values of BaseVertexIndex, which we should also return during calls to GetIndices. I have verified this works fine with native.