### PR TITLE
[d3d9] Optimize late buffer uploads with dirty bitmasks

### DIFF
--- a/src/d3d9/d3d9_common_buffer.h
+++ b/src/d3d9/d3d9_common_buffer.h
@@ -46,7 +46,7 @@ namespace dxvk {
 
     }
 
-    inline bool IsDegenerate() { return min == max; }
+    inline bool IsDegenerate() const { return min == max; }
 
     inline void Conjoin(D3D9Range range) {
       if (IsDegenerate())
@@ -180,7 +180,7 @@ namespace dxvk {
     /**
      * \brief Whether or not the staging buffer needs to be copied to the actual buffer
      */
-    inline bool NeedsUpload() { return m_desc.Pool != D3DPOOL_DEFAULT && !m_dirtyRange.IsDegenerate(); }
+    inline bool NeedsUpload() const { return m_desc.Pool != D3DPOOL_DEFAULT && !m_dirtyRange.IsDegenerate(); }
 
     void PreLoad();
 

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -4812,8 +4812,6 @@ namespace dxvk {
 
         if (texInfo == pResource) {
           m_activeTexturesToUpload |= 1 << i;
-          // We can early out here, no need to add another index for this.
-          break;
         }
       }
     }

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -1385,6 +1385,10 @@ namespace dxvk {
     uint32_t                        m_activeTexturesToUpload = 0;
     uint32_t                        m_activeTexturesToGen    = 0;
 
+    uint32_t                        m_activeVertexBuffers                = 0;
+    uint32_t                        m_activeVertexBuffersToUpload        = 0;
+    uint32_t                        m_activeVertexBuffersToUploadPerDraw = 0;
+
     // m_fetch4Enabled is whether fetch4 is currently enabled
     // from the application.
     //

--- a/src/d3d9/d3d9_vertex_declaration.cpp
+++ b/src/d3d9/d3d9_vertex_declaration.cpp
@@ -374,6 +374,8 @@ namespace dxvk {
 
       if (element.Usage == D3DDECLUSAGE_TEXCOORD)
         m_texcoordMask |= GetDecltypeCount(D3DDECLTYPE(element.Type)) << (element.UsageIndex * 3);
+
+      m_streamMask |= 1 << element.Stream;
     }
   }
 

--- a/src/d3d9/d3d9_vertex_declaration.h
+++ b/src/d3d9/d3d9_vertex_declaration.h
@@ -66,6 +66,10 @@ namespace dxvk {
       return m_texcoordMask;
     }
 
+    uint32_t GetStreamMask() const {
+      return m_streamMask;
+    }
+
   private:
 
     bool MapD3DDeclToFvf(
@@ -93,6 +97,8 @@ namespace dxvk {
     DWORD                          m_fvf;
 
     uint32_t                       m_texcoordMask = 0;
+
+    uint32_t                       m_streamMask = 0;
 
     std::array<uint32_t, caps::MaxStreams> m_sizes = {};
 


### PR DESCRIPTION
Based on #4274

Optimizes late buffer uploads (managed or per-draw) similar to how we're doing it for textures.
This avoids having to iterate over all 16 vertex buffers multiple times for every draw.