### PR TITLE
[d3d9] Optimize SWVP devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ The `DXVK_HUD` environment variable controls a HUD which can display the framera
 - `cs`: Shows worker thread statistics.
 - `compiler`: Shows shader compiler activity
 - `samplers`: Shows the current number of sampler pairs used *[D3D9 Only]*
+- `ffshaders`: Shows the current number of shaders generated from fixed function state *[D3D9 Only]*
+- `swvp`: Shows whether or not the device is running in software vertex processing mode *[D3D9 Only]*
 - `scale=x`: Scales the HUD by a factor of `x` (e.g. `1.5`)
 - `opacity=y`: Adjusts the HUD opacity by a factor of `y` (e.g. `0.5`, `1.0` being fully opaque).
 

--- a/src/d3d9/d3d9_common_buffer.h
+++ b/src/d3d9/d3d9_common_buffer.h
@@ -200,18 +200,17 @@ namespace dxvk {
 
 
     /**
-     * \brief Queries sequence number for a given subresource
+     * \brief Queries sequence number
      *
      * Returns which CS chunk the resource was last used on.
-     * \param [in] Subresource Subresource index
-     * \returns Sequence number for the given subresource
+     * \returns Sequence number
      */
     uint64_t GetMappingBufferSequenceNumber() const {
       return HasSequenceNumber() ? m_seq
         : DxvkCsThread::SynchronizeAll;
     }
 
-    bool IsSysmemDynamic() const {
+    bool DoPerDrawUpload() const {
       return m_desc.Pool == D3DPOOL_SYSTEMMEM && (m_desc.Usage & D3DUSAGE_DYNAMIC) != 0;
     }
 

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -1026,6 +1026,10 @@ namespace dxvk {
       return m_behaviorFlags & (D3DCREATE_MIXED_VERTEXPROCESSING | D3DCREATE_SOFTWARE_VERTEXPROCESSING);
     }
 
+    bool IsSWVP() const {
+      return m_isSWVP;
+    }
+
     UINT GetFixedFunctionVSCount() const {
       return m_ffModules.GetVSCount();
     }

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -774,7 +774,7 @@ namespace dxvk {
      * @param FirstIndex The first index
      * @param NumIndices The number of indices that will be drawn. If this is 0, the index buffer binding will not be modified.
      */
-    void UploadDynamicSysmemBuffers(
+    void UploadPerDrawData(
             UINT&                   FirstVertexIndex,
             UINT                    NumVertices,
             UINT&                   FirstIndex,
@@ -782,7 +782,7 @@ namespace dxvk {
             INT&                    BaseVertexIndex,
             bool*                   pDynamicVBOs,
             bool*                   pDynamicIBO);
-    
+
 
     void SetupFPU();
 
@@ -1022,6 +1022,10 @@ namespace dxvk {
       return m_behaviorFlags & D3DCREATE_SOFTWARE_VERTEXPROCESSING;
     }
 
+    bool CanSWVP() const {
+      return m_behaviorFlags & (D3DCREATE_MIXED_VERTEXPROCESSING | D3DCREATE_SOFTWARE_VERTEXPROCESSING);
+    }
+
     UINT GetFixedFunctionVSCount() const {
       return m_ffModules.GetVSCount();
     }
@@ -1061,10 +1065,6 @@ namespace dxvk {
         EmitCsChunk(std::move(m_csChunk));
         m_csChunk = AllocCsChunk();
       }
-    }
-
-    bool CanSWVP() const {
-      return m_behaviorFlags & (D3DCREATE_MIXED_VERTEXPROCESSING | D3DCREATE_SOFTWARE_VERTEXPROCESSING);
     }
 
     // Device Reset detection for D3D9SwapChainEx::Present

--- a/src/d3d9/d3d9_hud.cpp
+++ b/src/d3d9/d3d9_hud.cpp
@@ -125,4 +125,45 @@ namespace dxvk::hud {
     return position;
   }
 
+  HudSWVPState::HudSWVPState(D3D9DeviceEx* device)
+          : m_device          (device)
+          , m_isSWVPText ("") {}
+
+
+  void HudSWVPState::update(dxvk::high_resolution_clock::time_point time) {
+    if (m_device->IsSWVP()) {
+      if (m_device->CanOnlySWVP()) {
+        m_isSWVPText = "SWVP";
+      } else {
+        m_isSWVPText = "SWVP (Mixed)";
+      }
+    } else {
+      if (m_device->CanSWVP()) {
+        m_isSWVPText = "HWVP (Mixed)";
+      } else {
+        m_isSWVPText = "HWVP";
+      }
+    }
+  }
+
+
+  HudPos HudSWVPState::render(
+          HudRenderer&      renderer,
+          HudPos            position) {
+    position.y += 16.0f;
+
+    renderer.drawText(16.0f,
+      { position.x, position.y },
+      { 0.0f, 1.0f, 0.75f, 1.0f },
+      "Vertex Processing:");
+
+    renderer.drawText(16.0f,
+      { position.x + 240.0f, position.y },
+      { 1.0f, 1.0f, 1.0f, 1.0f },
+      m_isSWVPText);
+
+    position.y += 8.0f;
+    return position;
+  }
+
 }

--- a/src/d3d9/d3d9_hud.h
+++ b/src/d3d9/d3d9_hud.h
@@ -78,10 +78,29 @@ namespace dxvk::hud {
 
         D3D9DeviceEx* m_device;
 
-        dxvk::high_resolution_clock::time_point m_lastUpdate
-          = dxvk::high_resolution_clock::now();
-
         std::string m_ffShaderCount;
+
+    };
+
+    /**
+     * \brief HUD item to whether or not we're in SWVP mode
+     */
+    class HudSWVPState : public HudItem {
+    public:
+
+        HudSWVPState(D3D9DeviceEx* device);
+
+        void update(dxvk::high_resolution_clock::time_point time);
+
+        HudPos render(
+                HudRenderer&      renderer,
+                HudPos            position);
+
+    private:
+
+        D3D9DeviceEx* m_device;
+
+        std::string m_isSWVPText;
 
     };
 

--- a/src/d3d9/d3d9_swapchain.cpp
+++ b/src/d3d9/d3d9_swapchain.cpp
@@ -1101,6 +1101,7 @@ namespace dxvk {
       m_hud->addItem<hud::HudClientApiItem>("api", 1, GetApiName());
       m_hud->addItem<hud::HudSamplerCount>("samplers", -1, m_parent);
       m_hud->addItem<hud::HudFixedFunctionShaders>("ffshaders", -1, m_parent);
+      m_hud->addItem<hud::HudSWVPState>("swvp", -1, m_parent);
 
 #ifdef D3D9_ALLOW_UNMAPPING
       m_hud->addItem<hud::HudTextureMemory>("memory", -1, m_parent);


### PR DESCRIPTION
Needs lots of testing.

This makes D3D9 devices, that are configured to always use software vertex processing (so not `MIXED`), always use the late per draw buffer upload path. We copy the vertex data that each specific draw accesses to a temporary buffer and render from that, similar to Up-draws.
This makes sense because games that use pure SWVP expect vertex processing to be synchronous which has lead to both bugs and performance problems. For example we used to run into issues when respecting NOOVERWRITE or have dozens or even hundreds of queue syncs per frame. Considering that SWVP is supposed to run on the CPU, the amount of vertices is hopefully small.

I hope this won't impact more modern or demanding games.

The game that inspires this was Phantasmat from this comment:
https://github.com/doitsujin/dxvk/issues/4263#issuecomment-2358659238

It uses a single 96,000 byte vertex buffer (POOL = DEFAULT, USAGE = WRITEONLY, FVF != 0) and writes data to it before every single draw. Ofc it also doesn't specify a lock range, so we end up uploading the entire 96 KB buffer over and over again, run out of staging memory and then stall. It is a 2D game, so with this PR we upload 4 vertices for every draw.