### PR TITLE
[util] Enable cachedDynamicBuffers for Steel Soldiers and FIFA 2003

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -1137,11 +1137,19 @@ namespace dxvk {
     }} },
     /* Art of Murder FBI Confidential - CPU perf  */
     { R"(\\Art of Murder - FBI Confidential\\game\.exe$)", {{
-      { "d3d9.cachedDynamicBuffers",       "True" },
+      { "d3d9.cachedDynamicBuffers",        "True" },
     }} },
     /* Max Payne 1 - Stalls waiting for an index buffer */
     { R"(\\MaxPayne\.exe$)", {{
-      { "d3d9.allowDirectBufferMapping",    "False" },
+      { "d3d9.allowDirectBufferMapping",   "False" },
+    }} },
+    /* Z: Steel Soldiers                          */
+    { R"(\\z2\.exe$)", {{
+      { "d3d9.cachedDynamicBuffers",        "True" },
+    }} },
+    /* FIFA Football 2003                         */
+    { R"(\\fifa2003(demo)?\.exe$)", {{
+      { "d3d9.cachedDynamicBuffers",        "True" },
     }} },
   }};
 


### PR DESCRIPTION
Steel Soldiers does some "classic" CPU read-backs from DYNAMIC buffers. So does FIFA Football 2003. Plus some minor config file alignment, as it was a bit all over the place for the last two entries.