### PR TITLE
Global buffer

### DIFF
--- a/src/d3d11/d3d11_buffer.cpp
+++ b/src/d3d11/d3d11_buffer.cpp
@@ -94,17 +94,25 @@ namespace dxvk {
       if (m_desc.CPUAccessFlags)
         m_11on12.Resource->Map(0, nullptr, &importInfo.mapPtr);
 
+      // D3D12 will always have BDA enabled
+      info.usage |= VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT;
+
       m_buffer = m_parent->GetDXVKDevice()->importBuffer(info, importInfo, GetMemoryFlags());
       m_mapped = m_buffer->getSliceHandle();
 
-      m_mapMode = DetermineMapMode();
+      m_mapMode = DetermineMapMode(m_buffer->memFlags());
     } else if (!(pDesc->MiscFlags & D3D11_RESOURCE_MISC_TILE_POOL)) {
+      VkMemoryPropertyFlags memoryFlags = GetMemoryFlags();
+      m_mapMode = DetermineMapMode(memoryFlags);
+
+      if (m_mapMode == D3D11_COMMON_BUFFER_MAP_MODE_NONE
+       && m_parent->GetDXVKDevice()->features().vk12.bufferDeviceAddress)
+        info.usage |= VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT;
+
       // Create the buffer and set the entire buffer slice as mapped,
       // so that we only have to update it when invalidating the buffer
-      m_buffer = m_parent->GetDXVKDevice()->createBuffer(info, GetMemoryFlags());
+      m_buffer = m_parent->GetDXVKDevice()->createBuffer(info, memoryFlags);
       m_mapped = m_buffer->getSliceHandle();
-
-      m_mapMode = DetermineMapMode();
     } else {
       m_sparseAllocator = m_parent->GetDXVKDevice()->createSparsePageAllocator();
       m_sparseAllocator->setCapacity(info.size / SparseMemoryPageSize);
@@ -369,8 +377,8 @@ namespace dxvk {
   }
 
 
-  D3D11_COMMON_BUFFER_MAP_MODE D3D11Buffer::DetermineMapMode() {
-    return (m_buffer->memFlags() & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT)
+  D3D11_COMMON_BUFFER_MAP_MODE D3D11Buffer::DetermineMapMode(VkMemoryPropertyFlags MemFlags) {
+    return (MemFlags & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT)
       ? D3D11_COMMON_BUFFER_MAP_MODE_DIRECT
       : D3D11_COMMON_BUFFER_MAP_MODE_NONE;
   }

--- a/src/d3d11/d3d11_buffer.h
+++ b/src/d3d11/d3d11_buffer.h
@@ -198,7 +198,8 @@ namespace dxvk {
 
     Rc<DxvkBuffer> CreateSoCounterBuffer();
 
-    D3D11_COMMON_BUFFER_MAP_MODE DetermineMapMode();
+    static D3D11_COMMON_BUFFER_MAP_MODE DetermineMapMode(
+            VkMemoryPropertyFlags MemFlags);
 
   };
 

--- a/src/d3d11/d3d11_context.cpp
+++ b/src/d3d11/d3d11_context.cpp
@@ -532,6 +532,7 @@ namespace dxvk {
         bufferViewInfo.format      = rawFormat;
         bufferViewInfo.rangeOffset = 0;
         bufferViewInfo.rangeLength = bufferInfo.size;
+        bufferViewInfo.usage       = VK_BUFFER_USAGE_STORAGE_TEXEL_BUFFER_BIT;
 
         Rc<DxvkBufferView> bufferView = m_device->createBufferView(buffer,
           bufferViewInfo);

--- a/src/d3d11/d3d11_view_srv.cpp
+++ b/src/d3d11/d3d11_view_srv.cpp
@@ -43,6 +43,7 @@ namespace dxvk {
 
       // Fill in buffer view info
       DxvkBufferViewCreateInfo viewInfo;
+      viewInfo.usage = VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT;
 
       if (bufInfo.Flags & D3D11_BUFFEREX_SRV_FLAG_RAW) {
         // Raw buffer view. We'll represent this as a

--- a/src/d3d11/d3d11_view_uav.cpp
+++ b/src/d3d11/d3d11_view_uav.cpp
@@ -26,6 +26,7 @@ namespace dxvk {
       auto buffer = static_cast<D3D11Buffer*>(pResource);
       
       DxvkBufferViewCreateInfo viewInfo;
+      viewInfo.usage = VK_BUFFER_USAGE_STORAGE_TEXEL_BUFFER_BIT;
       
       if (pDesc->Buffer.Flags & D3D11_BUFFEREX_SRV_FLAG_RAW) {
         viewInfo.format      = VK_FORMAT_R32_UINT;
@@ -454,6 +455,7 @@ namespace dxvk {
     viewInfo.format = VK_FORMAT_UNDEFINED;
     viewInfo.rangeOffset = 0;
     viewInfo.rangeLength = sizeof(uint32_t);
+    viewInfo.usage = VK_BUFFER_USAGE_STORAGE_TEXEL_BUFFER_BIT;
 
     return device->createBufferView(buffer, viewInfo);
   }

--- a/src/d3d9/d3d9_format_helpers.cpp
+++ b/src/d3d9/d3d9_format_helpers.cpp
@@ -96,6 +96,7 @@ namespace dxvk {
     bufferViewInfo.format      = bufferFormat;
     bufferViewInfo.rangeOffset = srcSlice.offset();
     bufferViewInfo.rangeLength = srcSlice.length();
+    bufferViewInfo.usage = VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT;
     auto tmpBufferView = m_device->createBufferView(srcSlice.buffer(), bufferViewInfo);
 
     m_context->setSpecConstant(VK_PIPELINE_BIND_POINT_COMPUTE, 0, specConstantValue);

--- a/src/dxvk/dxvk_buffer.h
+++ b/src/dxvk/dxvk_buffer.h
@@ -52,6 +52,9 @@ namespace dxvk {
     
     /// Size of the buffer region to include in the view
     VkDeviceSize rangeLength;
+
+    /// Buffer view usage flags
+    VkBufferUsageFlags usage;
   };
 
 
@@ -577,7 +580,7 @@ namespace dxvk {
   public:
     
     DxvkBufferView(
-      const Rc<vk::DeviceFn>&         vkd,
+            DxvkDevice*               device,
       const Rc<DxvkBuffer>&           buffer,
       const DxvkBufferViewCreateInfo& info);
     
@@ -676,6 +679,7 @@ namespace dxvk {
     Rc<vk::DeviceFn>          m_vkd;
     DxvkBufferViewCreateInfo  m_info;
     Rc<DxvkBuffer>            m_buffer;
+    VkBufferUsageFlags        m_usage;
 
     DxvkBufferSliceHandle     m_bufferSlice;
     VkBufferView              m_bufferView;

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -873,10 +873,12 @@ namespace dxvk {
     viewInfo.format = format;
     viewInfo.rangeOffset = dstBufferOffset;
     viewInfo.rangeLength = dstBufferSlice.length;
+    viewInfo.usage = VK_BUFFER_USAGE_STORAGE_TEXEL_BUFFER_BIT;
     Rc<DxvkBufferView> dstView = m_device->createBufferView(dstBuffer, viewInfo);
 
     viewInfo.rangeOffset = srcBufferOffset;
     viewInfo.rangeLength = srcBufferSlice.length;
+    viewInfo.usage = VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT;
     Rc<DxvkBufferView> srcView;
 
     if (srcBuffer == dstBuffer
@@ -1066,11 +1068,13 @@ namespace dxvk {
     tmpViewInfoD.format      = dataFormatD;
     tmpViewInfoD.rangeOffset = 0;
     tmpViewInfoD.rangeLength = dataSizeD;
+    tmpViewInfoD.usage       = VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT;
 
     DxvkBufferViewCreateInfo tmpViewInfoS;
     tmpViewInfoS.format      = dataFormatS;
     tmpViewInfoS.rangeOffset = dataSizeD;
     tmpViewInfoS.rangeLength = dataSizeS;
+    tmpViewInfoS.usage       = VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT;
 
     auto tmpBufferViewD = m_device->createBufferView(tmpBuffer, tmpViewInfoD);
     auto tmpBufferViewS = m_device->createBufferView(tmpBuffer, tmpViewInfoS);

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -6386,6 +6386,10 @@ namespace dxvk {
     if (buffer->isForeign())
       return false;
 
+    // Don't discard buffers that need a stable device address
+    if (buffer->info().usage & VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT)
+      return false;
+
     // Suspend the current render pass if transform feedback is active prior to
     // invalidating the buffer, since otherwise we may invalidate a bound buffer.
     if ((buffer->info().usage & VK_BUFFER_USAGE_TRANSFORM_FEEDBACK_COUNTER_BUFFER_BIT_EXT)

--- a/src/dxvk/dxvk_device.cpp
+++ b/src/dxvk/dxvk_device.cpp
@@ -167,7 +167,7 @@ namespace dxvk {
   Rc<DxvkBufferView> DxvkDevice::createBufferView(
     const Rc<DxvkBuffer>&           buffer,
     const DxvkBufferViewCreateInfo& createInfo) {
-    return new DxvkBufferView(m_vkd, buffer, createInfo);
+    return new DxvkBufferView(this, buffer, createInfo);
   }
   
   

--- a/src/dxvk/hud/dxvk_hud_renderer.cpp
+++ b/src/dxvk/hud/dxvk_hud_renderer.cpp
@@ -251,9 +251,10 @@ namespace dxvk::hud {
 
   Rc<DxvkBufferView> HudRenderer::createDataView() {
     DxvkBufferViewCreateInfo info;
-    info.format = VK_FORMAT_R8_UINT;
-    info.rangeOffset = 0;
-    info.rangeLength = m_dataBuffer->info().size;
+    info.format         = VK_FORMAT_R8_UINT;
+    info.rangeOffset    = 0;
+    info.rangeLength    = m_dataBuffer->info().size;
+    info.usage          = VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT;
 
     return m_device->createBufferView(m_dataBuffer, info);
   }
@@ -278,6 +279,7 @@ namespace dxvk::hud {
     info.format         = VK_FORMAT_UNDEFINED;
     info.rangeOffset    = 0;
     info.rangeLength    = m_fontBuffer->info().size;
+    info.usage          = VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT;
 
     return m_device->createBufferView(m_fontBuffer, info);
   }

--- a/src/vulkan/vulkan_loader.h
+++ b/src/vulkan/vulkan_loader.h
@@ -198,8 +198,10 @@ namespace dxvk::vk {
     VULKAN_FN(vkBindImageMemory);
     VULKAN_FN(vkGetBufferMemoryRequirements);
     VULKAN_FN(vkGetBufferMemoryRequirements2);
+    VULKAN_FN(vkGetDeviceBufferMemoryRequirements);
     VULKAN_FN(vkGetImageMemoryRequirements);
     VULKAN_FN(vkGetImageMemoryRequirements2);
+    VULKAN_FN(vkGetDeviceImageMemoryRequirements);
     VULKAN_FN(vkGetImageSparseMemoryRequirements);
     VULKAN_FN(vkGetImageSparseMemoryRequirements2);
     VULKAN_FN(vkQueueBindSparse);


### PR DESCRIPTION
Basically do the vkd3d-proton thing of only creating one single VkBuffer per memory allocation whenever possible to open up some larger refactor. Works best if both maintenance4 and maintenance5 are supported, we still support creating a regular `VkBuffer` if necessary.

Needs testing with various games and various drivers.