### PR TITLE
[util] Use cdecl calling convention for __wine_dbg_output

### DIFF
--- a/src/util/log/log.cpp
+++ b/src/util/log/log.cpp
@@ -77,10 +77,14 @@ namespace dxvk {
         std::string adjusted = outstream.str();
 
         if (!adjusted.empty()) {
+#ifdef _WIN32
           if (m_wineLogOutput)
             m_wineLogOutput(adjusted.c_str());
           else
             std::cerr << adjusted;
+#else
+          std::cerr << adjusted;
+#endif
         }
 
         if (m_fileStream)
@@ -96,9 +100,11 @@ namespace dxvk {
     if (path == "none")
       return std::string();
 
+#ifdef _WIN32
     // Don't create a log file if we're writing to wine's console output
     if (path.empty() && m_wineLogOutput)
       return std::string();
+#endif
 
     if (!path.empty() && *path.rbegin() != '/')
       path += '/';

--- a/src/util/log/log.h
+++ b/src/util/log/log.h
@@ -18,7 +18,9 @@ namespace dxvk {
     None  = 5,
   };
   
-  using PFN_wineLogOutput = int (STDMETHODCALLTYPE *)(const char *);
+#ifdef _WIN32
+  using PFN_wineLogOutput = int (__cdecl *)(const char *);
+#endif
 
   /**
    * \brief Logger
@@ -55,7 +57,9 @@ namespace dxvk {
     std::ofstream     m_fileStream;
 
     bool              m_initialized = false;
+#ifdef _WIN32
     PFN_wineLogOutput m_wineLogOutput = nullptr;
+#endif
 
     void emitMsg(LogLevel level, const std::string& message);
     


### PR DESCRIPTION
This matches wine's definition, fixes crashes when wine is built with clang.