### PR TITLE
Remove supplementary contexts

### DIFF
--- a/src/d3d11/d3d11_device.cpp
+++ b/src/d3d11/d3d11_device.cpp
@@ -1842,6 +1842,10 @@ namespace dxvk {
   void D3D11Device::FlushInitContext(const D3D11InitChunkDispatchProc& DispatchProc) {
     m_initializer->EmitToCsThread(DispatchProc);
   }
+
+  void D3D11Device::InitializeTexture(D3D11CommonTexture* pTexture) {
+    m_initializer->InitTexture(pTexture, nullptr);
+  }
   
   
   D3D_FEATURE_LEVEL D3D11Device::GetMaxFeatureLevel(

--- a/src/d3d11/d3d11_device.cpp
+++ b/src/d3d11/d3d11_device.cpp
@@ -1839,8 +1839,8 @@ namespace dxvk {
   }
   
   
-  void D3D11Device::FlushInitContext() {
-    m_initializer->Flush();
+  void D3D11Device::FlushInitContext(const D3D11InitChunkDispatchProc& DispatchProc) {
+    m_initializer->EmitToCsThread(DispatchProc);
   }
   
   

--- a/src/d3d11/d3d11_device.h
+++ b/src/d3d11/d3d11_device.h
@@ -390,9 +390,9 @@ namespace dxvk {
     Rc<DxvkDevice> GetDXVKDevice() {
       return m_dxvkDevice;
     }
-    
-    void FlushInitContext();
-    
+
+    void FlushInitContext(const D3D11InitChunkDispatchProc& DispatchProc);
+
     VkPipelineStageFlags GetEnabledShaderStages() const {
       return m_dxvkDevice->getShaderPipelineStages();
     }

--- a/src/d3d11/d3d11_device.h
+++ b/src/d3d11/d3d11_device.h
@@ -392,6 +392,7 @@ namespace dxvk {
     }
 
     void FlushInitContext(const D3D11InitChunkDispatchProc& DispatchProc);
+    void InitializeTexture(D3D11CommonTexture* pTexture);
 
     VkPipelineStageFlags GetEnabledShaderStages() const {
       return m_dxvkDevice->getShaderPipelineStages();

--- a/src/d3d11/d3d11_swapchain.h
+++ b/src/d3d11/d3d11_swapchain.h
@@ -104,7 +104,6 @@ namespace dxvk {
     DXGI_SWAP_CHAIN_DESC1     m_desc;
 
     Rc<DxvkDevice>            m_device;
-    Rc<DxvkContext>           m_context;
 
     Rc<Presenter>             m_presenter;
 
@@ -138,11 +137,6 @@ namespace dxvk {
     DXGI_VK_FRAME_STATISTICS  m_frameStatistics = { };
 
     HRESULT PresentImage(UINT SyncInterval);
-
-    void SubmitPresent(
-            D3D11ImmediateContext*  pContext,
-      const PresenterSync&          Sync,
-            uint32_t                Repeat);
 
     void SynchronizePresent();
 

--- a/src/d3d9/d3d9_swapchain.cpp
+++ b/src/d3d9/d3d9_swapchain.cpp
@@ -830,7 +830,7 @@ namespace dxvk {
         swapImageView, srcRect);
 
       if (m_hud != nullptr)
-        m_hud->render(m_context, info.format, info.imageExtent);
+        m_hud->render(m_context, info.format.colorSpace, swapImageView);
 
       SubmitPresent(sync, i);
     }

--- a/src/dxvk/dxvk_buffer.h
+++ b/src/dxvk/dxvk_buffer.h
@@ -676,11 +676,14 @@ namespace dxvk {
      * well and needs to be re-created. Call this
      * prior to using the buffer view handle.
      */
-    void updateView() {
+    bool updateView() {
       DxvkBufferSliceHandle slice = getSliceHandle();
 
-      if (!m_bufferSlice.eq(slice))
+      if (!m_bufferSlice.eq(slice)) {
         this->updateBufferView(slice);
+        return true;
+      }
+      return false;
     }
     
   private:

--- a/src/dxvk/dxvk_cmdlist.h
+++ b/src/dxvk/dxvk_cmdlist.h
@@ -444,6 +444,19 @@ namespace dxvk {
     }
     
     
+    void cmdBindDescriptorSet(
+            DxvkCmdBuffer             cmdBuffer,
+            VkPipelineBindPoint       pipeline,
+            VkPipelineLayout          pipelineLayout,
+            VkDescriptorSet           descriptorSet,
+            uint32_t                  dynamicOffsetCount,
+      const uint32_t*                 pDynamicOffsets) {
+      m_vkd->vkCmdBindDescriptorSets(getCmdBuffer(cmdBuffer),
+        pipeline, pipelineLayout, 0, 1,
+        &descriptorSet, dynamicOffsetCount, pDynamicOffsets);
+    }
+    
+    
     void cmdBindDescriptorSets(
             VkPipelineBindPoint       pipeline,
             VkPipelineLayout          pipelineLayout,
@@ -481,6 +494,15 @@ namespace dxvk {
             VkPipelineBindPoint     pipelineBindPoint,
             VkPipeline              pipeline) {
       m_vkd->vkCmdBindPipeline(m_cmd.execBuffer,
+        pipelineBindPoint, pipeline);
+    }
+
+
+    void cmdBindPipeline(
+            DxvkCmdBuffer           cmdBuffer,
+            VkPipelineBindPoint     pipelineBindPoint,
+            VkPipeline              pipeline) {
+      m_vkd->vkCmdBindPipeline(getCmdBuffer(cmdBuffer),
         pipelineBindPoint, pipeline);
     }
 
@@ -535,28 +557,30 @@ namespace dxvk {
     
     
     void cmdClearColorImage(
+            DxvkCmdBuffer           cmdBuffer,
             VkImage                 image,
             VkImageLayout           imageLayout,
       const VkClearColorValue*      pColor,
             uint32_t                rangeCount,
       const VkImageSubresourceRange* pRanges) {
-      m_cmd.usedFlags.set(DxvkCmdBuffer::ExecBuffer);
+      m_cmd.usedFlags.set(cmdBuffer);
 
-      m_vkd->vkCmdClearColorImage(m_cmd.execBuffer,
+      m_vkd->vkCmdClearColorImage(getCmdBuffer(cmdBuffer),
         image, imageLayout, pColor,
         rangeCount, pRanges);
     }
     
     
     void cmdClearDepthStencilImage(
+            DxvkCmdBuffer           cmdBuffer,
             VkImage                 image,
             VkImageLayout           imageLayout,
       const VkClearDepthStencilValue* pDepthStencil,
             uint32_t                rangeCount,
       const VkImageSubresourceRange* pRanges) {
-      m_cmd.usedFlags.set(DxvkCmdBuffer::ExecBuffer);
+      m_cmd.usedFlags.set(cmdBuffer);
 
-      m_vkd->vkCmdClearDepthStencilImage(m_cmd.execBuffer,
+      m_vkd->vkCmdClearDepthStencilImage(getCmdBuffer(cmdBuffer),
         image, imageLayout, pDepthStencil,
         rangeCount, pRanges);
     }
@@ -619,6 +643,17 @@ namespace dxvk {
             uint32_t                y,
             uint32_t                z) {
       m_cmd.usedFlags.set(DxvkCmdBuffer::ExecBuffer);
+
+      m_vkd->vkCmdDispatch(m_cmd.execBuffer, x, y, z);
+    }
+    
+    
+    void cmdDispatch(
+            DxvkCmdBuffer           cmdBuffer,
+            uint32_t                x,
+            uint32_t                y,
+            uint32_t                z) {
+      m_cmd.usedFlags.set(cmdBuffer);
 
       m_vkd->vkCmdDispatch(m_cmd.execBuffer, x, y, z);
     }
@@ -775,6 +810,18 @@ namespace dxvk {
             uint32_t                size,
       const void*                   pValues) {
       m_vkd->vkCmdPushConstants(m_cmd.execBuffer,
+        layout, stageFlags, offset, size, pValues);
+    }
+    
+    
+    void cmdPushConstants(
+            DxvkCmdBuffer           cmdBuffer,
+            VkPipelineLayout        layout,
+            VkShaderStageFlags      stageFlags,
+            uint32_t                offset,
+            uint32_t                size,
+      const void*                   pValues) {
+      m_vkd->vkCmdPushConstants(getCmdBuffer(cmdBuffer),
         layout, stageFlags, offset, size, pValues);
     }
 

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -1523,13 +1523,13 @@ namespace dxvk {
         if (subresources.aspectMask & (VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT)) {
           VkClearDepthStencilValue value = { };
 
-          m_cmd->cmdClearDepthStencilImage(image->handle(),
-            clearLayout, &value, 1, &subresources);
+          m_cmd->cmdClearDepthStencilImage(DxvkCmdBuffer::ExecBuffer,
+            image->handle(), clearLayout, &value, 1, &subresources);
         } else {
           VkClearColorValue value = { };
 
-          m_cmd->cmdClearColorImage(image->handle(),
-            clearLayout, &value, 1, &subresources);
+          m_cmd->cmdClearColorImage(DxvkCmdBuffer::ExecBuffer,
+            image->handle(), clearLayout, &value, 1, &subresources);
         }
       }
 

--- a/src/dxvk/dxvk_context.h
+++ b/src/dxvk/dxvk_context.h
@@ -672,7 +672,8 @@ namespace dxvk {
             VkDeviceSize          srcBufferOffset,
             VkOffset2D            srcOffset,
             VkExtent2D            srcExtent,
-            VkFormat              format);
+            VkFormat              format,
+            bool                  forceInit = false);
 
     /**
      * \brief Copies pages from a sparse resource to a buffer
@@ -1057,7 +1058,8 @@ namespace dxvk {
       const Rc<DxvkBuffer>&           buffer,
             VkDeviceSize              offset,
             VkDeviceSize              size,
-      const void*                     data);
+      const void*                     data,
+            bool                      isInit = false);
     
     /**
      * \brief Updates an depth-stencil image
@@ -1108,7 +1110,7 @@ namespace dxvk {
       const void*                     data,
             VkDeviceSize              pitchPerRow,
             VkDeviceSize              pitchPerLayer);
-    
+
     /**
      * \brief Sets viewports
      * 

--- a/src/dxvk/dxvk_context.h
+++ b/src/dxvk/dxvk_context.h
@@ -1093,7 +1093,12 @@ namespace dxvk {
     void uploadBuffer(
       const Rc<DxvkBuffer>&           buffer,
       const void*                     data);
-    
+
+    void uploadBufferFromBuffer(
+      const Rc<DxvkBuffer>&           buffer,
+      const Rc<DxvkBuffer>&           srcBuffer,
+            VkDeviceSize              srcBufferOffset);
+
     /**
      * \brief Uses transfer queue to initialize image
      * 
@@ -1108,6 +1113,14 @@ namespace dxvk {
       const Rc<DxvkImage>&            image,
       const VkImageSubresourceLayers& subresources,
       const void*                     data,
+            VkDeviceSize              pitchPerRow,
+            VkDeviceSize              pitchPerLayer);
+
+    void uploadImageFromBuffer(
+      const Rc<DxvkImage>&            image,
+      const VkImageSubresourceLayers& subresources,
+      const Rc<DxvkBuffer>&           srcBuffer,
+            VkDeviceSize              srcOffset,
             VkDeviceSize              pitchPerRow,
             VkDeviceSize              pitchPerLayer);
 

--- a/src/dxvk/dxvk_context.h
+++ b/src/dxvk/dxvk_context.h
@@ -1410,6 +1410,43 @@ namespace dxvk {
             VkRect2D                srcRect,
       const Rc<DxvkImageView>&      gammaView);
 
+
+    void beginHudRendering(const Rc<DxvkImageView>&  dstView);
+    void endHudRendering();
+    void startTextRendering(
+      const Rc<DxvkImageView>&  dstView,
+            VkColorSpaceKHR     colorSpace,
+      const Rc<DxvkBufferView>& dataBufferView,
+      const Rc<DxvkBufferView>& fontBufferView,
+      const Rc<DxvkImageView>&  fontView);
+    void drawText(
+            float               size,
+            HudPos              pos,
+            HudColor            color,
+            uint32_t            stringLength,
+            VkColorSpaceKHR     colorSpace,
+            float               scale,
+            uint32_t            dataBufferOffset,
+      const Rc<DxvkImageView>&  dstView,
+      const Rc<DxvkBufferView>& dataBufferView,
+      const Rc<DxvkBufferView>& fontBufferView,
+      const Rc<DxvkImageView>&  fontView);
+
+    void startGraphRendering(
+            VkColorSpaceKHR     colorSpace,
+      const Rc<DxvkImageView>&  dstView,
+      const Rc<DxvkBufferView>& dataBufferView);
+    void drawGraph(
+            HudPos              pos,
+            HudPos              size,
+            size_t              pointCount,
+            VkColorSpaceKHR     colorSpace,
+            float               scale,
+            float               opacity,
+            uint32_t            dataBufferPointOffset,
+      const Rc<DxvkImageView>&  dstView,
+      const Rc<DxvkBufferView>& dataBufferView);
+
   private:
     
     Rc<DxvkDevice>          m_device;

--- a/src/dxvk/dxvk_context.h
+++ b/src/dxvk/dxvk_context.h
@@ -1403,6 +1403,13 @@ namespace dxvk {
         m_cmd->addStatCtr(counter, value);
     }
 
+    void presentBlit(
+      const Rc<DxvkImageView>&      dstView,
+            VkRect2D                dstRect,
+      const Rc<DxvkImageView>&      srcView,
+            VkRect2D                srcRect,
+      const Rc<DxvkImageView>&      gammaView);
+
   private:
     
     Rc<DxvkDevice>          m_device;

--- a/src/dxvk/dxvk_hud_objects.cpp
+++ b/src/dxvk/dxvk_hud_objects.cpp
@@ -1,0 +1,311 @@
+#include "dxvk_hud_objects.h"
+
+#include <dxvk_present_frag.h>
+#include <dxvk_present_frag_blit.h>
+#include <dxvk_present_frag_ms.h>
+#include <dxvk_present_frag_ms_amd.h>
+#include <dxvk_present_vert.h>
+
+#include <hud_graph_frag.h>
+#include <hud_graph_vert.h>
+
+#include <hud_text_frag.h>
+#include <hud_text_vert.h>
+
+#include "dxvk_device.h"
+
+namespace dxvk {
+
+  DxvkHudObjects::DxvkHudObjects(const DxvkDevice* device)
+    : m_vkd(device->vkd()) {
+    this->createShaders(device);
+    this->createFontSampler();
+  }
+
+  DxvkHudObjects::~DxvkHudObjects() {
+    m_vkd->vkDestroyShaderModule(m_vkd->device(), m_textVs, nullptr);
+    m_vkd->vkDestroyShaderModule(m_vkd->device(), m_textFs, nullptr);
+    m_vkd->vkDestroyShaderModule(m_vkd->device(), m_graphVs, nullptr);
+    m_vkd->vkDestroyShaderModule(m_vkd->device(), m_graphFs, nullptr);
+
+    m_vkd->vkDestroySampler(m_vkd->device(), m_fontSampler, nullptr);
+
+    for (const auto& [key, pipeline] : m_pipelines) {
+      m_vkd->vkDestroyPipeline(m_vkd->device(), pipeline.textPipeHandle, nullptr);
+      m_vkd->vkDestroyPipelineLayout(m_vkd->device(), pipeline.textPipeLayout, nullptr);
+      m_vkd->vkDestroyDescriptorSetLayout(m_vkd->device(), pipeline.textDSetLayout, nullptr);
+      m_vkd->vkDestroyPipeline(m_vkd->device(), pipeline.graphPipeHandle, nullptr);
+      m_vkd->vkDestroyPipelineLayout(m_vkd->device(), pipeline.graphPipeLayout, nullptr);
+      m_vkd->vkDestroyDescriptorSetLayout(m_vkd->device(), pipeline.graphDSetLayout, nullptr);
+    }
+  }
+
+  void DxvkHudObjects::createShaders(const DxvkDevice* device) {
+    SpirvCodeBuffer textVsCode(hud_text_vert);
+    SpirvCodeBuffer textFsCode(hud_text_frag);
+    SpirvCodeBuffer graphVsCode(hud_graph_vert);
+    SpirvCodeBuffer graphFsCode(hud_graph_frag);
+
+    VkShaderModuleCreateInfo info = { VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO };
+      info.codeSize               = textVsCode.size();
+      info.pCode                  = textVsCode.data();
+
+    if (m_vkd->vkCreateShaderModule(m_vkd->device(), &info, nullptr, &m_textVs) != VK_SUCCESS)
+      throw DxvkError("DxvkMetaBlitObjects: Failed to create shader module");
+
+    info.pCode                 = textFsCode.data();
+    info.codeSize              = textFsCode.size();
+
+    if (m_vkd->vkCreateShaderModule(m_vkd->device(), &info, nullptr, &m_textFs) != VK_SUCCESS)
+      throw DxvkError("DxvkMetaBlitObjects: Failed to create shader module");
+
+    info.pCode                 = graphVsCode.data();
+    info.codeSize              = graphVsCode.size();
+
+    if (m_vkd->vkCreateShaderModule(m_vkd->device(), &info, nullptr, &m_graphVs) != VK_SUCCESS)
+      throw DxvkError("DxvkMetaBlitObjects: Failed to create shader module");
+
+    info.pCode                 = graphFsCode.data();
+    info.codeSize              = graphFsCode.size();
+
+    if (m_vkd->vkCreateShaderModule(m_vkd->device(), &info, nullptr, &m_graphFs) != VK_SUCCESS)
+      throw DxvkError("DxvkMetaBlitObjects: Failed to create shader module");
+  }
+
+  void DxvkHudObjects::createFontSampler() {
+    VkSamplerCreateInfo info = { VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO };
+    info.magFilter               = VK_FILTER_LINEAR;
+    info.minFilter               = VK_FILTER_LINEAR;
+    info.mipmapMode              = VK_SAMPLER_MIPMAP_MODE_NEAREST;
+    info.addressModeU            = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+    info.addressModeV            = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+    info.addressModeW            = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+    info.borderColor             = VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK;
+    info.unnormalizedCoordinates = VK_TRUE;
+    info.maxAnisotropy           = 1.0f;
+
+    if (m_vkd->vkCreateSampler(m_vkd->device(), &info, nullptr, &m_fontSampler) != VK_SUCCESS)
+      throw DxvkError("DxvkMetaBlitObjects: Failed to create sampler");
+  }
+
+  DxvkHudPipelines DxvkHudObjects::getPipelines(
+        VkSampleCountFlagBits samples,
+        VkFormat              viewFormat,
+        VkColorSpaceKHR       colorSpace){
+    std::lock_guard<dxvk::mutex> lock(m_mutex);
+
+    DxvkHudPipelinesKey key;
+    key.samples    = samples;
+    key.viewFormat = viewFormat;
+    key.colorSpace = colorSpace;
+
+    auto entry = m_pipelines.find(key);
+    if (entry != m_pipelines.end())
+      return entry->second;
+
+    DxvkHudPipelines pipeline = this->createPipelines(key);
+    m_pipelines.insert({ key, pipeline });
+    return pipeline;
+  }
+
+  VkDescriptorSetLayout DxvkHudObjects::createTextDescriptorSetLayout() {
+    std::array<VkDescriptorSetLayoutBinding, 3> bindings = { VkDescriptorSetLayoutBinding { 0,
+        VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_VERTEX_BIT },
+      VkDescriptorSetLayoutBinding { 1,
+        VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER, 1, VK_SHADER_STAGE_VERTEX_BIT
+      }, VkDescriptorSetLayoutBinding { 2,
+        VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1, VK_SHADER_STAGE_FRAGMENT_BIT
+    } };
+
+    VkDescriptorSetLayoutCreateInfo setLayoutInfo = { VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO };
+    setLayoutInfo.bindingCount           = bindings.size();
+    setLayoutInfo.pBindings              = bindings.data();
+
+    VkDescriptorSetLayout descriptorSetLayout = VK_NULL_HANDLE;
+    if (m_vkd->vkCreateDescriptorSetLayout(m_vkd->device(), &setLayoutInfo, nullptr, &descriptorSetLayout) != VK_SUCCESS)
+      throw DxvkError("DxvkMetaBlitObjects: Failed to create descriptor set layout");
+
+    return descriptorSetLayout;
+  }
+
+  VkPipelineLayout DxvkHudObjects::createTextPipelineLayout(VkDescriptorSetLayout descriptorSetLayout) {
+    VkPushConstantRange pushRange = { VK_SHADER_STAGE_VERTEX_BIT, 0, sizeof(HudTextPushConstants) };
+
+    VkPipelineLayoutCreateInfo pipeLayoutInfo = { VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO };
+    pipeLayoutInfo.setLayoutCount         = 1;
+    pipeLayoutInfo.pSetLayouts            = &descriptorSetLayout;
+    pipeLayoutInfo.pushConstantRangeCount = 1;
+    pipeLayoutInfo.pPushConstantRanges    = &pushRange;
+
+    VkPipelineLayout pipelineLayout = VK_NULL_HANDLE;
+    if (m_vkd->vkCreatePipelineLayout(m_vkd->device(), &pipeLayoutInfo, nullptr, &pipelineLayout) != VK_SUCCESS)
+      throw DxvkError("DxvkMetaBlitObjects: Failed to create pipeline layout");
+
+    return pipelineLayout;
+  }
+
+  VkDescriptorSetLayout DxvkHudObjects::createGraphDescriptorSetLayout() {
+    std::array<VkDescriptorSetLayoutBinding, 3> bindings = { VkDescriptorSetLayoutBinding { 0,
+        VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_FRAGMENT_BIT
+    } };
+
+    VkDescriptorSetLayoutCreateInfo setLayoutInfo = { VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO };
+    setLayoutInfo.bindingCount           = bindings.size();
+    setLayoutInfo.pBindings              = bindings.data();
+
+    VkDescriptorSetLayout descriptorSetLayout = VK_NULL_HANDLE;
+    if (m_vkd->vkCreateDescriptorSetLayout(m_vkd->device(), &setLayoutInfo, nullptr, &descriptorSetLayout) != VK_SUCCESS)
+      throw DxvkError("DxvkMetaBlitObjects: Failed to create descriptor set layout");
+
+    return descriptorSetLayout;
+  }
+
+  VkPipelineLayout DxvkHudObjects::createGraphPipelineLayout(VkDescriptorSetLayout descriptorSetLayout) {
+    VkPushConstantRange pushRange = { VK_SHADER_STAGE_VERTEX_BIT, 0, sizeof(HudGraphPushConstants) };
+
+    VkPipelineLayoutCreateInfo pipeLayoutInfo = { VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO };
+    pipeLayoutInfo.setLayoutCount         = 1;
+    pipeLayoutInfo.pSetLayouts            = &descriptorSetLayout;
+    pipeLayoutInfo.pushConstantRangeCount = 1;
+    pipeLayoutInfo.pPushConstantRanges    = &pushRange;
+
+    VkPipelineLayout pipelineLayout = VK_NULL_HANDLE;
+    if (m_vkd->vkCreatePipelineLayout(m_vkd->device(), &pipeLayoutInfo, nullptr, &pipelineLayout) != VK_SUCCESS)
+      throw DxvkError("DxvkMetaBlitObjects: Failed to create pipeline layout");
+
+    return pipelineLayout;
+  }
+
+  DxvkHudPipelines DxvkHudObjects::createPipelines(
+    const DxvkHudPipelinesKey& key) {
+
+    VkDescriptorSetLayout textDescSetLayout = this->createTextDescriptorSetLayout();
+    VkPipelineLayout textPipeLayout = this->createTextPipelineLayout(textDescSetLayout);
+
+    VkPipeline textPipeline = this->createPipeline(
+      m_textVs,
+      m_textFs,
+      VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST,
+      key.samples,
+      key.viewFormat,
+      key.colorSpace,
+      textPipeLayout
+    );
+
+    VkDescriptorSetLayout graphDescSetLayout = this->createTextDescriptorSetLayout();
+    VkPipelineLayout graphPipeLayout = this->createTextPipelineLayout(graphDescSetLayout);
+
+    VkPipeline graphPipeline = this->createPipeline(
+      m_graphVs,
+      m_graphFs,
+      VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP,
+      key.samples,
+      key.viewFormat,
+      key.colorSpace,
+      graphPipeLayout
+    );
+
+    DxvkHudPipelines result;
+    result.textPipeHandle = textPipeline;
+    result.textPipeLayout = textPipeLayout;
+    result.textDSetLayout = textDescSetLayout;
+    result.graphPipeHandle = graphPipeline;
+    result.graphPipeLayout = graphPipeLayout;
+    result.graphDSetLayout = graphDescSetLayout;
+    return result;
+  }
+
+
+  VkPipeline DxvkHudObjects::createPipeline(
+          VkShaderModule        vs,
+          VkShaderModule        fs,
+          VkPrimitiveTopology   topology,
+          VkSampleCountFlagBits samples,
+          VkFormat              viewFormat,
+          VkColorSpaceKHR       colorSpace,
+          VkPipelineLayout      pipeLayout) {
+
+    VkSpecializationMapEntry specEntry = VkSpecializationMapEntry {
+      0, 0, sizeof(colorSpace)
+    };
+
+    VkSpecializationInfo specInfo = {
+      1, &specEntry, sizeof(colorSpace), &colorSpace
+    };
+
+    std::array<VkPipelineShaderStageCreateInfo, 2> stages;
+    stages[0] = VkPipelineShaderStageCreateInfo {
+      VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO, nullptr, 0,
+      VK_SHADER_STAGE_VERTEX_BIT, vs, "main" };
+
+    stages[1] = VkPipelineShaderStageCreateInfo {
+      VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO, nullptr, 0,
+      VK_SHADER_STAGE_FRAGMENT_BIT, fs, "main", &specInfo };
+
+    std::array<VkDynamicState, 2> dynStates = {{
+      VK_DYNAMIC_STATE_VIEWPORT_WITH_COUNT,
+      VK_DYNAMIC_STATE_SCISSOR_WITH_COUNT,
+    }};
+
+    VkPipelineDynamicStateCreateInfo dynState = { VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO };
+    dynState.dynamicStateCount = dynStates.size();
+    dynState.pDynamicStates    = dynStates.data();
+
+    VkPipelineVertexInputStateCreateInfo viState = { VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO };
+
+    VkPipelineInputAssemblyStateCreateInfo iaState = { VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO };
+    iaState.topology               = topology;
+    iaState.primitiveRestartEnable = VK_FALSE;
+
+    VkPipelineViewportStateCreateInfo vpState = { VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO };
+
+    VkPipelineRasterizationStateCreateInfo rsState = { VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO };
+    rsState.polygonMode = VK_POLYGON_MODE_FILL;
+    rsState.cullMode = VK_CULL_MODE_BACK_BIT;
+    rsState.frontFace = VK_FRONT_FACE_CLOCKWISE;
+    rsState.lineWidth = 1.0f;
+
+    uint32_t msMask = 0xFFFFFFFF;
+    VkPipelineMultisampleStateCreateInfo msState = { VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO };
+    msState.rasterizationSamples = samples;
+    msState.pSampleMask = &msMask;
+
+    VkPipelineColorBlendAttachmentState cbAttachment = { };
+    cbAttachment.blendEnable         = VK_TRUE;
+    cbAttachment.srcColorBlendFactor = VK_BLEND_FACTOR_ONE;
+    cbAttachment.dstColorBlendFactor = VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA;
+    cbAttachment.colorBlendOp        = VK_BLEND_OP_ADD;
+    cbAttachment.srcAlphaBlendFactor = VK_BLEND_FACTOR_ONE;
+    cbAttachment.dstAlphaBlendFactor = VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA;
+    cbAttachment.alphaBlendOp        = VK_BLEND_OP_ADD;
+    cbAttachment.colorWriteMask      =
+      VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT |
+      VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT;
+
+    VkPipelineColorBlendStateCreateInfo cbState = { VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO };
+    cbState.attachmentCount     = 1;
+    cbState.pAttachments        = &cbAttachment;
+
+    VkPipelineRenderingCreateInfo rtState = { VK_STRUCTURE_TYPE_PIPELINE_RENDERING_CREATE_INFO };
+    rtState.colorAttachmentCount = 1;
+    rtState.pColorAttachmentFormats = &viewFormat;
+
+    VkGraphicsPipelineCreateInfo info = { VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO, &rtState };
+    info.stageCount             = 2;
+    info.pStages                = stages.data();
+    info.pVertexInputState      = &viState;
+    info.pInputAssemblyState    = &iaState;
+    info.pViewportState         = &vpState;
+    info.pRasterizationState    = &rsState;
+    info.pMultisampleState      = &msState;
+    info.pColorBlendState       = &cbState;
+    info.pDynamicState          = &dynState;
+    info.layout                 = pipeLayout;
+    info.basePipelineIndex      = -1;
+
+    VkPipeline pipeline = VK_NULL_HANDLE;
+    if (m_vkd->vkCreateGraphicsPipelines(m_vkd->device(), VK_NULL_HANDLE, 1, &info, nullptr, &pipeline) != VK_SUCCESS)
+      throw DxvkError("DxvkMetaBlitObjects: Failed to create graphics pipeline");
+    return pipeline;
+  }
+}

--- a/src/dxvk/dxvk_hud_objects.h
+++ b/src/dxvk/dxvk_hud_objects.h
@@ -114,7 +114,9 @@ namespace dxvk {
         VkFormat              viewFormat,
         VkColorSpaceKHR       colorSpace);
 
-    VkSampler getFontSampler();
+    VkSampler getFontSampler() const {
+      return m_fontSampler;
+    }
 
   private:
 

--- a/src/dxvk/dxvk_hud_objects.h
+++ b/src/dxvk/dxvk_hud_objects.h
@@ -1,0 +1,161 @@
+#pragma once
+
+#include "../dxvk/dxvk_hash.h"
+#include "../dxvk/dxvk_image.h"
+#include "../vulkan/vulkan_loader.h"
+
+namespace dxvk {
+
+  /**
+   * \brief HUD coordinates
+   *
+   * Coordinates relative to the top-left
+   * corner of the swap image, in pixels.
+   */
+  struct HudPos {
+    float x;
+    float y;
+  };
+
+  /**
+   * \brief Color
+   *
+   * SRGB color with alpha channel. The text
+   * will use this color for the most part.
+   */
+  struct HudColor {
+    float r;
+    float g;
+    float b;
+    float a;
+  };
+
+  /**
+   * \brief Normalized color
+   *
+   * SRGB color with alpha channel.
+   */
+  struct HudNormColor {
+    uint8_t a;
+    uint8_t b;
+    uint8_t g;
+    uint8_t r;
+  };
+
+  /**
+   * \brief Graph point with color
+   */
+  struct HudGraphPoint {
+    float         value;
+    HudNormColor  color;
+  };
+
+  /**
+   * \brief HUD push constant data
+   */
+  struct HudTextPushConstants {
+    HudColor color;
+    HudPos pos;
+    uint32_t offset;
+    float size;
+    HudPos scale;
+  };
+
+  struct HudGraphPushConstants {
+    uint32_t offset;
+    uint32_t count;
+    HudPos pos;
+    HudPos size;
+    HudPos scale;
+    float  opacity;
+  };
+
+  struct DxvkHudPipelinesKey {
+    VkSampleCountFlagBits samples;
+    VkFormat              viewFormat;
+    VkColorSpaceKHR       colorSpace;
+
+    bool eq(const DxvkHudPipelinesKey& other) const {
+      return this->samples  == other.samples
+        && this->viewFormat == other.viewFormat
+        && this->colorSpace == other.colorSpace;
+    }
+
+    size_t hash() const {
+      DxvkHashState result;
+      result.add(uint32_t(this->samples));
+      result.add(uint32_t(this->viewFormat));
+      result.add(uint32_t(this->colorSpace));
+      return result;
+    }
+  };
+
+
+  struct DxvkHudPipelines {
+    VkDescriptorSetLayout textDSetLayout;
+    VkPipelineLayout textPipeLayout;
+    VkPipeline textPipeHandle;
+    VkDescriptorSetLayout graphDSetLayout;
+    VkPipelineLayout graphPipeLayout;
+    VkPipeline graphPipeHandle;
+  };
+
+  class DxvkDevice;
+
+  class DxvkHudObjects {
+
+  public:
+
+    DxvkHudObjects(const DxvkDevice* device);
+    ~DxvkHudObjects();
+
+    DxvkHudPipelines getPipelines(
+        VkSampleCountFlagBits samples,
+        VkFormat              viewFormat,
+        VkColorSpaceKHR       colorSpace);
+
+    VkSampler getFontSampler();
+
+  private:
+
+    Rc<vk::DeviceFn>  m_vkd;
+
+    VkShaderModule     m_textVs;
+    VkShaderModule     m_textFs;
+    VkShaderModule     m_graphVs;
+    VkShaderModule     m_graphFs;
+
+    VkSampler m_fontSampler;
+
+    dxvk::mutex m_mutex;
+
+    std::unordered_map<
+      DxvkHudPipelinesKey,
+      DxvkHudPipelines,
+      DxvkHash, DxvkEq> m_pipelines;
+
+    void createShaders(const DxvkDevice* device);
+
+    void createFontSampler();
+
+    VkPipeline createPipeline(
+          VkShaderModule        vs,
+          VkShaderModule        fs,
+          VkPrimitiveTopology   topology,
+          VkSampleCountFlagBits samples,
+          VkFormat              viewFormat,
+          VkColorSpaceKHR       colorSpace,
+          VkPipelineLayout      pipeLayout);
+
+    DxvkHudPipelines createPipelines(
+      const DxvkHudPipelinesKey& key);
+
+    VkDescriptorSetLayout createTextDescriptorSetLayout();
+    VkDescriptorSetLayout createGraphDescriptorSetLayout();
+
+    VkPipelineLayout createTextPipelineLayout(VkDescriptorSetLayout descriptorSetLayout);
+    VkPipelineLayout createGraphPipelineLayout(VkDescriptorSetLayout descriptorSetLayout);
+
+  };
+
+}

--- a/src/dxvk/dxvk_meta_present_blit.cpp
+++ b/src/dxvk/dxvk_meta_present_blit.cpp
@@ -21,6 +21,15 @@ namespace dxvk {
     m_vkd->vkDestroyShaderModule(m_vkd->device(), m_fsCopy, nullptr);
     m_vkd->vkDestroyShaderModule(m_vkd->device(), m_fsBlit, nullptr);
     m_vkd->vkDestroyShaderModule(m_vkd->device(), m_fsResolve, nullptr);
+
+    m_vkd->vkDestroySampler(m_vkd->device(), m_srcSampler, nullptr);
+    m_vkd->vkDestroySampler(m_vkd->device(), m_gammaSampler, nullptr);
+
+    for (const auto& [key, pipeline] : m_pipelines) {
+      m_vkd->vkDestroyPipeline(m_vkd->device(), pipeline.pipeHandle, nullptr);
+      m_vkd->vkDestroyPipelineLayout(m_vkd->device(), pipeline.pipeLayout, nullptr);
+      m_vkd->vkDestroyDescriptorSetLayout(m_vkd->device(), pipeline.dsetLayout, nullptr);
+    }
   }
 
   void DxvkMetaPresentBlitObjects::createShaders(const DxvkDevice* device) {

--- a/src/dxvk/dxvk_meta_present_blit.cpp
+++ b/src/dxvk/dxvk_meta_present_blit.cpp
@@ -1,0 +1,322 @@
+#include "dxvk_meta_present_blit.h"
+
+#include <dxvk_present_frag.h>
+#include <dxvk_present_frag_blit.h>
+#include <dxvk_present_frag_ms.h>
+#include <dxvk_present_frag_ms_amd.h>
+#include <dxvk_present_vert.h>
+
+#include "dxvk_device.h"
+
+namespace dxvk {
+
+  DxvkMetaPresentBlitObjects::DxvkMetaPresentBlitObjects(const DxvkDevice* device)
+    : m_vkd(device->vkd()) {
+    this->createShaders(device);
+    this->createSamplers();
+  }
+
+  DxvkMetaPresentBlitObjects::~DxvkMetaPresentBlitObjects() {
+    m_vkd->vkDestroyShaderModule(m_vkd->device(), m_vs, nullptr);
+    m_vkd->vkDestroyShaderModule(m_vkd->device(), m_fsCopy, nullptr);
+    m_vkd->vkDestroyShaderModule(m_vkd->device(), m_fsBlit, nullptr);
+    m_vkd->vkDestroyShaderModule(m_vkd->device(), m_fsResolve, nullptr);
+  }
+
+  void DxvkMetaPresentBlitObjects::createShaders(const DxvkDevice* device) {
+    SpirvCodeBuffer vsCode(dxvk_present_vert);
+    SpirvCodeBuffer fsCodeBlit(dxvk_present_frag_blit);
+    SpirvCodeBuffer fsCodeCopy(dxvk_present_frag);
+    SpirvCodeBuffer fsCodeResolve(dxvk_present_frag_ms);
+    SpirvCodeBuffer fsCodeResolveAmd(dxvk_present_frag_ms_amd);
+
+    VkShaderModuleCreateInfo info = { VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO };
+      info.codeSize               = vsCode.size();
+      info.pCode                  = vsCode.data();
+
+    if (m_vkd->vkCreateShaderModule(m_vkd->device(), &info, nullptr, &m_vs) != VK_SUCCESS)
+      throw DxvkError("DxvkMetaBlitObjects: Failed to create shader module");
+
+    info.pCode                 = fsCodeCopy.data();
+    info.codeSize              = fsCodeCopy.size();
+
+    if (m_vkd->vkCreateShaderModule(m_vkd->device(), &info, nullptr, &m_fsCopy) != VK_SUCCESS)
+      throw DxvkError("DxvkMetaBlitObjects: Failed to create shader module");
+
+    info.pCode                 = fsCodeBlit.data();
+    info.codeSize              = fsCodeBlit.size();
+
+    if (m_vkd->vkCreateShaderModule(m_vkd->device(), &info, nullptr, &m_fsBlit) != VK_SUCCESS)
+      throw DxvkError("DxvkMetaBlitObjects: Failed to create shader module");
+
+    info.pCode                 = device->features().amdShaderFragmentMask ? fsCodeResolveAmd.data() : fsCodeResolve.data();
+    info.codeSize              = device->features().amdShaderFragmentMask ? fsCodeResolveAmd.size() : fsCodeResolve.size();
+
+    if (m_vkd->vkCreateShaderModule(m_vkd->device(), &info, nullptr, &m_fsResolve) != VK_SUCCESS)
+      throw DxvkError("DxvkMetaBlitObjects: Failed to create shader module");
+  }
+
+  void DxvkMetaPresentBlitObjects::createSamplers() {
+    VkSamplerCreateInfo info = { VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO };
+    info.magFilter              = VK_FILTER_LINEAR;
+    info.minFilter              = VK_FILTER_LINEAR;
+    info.mipmapMode             = VK_SAMPLER_MIPMAP_MODE_NEAREST;
+    info.addressModeU           = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+    info.addressModeV           = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+    info.addressModeW           = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+    info.borderColor            = VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK;
+
+    if (m_vkd->vkCreateSampler(m_vkd->device(), &info, nullptr, &m_gammaSampler) != VK_SUCCESS)
+      throw DxvkError("DxvkMetaBlitObjects: Failed to create sampler");
+
+
+    info.addressModeU           = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+    info.addressModeV           = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+    info.addressModeW           = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+
+    if (m_vkd->vkCreateSampler(m_vkd->device(), &info, nullptr, &m_srcSampler) != VK_SUCCESS)
+      throw DxvkError("DxvkMetaBlitObjects: Failed to create sampler");
+  }
+
+  DxvkMetaPresentBlitPipeline DxvkMetaPresentBlitObjects::getPipeline(
+          DxvkPresentBlitFsType   fs,
+          VkSampleCountFlagBits   srcSamples,
+          VkSampleCountFlagBits   dstSamples,
+          VkFormat                viewFormat,
+          bool                    hasGammaView) {
+    std::lock_guard<dxvk::mutex> lock(m_mutex);
+
+    DxvkMetaPresentBlitPipelineKey key;
+    key.fs           = fs;
+    key.srcSamples   = srcSamples;
+    key.dstSamples   = dstSamples;
+    key.viewFormat   = viewFormat;
+    key.hasGammaView = hasGammaView;
+
+    auto entry = m_pipelines.find(key);
+    if (entry != m_pipelines.end())
+      return entry->second;
+
+    DxvkMetaPresentBlitPipeline pipeline = this->createPipeline(key);
+    m_pipelines.insert({ key, pipeline });
+    return pipeline;
+  }
+
+  VkDescriptorSetLayout DxvkMetaPresentBlitObjects::createDescriptorSetLayout() {
+    std::array<VkDescriptorSetLayoutBinding, 2> bindings = { VkDescriptorSetLayoutBinding { BindingIds::Image,
+      VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1, VK_SHADER_STAGE_FRAGMENT_BIT },
+      VkDescriptorSetLayoutBinding { BindingIds::Gamma,
+      VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1, VK_SHADER_STAGE_FRAGMENT_BIT
+    } };
+
+    VkDescriptorSetLayoutCreateInfo setLayoutInfo = { VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO };
+    setLayoutInfo.bindingCount           = bindings.size();
+    setLayoutInfo.pBindings              = bindings.data();
+
+    VkDescriptorSetLayout descriptorSetLayout = VK_NULL_HANDLE;
+    if (m_vkd->vkCreateDescriptorSetLayout(m_vkd->device(), &setLayoutInfo, nullptr, &descriptorSetLayout) != VK_SUCCESS)
+      throw DxvkError("DxvkMetaBlitObjects: Failed to create descriptor set layout");
+
+    return descriptorSetLayout;
+  }
+
+  VkPipelineLayout DxvkMetaPresentBlitObjects::createPipelineLayout(VkDescriptorSetLayout descriptorSetLayout) {
+    VkPushConstantRange pushRange = { VK_SHADER_STAGE_FRAGMENT_BIT, 0, sizeof(PresenterArgs) };
+
+    VkPipelineLayoutCreateInfo pipeLayoutInfo = { VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO };
+    pipeLayoutInfo.setLayoutCount         = 1;
+    pipeLayoutInfo.pSetLayouts            = &descriptorSetLayout;
+    pipeLayoutInfo.pushConstantRangeCount = 1;
+    pipeLayoutInfo.pPushConstantRanges    = &pushRange;
+
+    VkPipelineLayout pipelineLayout = VK_NULL_HANDLE;
+    if (m_vkd->vkCreatePipelineLayout(m_vkd->device(), &pipeLayoutInfo, nullptr, &pipelineLayout) != VK_SUCCESS)
+      throw DxvkError("DxvkMetaBlitObjects: Failed to create pipeline layout");
+
+    return pipelineLayout;
+  }
+
+  DxvkMetaPresentBlitPipeline DxvkMetaPresentBlitObjects::createPipeline(
+    const DxvkMetaPresentBlitPipelineKey& key) {
+
+    VkDescriptorSetLayout descSetLayout = this->createDescriptorSetLayout();
+
+    VkPipelineLayout pipeLayout = this->createPipelineLayout(descSetLayout);
+
+    VkPipeline pipeline = this->createPipeline(
+      key.fs,
+      key.srcSamples,
+      key.dstSamples,
+      key.viewFormat,
+      key.hasGammaView,
+      pipeLayout
+    );
+
+    DxvkMetaPresentBlitPipeline result;
+    result.pipeHandle = pipeline;
+    result.pipeLayout = pipeLayout;
+    result.dsetLayout = descSetLayout;
+    return result;
+  }
+
+
+  VkPipeline DxvkMetaPresentBlitObjects::createPipeline(
+          DxvkPresentBlitFsType   fsType,
+          VkSampleCountFlagBits   srcSamples,
+          VkSampleCountFlagBits   dstSamples,
+          VkFormat                viewFormat,
+          bool                    hasGammaView,
+          VkPipelineLayout        pipeLayout) {
+
+    std::array<VkSpecializationMapEntry, 2> specMap = { VkSpecializationMapEntry {
+        0, 0, 4
+      }, VkSpecializationMapEntry {
+        1, 4, 4
+      }
+    };
+
+    std::array<uint32_t, 2> data = {
+      srcSamples, hasGammaView ? 1u : 0u
+    };
+
+    VkSpecializationInfo specInfo = {
+      specMap.size(), specMap.data(), 8, data.data()
+    };
+
+    std::array<VkPipelineShaderStageCreateInfo, 2> stages;
+    stages[0] = VkPipelineShaderStageCreateInfo {
+      VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO, nullptr, 0,
+      VK_SHADER_STAGE_VERTEX_BIT, m_vs, "main" };
+
+    VkShaderModule fs;
+    switch (fsType) {
+      case dxvk::DxvkPresentBlitFsType::Copy:       fs = m_fsCopy;       break;
+      case dxvk::DxvkPresentBlitFsType::Blit:       fs = m_fsBlit;       break;
+      case dxvk::DxvkPresentBlitFsType::Resolve:    fs = m_fsResolve;    break;
+      default: throw DxvkError("DxvkPresentBlitter: Invalid FS type");
+    }
+
+    stages[1] = VkPipelineShaderStageCreateInfo {
+      VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO, nullptr, 0,
+      VK_SHADER_STAGE_FRAGMENT_BIT, fs, "main", &specInfo };
+
+    std::array<VkDynamicState, 2> dynStates = {{
+      VK_DYNAMIC_STATE_VIEWPORT_WITH_COUNT,
+      VK_DYNAMIC_STATE_SCISSOR_WITH_COUNT,
+    }};
+
+    VkPipelineDynamicStateCreateInfo dynState = { VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO };
+    dynState.dynamicStateCount = dynStates.size();
+    dynState.pDynamicStates = dynStates.data();
+
+    VkPipelineVertexInputStateCreateInfo viState = { VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO };
+
+    VkPipelineInputAssemblyStateCreateInfo iaState = { VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO };
+    iaState.topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP;
+    iaState.primitiveRestartEnable  = VK_FALSE;
+
+    VkPipelineViewportStateCreateInfo vpState = { VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO };
+
+    VkPipelineRasterizationStateCreateInfo rsState = { VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO };
+    rsState.polygonMode = VK_POLYGON_MODE_FILL;
+    rsState.cullMode = VK_CULL_MODE_NONE;
+    rsState.frontFace = VK_FRONT_FACE_COUNTER_CLOCKWISE;
+    rsState.lineWidth = 1.0f;
+
+    uint32_t msMask = 0xFFFFFFFF;
+    VkPipelineMultisampleStateCreateInfo msState = { VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO };
+    msState.rasterizationSamples = dstSamples;
+    msState.pSampleMask = &msMask;
+
+    VkPipelineColorBlendAttachmentState cbAttachment = { };
+    cbAttachment.colorWriteMask =
+      VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT |
+      VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT;
+
+    VkPipelineColorBlendStateCreateInfo cbState = { VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO };
+    cbState.attachmentCount     = 1;
+    cbState.pAttachments        = &cbAttachment;
+
+    VkPipelineRenderingCreateInfo rtState = { VK_STRUCTURE_TYPE_PIPELINE_RENDERING_CREATE_INFO };
+    rtState.colorAttachmentCount = 1;
+    rtState.pColorAttachmentFormats = &viewFormat;
+
+    std::array<VkDescriptorSetLayoutBinding, 2> bindings = { VkDescriptorSetLayoutBinding { BindingIds::Image,
+      VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1, VK_SHADER_STAGE_FRAGMENT_BIT },
+      VkDescriptorSetLayoutBinding { BindingIds::Gamma,
+      VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1, VK_SHADER_STAGE_FRAGMENT_BIT
+    } };
+
+    VkDescriptorSetLayoutCreateInfo setLayoutInfo = { VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO };
+    setLayoutInfo.bindingCount           = bindings.size();
+    setLayoutInfo.pBindings              = bindings.data();
+
+    VkDescriptorSetLayout descriptorSetLayout = VK_NULL_HANDLE;
+    if (m_vkd->vkCreateDescriptorSetLayout(m_vkd->device(), &setLayoutInfo, nullptr, &descriptorSetLayout) != VK_SUCCESS)
+      throw DxvkError("DxvkMetaBlitObjects: Failed to create descriptor set layout");
+
+    VkPushConstantRange pushRange = { VK_SHADER_STAGE_FRAGMENT_BIT, 0, sizeof(PresenterArgs) };
+
+    VkPipelineLayoutCreateInfo pipeLayoutInfo = { VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO };
+    pipeLayoutInfo.setLayoutCount         = 1;
+    pipeLayoutInfo.pSetLayouts            = &descriptorSetLayout;
+    pipeLayoutInfo.pushConstantRangeCount = 1;
+    pipeLayoutInfo.pPushConstantRanges    = &pushRange;
+
+    VkPipelineLayout pipelineLayout = VK_NULL_HANDLE;
+    if (m_vkd->vkCreatePipelineLayout(m_vkd->device(), &pipeLayoutInfo, nullptr, &pipelineLayout) != VK_SUCCESS)
+      throw DxvkError("DxvkMetaBlitObjects: Failed to create pipeline layout");
+
+    VkGraphicsPipelineCreateInfo info = { VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO, &rtState };
+    info.stageCount             = 2;
+    info.pStages                = stages.data();
+    info.pVertexInputState      = &viState;
+    info.pInputAssemblyState    = &iaState;
+    info.pViewportState         = &vpState;
+    info.pRasterizationState    = &rsState;
+    info.pMultisampleState      = &msState;
+    info.pColorBlendState       = &cbState;
+    info.pDynamicState          = &dynState;
+    info.layout                 = pipelineLayout;
+    info.basePipelineIndex      = -1;
+
+    VkPipeline pipeline = VK_NULL_HANDLE;
+    if (m_vkd->vkCreateGraphicsPipelines(m_vkd->device(), VK_NULL_HANDLE, 1, &info, nullptr, &pipeline) != VK_SUCCESS)
+      throw DxvkError("DxvkMetaBlitObjects: Failed to create graphics pipeline");
+    return pipeline;
+  }
+
+  Rc<DxvkImageView> DxvkMetaPresentBlitObjects::createResolveImage(const Rc<DxvkDevice>& device, const DxvkImageCreateInfo& info) {
+    DxvkImageCreateInfo newInfo;
+    newInfo.type = VK_IMAGE_TYPE_2D;
+    newInfo.format = info.format;
+    newInfo.flags = 0;
+    newInfo.sampleCount = VK_SAMPLE_COUNT_1_BIT;
+    newInfo.extent = info.extent;
+    newInfo.numLayers = 1;
+    newInfo.mipLevels = 1;
+    newInfo.usage  = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT
+                   | VK_IMAGE_USAGE_TRANSFER_DST_BIT
+                   | VK_IMAGE_USAGE_SAMPLED_BIT;
+    newInfo.stages = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT
+                   | VK_PIPELINE_STAGE_TRANSFER_BIT
+                   | VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
+    newInfo.access = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT
+                   | VK_ACCESS_TRANSFER_WRITE_BIT
+                   | VK_ACCESS_SHADER_READ_BIT;
+    newInfo.tiling = VK_IMAGE_TILING_OPTIMAL;
+    newInfo.layout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+    Rc<DxvkImage> image = device->createImage(newInfo, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+
+    DxvkImageViewCreateInfo viewInfo;
+    viewInfo.type = VK_IMAGE_VIEW_TYPE_2D;
+    viewInfo.format = info.format;
+    viewInfo.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
+    viewInfo.aspect = VK_IMAGE_ASPECT_COLOR_BIT;
+    viewInfo.minLevel  = 0;
+    viewInfo.numLevels = 1;
+    viewInfo.minLayer  = 0;
+    viewInfo.numLayers = 1;
+    return device->createImageView(image, viewInfo);
+  }
+}

--- a/src/dxvk/dxvk_meta_present_blit.h
+++ b/src/dxvk/dxvk_meta_present_blit.h
@@ -88,14 +88,10 @@ namespace dxvk {
 
     Rc<vk::DeviceFn>  m_vkd;
 
-    VkSampler m_samplerCopy;
-    VkSampler m_samplerBlit;
-
     VkShaderModule     m_vs;
     VkShaderModule     m_fsBlit;
     VkShaderModule     m_fsCopy;
     VkShaderModule     m_fsResolve;
-    VkShaderModule     m_fsResolveAmd;
 
     VkSampler m_srcSampler;
     VkSampler m_gammaSampler;

--- a/src/dxvk/dxvk_meta_present_blit.h
+++ b/src/dxvk/dxvk_meta_present_blit.h
@@ -1,0 +1,131 @@
+#pragma once
+
+#include "../dxvk/dxvk_hash.h"
+#include "../dxvk/dxvk_image.h"
+#include "../vulkan/vulkan_loader.h"
+
+namespace dxvk {
+
+  enum class DxvkPresentBlitFsType {
+    Copy,
+    Blit,
+    Resolve
+  };
+
+  struct DxvkMetaPresentBlitPipelineKey {
+    DxvkPresentBlitFsType fs;
+    VkSampleCountFlagBits   srcSamples;
+    VkSampleCountFlagBits   dstSamples;
+    VkFormat                viewFormat;
+    bool                    hasGammaView;
+
+    bool eq(const DxvkMetaPresentBlitPipelineKey& other) const {
+      return this->fs         == other.fs
+        && this->srcSamples   == other.srcSamples
+        && this->dstSamples   == other.dstSamples
+        && this->viewFormat   == other.viewFormat
+        && this->hasGammaView == other.hasGammaView;
+    }
+
+    size_t hash() const {
+      DxvkHashState result;
+      result.add(uint32_t(this->fs));
+      result.add(uint32_t(this->srcSamples));
+      result.add(uint32_t(this->dstSamples));
+      result.add(uint32_t(this->viewFormat));
+      result.add(uint32_t(this->hasGammaView));
+      return result;
+    }
+  };
+
+
+  struct DxvkMetaPresentBlitPipeline {
+    VkDescriptorSetLayout dsetLayout;
+    VkPipelineLayout pipeLayout;
+    VkPipeline pipeHandle;
+  };
+
+  class DxvkDevice;
+
+  class DxvkMetaPresentBlitObjects {
+
+  public:
+
+    DxvkMetaPresentBlitObjects(const DxvkDevice* device);
+    ~DxvkMetaPresentBlitObjects();
+
+    DxvkMetaPresentBlitPipeline getPipeline(
+          DxvkPresentBlitFsType   fs,
+          VkSampleCountFlagBits   srcSamples,
+          VkSampleCountFlagBits   dstSamples,
+          VkFormat                viewFormat,
+          bool                    hasGammaView);
+
+    enum BindingIds : uint32_t {
+      Image = 0,
+      Gamma = 1,
+    };
+
+    struct PresenterArgs {
+      VkOffset2D srcOffset;
+      union {
+        VkExtent2D srcExtent;
+        VkOffset2D dstOffset;
+      };
+    };
+
+    VkSampler gammaSampler() const {
+      return m_gammaSampler;
+    }
+
+    VkSampler srcSampler() const {
+      return m_srcSampler;
+    }
+
+    Rc<DxvkImageView> createResolveImage(const Rc<DxvkDevice>& device, const DxvkImageCreateInfo& info);
+
+  private:
+
+    Rc<vk::DeviceFn>  m_vkd;
+
+    VkSampler m_samplerCopy;
+    VkSampler m_samplerBlit;
+
+    VkShaderModule     m_vs;
+    VkShaderModule     m_fsBlit;
+    VkShaderModule     m_fsCopy;
+    VkShaderModule     m_fsResolve;
+    VkShaderModule     m_fsResolveAmd;
+
+    VkSampler m_srcSampler;
+    VkSampler m_gammaSampler;
+
+    dxvk::mutex m_mutex;
+
+    std::unordered_map<
+      DxvkMetaPresentBlitPipelineKey,
+      DxvkMetaPresentBlitPipeline,
+      DxvkHash, DxvkEq> m_pipelines;
+
+    void createShaders(const DxvkDevice* device);
+
+    void createSamplers();
+
+    VkPipeline createPipeline(
+          DxvkPresentBlitFsType fs,
+          VkSampleCountFlagBits   srcSamples,
+          VkSampleCountFlagBits   dstSamples,
+          VkFormat                viewFormat,
+          bool                    hasGammaView,
+          VkPipelineLayout        pipeLayout);
+
+    DxvkMetaPresentBlitPipeline createPipeline(
+      const DxvkMetaPresentBlitPipelineKey& key);
+
+    VkDescriptorSetLayout createDescriptorSetLayout();
+
+    VkPipelineLayout createPipelineLayout(VkDescriptorSetLayout descriptorSetLayout);
+
+  };
+
+}

--- a/src/dxvk/dxvk_objects.h
+++ b/src/dxvk/dxvk_objects.h
@@ -2,6 +2,7 @@
 
 #include "dxvk_gpu_event.h"
 #include "dxvk_gpu_query.h"
+#include "dxvk_hud_objects.h"
 #include "dxvk_memory.h"
 #include "dxvk_meta_blit.h"
 #include "dxvk_meta_clear.h"
@@ -10,6 +11,7 @@
 #include "dxvk_meta_pack.h"
 #include "dxvk_meta_resolve.h"
 #include "dxvk_meta_present_blit.h"
+#include "dxvk_hud_objects.h"
 #include "dxvk_pipemanager.h"
 #include "dxvk_renderpass.h"
 #include "dxvk_unbound.h"
@@ -76,6 +78,10 @@ namespace dxvk {
       return m_metaPresentBlit.get(m_device);
     }
 
+    DxvkHudObjects& hud() {
+      return m_hud.get(m_device);
+    }
+
   private:
 
     DxvkDevice*                   m_device;
@@ -94,6 +100,7 @@ namespace dxvk {
     Lazy<DxvkMetaResolveObjects>     m_metaResolve;
     Lazy<DxvkMetaPackObjects>        m_metaPack;
     Lazy<DxvkMetaPresentBlitObjects> m_metaPresentBlit;
+    Lazy<DxvkHudObjects>             m_hud;
 
   };
 

--- a/src/dxvk/dxvk_objects.h
+++ b/src/dxvk/dxvk_objects.h
@@ -9,6 +9,7 @@
 #include "dxvk_meta_mipgen.h"
 #include "dxvk_meta_pack.h"
 #include "dxvk_meta_resolve.h"
+#include "dxvk_meta_present_blit.h"
 #include "dxvk_pipemanager.h"
 #include "dxvk_renderpass.h"
 #include "dxvk_unbound.h"
@@ -66,9 +67,13 @@ namespace dxvk {
     DxvkMetaResolveObjects& metaResolve() {
       return m_metaResolve.get(m_device);
     }
-    
+
     DxvkMetaPackObjects& metaPack() {
       return m_metaPack.get(m_device);
+    }
+
+    DxvkMetaPresentBlitObjects& metaPresentBlit() {
+      return m_metaPresentBlit.get(m_device);
     }
 
   private:
@@ -83,11 +88,12 @@ namespace dxvk {
 
     DxvkUnboundResources          m_dummyResources;
 
-    Lazy<DxvkMetaBlitObjects>     m_metaBlit;
-    Lazy<DxvkMetaClearObjects>    m_metaClear;
-    Lazy<DxvkMetaCopyObjects>     m_metaCopy;
-    Lazy<DxvkMetaResolveObjects>  m_metaResolve;
-    Lazy<DxvkMetaPackObjects>     m_metaPack;
+    Lazy<DxvkMetaBlitObjects>        m_metaBlit;
+    Lazy<DxvkMetaClearObjects>       m_metaClear;
+    Lazy<DxvkMetaCopyObjects>        m_metaCopy;
+    Lazy<DxvkMetaResolveObjects>     m_metaResolve;
+    Lazy<DxvkMetaPackObjects>        m_metaPack;
+    Lazy<DxvkMetaPresentBlitObjects> m_metaPresentBlit;
 
   };
 

--- a/src/dxvk/dxvk_swapchain_blitter.cpp
+++ b/src/dxvk/dxvk_swapchain_blitter.cpp
@@ -7,17 +7,12 @@
 #include <dxvk_present_vert.h>
 
 namespace dxvk {
-  
+
   DxvkSwapchainBlitter::DxvkSwapchainBlitter(const Rc<DxvkDevice>& device)
-  : m_device(device) {
-    this->createSampler();
-    this->createShaders();
-  }
+  : m_device(device) { }
 
 
-  DxvkSwapchainBlitter::~DxvkSwapchainBlitter() {
-    
-  }
+  DxvkSwapchainBlitter::~DxvkSwapchainBlitter() { }
 
 
   void DxvkSwapchainBlitter::presentImage(
@@ -29,44 +24,7 @@ namespace dxvk {
     if (m_gammaDirty)
       this->updateGammaTexture(ctx);
 
-    // Fix up default present areas if necessary
-    if (!dstRect.extent.width || !dstRect.extent.height) {
-      dstRect.offset = { 0, 0 };
-      dstRect.extent = {
-        dstView->imageInfo().extent.width,
-        dstView->imageInfo().extent.height };
-    }
-
-    if (!srcRect.extent.width || !srcRect.extent.height) {
-      srcRect.offset = { 0, 0 };
-      srcRect.extent = {
-        srcView->imageInfo().extent.width,
-        srcView->imageInfo().extent.height };
-    }
-
-    bool sameSize = dstRect.extent == srcRect.extent;
-    bool usedResolveImage = false;
-
-    if (srcView->imageInfo().sampleCount == VK_SAMPLE_COUNT_1_BIT) {
-      this->draw(ctx, sameSize ? m_fsCopy : m_fsBlit,
-        dstView, dstRect, srcView, srcRect);
-    } else if (sameSize) {
-      this->draw(ctx, m_fsResolve,
-        dstView, dstRect, srcView, srcRect);
-    } else {
-      if (m_resolveImage == nullptr
-       || m_resolveImage->info().extent != srcView->imageInfo().extent
-       || m_resolveImage->info().format != srcView->imageInfo().format)
-        this->createResolveImage(srcView->imageInfo());
-
-      this->resolve(ctx, m_resolveView, srcView);
-      this->draw(ctx, m_fsBlit, dstView, dstRect, m_resolveView, srcRect);
-
-      usedResolveImage = true;
-    }
-
-    if (!usedResolveImage)
-      this->destroyResolveImage();
+    ctx->presentBlit(dstView, dstRect, srcView, srcRect, m_gammaView);
   }
 
 
@@ -99,135 +57,6 @@ namespace dxvk {
 
     m_gammaCpCount = cpCount;
     m_gammaDirty = true;
-  }
-
-
-  void DxvkSwapchainBlitter::draw(
-          DxvkContext*        ctx,
-    const Rc<DxvkShader>&     fs,
-    const Rc<DxvkImageView>&  dstView,
-          VkRect2D            dstRect,
-    const Rc<DxvkImageView>&  srcView,
-          VkRect2D            srcRect) {
-    DxvkInputAssemblyState iaState;
-    iaState.primitiveTopology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP;
-    iaState.primitiveRestart  = VK_FALSE;
-    iaState.patchVertexCount  = 0;
-    ctx->setInputAssemblyState(iaState);
-    ctx->setInputLayout(0, nullptr, 0, nullptr);
-    
-    DxvkRasterizerState rsState;
-    rsState.polygonMode        = VK_POLYGON_MODE_FILL;
-    rsState.cullMode           = VK_CULL_MODE_BACK_BIT;
-    rsState.frontFace          = VK_FRONT_FACE_COUNTER_CLOCKWISE;
-    rsState.depthClipEnable    = VK_FALSE;
-    rsState.depthBiasEnable    = VK_FALSE;
-    rsState.conservativeMode   = VK_CONSERVATIVE_RASTERIZATION_MODE_DISABLED_EXT;
-    rsState.sampleCount        = VK_SAMPLE_COUNT_1_BIT;
-    rsState.flatShading        = VK_FALSE;
-    rsState.lineMode           = VK_LINE_RASTERIZATION_MODE_DEFAULT_EXT;
-    ctx->setRasterizerState(rsState);
-    
-    DxvkMultisampleState msState;
-    msState.sampleMask            = 0xffffffff;
-    msState.enableAlphaToCoverage = VK_FALSE;
-    ctx->setMultisampleState(msState);
-    
-    VkStencilOpState stencilOp;
-    stencilOp.failOp      = VK_STENCIL_OP_KEEP;
-    stencilOp.passOp      = VK_STENCIL_OP_KEEP;
-    stencilOp.depthFailOp = VK_STENCIL_OP_KEEP;
-    stencilOp.compareOp   = VK_COMPARE_OP_ALWAYS;
-    stencilOp.compareMask = 0xFFFFFFFF;
-    stencilOp.writeMask   = 0xFFFFFFFF;
-    stencilOp.reference   = 0;
-    
-    DxvkDepthStencilState dsState;
-    dsState.enableDepthTest   = VK_FALSE;
-    dsState.enableDepthWrite  = VK_FALSE;
-    dsState.enableStencilTest = VK_FALSE;
-    dsState.depthCompareOp    = VK_COMPARE_OP_ALWAYS;
-    dsState.stencilOpFront    = stencilOp;
-    dsState.stencilOpBack     = stencilOp;
-    ctx->setDepthStencilState(dsState);
-    
-    DxvkLogicOpState loState;
-    loState.enableLogicOp = VK_FALSE;
-    loState.logicOp       = VK_LOGIC_OP_NO_OP;
-    ctx->setLogicOpState(loState);
-
-    DxvkBlendMode blendMode;
-    blendMode.enableBlending  = VK_FALSE;
-    blendMode.colorSrcFactor  = VK_BLEND_FACTOR_ONE;
-    blendMode.colorDstFactor  = VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA;
-    blendMode.colorBlendOp    = VK_BLEND_OP_ADD;
-    blendMode.alphaSrcFactor  = VK_BLEND_FACTOR_ONE;
-    blendMode.alphaDstFactor  = VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA;
-    blendMode.alphaBlendOp    = VK_BLEND_OP_ADD;
-    blendMode.writeMask       = VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT
-                              | VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT;
-    ctx->setBlendMode(0, blendMode);
-
-    VkViewport viewport;
-    viewport.x        = float(dstRect.offset.x);
-    viewport.y        = float(dstRect.offset.y);
-    viewport.width    = float(dstRect.extent.width);
-    viewport.height   = float(dstRect.extent.height);
-    viewport.minDepth = 0.0f;
-    viewport.maxDepth = 1.0f;
-    
-    ctx->setViewports(1, &viewport, &dstRect);
-
-    DxvkRenderTargets renderTargets;
-    renderTargets.color[0].view   = dstView;
-    renderTargets.color[0].layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
-
-    ctx->bindRenderTargets(std::move(renderTargets), 0u);
-
-    VkExtent2D dstExtent = {
-      dstView->imageInfo().extent.width,
-      dstView->imageInfo().extent.height };
-
-    if (dstRect.extent == dstExtent)
-      ctx->discardImageView(dstView, VK_IMAGE_ASPECT_COLOR_BIT);
-    else
-      ctx->clearRenderTarget(dstView, VK_IMAGE_ASPECT_COLOR_BIT, VkClearValue());
-
-    ctx->bindResourceSampler(VK_SHADER_STAGE_FRAGMENT_BIT, BindingIds::Image, Rc<DxvkSampler>(m_samplerPresent));
-    ctx->bindResourceSampler(VK_SHADER_STAGE_FRAGMENT_BIT, BindingIds::Gamma, Rc<DxvkSampler>(m_samplerGamma));
-
-    ctx->bindResourceImageView(VK_SHADER_STAGE_FRAGMENT_BIT, BindingIds::Image, Rc<DxvkImageView>(srcView));
-    ctx->bindResourceImageView(VK_SHADER_STAGE_FRAGMENT_BIT, BindingIds::Gamma, Rc<DxvkImageView>(m_gammaView));
-
-    ctx->bindShader<VK_SHADER_STAGE_VERTEX_BIT>(Rc<DxvkShader>(m_vs));
-    ctx->bindShader<VK_SHADER_STAGE_FRAGMENT_BIT>(Rc<DxvkShader>(fs));
-
-    PresenterArgs args;
-    args.srcOffset = srcRect.offset;
-
-    if (dstRect.extent == srcRect.extent)
-      args.dstOffset = dstRect.offset;
-    else
-      args.srcExtent = srcRect.extent;
-
-    ctx->pushConstants(0, sizeof(args), &args);
-
-    ctx->setSpecConstant(VK_PIPELINE_BIND_POINT_GRAPHICS, 0, srcView->imageInfo().sampleCount);
-    ctx->setSpecConstant(VK_PIPELINE_BIND_POINT_GRAPHICS, 1, m_gammaView != nullptr);
-    ctx->draw(3, 1, 0, 0);
-  }
-
-  void DxvkSwapchainBlitter::resolve(
-          DxvkContext*        ctx,
-    const Rc<DxvkImageView>&  dstView,
-    const Rc<DxvkImageView>&  srcView) {
-    VkImageResolve resolve;
-    resolve.srcSubresource = { VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1 };
-    resolve.srcOffset      = { 0, 0, 0 };
-    resolve.dstSubresource = { VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1 };
-    resolve.dstOffset      = { 0, 0, 0 };
-    resolve.extent         = dstView->imageInfo().extent;
-    ctx->resolveImage(dstView->image(), srcView->image(), resolve, VK_FORMAT_UNDEFINED);
   }
 
 
@@ -284,111 +113,6 @@ namespace dxvk {
     }
 
     m_gammaDirty = false;
-  }
-
-
-  void DxvkSwapchainBlitter::createSampler() {
-    DxvkSamplerCreateInfo samplerInfo;
-    samplerInfo.magFilter       = VK_FILTER_LINEAR;
-    samplerInfo.minFilter       = VK_FILTER_LINEAR;
-    samplerInfo.mipmapMode      = VK_SAMPLER_MIPMAP_MODE_NEAREST;
-    samplerInfo.mipmapLodBias   = 0.0f;
-    samplerInfo.mipmapLodMin    = 0.0f;
-    samplerInfo.mipmapLodMax    = 0.0f;
-    samplerInfo.useAnisotropy   = VK_FALSE;
-    samplerInfo.maxAnisotropy   = 1.0f;
-    samplerInfo.addressModeU    = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER;
-    samplerInfo.addressModeV    = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER;
-    samplerInfo.addressModeW    = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER;
-    samplerInfo.compareToDepth  = VK_FALSE;
-    samplerInfo.compareOp       = VK_COMPARE_OP_ALWAYS;
-    samplerInfo.reductionMode   = VK_SAMPLER_REDUCTION_MODE_WEIGHTED_AVERAGE;
-    samplerInfo.borderColor     = VkClearColorValue();
-    samplerInfo.usePixelCoord   = VK_TRUE;
-    samplerInfo.nonSeamless     = VK_FALSE;
-    m_samplerPresent = m_device->createSampler(samplerInfo);
-
-    samplerInfo.addressModeU    = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
-    samplerInfo.addressModeV    = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
-    samplerInfo.addressModeW    = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
-    samplerInfo.usePixelCoord   = VK_FALSE;
-    m_samplerGamma = m_device->createSampler(samplerInfo);
-  }
-
-  void DxvkSwapchainBlitter::createShaders() {
-    SpirvCodeBuffer vsCode(dxvk_present_vert);
-    SpirvCodeBuffer fsCodeBlit(dxvk_present_frag_blit);
-    SpirvCodeBuffer fsCodeCopy(dxvk_present_frag);
-    SpirvCodeBuffer fsCodeResolve(dxvk_present_frag_ms);
-    SpirvCodeBuffer fsCodeResolveAmd(dxvk_present_frag_ms_amd);
-
-    const std::array<DxvkBindingInfo, 2> fsBindings = {{
-      { VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, BindingIds::Image, VK_IMAGE_VIEW_TYPE_2D, VK_SHADER_STAGE_FRAGMENT_BIT, VK_ACCESS_SHADER_READ_BIT },
-      { VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, BindingIds::Gamma, VK_IMAGE_VIEW_TYPE_1D, VK_SHADER_STAGE_FRAGMENT_BIT, VK_ACCESS_SHADER_READ_BIT },
-    }};
-
-    DxvkShaderCreateInfo vsInfo;
-    vsInfo.stage = VK_SHADER_STAGE_VERTEX_BIT;
-    vsInfo.pushConstStages = VK_SHADER_STAGE_FRAGMENT_BIT;
-    vsInfo.pushConstSize = sizeof(PresenterArgs);
-    vsInfo.outputMask = 0x1;
-    m_vs = new DxvkShader(vsInfo, std::move(vsCode));
-    
-    DxvkShaderCreateInfo fsInfo;
-    fsInfo.stage = VK_SHADER_STAGE_FRAGMENT_BIT;
-    fsInfo.bindingCount = fsBindings.size();
-    fsInfo.bindings = fsBindings.data();
-    fsInfo.pushConstStages = VK_SHADER_STAGE_FRAGMENT_BIT;
-    fsInfo.pushConstSize = sizeof(PresenterArgs);
-    fsInfo.inputMask = 0x1;
-    fsInfo.outputMask = 0x1;
-    m_fsBlit = new DxvkShader(fsInfo, std::move(fsCodeBlit));
-    
-    fsInfo.inputMask = 0;
-    m_fsCopy = new DxvkShader(fsInfo, std::move(fsCodeCopy));
-    m_fsResolve = new DxvkShader(fsInfo, m_device->features().amdShaderFragmentMask
-      ? std::move(fsCodeResolveAmd)
-      : std::move(fsCodeResolve));
-  }
-
-  void DxvkSwapchainBlitter::createResolveImage(const DxvkImageCreateInfo& info) {
-    DxvkImageCreateInfo newInfo;
-    newInfo.type = VK_IMAGE_TYPE_2D;
-    newInfo.format = info.format;
-    newInfo.flags = 0;
-    newInfo.sampleCount = VK_SAMPLE_COUNT_1_BIT;
-    newInfo.extent = info.extent;
-    newInfo.numLayers = 1;
-    newInfo.mipLevels = 1;
-    newInfo.usage  = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT
-                   | VK_IMAGE_USAGE_TRANSFER_DST_BIT
-                   | VK_IMAGE_USAGE_SAMPLED_BIT;
-    newInfo.stages = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT
-                   | VK_PIPELINE_STAGE_TRANSFER_BIT
-                   | VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
-    newInfo.access = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT
-                   | VK_ACCESS_TRANSFER_WRITE_BIT
-                   | VK_ACCESS_SHADER_READ_BIT;
-    newInfo.tiling = VK_IMAGE_TILING_OPTIMAL;
-    newInfo.layout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
-    m_resolveImage = m_device->createImage(newInfo, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
-
-    DxvkImageViewCreateInfo viewInfo;
-    viewInfo.type = VK_IMAGE_VIEW_TYPE_2D;
-    viewInfo.format = info.format;
-    viewInfo.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
-    viewInfo.aspect = VK_IMAGE_ASPECT_COLOR_BIT;
-    viewInfo.minLevel  = 0;
-    viewInfo.numLevels = 1;
-    viewInfo.minLayer  = 0;
-    viewInfo.numLayers = 1;
-    m_resolveView = m_device->createImageView(m_resolveImage, viewInfo);
-  }
-
-
-  void DxvkSwapchainBlitter::destroyResolveImage() {
-    m_resolveImage = nullptr;
-    m_resolveView = nullptr;
   }
 
 }

--- a/src/dxvk/dxvk_swapchain_blitter.h
+++ b/src/dxvk/dxvk_swapchain_blitter.h
@@ -11,7 +11,7 @@ namespace dxvk {
   struct DxvkGammaCp {
     uint16_t r, g, b, a;
   };
-  
+
   /**
    * \brief Swap chain blitter
    *
@@ -19,7 +19,7 @@ namespace dxvk {
    * rendered images to a swap chain image.
    */
   class DxvkSwapchainBlitter : public RcObject {
-    
+
   public:
 
     DxvkSwapchainBlitter(const Rc<DxvkDevice>& device);
@@ -56,25 +56,7 @@ namespace dxvk {
 
   private:
 
-    enum BindingIds : uint32_t {
-      Image = 0,
-      Gamma = 1,
-    };
-
-    struct PresenterArgs {
-      VkOffset2D srcOffset;
-      union {
-        VkExtent2D srcExtent;
-        VkOffset2D dstOffset;
-      };
-    };
-
     Rc<DxvkDevice>      m_device;
-
-    Rc<DxvkShader>      m_fsCopy;
-    Rc<DxvkShader>      m_fsBlit;
-    Rc<DxvkShader>      m_fsResolve;
-    Rc<DxvkShader>      m_vs;
 
     Rc<DxvkBuffer>      m_gammaBuffer;
     Rc<DxvkImage>       m_gammaImage;
@@ -83,36 +65,8 @@ namespace dxvk {
     bool                m_gammaDirty = false;
     DxvkBufferSliceHandle m_gammaSlice = { };
 
-    Rc<DxvkImage>       m_resolveImage;
-    Rc<DxvkImageView>   m_resolveView;
-
-    Rc<DxvkSampler>     m_samplerPresent;
-    Rc<DxvkSampler>     m_samplerGamma;
-
-    void draw(
-            DxvkContext*        ctx,
-      const Rc<DxvkShader>&     fs,
-      const Rc<DxvkImageView>&  dstView,
-            VkRect2D            dstRect,
-      const Rc<DxvkImageView>&  srcView,
-            VkRect2D            srcRect);
-
-    void resolve(
-            DxvkContext*        ctx,
-      const Rc<DxvkImageView>&  dstView,
-      const Rc<DxvkImageView>&  srcView);
-
     void updateGammaTexture(DxvkContext* ctx);
 
-    void createSampler();
-
-    void createShaders();
-
-    void createResolveImage(
-      const DxvkImageCreateInfo&  info);
-
-    void destroyResolveImage();
-
   };
-  
+
 }

--- a/src/dxvk/hud/dxvk_hud.cpp
+++ b/src/dxvk/hud/dxvk_hud.cpp
@@ -69,45 +69,19 @@ namespace dxvk::hud {
   
   void Hud::render(
     const Rc<DxvkContext>&  ctx,
-          VkSurfaceFormatKHR surfaceFormat,
-          VkExtent2D        surfaceSize) {
-    this->setupRendererState(ctx, surfaceFormat, surfaceSize);
-    this->renderHudElements(ctx);
-  }
-  
-  
-  Rc<Hud> Hud::createHud(const Rc<DxvkDevice>& device) {
-    return new Hud(device);
-  }
-
-
-  void Hud::setupRendererState(
-    const Rc<DxvkContext>&  ctx,
-          VkSurfaceFormatKHR surfaceFormat,
-          VkExtent2D        surfaceSize) {
-    VkColorSpaceKHR colorSpace = surfaceFormat.colorSpace;
-
-    if (lookupFormatInfo(surfaceFormat.format)->flags.test(DxvkFormatFlag::ColorSpaceSrgb))
+          VkColorSpaceKHR colorSpace,
+    const Rc<DxvkImageView>& dstView) {
+    if (lookupFormatInfo(dstView->info().format)->flags.test(DxvkFormatFlag::ColorSpaceSrgb))
       colorSpace = VK_COLOR_SPACE_PASS_THROUGH_EXT;
 
-    VkViewport viewport;
-    viewport.x = 0.0f;
-    viewport.y = 0.0f;
-    viewport.width = float(surfaceSize.width);
-    viewport.height = float(surfaceSize.height);
-    viewport.minDepth = 0.0f;
-    viewport.maxDepth = 1.0f;
+    m_renderer.beginFrame(ctx, dstView, colorSpace, m_scale, m_opacity);
+    renderHudElements(ctx);
+    m_renderer.endFrame(ctx);
+  }
 
-    VkRect2D scissor;
-    scissor.offset = { 0, 0 };
-    scissor.extent = surfaceSize;
 
-    ctx->setViewports(1, &viewport, &scissor);
-    ctx->setRasterizerState(m_rsState);
-    ctx->setBlendMode(0, m_blendMode);
-
-    ctx->setSpecConstant(VK_PIPELINE_BIND_POINT_GRAPHICS, 0, colorSpace);
-    m_renderer.beginFrame(ctx, surfaceSize, m_scale, m_opacity);
+  Rc<Hud> Hud::createHud(const Rc<DxvkDevice>& device) {
+    return new Hud(device);
   }
 
 

--- a/src/dxvk/hud/dxvk_hud.h
+++ b/src/dxvk/hud/dxvk_hud.h
@@ -45,9 +45,9 @@ namespace dxvk::hud {
      * \param [in] surfaceSize Image size, in pixels
      */
     void render(
-      const Rc<DxvkContext>&  ctx,
-            VkSurfaceFormatKHR surfaceFormat,
-            VkExtent2D        surfaceSize);
+      const Rc<DxvkContext>&   ctx,
+            VkColorSpaceKHR    colorSpace,
+      const Rc<DxvkImageView>& dstView);
 
     /**
      * \brief Adds a HUD item if enabled
@@ -85,11 +85,6 @@ namespace dxvk::hud {
 
     float                 m_scale;
     float                 m_opacity;
-
-    void setupRendererState(
-      const Rc<DxvkContext>&  ctx,
-            VkSurfaceFormatKHR surfaceFormat,
-            VkExtent2D        surfaceSize);
 
     void renderHudElements(
       const Rc<DxvkContext>&  ctx);

--- a/src/dxvk/hud/dxvk_hud_renderer.h
+++ b/src/dxvk/hud/dxvk_hud_renderer.h
@@ -3,6 +3,7 @@
 #include "../dxvk_device.h"
 
 #include "dxvk_hud_font.h"
+#include "vulkan/vulkan_core.h"
 
 namespace dxvk::hud {
   
@@ -142,6 +143,12 @@ namespace dxvk::hud {
       Rc<DxvkShader> vert;
       Rc<DxvkShader> frag;
     };
+
+    struct Pipeline {
+      VkPipeline pipeline;
+      VkDescriptorSetLayout descriptorSet;
+      VkPipelineLayout pipelineLayout;
+    };
     
     Mode                m_mode;
     float               m_scale;
@@ -172,8 +179,8 @@ namespace dxvk::hud {
 
     VkDeviceSize allocDataBuffer(VkDeviceSize size);
 
-    ShaderPair createTextShaders();
-    ShaderPair createGraphShaders();
+    Pipeline createTextPipeline();
+    Pipeline createGraphPipeline();
 
     Rc<DxvkBuffer> createDataBuffer();
     Rc<DxvkBufferView> createDataView();

--- a/src/dxvk/hud/dxvk_hud_renderer.h
+++ b/src/dxvk/hud/dxvk_hud_renderer.h
@@ -6,30 +6,6 @@
 #include "vulkan/vulkan_core.h"
 
 namespace dxvk::hud {
-  
-  /**
-   * \brief HUD coordinates
-   * 
-   * Coordinates relative to the top-left
-   * corner of the swap image, in pixels.
-   */
-  struct HudPos {
-    float x;
-    float y;
-  };
-  
-  /**
-   * \brief Color
-   * 
-   * SRGB color with alpha channel. The text
-   * will use this color for the most part.
-   */
-  struct HudColor {
-    float r;
-    float g;
-    float b;
-    float a;
-  };
 
   /**
    * \brief Normalized color
@@ -106,10 +82,11 @@ namespace dxvk::hud {
     ~HudRenderer();
     
     void beginFrame(
-      const Rc<DxvkContext>&  context,
-            VkExtent2D        surfaceSize,
-            float             scale,
-            float             opacity);
+      const Rc<DxvkContext>&   context,
+      const Rc<DxvkImageView>& dstView,
+            VkColorSpaceKHR    colorSpace,
+            float              scale,
+            float              opacity);
     
     void drawText(
             float             size,
@@ -122,9 +99,13 @@ namespace dxvk::hud {
             HudPos            size,
             size_t            pointCount,
       const HudGraphPoint*    pointData);
-    
+
+
+    void endFrame(
+      const Rc<DxvkContext>&   context);
+
     VkExtent2D surfaceSize() const {
-      return m_surfaceSize;
+      return VkExtent2D { m_dstView->imageInfo().extent.width, m_dstView->imageInfo().extent.height };
     }
 
     float scale() const {
@@ -153,7 +134,8 @@ namespace dxvk::hud {
     Mode                m_mode;
     float               m_scale;
     float               m_opacity;
-    VkExtent2D          m_surfaceSize;
+    Rc<DxvkImageView>   m_dstView;
+    VkColorSpaceKHR     m_colorSpace;
 
     Rc<DxvkDevice>      m_device;
     Rc<DxvkContext>     m_context;

--- a/src/dxvk/meson.build
+++ b/src/dxvk/meson.build
@@ -86,6 +86,7 @@ dxvk_src = [
   'dxvk_meta_mipgen.cpp',
   'dxvk_meta_pack.cpp',
   'dxvk_meta_resolve.cpp',
+  'dxvk_meta_present_blit.cpp',
   'dxvk_options.cpp',
   'dxvk_pipelayout.cpp',
   'dxvk_pipemanager.cpp',

--- a/src/dxvk/meson.build
+++ b/src/dxvk/meson.build
@@ -87,6 +87,7 @@ dxvk_src = [
   'dxvk_meta_pack.cpp',
   'dxvk_meta_resolve.cpp',
   'dxvk_meta_present_blit.cpp',
+  'dxvk_hud_objects.cpp',
   'dxvk_options.cpp',
   'dxvk_pipelayout.cpp',
   'dxvk_pipemanager.cpp',


### PR DESCRIPTION
You did express some interest in this when I mentioned it so I'd like to get some feedback.
This PR isn't in a state that I'd just merge it as is, I consider it as more of a jumping off point. 
Right now it only handles the D3D11 frontend. The D3D9 backend will be more of the same 
but I'll handle that once we have the D3D11 frontend in a state that we're reasonably happy with.

The D3D11 frontend uses two supplementary contexts:
- the initializer
- the swapchain

### Initializer

The initializer works similar to a deferred context and collects CsChunks.
There's two ways to ensure the ordering doesn't get messed up when doing it this way:
- flush the initializer every time the immediate context dispatches chunks to the cs thread
- make sure all context functions called by the initializer only write to the init cmd buffer and flush the initializer every time the immediate context gets flushed (every time it finishes and submits the cmd buffer)

I decided to go for the second approach. Besides just ordering, special care needs to be taken to not screw up the sequence numbers which is much easier with the second approach.

### Swapchain

The swapchain already emits to the CS thread, so it's fairly easy to move the parts that use a supplementary context into the `EmitCs` function instead. This however reveals the reason why it had a supplementary context to begin with which is to avoid polluting the state of the primary DXVK context.

There's once again two possible solutions here:
- save and restore all context state before and after the HUD & present blit
- avoid messing with the state in the first place and do the HUD and present blit using raw Vulkan

I once again picked the latter approach. So I moved most of the logic of both the swapchain blitter and the HUD into the context itself and rewrote it using mostly raw Vulkan functions. I'm pretty happy with the result for the swapchain blitter because that's kind of a neat meta pass in the end. The HUD is much less neat, maybe we can come up with a better solution for that.

This entire project will obviously need a LOT of testing in the end. I haven't done much of that yet.