### PR TITLE
[d3d8] Ignore unsupported D3DPRESENT_RATE_UNLIMITED

### DIFF
--- a/src/d3d8/d3d8_d3d9_util.h
+++ b/src/d3d8/d3d8_d3d9_util.h
@@ -107,7 +107,12 @@ namespace dxvk {
     params.AutoDepthStencilFormat = d3d9::D3DFORMAT(pParams->AutoDepthStencilFormat);
     params.Flags = pParams->Flags;
 
-    params.FullScreen_RefreshRateInHz = pParams->FullScreen_RefreshRateInHz;
+    // D3DPRESENT_RATE_UNLIMITED is unsupported, use D3DPRESENT_RATE_DEFAULT (or 0)
+    if (unlikely(pParams->FullScreen_RefreshRateInHz == D3DPRESENT_RATE_UNLIMITED)) {
+      params.FullScreen_RefreshRateInHz = D3DPRESENT_RATE_DEFAULT;
+    } else {
+      params.FullScreen_RefreshRateInHz = pParams->FullScreen_RefreshRateInHz;
+    }
 
     // FullScreen_PresentationInterval -> PresentationInterval
     params.PresentationInterval = PresentationInterval;

--- a/src/d3d8/d3d8_include.h
+++ b/src/d3d8/d3d8_include.h
@@ -191,6 +191,10 @@ namespace d3d9 {
 #define D3DDEVINFOID_VERTEXSTATS        6   // Aka D3DDEVINFOID_D3DVERTEXSTATS
 #endif
 
+#ifndef D3DPRESENT_RATE_UNLIMITED
+#define D3DPRESENT_RATE_UNLIMITED       0x7FFFFFFF
+#endif
+
 #else // _MSC_VER
 
 // These are enum typedefs in the MinGW headers, but not defined by Microsoft


### PR DESCRIPTION
A minor nit, and most likely generally unused, but better safe than sorry. D3DPRESENT_RATE_UNLIMITED (0x7FFFFFFF) is present in the d3d8 spec, but unsupported. Ignore it and revert to D3DPRESENT_RATE_DEFAULT (0) in case any early d3d8 games are mad enough to use it. [D3DPRESENT_RATE_UNLIMITED was removed in d3d9](https://learn.microsoft.com/en-us/windows/win32/direct3d9/converting-to-directx-9#intervals-and-swapeffects-changes), but may have actually been scrapped as far back as d3d8 with the DX8.1 release.