### PR TITLE
[util] Enable cachedDynamicBuffers for Battle Mages

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -964,6 +964,10 @@ namespace dxvk {
     { R"(\\APB\.exe$)", {{
       { "d3d9.cachedDynamicBuffers",        "True" },
     }} },
+    /* Battle Mages - helps CPU bound perf         */
+    { R"(\\Battle Mages\\mages\.exe$)", {{
+      { "d3d9.cachedDynamicBuffers",        "True" },
+    }} },
 
     /**********************************************/
     /* D3D8 GAMES                                 */


### PR DESCRIPTION
Helps CPU bound performance.

<details>
  <summary>Comparison</summary>
  
![image](https://github.com/user-attachments/assets/2e965078-af52-401d-a1d6-acd5db1b68bb)
![image](https://github.com/user-attachments/assets/b45ac178-fb36-4230-a5d8-657d85edeaaa)
</details>

Didn't find that any of the other games from the dev around that time benefited. Neither the other Battle Mages game.