### PR TITLE
[d3d8] Clean up D3D9 shaders on D3D8 device release

### DIFF
--- a/src/d3d8/d3d8_device.h
+++ b/src/d3d8/d3d8_device.h
@@ -441,10 +441,10 @@ namespace dxvk {
     Com<D3D8Surface, false>     m_renderTarget;
     Com<D3D8Surface, false>     m_depthStencil;
 
-    std::vector<D3D8VertexShaderInfo>           m_vertexShaders;
-    std::vector<d3d9::IDirect3DPixelShader9*>   m_pixelShaders;
-    DWORD                                       m_currentVertexShader  = 0; // can be FVF or vs index (marked by D3DFVF_RESERVED0)
-    DWORD                                       m_currentPixelShader   = 0;
+    std::vector<D3D8VertexShaderInfo>               m_vertexShaders;
+    std::vector<Com<d3d9::IDirect3DPixelShader9>>   m_pixelShaders;
+    DWORD                                           m_currentVertexShader  = 0; // can be FVF or vs index (marked by D3DFVF_RESERVED0)
+    DWORD                                           m_currentPixelShader   = 0;
 
     D3DDEVTYPE            m_deviceType;
     HWND                  m_window;


### PR DESCRIPTION
In D3D8 the runtime owns VS & definitions, PS and state blocks. Client applications interact with them by means of handles/tokens used in D3D8 API calls. Thus, from a D3D9 standpoint, we are responsible for managing the object lifecycle, and for releasing them when appropriate.

D3D8 typically does this on device release, since none of the above mentioned objects are considered perishable, ergo they survive device resets. So far we were not handling the release of VS & definitions and PS that were created by D3D9 for us.

This PR addresses that and also changes the stored pointers to Com objects, so that we can more easily clear them, instead of having to manually call Release().

Fixes this obscure crash in Hitman 2: https://github.com/AlpyneDreams/d8vk/issues/11 :tada: .

It will need some extensive testing before merging, as we previously did with other refcount affecting d8vk PRs. I suspect it would also have to be rebased on top of #4217, which should ideally be merged first.