### PR TITLE
[d3d8] Respect D3DCREATE_MULTITHREADED and make d3d8 thread safe

### DIFF
--- a/src/d3d8/d3d8_device.h
+++ b/src/d3d8/d3d8_device.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "d3d8_include.h"
+#include "d3d8_multithread.h"
 #include "d3d8_texture.h"
 #include "d3d8_buffer.h"
 #include "d3d8_swapchain.h"
@@ -360,6 +361,10 @@ namespace dxvk {
     inline bool ShouldRecord() { return m_recorder != nullptr; }
     inline bool ShouldBatch()  { return m_batcher  != nullptr; }
 
+    D3D8DeviceLock LockDevice() {
+      return m_multithread.AcquireLock();
+    }
+
     /**
      * Marks any state change in the device, so we can signal
      * the batcher to emit draw calls. StateChange should be
@@ -450,6 +455,8 @@ namespace dxvk {
     HWND                  m_window;
 
     DWORD                 m_behaviorFlags;
+
+    D3D8Multithread       m_multithread;
 
   };
 

--- a/src/d3d8/d3d8_include.h
+++ b/src/d3d8/d3d8_include.h
@@ -117,6 +117,8 @@ namespace d3d9 {
 #include "../util/log/log.h"
 #include "../util/log/log_debug.h"
 
+#include "../util/sync/sync_recursive.h"
+
 #include "../util/util_error.h"
 #include "../util/util_likely.h"
 #include "../util/util_string.h"

--- a/src/d3d8/d3d8_multithread.cpp
+++ b/src/d3d8/d3d8_multithread.cpp
@@ -1,0 +1,9 @@
+#include "d3d8_device.h"
+
+namespace dxvk {
+
+  D3D8Multithread::D3D8Multithread(
+          BOOL                  Protected)
+    : m_protected( Protected ) { }
+
+}

--- a/src/d3d8/d3d8_multithread.h
+++ b/src/d3d8/d3d8_multithread.h
@@ -1,0 +1,77 @@
+#pragma once
+
+#include "d3d8_include.h"
+
+namespace dxvk {
+
+  /**
+   * \brief Device lock
+   *
+   * Lightweight RAII wrapper that implements
+   * a subset of the functionality provided by
+   * \c std::unique_lock, with the goal of being
+   * cheaper to construct and destroy.
+   */
+  class D3D8DeviceLock {
+
+  public:
+
+    D3D8DeviceLock()
+      : m_mutex(nullptr) { }
+
+    D3D8DeviceLock(sync::RecursiveSpinlock& mutex)
+      : m_mutex(&mutex) {
+      mutex.lock();
+    }
+
+    D3D8DeviceLock(D3D8DeviceLock&& other)
+      : m_mutex(other.m_mutex) {
+      other.m_mutex = nullptr;
+    }
+
+    D3D8DeviceLock& operator = (D3D8DeviceLock&& other) {
+      if (m_mutex)
+        m_mutex->unlock();
+
+      m_mutex = other.m_mutex;
+      other.m_mutex = nullptr;
+      return *this;
+    }
+
+    ~D3D8DeviceLock() {
+      if (m_mutex != nullptr)
+        m_mutex->unlock();
+    }
+
+  private:
+
+    sync::RecursiveSpinlock* m_mutex;
+
+  };
+
+
+  /**
+   * \brief D3D8 context lock
+   */
+  class D3D8Multithread {
+
+  public:
+
+    D3D8Multithread(
+      BOOL                  Protected);
+
+    D3D8DeviceLock AcquireLock() {
+      return m_protected
+        ? D3D8DeviceLock(m_mutex)
+        : D3D8DeviceLock();
+    }
+
+  private:
+
+    BOOL            m_protected;
+
+    sync::RecursiveSpinlock m_mutex;
+
+  };
+
+}

--- a/src/d3d8/meson.build
+++ b/src/d3d8/meson.build
@@ -4,6 +4,7 @@ d3d8_src = [
   'd3d8_main.cpp',
   'd3d8_interface.cpp',
   'd3d8_device.cpp',
+  'd3d8_multithread.cpp',
   'd3d8_options.cpp',
   'd3d8_surface.cpp',
   'd3d8_state_block.cpp',

--- a/src/d3d9/d3d9_bridge.h
+++ b/src/d3d9/d3d9_bridge.h
@@ -31,7 +31,7 @@ IDxvkD3D8Bridge : public IUnknown {
   /**
    * \brief Enables or disables D3D9-specific device features and validations
    * 
-   * \param [in] compatibility state
+   * \param [in] compatMode Compatibility state
    */
   virtual void SetD3D8CompatibilityMode(const bool compatMode) = 0;
 


### PR DESCRIPTION
By popular demand, thread-safe d3d8, ported over from d3d9 and sprinkled wherever it affects state. Unsure if anything is actually affected by it (based on testing so far doesn't seem like it), but the overhead is probably rather negligible anyway in d3d8 space.