### PR TITLE
[d3d8] Add a framecap for Chrome: Gold Edition

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -1116,6 +1116,11 @@ namespace dxvk {
     { R"(\\SplinterCell2\.exe$)", {{
       { "d3d9.maxFrameRate",                  "60" },
     }} },
+    /* Chrome: Gold Edition                       *
+     * Broken character model motion at high FPS  */
+    { R"(\\Chrome(Single|Net)\.exe$)", {{
+      { "d3d9.maxFrameRate",                  "60" },
+    }} },
   }};
 
 


### PR DESCRIPTION
Chrome has regressed at some point prior to the d8vk merge, during the last rebase we did.

The game is weird. It calls CopyRects on a X8R8G8B8 surface (D3DPOOL_DEFAULT) as source and a R8G8B8 off-screen surface (D3DPOOL_SCRATCH) as target. This would never work in practice (and the game indeed crashes during start-up), because CopyRects doesn't perform format conversions, especially not on unsupported formats, so I can only assume that the game relied on hardware R8G8B8 support originally.

As a workaround, we can do the opposite and force convert the target surface to X8R8G8B8 when it gets created. This seems to work fine with a minor annoyance: the screenshots captured by the game alongside save games are corrupted.

WineD3D works fine on both accounts, but unfortunately I can't quite figure out why, because the game crashes on apitrace capture.

I'll open an issue to track the screenshot problem separately, but this should be fine for now and makes the game completely playable. We probably need to implement a proper format conversion for these situations.