### PR TITLE
[util] Add a framecap for Pandora Tomorrow

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -1111,6 +1111,11 @@ namespace dxvk {
     { R"(\\fifa2003(demo)?\.exe$)", {{
       { "d3d9.cachedDynamicBuffers",        "True" },
     }} },
+    /* Splinter Cell: Pandora Tomorrow            *
+     * Broken inputs and physics above 60 FPS     */
+    { R"(\\SplinterCell2\.exe$)", {{
+      { "d3d9.maxFrameRate",                  "60" },
+    }} },
   }};
 
 


### PR DESCRIPTION
Pretty much what the description says: inputs and some physics-based effects are broken above 60 fps. 

The game also needs **Nvidia Shadow Buffers** support to be fully playable (as in camera avoidance gameplay depends on it), but I'm hoping @AlpyneDreams will get to reinstate it at some point.