### PR TITLE
A bunch of validation error fixes

### DIFF
--- a/src/d3d9/d3d9_common_texture.cpp
+++ b/src/d3d9/d3d9_common_texture.cpp
@@ -72,7 +72,8 @@ namespace dxvk {
         ExportImageInfo();
       }
 
-      CreateSampleView(0);
+      if ((m_image->info().usage & VK_IMAGE_USAGE_SAMPLED_BIT) != 0)
+        CreateSampleView(0);
 
       if (!IsManaged()) {
         m_size = m_image->memory().length();

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -4233,7 +4233,7 @@ namespace dxvk {
 
 
   bool D3D9DeviceEx::SupportsSWVP() {
-    return m_dxvkDevice->features().core.features.vertexPipelineStoresAndAtomics;
+    return m_dxvkDevice->features().core.features.vertexPipelineStoresAndAtomics && m_dxvkDevice->features().vk12.shaderInt8;
   }
 
 
@@ -4261,6 +4261,7 @@ namespace dxvk {
 
     // ProcessVertices
     enabled.core.features.vertexPipelineStoresAndAtomics = supported.core.features.vertexPipelineStoresAndAtomics;
+    enabled.vk12.shaderInt8 = supported.vk12.shaderInt8;
 
     // DXVK Meta
     enabled.core.features.imageCubeArray = VK_TRUE;

--- a/src/d3d9/d3d9_swapchain.cpp
+++ b/src/d3d9/d3d9_swapchain.cpp
@@ -302,6 +302,7 @@ namespace dxvk {
       resolveInfo.mipLevels     = 1;
       resolveInfo.usage         = VK_IMAGE_USAGE_SAMPLED_BIT
                                 | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT
+                                | VK_IMAGE_USAGE_TRANSFER_SRC_BIT
                                 | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
       resolveInfo.stages        = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT
                                 | VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT
@@ -357,6 +358,7 @@ namespace dxvk {
       blitCreateInfo.mipLevels     = 1;
       blitCreateInfo.usage         = VK_IMAGE_USAGE_SAMPLED_BIT
                                    | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT
+                                   | VK_IMAGE_USAGE_TRANSFER_SRC_BIT
                                    | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
       blitCreateInfo.stages        = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT
                                    | VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT

--- a/src/d3d9/d3d9_swvp_emu.cpp
+++ b/src/d3d9/d3d9_swvp_emu.cpp
@@ -262,8 +262,8 @@ namespace dxvk {
 
         // Bitcast to dwords before we write.
         uint32_t dwordCount  = GetDecltypeSize(D3DDECLTYPE(element.Type)) / sizeof(uint32_t);
-        uint32_t dwordVector = m_module.opBitcast(
-          m_module.defVectorType(uint_t, dwordCount),
+        uint32_t dwordVal = m_module.opBitcast(
+          dwordCount != 1 ? m_module.defVectorType(uint_t, dwordCount) : uint_t,
           componentSet);
 
         // Finally write each dword to the buffer!
@@ -271,7 +271,7 @@ namespace dxvk {
           std::array<uint32_t, 2> bufferIndices = { m_module.constu32(0), elementOffset };
 
           uint32_t writeDest = m_module.opAccessChain(m_module.defPointerType(uint_t, spv::StorageClassUniform), buffer, bufferIndices.size(), bufferIndices.data());
-          uint32_t currentDword = m_module.opCompositeExtract(uint_t, dwordVector, 1, &i);
+          uint32_t currentDword = dwordCount != 1 ? m_module.opCompositeExtract(uint_t, dwordVal, 1, &i) : dwordVal;
 
           m_module.opStore(writeDest, currentDword);
 


### PR DESCRIPTION
```
err:   VUID-VkImageViewCreateInfo-pNext-02662: 
err:   Validation Error: [ VUID-VkImageViewCreateInfo-pNext-02662 ] Object 0: handle = 0x612f93000000004e, type = VK_OBJECT_TYPE_IMAGE; | MessageID = 0xfcaee507 | vkCreateImageView(): pCreateInfo->pNext<VkImageViewUsageCreateInfo>.usage (VK_IMAGE_USAGE_SAMPLED_BIT) must not include any bits that were not set in VkImageCreateInfo::usage (VK_IMAGE_USAGE_TRANSFER_SRC_BIT|VK_IMAGE_USAGE_TRANSFER_DST_BIT|VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT) of the image. The Vulkan spec states: If the pNext chain includes a VkImageViewUsageCreateInfo structure, and image was not created with a VkImageStencilUsageCreateInfo structure included in the pNext chain of VkImageCreateInfo, its usage member must not include any bits that were not set in the usage member of the VkImageCreateInfo structure used to create image (https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#VUID-VkImageViewCreateInfo-pNext-02662)
err:   VUID-VkImageViewCreateInfo-pNext-02662: 
err:   Validation Error: [ VUID-VkImageViewCreateInfo-pNext-02662 ] Object 0: handle = 0x612f93000000004e, type = VK_OBJECT_TYPE_IMAGE; | MessageID = 0xfcaee507 | vkCreateImageView(): pCreateInfo->pNext<VkImageViewUsageCreateInfo>.usage (VK_IMAGE_USAGE_SAMPLED_BIT) must not include any bits that were not set in VkImageCreateInfo::usage (VK_IMAGE_USAGE_TRANSFER_SRC_BIT|VK_IMAGE_USAGE_TRANSFER_DST_BIT|VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT) of the image. The Vulkan spec states: If the pNext chain includes a VkImageViewUsageCreateInfo structure, and image was not created with a VkImageStencilUsageCreateInfo structure included in the pNext chain of VkImageCreateInfo, its usage member must not include any bits that were not set in the usage member of the VkImageCreateInfo structure used to create image (https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#VUID-VkImageViewCreateInfo-pNext-02662)

err:   VUID-vkBindBufferMemory-bufferDeviceAddress-03339: 
err:   Validation Error: [ VUID-vkBindBufferMemory-bufferDeviceAddress-03339 ] Object 0: handle = 0x2d0f10000000124, type = VK_OBJECT_TYPE_BUFFER; Object 1: handle = 0xd27c3e0000000123, type = VK_OBJECT_TYPE_DEVICE_MEMORY; | MessageID = 0x44a78781 | vkBindBufferMemory(): buffer was created with the VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT bit set, memory must have been allocated with the VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT bit set. The Vulkan spec states: If the VkPhysicalDeviceBufferDeviceAddressFeatures::bufferDeviceAddress feature is enabled and buffer was created with the VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT bit set, memory must have been allocated with the VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT bit set (https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#VUID-vkBindBufferMemory-bufferDeviceAddress-03339)
err:   VUID-vkBindBufferMemory-bufferDeviceAddress-03339: 
err:   Validation Error: [ VUID-vkBindBufferMemory-bufferDeviceAddress-03339 ] Object 0: handle = 0xf34a48000000013c, type = VK_OBJECT_TYPE_BUFFER; Object 1: handle = 0x85ef67000000013b, type = VK_OBJECT_TYPE_DEVICE_MEMORY; | MessageID = 0x44a78781 | vkBindBufferMemory(): buffer was created with the VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT bit set, memory must have been allocated with the VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT bit set. The Vulkan spec states: If the VkPhysicalDeviceBufferDeviceAddressFeatures::bufferDeviceAddress feature is enabled and buffer was created with the VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT bit set, memory must have been allocated with the VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT bit set (https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#VUID-vkBindBufferMemory-bufferDeviceAddress-03339)

err:   VUID-VkShaderModuleCreateInfo-pCode-08737: 
err:   Validation Error: [ VUID-VkShaderModuleCreateInfo-pCode-08737 ] | MessageID = 0xa5625282 | vkCreateGraphicsPipelines(): pCreateInfos[0].pStages[1].pNext<VkShaderModuleCreateInfo>.pCode (spirv-val produced an error):
err:   Illegal number of components (1) for TypeVector
err:     %v1uint = OpTypeVector %uint 1
err:   . The Vulkan spec states: If pCode is a pointer to SPIR-V code, pCode must adhere to the validation rules described by the Validation Rules within a Module section of the SPIR-V Environment appendix (https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#VUID-VkShaderModuleCreateInfo-pCode-08737)
err:   VUID-VkShaderModuleCreateInfo-pCode-08740: 
err:   Validation Error: [ VUID-VkShaderModuleCreateInfo-pCode-08740 ] | MessageID = 0x6e224e9 | vkCreateGraphicsPipelines(): pCreateInfos[0].pStages[1].pNext<VkShaderModuleCreateInfo>.pCode SPIR-V Capability Int8 was declared, but one of the following requirements is required (VkPhysicalDeviceVulkan12Features::shaderInt8). The Vulkan spec states: If pCode is a pointer to SPIR-V code, and pCode declares any of the capabilities listed in the SPIR-V Environment appendix, one of the corresponding requirements must be satisfied (https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#VUID-VkShaderModuleCreateInfo-pCode-08740)

err:   VUID-VkShaderModuleCreateInfo-pCode-08737: 
err:   Validation Error: [ VUID-VkShaderModuleCreateInfo-pCode-08737 ] | MessageID = 0xa5625282 | vkCreateGraphicsPipelines(): pCreateInfos[0].pStages[1].pNext<VkShaderModuleCreateInfo>.pCode (spirv-val produced an error):
err:   Illegal number of components (1) for TypeVector
err:     %v1uint = OpTypeVector %uint 1
err:   . The Vulkan spec states: If pCode is a pointer to SPIR-V code, pCode must adhere to the validation rules described by the Validation Rules within a Module section of the SPIR-V Environment appendix (https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#VUID-VkShaderModuleCreateInfo-pCode-08737)
err:   VUID-VkShaderModuleCreateInfo-pCode-08740: 
err:   Validation Error: [ VUID-VkShaderModuleCreateInfo-pCode-08740 ] | MessageID = 0x6e224e9 | vkCreateGraphicsPipelines(): pCreateInfos[0].pStages[1].pNext<VkShaderModuleCreateInfo>.pCode SPIR-V Capability Int8 was declared, but one of the following requirements is required (VkPhysicalDeviceVulkan12Features::shaderInt8). The Vulkan spec states: If pCode is a pointer to SPIR-V code, and pCode declares any of the capabilities listed in the SPIR-V Environment appendix, one of the corresponding requirements must be satisfied (https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#VUID-VkShaderModuleCreateInfo-pCode-08740)

err:   VUID-vkBindBufferMemory-bufferDeviceAddress-03339: 
err:   Validation Error: [ VUID-vkBindBufferMemory-bufferDeviceAddress-03339 ] Object 0: handle = 0x5c112e0000000675, type = VK_OBJECT_TYPE_BUFFER; Object 1: handle = 0x81c4570000000674, type = VK_OBJECT_TYPE_DEVICE_MEMORY; | MessageID = 0x44a78781 | vkBindBufferMemory(): buffer was created with the VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT bit set, memory must have been allocated with the VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT bit set. The Vulkan spec states: If the VkPhysicalDeviceBufferDeviceAddressFeatures::bufferDeviceAddress feature is enabled and buffer was created with the VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT bit set, memory must have been allocated with the VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT bit set (https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#VUID-vkBindBufferMemory-bufferDeviceAddress-03339)
err:   VUID-vkBindBufferMemory-bufferDeviceAddress-03339: 
err:   Validation Error: [ VUID-vkBindBufferMemory-bufferDeviceAddress-03339 ] Object 0: handle = 0x52707b0000000678, type = VK_OBJECT_TYPE_BUFFER; Object 1: handle = 0x9aa73c0000000677, type = VK_OBJECT_TYPE_DEVICE_MEMORY; | MessageID = 0x44a78781 | vkBindBufferMemory(): buffer was created with the VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT bit set, memory must have been allocated with the VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT bit set. The Vulkan spec states: If the VkPhysicalDeviceBufferDeviceAddressFeatures::bufferDeviceAddress feature is enabled and buffer was created with the VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT bit set, memory must have been allocated with the VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT bit set (https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#VUID-vkBindBufferMemory-bufferDeviceAddress-03339)
err:   VUID-VkImageMemoryBarrier2-oldLayout-01212: 
err:   Validation Error: [ VUID-VkImageMemoryBarrier2-oldLayout-01212 ] Object 0: handle = 0x58baf50000000676, type = VK_OBJECT_TYPE_IMAGE; | MessageID = 0x4636ad61 | vkCmdPipelineBarrier2(): pDependencyInfo->pImageMemoryBarriers[0].newLayout (VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL) is not compatible with VkImage 0x58baf50000000676[] usage flags VK_IMAGE_USAGE_TRANSFER_DST_BIT|VK_IMAGE_USAGE_SAMPLED_BIT|VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT. The Vulkan spec states: If srcQueueFamilyIndex and dstQueueFamilyIndex define a queue family ownership transfer or oldLayout and newLayout define an image layout transition, and oldLayout or newLayout is VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL then image must have been created with VK_IMAGE_USAGE_TRANSFER_SRC_BIT (https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#VUID-VkImageMemoryBarrier2-oldLayout-01212)
err:   VUID-VkCopyImageToBufferInfo2-srcImage-00186: 
err:   Validation Error: [ VUID-VkCopyImageToBufferInfo2-srcImage-00186 ] Object 0: handle = 0x7bbd78004760, type = VK_OBJECT_TYPE_COMMAND_BUFFER; Object 1: handle = 0x58baf50000000676, type = VK_OBJECT_TYPE_IMAGE; | MessageID = 0x1ce6f32f | vkCmdCopyImageToBuffer2(): pCopyImageToBufferInfo->srcImage (VkImage 0x58baf50000000676[]) was created with VK_IMAGE_USAGE_TRANSFER_DST_BIT|VK_IMAGE_USAGE_SAMPLED_BIT|VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT but requires VK_IMAGE_USAGE_TRANSFER_SRC_BIT. The Vulkan spec states: srcImage must have been created with VK_IMAGE_USAGE_TRANSFER_SRC_BIT usage flag (https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#VUID-VkCopyImageToBufferInfo2-srcImage-00186)
err:   VUID-VkImageMemoryBarrier2-oldLayout-01212: 
err:   Validation Error: [ VUID-VkImageMemoryBarrier2-oldLayout-01212 ] Object 0: handle = 0x58baf50000000676, type = VK_OBJECT_TYPE_IMAGE; | MessageID = 0x4636ad61 | vkCmdPipelineBarrier2(): pDependencyInfo->pImageMemoryBarriers[0].oldLayout (VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL) is not compatible with VkImage 0x58baf50000000676[] usage flags VK_IMAGE_USAGE_TRANSFER_DST_BIT|VK_IMAGE_USAGE_SAMPLED_BIT|VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT. The Vulkan spec states: If srcQueueFamilyIndex and dstQueueFamilyIndex define a queue family ownership transfer or oldLayout and newLayout define an image layout transition, and oldLayout or newLayout is VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL then image must have been created with VK_IMAGE_USAGE_TRANSFER_SRC_BIT (https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#VUID-VkImageMemoryBarrier2-oldLayout-01212)
err:   UNASSIGNED-CoreValidation-DrawState-InvalidImageLayout: 
err:   Validation Error: [ UNASSIGNED-CoreValidation-DrawState-InvalidImageLayout ] Object 0: handle = 0x7bbd78004760, type = VK_OBJECT_TYPE_COMMAND_BUFFER; Object 1: handle = 0x58baf50000000676, type = VK_OBJECT_TYPE_IMAGE; | MessageID = 0x4dae5635 | vkQueueSubmit2(): pSubmits[0].pCommandBufferInfos[0].commandBuffer command buffer VkCommandBuffer 0x7bbd78004760[] expects VkImage 0x58baf50000000676[] (subresource: aspectMask 0x1 array layer 0, mip level 0) to be in layout VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL--instead, current layout is VK_IMAGE_LAYOUT_UNDEFINED.
```