### PR TITLE
Rewrite memory allocator

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ The `DXVK_HUD` environment variable controls a HUD which can display the framera
 - `pipelines`: Shows the total number of graphics and compute pipelines.
 - `descriptors`: Shows the number of descriptor pools and descriptor sets.
 - `memory`: Shows the amount of device memory allocated and used.
+- `allocations`: Shows detailed memory chunk suballocation info.
 - `gpuload`: Shows estimated GPU load. May be inaccurate.
 - `version`: Shows DXVK version.
 - `api`: Shows the D3D feature level used by the application.

--- a/package-release.sh
+++ b/package-release.sh
@@ -64,6 +64,7 @@ function build_arch {
         $opt_strip                                          \
         --bindir "x$1"                                      \
         --libdir "x$1"                                      \
+        -Db_ndebug=if-release                               \
         -Dbuild_id=$opt_buildid                             \
         "$DXVK_BUILD_DIR/build.$1"
 

--- a/src/dxvk/dxvk_adapter.cpp
+++ b/src/dxvk/dxvk_adapter.cpp
@@ -55,14 +55,14 @@ namespace dxvk {
       if (m_hasMemoryBudget) {
         // Handle DXVK's memory allocations separately so that
         // freeing  resources actually is visible to applications.
-        VkDeviceSize allocated = m_memoryAllocated[i].load();
-        VkDeviceSize used = m_memoryUsed[i].load();
+        VkDeviceSize allocated = m_memoryStats[i].allocated.load();
+        VkDeviceSize used = m_memoryStats[i].used.load();
 
         info.heaps[i].memoryBudget    = memBudget.heapBudget[i];
         info.heaps[i].memoryAllocated = std::max(memBudget.heapUsage[i], allocated) - allocated + used;
       } else {
         info.heaps[i].memoryBudget    = memProps.memoryProperties.memoryHeaps[i].size;
-        info.heaps[i].memoryAllocated = m_memoryUsed[i].load();
+        info.heaps[i].memoryAllocated = m_memoryStats[i].used.load();
       }
     }
 
@@ -654,19 +654,14 @@ namespace dxvk {
   }
 
 
-  void DxvkAdapter::notifyMemoryAlloc(
+  void DxvkAdapter::notifyMemoryStats(
           uint32_t            heap,
-          int64_t             bytes) {
-    if (heap < m_memoryAllocated.size())
-      m_memoryAllocated[heap] += bytes;
-  }
-
-
-  void DxvkAdapter::notifyMemoryUse(
-          uint32_t            heap,
-          int64_t             bytes) {
-    if (heap < m_memoryUsed.size())
-      m_memoryUsed[heap] += bytes;
+          int64_t             allocated,
+          int64_t             used) {
+    if (heap < m_memoryStats.size()) {
+      m_memoryStats[heap].allocated += allocated;
+      m_memoryStats[heap].used += used;
+    }
   }
 
 

--- a/src/dxvk/dxvk_adapter.h
+++ b/src/dxvk/dxvk_adapter.h
@@ -57,7 +57,19 @@ namespace dxvk {
     uint32_t transfer;
     uint32_t sparse;
   };
-  
+
+
+  /**
+   * \brief Adapter memory statistics
+   *
+   * Periodically updated by the devices using this adapter.
+   */
+  struct DxvkAdapterMemoryStats {
+    std::atomic<uint64_t> allocated = { 0u };
+    std::atomic<uint64_t> used = { 0u };
+  };
+
+
   /**
    * \brief Device import info
    */
@@ -228,22 +240,13 @@ namespace dxvk {
      * 
      * Updates memory alloc info accordingly.
      * \param [in] heap Memory heap index
-     * \param [in] bytes Allocation size
+     * \param [in] allocated Allocated size delta
+     * \param [in] used Used size delta
      */
-    void notifyMemoryAlloc(
+    void notifyMemoryStats(
             uint32_t            heap,
-            int64_t             bytes);
-    
-    /**
-     * \brief Registers memory suballocation
-     * 
-     * Updates memory alloc info accordingly.
-     * \param [in] heap Memory heap index
-     * \param [in] bytes Allocation size
-     */
-    void notifyMemoryUse(
-            uint32_t            heap,
-            int64_t             bytes);
+            int64_t             allocated,
+            int64_t             used);
     
     /**
      * \brief Tests if the driver matches certain criteria
@@ -328,8 +331,7 @@ namespace dxvk {
 
     std::vector<VkQueueFamilyProperties> m_queueFamilies;
 
-    std::array<std::atomic<uint64_t>, VK_MAX_MEMORY_HEAPS> m_memoryAllocated = { };
-    std::array<std::atomic<uint64_t>, VK_MAX_MEMORY_HEAPS> m_memoryUsed = { };
+    std::array<DxvkAdapterMemoryStats, VK_MAX_MEMORY_HEAPS> m_memoryStats = { };
 
     void queryExtensions();
     void queryDeviceInfo();

--- a/src/dxvk/dxvk_allocator.cpp
+++ b/src/dxvk/dxvk_allocator.cpp
@@ -1,0 +1,521 @@
+#include <algorithm>
+#include <utility>
+
+#include "dxvk_allocator.h"
+
+#include "../util/util_bit.h"
+#include "../util/util_likely.h"
+
+namespace dxvk {
+
+  DxvkPageAllocator::DxvkPageAllocator(uint64_t capacity)
+  : m_pageCount(capacity / PageSize), m_freeListLutByPage(m_pageCount, -1) {
+    PageRange freeRange = { };
+    freeRange.index = 0u;
+    freeRange.count = m_pageCount;
+
+    insertFreeRange(freeRange, -1);
+  }
+
+
+  DxvkPageAllocator::~DxvkPageAllocator() {
+
+  }
+
+
+  int64_t DxvkPageAllocator::alloc(uint64_t size, uint64_t alignment) {
+    uint32_t pageCount = (size + PageSize - 1u) / PageSize;
+    uint32_t pageAlign = (alignment + PageSize - 1u) / PageSize;
+
+    return std::max<int64_t>(-1, int64_t(allocPages(pageCount, pageAlign)) * int64_t(PageSize));
+  }
+
+
+  int32_t DxvkPageAllocator::allocPages(uint32_t count, uint32_t alignment) {
+    int32_t index = searchFreeList(count);
+
+    while (index--) {
+      PageRange entry = m_freeList[index];
+
+      if (likely(!(entry.index & (alignment - 1u)))) {
+        // If the current free range is sufficiently aligned, we can use
+        // it as-is and simply modify the remaining free list entry.
+        uint32_t pageIndex = entry.index;
+
+        entry.index += count;
+        entry.count -= count;
+
+        insertFreeRange(entry, index);
+
+        m_pagesUsed += count;
+        return pageIndex;
+      } else {
+        // Apply alignment and skip if the free range is too small.
+        uint32_t pageIndex = align(entry.index, alignment);
+
+        if (pageIndex + count > entry.index + entry.count)
+          continue;
+
+        // Insert free range before the first allocated page,
+        // guaranteed to be non-empty at this point.
+        PageRange prevRange = { };
+        prevRange.index = entry.index;
+        prevRange.count = pageIndex - entry.index;
+
+        insertFreeRange(prevRange, index);
+
+        // Insert free range after the last allocated page.
+        PageRange nextRange = { };
+        nextRange.index = pageIndex + count;
+        nextRange.count = entry.index + entry.count - nextRange.index;
+
+        if (nextRange.count)
+          insertFreeRange(nextRange, -1);
+
+        m_pagesUsed += count;
+        return pageIndex;
+      }
+    }
+
+    return -1;    
+  }
+
+
+  void DxvkPageAllocator::free(uint64_t address, uint64_t size) {
+    uint32_t pageIndex = address / PageSize;
+    uint32_t pageCount = (size + PageSize - 1u) / PageSize;
+
+    freePages(pageIndex, pageCount);
+  }
+
+
+  void DxvkPageAllocator::freePages(uint32_t index, uint32_t count) {
+    // Use the lookup table to quickly determine which
+    // free ranges we can actually merge with
+    int32_t prevRange = -1;
+    int32_t nextRange = -1;
+
+    if (index > 0u)
+      prevRange = m_freeListLutByPage[index - 1];
+
+    if (index + count < m_pageCount)
+      nextRange = m_freeListLutByPage[index + count];
+
+    if (prevRange < 0) {
+      if (nextRange < 0) {
+        // No adjacent range, need to insert a new one
+        PageRange range = { };
+        range.index = index;
+        range.count = count;
+
+        insertFreeRange(range, -1);
+      } else {
+        // One adjacent range after the current one
+        PageRange range = m_freeList[nextRange];
+        range.index = index;
+        range.count += count;
+
+        insertFreeRange(range, nextRange);
+      }
+    } else if (nextRange < 0) {
+        // One adjacent range before the current one
+      PageRange range = m_freeList[prevRange];
+      range.count += count;
+
+      insertFreeRange(range, prevRange);
+    } else {
+      // Two adjacent ranges, need to merge with both
+      // and replace one while removing the other.
+      PageRange prev = m_freeList[prevRange];
+      PageRange next = m_freeList[nextRange];
+
+      PageRange mergedRange = { };
+      mergedRange.index = prev.index;
+      mergedRange.count = next.index + next.count - prev.index;
+
+      PageRange emptyRange = { };
+
+      // Remove the range at the higher index, then replace the one at the
+      // lower index with the merged range. The order is important here since
+      // having overlapping entries in the free list would cause issues for
+      // the look-up table, and using the correct indices is important since
+      // the index for the second operation could otherwise be invalidated.
+      insertFreeRange(emptyRange, std::max(prevRange, nextRange));
+      insertFreeRange(mergedRange, std::min(prevRange, nextRange));
+    }
+
+    m_pagesUsed -= count;
+  }
+
+
+  void DxvkPageAllocator::getPageAllocationMask(uint32_t* pageMask) const {
+    // Initialize bit mask with all ones
+    uint32_t fullCount = m_pageCount / 32u;
+    uint32_t lastCount = m_pageCount % 32u;
+
+    for (uint32_t i = 0; i < fullCount; i++)
+      pageMask[i] = ~0u;
+
+    if (lastCount)
+      pageMask[fullCount] = (1u << lastCount) - 1u;
+
+    // Iterate over free list and set all included pages to 0.
+    for (PageRange range : m_freeList) {
+      uint32_t index = range.index / 32u;
+      uint32_t shift = range.index % 32u;
+
+      if (shift + range.count < 32u) {
+        // Entire free range fits in one single mask
+        pageMask[index] ^= ((1u << range.count) - 1u) << shift;
+      } else {
+        if (shift) {
+          pageMask[index++] ^= ~0u << shift;
+          range.count -= 32u - shift;
+        }
+
+        while (range.count >= 32u) {
+          pageMask[index++] = 0u;
+          range.count -= 32u;
+        }
+
+        if (range.count)
+          pageMask[index++] &= ~0u << range.count;
+      }
+    }
+  }
+
+
+  int32_t DxvkPageAllocator::searchFreeList(uint32_t count) {
+    // Find the insertion index of a free list entry with the given page count.
+    // All entries with an index lower than but not equal to the return value
+    // will have a page count greater than or equal to count.
+    if (unlikely(m_freeList.empty()))
+      return 0u;
+
+    // Do a binary search, but optimize for the common
+    // case where we request a small page count
+    uint32_t lo = 0u;
+    uint32_t hi = m_freeList.size();
+
+    if (count <= m_freeList.back().count)
+      return int32_t(hi);
+
+    while (lo < hi) {
+      uint32_t mid = (lo + hi) / 2u;
+
+      if (count <= m_freeList[mid].count)
+        lo = mid + 1;
+      else
+        hi = mid;
+    }
+
+    return int32_t(lo);
+  }
+
+
+  void DxvkPageAllocator::addLutEntry(const PageRange& range, int32_t index) {
+    m_freeListLutByPage[range.index] = index;
+    m_freeListLutByPage[range.index + range.count - 1u] = index;
+  }
+
+
+  void DxvkPageAllocator::removeLutEntry(const PageRange& range) {
+    m_freeListLutByPage[range.index] = -1;
+    m_freeListLutByPage[range.index + range.count - 1u] = -1;
+  }
+
+
+  void DxvkPageAllocator::insertFreeRange(PageRange newRange, int32_t currentIndex) {
+    size_t count = m_freeList.size();
+    size_t index = size_t(currentIndex);
+
+    if (unlikely(currentIndex < 0)) {
+      m_freeList.emplace_back();
+      index = count++;
+    }
+
+    // Remove old range from the LUT since it gets replaced
+    PageRange oldRange = m_freeList[index];
+
+    if (likely(oldRange.count))
+      removeLutEntry(oldRange);
+
+    // Move range within the free list until the proper ordering
+    // is restored again and update LUT entries for all ranges we
+    // move in the process.
+    if (newRange.count < oldRange.count) {
+      while (index + 1u < count) {
+        PageRange next = m_freeList[index + 1u];
+
+        if (newRange.count >= next.count)
+          break;
+
+        addLutEntry(next, index);
+        m_freeList[index++] = next;
+      }
+    } else if (newRange.count > oldRange.count) {
+      while (index) {
+        PageRange prev = m_freeList[index - 1u];
+
+        if (newRange.count <= prev.count)
+          break;
+
+        addLutEntry(prev, index);
+        m_freeList[index--] = prev;
+      }
+    }
+
+    if (newRange.count) {
+      m_freeList[index] = newRange;
+      addLutEntry(newRange, index);
+    } else {
+      m_freeList.pop_back();
+    }
+  }
+
+
+
+  DxvkPoolAllocator::DxvkPoolAllocator(DxvkPageAllocator& pageAllocator)
+  : m_pageAllocator(&pageAllocator), m_pageInfos(m_pageAllocator->pageCount()) {
+
+  }
+
+
+  DxvkPoolAllocator::~DxvkPoolAllocator() {
+
+  }
+
+
+  int64_t DxvkPoolAllocator::alloc(uint64_t size) {
+    uint32_t listIndex = computeListIndex(size);
+    uint32_t poolCapacity = computePoolCapacity(listIndex);
+
+    // Obtain a page for the size category
+    int32_t pageIndex = m_pageLists[listIndex].head;
+
+    if (unlikely(pageIndex < 0)) {
+      if ((pageIndex = allocPage(listIndex)) < 0)
+        return -1;
+
+      // Initialize suballocator for the page
+      PageInfo& page = m_pageInfos[pageIndex];
+
+      if (likely(poolCapacity <= MaskBits)) {
+        // Initialize free mask with the first item marked as used
+        page.pool = (MaskType(2) << (poolCapacity - 1u)) - 2u;
+      } else {
+        // This is also going to have its first item used already
+        page.pool = allocPagePool(poolCapacity);
+      }
+
+      return computeByteAddress(pageIndex, 0, listIndex);
+    }
+
+    if (likely(poolCapacity <= MaskBits)) {
+      // Fast path that uses the pool index as an allocator.
+      // Frequent allocations should ideally hit this path.
+      PageInfo& page = m_pageInfos[pageIndex];
+
+      uint32_t itemIndex = bit::tzcnt(page.pool);
+      page.pool &= page.pool - 1u;
+
+      if (unlikely(!page.pool))
+        removePageFromList(pageIndex, listIndex);
+
+      return computeByteAddress(pageIndex, itemIndex, listIndex);
+    } else {
+      PageInfo& page = m_pageInfos[pageIndex];
+      PagePool& pool = m_pagePools[page.pool];
+
+      // Check top-level masks to find which low-level mask to use
+      uint32_t maskIndex = bit::tzcnt(uint32_t(pool.freeMask));
+      MaskType maskBit = MaskType(1) << maskIndex;
+
+      pool.usedMask |= maskBit;
+
+      // Allocate item from the selected low-level mask
+      MaskType& mask = pool.subPools[maskIndex];
+      uint32_t itemIndex = bit::tzcnt(mask) + maskIndex * MaskBits;
+
+      if (!(mask &= mask - 1u)) {
+        pool.freeMask &= ~maskBit;
+
+        if (unlikely(!pool.freeMask))
+          removePageFromList(pageIndex, listIndex);
+      }
+
+      return computeByteAddress(pageIndex, itemIndex, listIndex);
+    }
+  }
+
+
+  void DxvkPoolAllocator::free(uint64_t address, uint64_t size) {
+    uint32_t listIndex = computeListIndex(size);
+
+    uint32_t pageIndex = computePageIndexFromByteAddress(address);
+    uint32_t itemIndex = computeItemIndexFromByteAddress(address, listIndex);
+
+    uint32_t poolCapacity = computePoolCapacity(listIndex);
+
+    // Return the allocation to the given pool and add the page back
+    // to the free list if it was previously full. If the page is now
+    // unused, return it to the allocator.
+    if (likely(poolCapacity <= MaskBits)) {
+      PageInfo& page = m_pageInfos[pageIndex];
+
+      if (unlikely(!page.pool))
+        addPageToList(pageIndex, listIndex);
+
+      page.pool |= MaskType(1) << itemIndex;
+
+      if (unlikely(bit::tzcnt(page.pool + 1u) >= poolCapacity))
+        freePage(pageIndex, listIndex);
+    } else {
+      PageInfo& page = m_pageInfos[pageIndex];
+      PagePool& pool = m_pagePools[page.pool];
+
+      if (unlikely(!pool.freeMask))
+        addPageToList(pageIndex, listIndex);
+
+      uint32_t maskIndex = itemIndex / MaskBits;
+      MaskType maskBit = MaskType(1) << maskIndex;
+
+      MaskType& mask = pool.subPools[maskIndex];
+      mask |= MaskType(1) << (itemIndex % MaskBits);
+
+      pool.freeMask |= maskBit;
+
+      if (!(mask + 1u)) {
+        pool.usedMask &= ~maskBit;
+
+        if (unlikely(!pool.usedMask)) {
+          freePagePool(page.pool);
+          freePage(pageIndex, listIndex);
+        }
+      }
+    }
+  }
+
+
+  int32_t DxvkPoolAllocator::allocPage(uint32_t listIndex) {
+    int32_t pageIndex = m_pageAllocator->allocPages(1u, 1u);
+
+    if (unlikely(pageIndex < 0))
+      return -1;
+
+    addPageToList(pageIndex, listIndex);
+    return pageIndex;
+  }
+
+
+  void DxvkPoolAllocator::freePage(uint32_t pageIndex, uint32_t listIndex) {
+    removePageFromList(pageIndex, listIndex);
+
+    m_pageAllocator->freePages(pageIndex, 1u);
+  }
+
+
+  void DxvkPoolAllocator::addPageToList(uint32_t pageIndex, uint32_t listIndex) {
+    // Add page to the end of the list. Allocations within a single page
+    // often have similar lifetimes, so not reusing the page immediately
+    // increases the chances of it getting freed.
+    PageInfo& page = m_pageInfos[pageIndex];
+    page.prev = m_pageLists[listIndex].tail;
+
+    if (page.prev >= 0)
+      m_pageInfos[page.prev].next = pageIndex;
+    else
+      m_pageLists[listIndex].head = pageIndex;
+
+    m_pageLists[listIndex].tail = pageIndex;
+  }
+
+
+  void DxvkPoolAllocator::removePageFromList(uint32_t pageIndex, uint32_t listIndex) {
+    // The list of non-full pages is organized in a double-linked list so
+    // that entries can get removed in constant time whenever a page gets
+    // filled or removed.
+    PageInfo& page = m_pageInfos[pageIndex];
+
+    if (page.prev >= 0)
+      m_pageInfos[page.prev].next = page.next;
+    else
+      m_pageLists[listIndex].head = page.next;
+
+    if (page.next >= 0)
+      m_pageInfos[page.next].prev = page.prev;
+    else
+      m_pageLists[listIndex].tail = page.prev;
+
+    page.prev = -1;
+    page.next = -1;
+  }
+
+
+  uint32_t DxvkPoolAllocator::allocPagePool(uint32_t capacity) {
+    PagePool* pool;
+    uint32_t poolIndex;
+
+    if (unlikely(m_freePool < 0)) {
+      // Allocate new pool as necessary
+      pool = &m_pagePools.emplace_back();
+      pool->subPools.fill(MaskType(-1));
+
+      poolIndex = uint32_t(m_pagePools.size() - 1u);
+    } else {
+      // Otherwise, just use the free list
+      pool = &m_pagePools[m_freePool];
+      poolIndex = std::exchange(m_freePool, pool->nextPool);
+    }
+
+    // Initialize free mask to the correct capacity. Everything
+    // else is assumed to be in its default initialized state.
+    uint32_t maskCount = capacity / MaskBits;
+    pool->freeMask = (1u << maskCount) - 1u;
+    pool->usedMask = 1u;
+    pool->subPools[0] = MaskType(-2);
+    return poolIndex;
+  }
+
+
+  void DxvkPoolAllocator::freePagePool(uint32_t poolIndex) {
+    PagePool* pool = &m_pagePools[poolIndex];
+    pool->nextPool = m_freePool;
+
+    m_freePool = poolIndex;
+  }
+
+
+  uint32_t DxvkPoolAllocator::computeListIndex(uint64_t size) {
+    size = std::max(size, MinSize);
+
+    // Use leading zero count to determine the size category and
+    // basically round up to the next power of two. Pools are
+    // ordered by allocation size in descending order.
+    return bit::lzcnt(uint32_t(size) - 1u) - (33u - DxvkPageAllocator::PageBits);
+  }
+
+
+  uint32_t DxvkPoolAllocator::computePoolCapacity(uint32_t index) {
+    // Number of objects we can allocate in the pool
+    return 2u << index;
+  }
+
+
+  uint64_t DxvkPoolAllocator::computeByteAddress(uint32_t page, uint32_t index, uint32_t list) {
+    uint32_t shift = DxvkPageAllocator::PageBits - 1u - list;
+    return DxvkPageAllocator::PageSize * uint64_t(page) + (index << shift);
+  }
+
+
+  uint32_t DxvkPoolAllocator::computePageIndexFromByteAddress(uint64_t address) {
+    return address / DxvkPageAllocator::PageSize;
+  }
+
+
+  uint32_t DxvkPoolAllocator::computeItemIndexFromByteAddress(uint64_t address, uint32_t list) {
+    uint32_t shift = DxvkPageAllocator::PageBits - 1u - list;
+    return (address & (DxvkPageAllocator::PageSize - 1u)) >> shift;
+  }
+
+}

--- a/src/dxvk/dxvk_allocator.h
+++ b/src/dxvk/dxvk_allocator.h
@@ -1,0 +1,222 @@
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <type_traits>
+#include <vector>
+
+#include "../util/util_env.h"
+
+namespace dxvk {
+
+  /**
+   * \brief Page allocator
+   *
+   * Implements a best-fit allocation strategy for coarse allocations
+   * using an ordered free list. While allocating and freeing memory
+   * are both linear in the worst case, minimum-size allocations can
+   * generally be performed in constant time, with larger allocations
+   * getting gradually slower.
+   */
+  class DxvkPageAllocator {
+
+  public:
+
+    /// Page size. While the allocator interface is fully designed around
+    /// pages, defining a page size is useful for classes built on top of it.
+    constexpr static uint32_t PageBits = 16;
+    constexpr static uint64_t PageSize = 1u << PageBits;
+
+    DxvkPageAllocator(uint64_t capacity);
+
+    ~DxvkPageAllocator();
+
+    /**
+     * \brief Queries number of available pages
+     * \returns Total page count
+     */
+    uint32_t pageCount() const {
+      return m_pageCount;
+    }
+
+    /**
+     * \brief Queries number of allocated pages
+     * \returns \c Used page count
+     */
+    uint32_t pagesUsed() const {
+      return m_pagesUsed;
+    }
+
+    /**
+     * \brief Allocates given number of bytes from the pool
+     *
+     * \param [in] size Allocation size, in bytes
+     * \param [in] alignment Required aligment, in bytes
+     * \returns Allocated byte address
+     */
+    int64_t alloc(uint64_t size, uint64_t alignment);
+
+    /**
+     * \brief Allocates pages
+     *
+     * \param [in] count Number of pages to allocate.
+     *    Must be multiple of \c alignment.
+     * \param [in] alignment Required alignment, in pages
+     * \returns Page index, or -1 if not enough memory
+     *    is available in the chunk.
+     */
+    int32_t allocPages(uint32_t count, uint32_t alignment);
+
+    /**
+     * \brief Frees allocated memory region
+     *
+     * \param [in] address Allocated address, in bytes
+     * \param [in] size Allocation size, in bytes
+     */
+    void free(uint64_t address, uint64_t size);
+
+    /**
+     * \brief Frees pages
+     *
+     * \param [in] index Index of first page to free
+     * \param [in] count Number of pages to free
+     */
+    void freePages(uint32_t index, uint32_t count);
+
+    /**
+     * \brief Queries page allocation mask
+     *
+     * Should be used for informational purposes only. Retrieves
+     * a bit mask where each set bit represents an allocated page,
+     * with the page index corresponding to the page index. The
+     * output array must be sized appropriately.
+     * \param [out] pageMask Page mask
+     */
+    void getPageAllocationMask(uint32_t* pageMask) const;
+
+  private:
+
+    struct PageRange {
+      uint32_t index = 0u;
+      uint32_t count = 0u;
+    };
+
+    uint32_t                m_pageCount = 0u;
+    uint32_t                m_pagesUsed = 0u;
+
+    std::vector<PageRange>  m_freeList;
+    std::vector<int32_t>    m_freeListLutByPage;
+
+    int32_t searchFreeList(uint32_t count);
+
+    void addLutEntry(const PageRange& range, int32_t index);
+
+    void removeLutEntry(const PageRange& range);
+
+    void insertFreeRange(PageRange newRange, int32_t currentIndex);
+
+  };
+
+
+  /**
+   * \brief Pool allocator
+   *
+   * Implements an fast allocator for objects less than the size of one
+   * page. Uses a regular page allocator to allocate backing storage for
+   * each object pool.
+   */
+  class DxvkPoolAllocator {
+    // Use the machine's native word size for bit masks to enable fast paths
+    using MaskType = std::conditional_t<env::is32BitHostPlatform(), uint32_t, uint64_t>;
+
+    constexpr static uint32_t MaskBits = sizeof(MaskType) * 8u;
+
+    constexpr static uint32_t MaxCapacityBits = 8u;
+    constexpr static uint32_t MaxCapacity = 1u << MaxCapacityBits;
+
+    constexpr static uint32_t MasksPerPage = MaxCapacity / MaskBits;
+  public:
+
+    /// Allocation granularity. Smaller allocations are rounded up to
+    /// be at least of this size.
+    constexpr static uint64_t MinSize = DxvkPageAllocator::PageSize >> MaxCapacityBits;
+
+    /// Minimum supported allocation size. Always set to half a page
+    /// so that any pools we manage can at least hold two allocations.
+    constexpr static uint64_t MaxSize = DxvkPageAllocator::PageSize >> 1u;
+
+    DxvkPoolAllocator(DxvkPageAllocator& pageAllocator);
+
+    ~DxvkPoolAllocator();
+
+    /**
+     * \brief Allocates given number of bytes from the pool
+     *
+     * \param [in] size Allocation size, in bytes
+     * \returns Allocated address, in bytes
+     */
+    int64_t alloc(uint64_t size);
+
+    /**
+     * \brief Frees allocated memory region
+     *
+     * \param [in] address Memory address, in bytes
+     * \param [in] size Allocation size, in bytes
+     */
+    void free(uint64_t address, uint64_t size);
+
+  private:
+
+    struct PageList {
+      int32_t   head = -1;
+      int32_t   tail = -1;
+    };
+
+    struct PageInfo {
+      MaskType  pool = 0u;
+      int32_t   prev = -1;
+      int32_t   next = -1;
+    };
+
+    struct PagePool {
+      int32_t   nextPool  = -1;
+      uint16_t  freeMask  = 0u;
+      uint16_t  usedMask  = 0u;
+
+      std::array<MaskType, MasksPerPage> subPools = { };
+    };
+
+    DxvkPageAllocator*      m_pageAllocator = nullptr;
+
+    std::vector<PageInfo>   m_pageInfos;
+    std::vector<PagePool>   m_pagePools;
+    int32_t                 m_freePool = -1;
+
+    std::array<PageList, MaxCapacityBits> m_pageLists = { };
+
+    int32_t allocPage(uint32_t listIndex);
+
+    void freePage(uint32_t pageIndex, uint32_t listIndex);
+
+    void addPageToList(uint32_t pageIndex, uint32_t listIndex);
+
+    void removePageFromList(uint32_t pageIndex, uint32_t listIndex);
+
+    uint32_t allocPagePool(uint32_t capacity);
+
+    void freePagePool(uint32_t poolIndex);
+
+    static uint32_t computeListIndex(uint64_t size);
+
+    static uint32_t computePoolCapacity(uint32_t index);
+
+    static uint64_t computeByteAddress(uint32_t page, uint32_t index, uint32_t list);
+
+    static uint32_t computePageIndexFromByteAddress(uint64_t address);
+
+    static uint32_t computeItemIndexFromByteAddress(uint64_t address, uint32_t list);
+
+  };
+
+}

--- a/src/dxvk/dxvk_buffer.cpp
+++ b/src/dxvk/dxvk_buffer.cpp
@@ -126,24 +126,7 @@ namespace dxvk {
       memoryProperties.dedicated.buffer = handle.buffer;
     }
 
-    // Use high memory priority for GPU-writable resources
-    bool isGpuWritable = (m_info.access & (
-      VK_ACCESS_SHADER_WRITE_BIT |
-      VK_ACCESS_TRANSFORM_FEEDBACK_WRITE_BIT_EXT)) != 0;
-
-    DxvkMemoryFlags hints(DxvkMemoryFlag::GpuReadable);
-
-    if (isGpuWritable)
-      hints.set(DxvkMemoryFlag::GpuWritable);
-
-    // Staging buffers that can't even be used as a transfer destinations
-    // are likely short-lived, so we should put them on a separate memory
-    // pool in order to avoid fragmentation
-    if ((DxvkBarrierSet::getAccessTypes(m_info.access) == DxvkAccess::Read)
-     && (m_info.usage & VK_BUFFER_USAGE_TRANSFER_SRC_BIT))
-      hints.set(DxvkMemoryFlag::Transient);
-
-    handle.memory = m_memAlloc->alloc(memoryRequirements, memoryProperties, hints);
+    handle.memory = m_memAlloc->alloc(memoryRequirements, memoryProperties);
 
     if (!handle.buffer && (!handle.memory.buffer() || (handle.memory.getBufferUsage() & info.usage) != info.usage))
       handle.buffer = createBuffer(info);

--- a/src/dxvk/dxvk_device.cpp
+++ b/src/dxvk/dxvk_device.cpp
@@ -235,6 +235,11 @@ namespace dxvk {
   }
 
 
+  void DxvkDevice::getMemoryAllocationStats(DxvkMemoryAllocationStats& stats) {
+    return m_objects.memoryManager().getAllocationStats(stats);
+  }
+
+
   uint32_t DxvkDevice::getCurrentFrameId() const {
     return m_statCounters.getCtr(DxvkStatCounter::QueuePresentCount);
   }

--- a/src/dxvk/dxvk_device.h
+++ b/src/dxvk/dxvk_device.h
@@ -396,12 +396,20 @@ namespace dxvk {
     DxvkStatCounters getStatCounters();
 
     /**
-     * \brief Retrieves memors statistics
+     * \brief Queries memory statistics
      *
      * \param [in] heap Memory heap index
-     * \returns Memory stats for this heap
+     * \returns Memory usage for this heap
      */
     DxvkMemoryStats getMemoryStats(uint32_t heap);
+
+    /**
+     * \brief Queries detailed memory allocation statistics
+     *
+     * Expensive, should be used with caution.
+     * \param [out] stats Allocation statistics
+     */
+    void getMemoryAllocationStats(DxvkMemoryAllocationStats& stats);
 
     /**
      * \brief Retreves current frame ID

--- a/src/dxvk/dxvk_device.h
+++ b/src/dxvk/dxvk_device.h
@@ -418,27 +418,17 @@ namespace dxvk {
     uint32_t getCurrentFrameId() const;
     
     /**
-     * \brief Notifies adapter about memory allocation
+     * \brief Notifies adapter about memory allocation changes
      *
      * \param [in] heap Memory heap index
-     * \param [in] bytes Allocation size
+     * \param [in] allocated Allocated size delta
+     * \param [in] used Used size delta
      */
-    void notifyMemoryAlloc(
+    void notifyMemoryStats(
             uint32_t            heap,
-            int64_t             bytes) {
-      m_adapter->notifyMemoryAlloc(heap, bytes);
-    }
-
-    /**
-     * \brief Notifies adapter about memory suballocation
-     *
-     * \param [in] heap Memory heap index
-     * \param [in] bytes Allocation size
-     */
-    void notifyMemoryUse(
-            uint32_t            heap,
-            int64_t             bytes) {
-      m_adapter->notifyMemoryUse(heap, bytes);
+            int64_t             allocated,
+            int64_t             used) {
+      m_adapter->notifyMemoryStats(heap, allocated, used);
     }
 
     /**

--- a/src/dxvk/dxvk_image.cpp
+++ b/src/dxvk/dxvk_image.cpp
@@ -97,20 +97,7 @@ namespace dxvk {
         memoryProperties.dedicated.image = m_image.image;
       }
 
-      // Use high memory priority for GPU-writable resources
-      bool isGpuWritable = (m_info.access & (
-        VK_ACCESS_SHADER_WRITE_BIT                  |
-        VK_ACCESS_COLOR_ATTACHMENT_READ_BIT         |
-        VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT        |
-        VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_READ_BIT |
-        VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT)) != 0;
-
-      DxvkMemoryFlags hints(DxvkMemoryFlag::GpuReadable);
-
-      if (isGpuWritable)
-        hints.set(DxvkMemoryFlag::GpuWritable);
-
-      m_image.memory = memAlloc.alloc(memoryRequirements, memoryProperties, hints);
+      m_image.memory = memAlloc.alloc(memoryRequirements, memoryProperties);
 
       // Try to bind the allocated memory slice to the image
       if (m_vkd->vkBindImageMemory(m_vkd->device(), m_image.image,
@@ -140,8 +127,7 @@ namespace dxvk {
         core.size      = SparseMemoryPageSize * properties.metadataPageCount;
         core.alignment = SparseMemoryPageSize;
 
-        m_image.memory = memAlloc.alloc(memoryRequirements,
-          memoryProperties, DxvkMemoryFlag::GpuReadable);
+        m_image.memory = memAlloc.alloc(memoryRequirements, memoryProperties);
       }
     }
   }

--- a/src/dxvk/dxvk_memory.cpp
+++ b/src/dxvk/dxvk_memory.cpp
@@ -68,9 +68,8 @@ namespace dxvk {
           DxvkMemoryType*       type,
           DxvkDeviceMemory      memory)
   : m_alloc(alloc), m_type(type), m_memory(memory),
-    m_pageAllocator(memory.memSize),
     m_poolAllocator(m_pageAllocator) {
-
+    m_pageAllocator.addChunk(memory.memSize);
   }
   
   
@@ -131,19 +130,19 @@ namespace dxvk {
   
   
   bool DxvkMemoryChunk::isEmpty() const {
-    return m_pageAllocator.pagesUsed() == 0u;
+    return m_pageAllocator.pagesUsed(0u) == 0u;
   }
 
 
   void DxvkMemoryChunk::getAllocationStats(DxvkMemoryAllocationStats& stats) const {
     auto& chunkStats = stats.chunks.emplace_back();
-    chunkStats.capacity = uint64_t(m_pageAllocator.pageCount()) * DxvkPageAllocator::PageSize;
-    chunkStats.used = uint64_t(m_pageAllocator.pagesUsed()) * DxvkPageAllocator::PageSize;
+    chunkStats.capacity = uint64_t(m_pageAllocator.pageCount(0u)) * DxvkPageAllocator::PageSize;
+    chunkStats.used = uint64_t(m_pageAllocator.pagesUsed(0u)) * DxvkPageAllocator::PageSize;
     chunkStats.pageMaskOffset = stats.pageMasks.size();
-    chunkStats.pageCount = m_pageAllocator.pageCount();
+    chunkStats.pageCount = m_pageAllocator.pageCount(0u);
 
     stats.pageMasks.resize(chunkStats.pageMaskOffset + (chunkStats.pageCount + 31u) / 32u);
-    m_pageAllocator.getPageAllocationMask(&stats.pageMasks.at(chunkStats.pageMaskOffset));
+    m_pageAllocator.getPageAllocationMask(0u, &stats.pageMasks.at(chunkStats.pageMaskOffset));
   }
 
 

--- a/src/dxvk/dxvk_memory.cpp
+++ b/src/dxvk/dxvk_memory.cpp
@@ -613,6 +613,7 @@ namespace dxvk {
       chunkStats.used = pool.pageAllocator.pagesUsed(i) * DxvkPageAllocator::PageSize;
       chunkStats.pageMaskOffset = stats.pageMasks.size();
       chunkStats.pageCount = pool.pageAllocator.pageCount(i);
+      chunkStats.mapped = &pool == &type.mappedPool;
 
       size_t maskCount = (chunkStats.pageCount + 31u) / 32u;
       stats.pageMasks.resize(chunkStats.pageMaskOffset + maskCount);

--- a/src/dxvk/dxvk_memory.cpp
+++ b/src/dxvk/dxvk_memory.cpp
@@ -531,11 +531,11 @@ namespace dxvk {
       }
 
       // Free chunks that have not been used in some time, but only free
-      // one chunk at a time and keep at least one empty chunk alive.
+      // one chunk per iteration. Reset the timer if we already freed one.
       if (!shouldFree && time != high_resolution_clock::time_point()) {
         if (chunk.unusedTime == high_resolution_clock::time_point() || chunkFreed)
           chunk.unusedTime = time;
-        else if (unusedMemory > chunk.memory.size)
+        else
           shouldFree = time - chunk.unusedTime >= std::chrono::seconds(20);
       }
 

--- a/src/dxvk/dxvk_memory.cpp
+++ b/src/dxvk/dxvk_memory.cpp
@@ -279,6 +279,12 @@ namespace dxvk {
     const void*                 next) {
     auto vk = m_device->vkd();
 
+    // If global buffers are enabled for this allocation, pad the allocation size
+    // to a multiple of the global buffer alignment. This can happen when we create
+    // a dedicated allocation for a large resource.
+    if (type.bufferUsage && !next)
+      size = align(size, GlobalBufferAlignment);
+
     // Preemptively free some unused allocations to reduce memory waste
     freeEmptyChunksInHeap(*type.heap, size, high_resolution_clock::now());
 

--- a/src/dxvk/dxvk_memory.h
+++ b/src/dxvk/dxvk_memory.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "dxvk_adapter.h"
+#include "dxvk_allocator.h"
 
 namespace dxvk {
   
@@ -287,17 +288,13 @@ namespace dxvk {
 
   private:
     
-    struct FreeSlice {
-      VkDeviceSize offset;
-      VkDeviceSize length;
-    };
-    
     DxvkMemoryAllocator*  m_alloc;
     DxvkMemoryType*       m_type;
     DxvkDeviceMemory      m_memory;
     DxvkMemoryFlags       m_hints;
-    
-    std::vector<FreeSlice> m_freeList;
+
+    DxvkPageAllocator     m_pageAllocator;
+    DxvkPoolAllocator     m_poolAllocator;
 
     bool checkHints(DxvkMemoryFlags hints) const;
     

--- a/src/dxvk/dxvk_memory.h
+++ b/src/dxvk/dxvk_memory.h
@@ -335,6 +335,10 @@ namespace dxvk {
 
     constexpr static VkDeviceSize MinChunkSize =   4ull << 20;
     constexpr static VkDeviceSize MaxChunkSize = 256ull << 20;
+
+    // Assume an alignment of 256 bytes. This is enough to satisfy all
+    // buffer use cases, and matches our minimum allocation size.
+    constexpr static VkDeviceSize GlobalBufferAlignment = 256u;
   public:
     
     DxvkMemoryAllocator(DxvkDevice* device);

--- a/src/dxvk/dxvk_memory.h
+++ b/src/dxvk/dxvk_memory.h
@@ -335,8 +335,6 @@ namespace dxvk {
 
     constexpr static VkDeviceSize MinChunkSize =   4ull << 20;
     constexpr static VkDeviceSize MaxChunkSize = 256ull << 20;
-
-    constexpr static VkDeviceSize MinResourcesPerChunk = 4u;
   public:
     
     DxvkMemoryAllocator(DxvkDevice* device);

--- a/src/dxvk/dxvk_memory.h
+++ b/src/dxvk/dxvk_memory.h
@@ -173,9 +173,11 @@ namespace dxvk {
     VkDeviceSize used = 0u;
     /// Index of first page mask belonging to this
     /// chunk in the page mask array
-    size_t pageMaskOffset = 0u;
+    uint32_t pageMaskOffset = 0u;
     /// Number of pages in this chunk.
-    size_t pageCount = 0u;
+    uint16_t pageCount = 0u;
+    /// Whether this chunk is mapped
+    bool mapped = false;
   };
 
 

--- a/src/dxvk/dxvk_memory.h
+++ b/src/dxvk/dxvk_memory.h
@@ -92,6 +92,49 @@ namespace dxvk {
   
   
   /**
+   * \brief Memory type statistics
+   */
+  struct DxvkMemoryTypeStats {
+    /// Memory type properties
+    VkMemoryType properties = { };
+    /// Amount of memory allocated
+    VkDeviceSize allocated = 0u;
+    /// Amount of memory used
+    VkDeviceSize used = 0u;
+    /// First chunk in the array
+    size_t chunkIndex = 0u;
+    /// Number of chunks allocated
+    size_t chunkCount = 0u;
+  };
+
+
+  /**
+   * \brief Chunk statistics
+   */
+  struct DxvkMemoryChunkStats {
+    /// Chunk size, in bytes
+    VkDeviceSize capacity = 0u;
+    /// Used memory, in bytes
+    VkDeviceSize used = 0u;
+    /// Index of first page mask belonging to this
+    /// chunk in the page mask array
+    size_t pageMaskOffset = 0u;
+    /// Number of pages in this chunk.
+    size_t pageCount = 0u;
+  };
+
+
+  /**
+   * \brief Detailed memory allocation statistics
+   */
+  struct DxvkMemoryAllocationStats {
+    std::array<DxvkMemoryTypeStats, VK_MAX_MEMORY_TYPES> memoryTypes = { };
+    std::vector<DxvkMemoryChunkStats> chunks;
+    std::vector<uint32_t> pageMasks;
+  };
+
+
+  /**
    * \brief Memory slice
    * 
    * Represents a slice of memory that has
@@ -260,6 +303,14 @@ namespace dxvk {
      */
     bool isEmpty() const;
 
+    /**
+     * \brief Retrieves allocation stats for this chunk
+     *
+     * Adds overall stats and the page mask to the given structure.
+     * \param [out] stats Allocation stats
+     */
+    void getAllocationStats(DxvkMemoryAllocationStats& stats) const;
+
   private:
     
     DxvkMemoryAllocator*  m_alloc;
@@ -349,6 +400,15 @@ namespace dxvk {
      */
     DxvkMemoryStats getMemoryStats(uint32_t heap) const;
     
+    /**
+     * \brief Retrieves detailed memory statistics
+     *
+     * Queries statistics for each memory type and each allocated chunk.
+     * Can be useful to determine the degree of memory fragmentation.
+     * \param [out] stats Memory statistics
+     */
+    void getAllocationStats(DxvkMemoryAllocationStats& stats);
+
     /**
      * \brief Queries buffer memory requirements
      *

--- a/src/dxvk/dxvk_memory.h
+++ b/src/dxvk/dxvk_memory.h
@@ -64,8 +64,7 @@ namespace dxvk {
    * its properties as well as allocation statistics.
    */
   struct DxvkMemoryHeap {
-    VkMemoryHeap      properties;
-    DxvkMemoryStats   stats;
+    VkMemoryHeap      properties    = { };
   };
 
 
@@ -77,14 +76,16 @@ namespace dxvk {
    * this memory type.
    */
   struct DxvkMemoryType {
-    DxvkMemoryHeap*   heap;
-    uint32_t          heapId;
+    DxvkMemoryHeap*   heap          = nullptr;
+    uint32_t          heapId        = 0u;
 
-    VkMemoryType      memType;
-    uint32_t          memTypeId;
+    VkMemoryType      memType       = { };
+    uint32_t          memTypeId     = 0u;
 
-    VkDeviceSize      chunkSize;
-    VkBufferUsageFlags bufferUsage;
+    DxvkMemoryStats   stats         = { };
+
+    VkDeviceSize      chunkSize     = 0u;
+    VkBufferUsageFlags bufferUsage  = 0u;
 
     std::vector<Rc<DxvkMemoryChunk>> chunks;
   };
@@ -346,9 +347,7 @@ namespace dxvk {
      * \param [in] heap Heap index
      * \returns Memory stats for this heap
      */
-    DxvkMemoryStats getMemoryStats(uint32_t heap) const {
-      return m_memHeaps[heap].stats;
-    }
+    DxvkMemoryStats getMemoryStats(uint32_t heap) const;
     
     /**
      * \brief Queries buffer memory requirements
@@ -427,7 +426,7 @@ namespace dxvk {
       const Rc<DxvkMemoryChunk>&  chunk) const;
 
     bool shouldFreeEmptyChunks(
-      const DxvkMemoryHeap*       heap,
+            uint32_t              heapIndex,
             VkDeviceSize          allocationSize) const;
 
     void freeEmptyChunks(

--- a/src/dxvk/dxvk_sparse.cpp
+++ b/src/dxvk/dxvk_sparse.cpp
@@ -153,9 +153,7 @@ namespace dxvk {
     DxvkMemoryProperties memoryProperties = { };
     memoryProperties.flags = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
 
-    DxvkMemory memory = m_memory->alloc(memoryRequirements,
-      memoryProperties, DxvkMemoryFlag::GpuReadable);
-
+    DxvkMemory memory = m_memory->alloc(memoryRequirements, memoryProperties);
     return new DxvkSparsePage(std::move(memory));
   }
 

--- a/src/dxvk/hud/dxvk_hud.cpp
+++ b/src/dxvk/hud/dxvk_hud.cpp
@@ -51,6 +51,7 @@ namespace dxvk::hud {
     addItem<HudPipelineStatsItem>("pipelines", -1, device);
     addItem<HudDescriptorStatsItem>("descriptors", -1, device);
     addItem<HudMemoryStatsItem>("memory", -1, device);
+    addItem<HudMemoryDetailsItem>("allocations", -1, device);
     addItem<HudCsThreadItem>("cs", -1, device);
     addItem<HudGpuLoadItem>("gpuload", -1, device);
     addItem<HudCompilerActivityItem>("compiler", -1, device);

--- a/src/dxvk/hud/dxvk_hud_item.cpp
+++ b/src/dxvk/hud/dxvk_hud_item.cpp
@@ -825,13 +825,13 @@ namespace dxvk::hud {
     args.size = size;
 
     if (!(memoryType.propertyFlags & VK_MEMORY_HEAP_DEVICE_LOCAL_BIT)) {
-      if (!(memoryType.propertyFlags & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT))
+      if (!stats.mapped)
         args.color = 0xff202020u;
       else if (memoryType.propertyFlags & VK_MEMORY_PROPERTY_HOST_CACHED_BIT)
         args.color = 0xff208020u;
       else
         args.color = 0xff202080u;
-    } else if (memoryType.propertyFlags & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT) {
+    } else if (stats.mapped) {
       args.color = 0xff208080u;
     } else {
       args.color = 0xff804020u;

--- a/src/dxvk/hud/dxvk_hud_item.cpp
+++ b/src/dxvk/hud/dxvk_hud_item.cpp
@@ -1,5 +1,9 @@
 #include "dxvk_hud_item.h"
 
+#include <hud_chunk_frag_background.h>
+#include <hud_chunk_frag_visualize.h>
+#include <hud_chunk_vert.h>
+
 #include <iomanip>
 #include <version.h>
 
@@ -611,6 +615,235 @@ namespace dxvk::hud {
   }
 
 
+
+
+  HudMemoryDetailsItem::HudMemoryDetailsItem(const Rc<DxvkDevice>& device)
+  : m_device(device) {
+    DxvkShaderCreateInfo shaderInfo;
+    shaderInfo.stage = VK_SHADER_STAGE_VERTEX_BIT;
+    shaderInfo.pushConstStages = VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT;
+    shaderInfo.pushConstSize = sizeof(ShaderArgs);
+    shaderInfo.outputMask = 0x1;
+
+    m_vs = new DxvkShader(shaderInfo, SpirvCodeBuffer(hud_chunk_vert));
+
+    shaderInfo.stage = VK_SHADER_STAGE_FRAGMENT_BIT;
+    shaderInfo.outputMask = 0x1;
+
+    m_fsBackground = new DxvkShader(shaderInfo, SpirvCodeBuffer(hud_chunk_frag_background));
+
+    DxvkBindingInfo pageMaskBinding = {
+      VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 0, VK_IMAGE_VIEW_TYPE_MAX_ENUM,
+      VK_SHADER_STAGE_FRAGMENT_BIT, VK_ACCESS_SHADER_READ_BIT };
+
+    shaderInfo.stage = VK_SHADER_STAGE_FRAGMENT_BIT;
+    shaderInfo.bindingCount = 1;
+    shaderInfo.bindings = &pageMaskBinding;
+    shaderInfo.inputMask = 0x1;
+    shaderInfo.outputMask = 0x1;
+
+    m_fsVisualize = new DxvkShader(shaderInfo, SpirvCodeBuffer(hud_chunk_frag_visualize));
+  }
+
+
+  HudMemoryDetailsItem::~HudMemoryDetailsItem() {
+
+  }
+
+
+  void HudMemoryDetailsItem::update(dxvk::high_resolution_clock::time_point time) {
+    m_device->getMemoryAllocationStats(m_stats);
+  }
+
+
+  HudPos HudMemoryDetailsItem::render(
+          HudRenderer&      renderer,
+          HudPos            position) {
+    uploadChunkData(renderer);
+
+    // Chunk memory per type, not including dedicated allocations
+    std::array<VkDeviceSize, VK_MAX_MEMORY_TYPES> chunkMemoryAllocated = { };
+    std::array<VkDeviceSize, VK_MAX_MEMORY_TYPES> chunkMemoryUsed = { };
+
+    // Compute layout, align the entire element to the bottom right.
+    float maxWidth = 556.0f;
+
+    HudPos pos = {
+      float(renderer.surfaceSize().width) / renderer.scale() - 8.0f - maxWidth,
+      float(renderer.surfaceSize().height) / renderer.scale() - 8.0f,
+    };
+
+    for (uint32_t i = 0; i < m_stats.memoryTypes.size(); i++) {
+      const auto& type = m_stats.memoryTypes.at(i);
+
+      if (!type.allocated)
+        continue;
+
+      // Reserve space for one line of text
+      pos.y -= 20.0f;
+
+      float width = 0.0f;
+
+      for (uint32_t j = 0; j < type.chunkCount; j++) {
+        const auto& chunk = m_stats.chunks.at(type.chunkIndex + j);
+        chunkMemoryAllocated.at(i) += chunk.capacity;
+        chunkMemoryUsed.at(i) += chunk.used;
+
+        float pixels = float((chunk.pageCount + 15u) / 16u);
+
+        if (width + pixels > maxWidth) {
+          pos.y -= 30.0f;
+          width = 0.0f;
+        }
+
+        width += pixels + 6.0f;
+      }
+
+      pos.y -= 30.0f + 4.0f;
+    }
+
+    // Actually render the thing
+    for (uint32_t i = 0; i < m_stats.memoryTypes.size(); i++) {
+      const auto& type = m_stats.memoryTypes.at(i);
+
+      if (!type.allocated)
+        continue;
+
+      VkDeviceSize dedicated = type.allocated - chunkMemoryAllocated.at(i);
+      VkDeviceSize allocated = chunkMemoryAllocated.at(i) + dedicated;
+      VkDeviceSize used = chunkMemoryUsed.at(i) + dedicated;
+
+      std::string headline = str::format("Mem type ", i, " [", type.properties.heapIndex, "]: ",
+        type.chunkCount, " chunk", type.chunkCount != 1u ? "s" : "", " (", (allocated >> 20u), " MB, ",
+        ((used >= (1u << 20u)) ? used >> 20 : used >> 10),
+        (used >= (1u << 20u) ? " MB" : " kB"), " used)");
+
+      renderer.drawText(14.0f,
+        { pos.x, pos.y },
+        { 1.0f, 1.0f, 1.0f, 1.0f },
+        headline);
+
+      pos.y += 8.0f;
+
+      float width = 0.0f;
+
+      for (uint32_t j = 0; j < type.chunkCount; j++) {
+        const auto& chunk = m_stats.chunks.at(type.chunkIndex + j);
+        float pixels = float((chunk.pageCount + 15u) / 16u);
+
+        if (width + pixels > maxWidth) {
+          pos.y += 30.0f;
+          width = 0.0f;
+        }
+
+        drawChunk(renderer,
+          { pos.x + width, pos.y },
+          { pixels, 24.0f },
+          type.properties, chunk);
+
+        width += pixels + 6.0f;
+      }
+
+      pos.y += 46.0f;
+    }
+
+    return position;
+  }
+
+
+  void HudMemoryDetailsItem::uploadChunkData(HudRenderer& renderer) {
+    DxvkContext* context = renderer.getContext();
+
+    VkDeviceSize size = sizeof(uint32_t) * m_stats.pageMasks.size();
+
+    if (m_pageMaskBuffer == nullptr || m_pageMaskBuffer->info().size < size) {
+      DxvkBufferCreateInfo info = { };
+      info.size = std::max(VkDeviceSize(1u << 14),
+        (VkDeviceSize(-1) >> bit::lzcnt(size - 1u)) + 1u);
+      info.usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
+      info.access = VK_ACCESS_SHADER_READ_BIT;
+      info.stages = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
+
+      m_pageMaskBuffer = m_device->createBuffer(info,
+        VK_MEMORY_HEAP_DEVICE_LOCAL_BIT |
+        VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT |
+        VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+
+      DxvkBufferViewCreateInfo viewInfo = { };
+      viewInfo.format = VK_FORMAT_UNDEFINED;
+      viewInfo.rangeOffset = 0;
+      viewInfo.rangeLength = info.size;
+      viewInfo.usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
+
+      m_pageMaskView = m_device->createBufferView(m_pageMaskBuffer, viewInfo);
+    }
+
+    if (!m_stats.pageMasks.empty()) {
+      context->invalidateBuffer(m_pageMaskBuffer, m_pageMaskBuffer->allocSlice());
+      std::memcpy(m_pageMaskBuffer->mapPtr(0), &m_stats.pageMasks.at(0), size);
+    }
+  }
+
+
+  void HudMemoryDetailsItem::drawChunk(
+          HudRenderer&      renderer,
+          HudPos            pos,
+          HudPos            size,
+    const VkMemoryType&     memoryType,
+    const DxvkMemoryChunkStats& stats) const {
+    DxvkContext* context = renderer.getContext();
+    VkExtent2D surfaceSize = renderer.surfaceSize();
+
+    static const DxvkInputAssemblyState iaState = {
+      VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP,
+      VK_FALSE, 0 };
+
+    context->setInputAssemblyState(iaState);
+    context->bindResourceBufferView(VK_SHADER_STAGE_FRAGMENT_BIT, 0, Rc<DxvkBufferView>(m_pageMaskView));
+
+    context->bindShader<VK_SHADER_STAGE_VERTEX_BIT>(Rc<DxvkShader>(m_vs));
+    context->bindShader<VK_SHADER_STAGE_FRAGMENT_BIT>(Rc<DxvkShader>(m_fsBackground));
+
+    ShaderArgs args = { };
+    args.pos.x = pos.x - 1.0f;
+    args.pos.y = pos.y - 1.0f;
+    args.size.x = size.x + 2.0f;
+    args.size.y = size.y + 2.0f;
+    args.scale.x = renderer.scale() / std::max(float(surfaceSize.width), 1.0f);
+    args.scale.y = renderer.scale() / std::max(float(surfaceSize.height), 1.0f);
+    args.opacity = renderer.opacity();
+    args.color = 0xc0000000u;
+    args.maskIndex = stats.pageMaskOffset;
+    args.pageCount = stats.pageCount;
+
+    context->pushConstants(0, sizeof(args), &args);
+    context->draw(4, 1, 0, 0);
+
+    context->bindShader<VK_SHADER_STAGE_FRAGMENT_BIT>(Rc<DxvkShader>(m_fsVisualize));
+
+    args.pos = pos;
+    args.size = size;
+
+    if (!(memoryType.propertyFlags & VK_MEMORY_HEAP_DEVICE_LOCAL_BIT)) {
+      if (!(memoryType.propertyFlags & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT))
+        args.color = 0xff202020u;
+      else if (memoryType.propertyFlags & VK_MEMORY_PROPERTY_HOST_CACHED_BIT)
+        args.color = 0xff208020u;
+      else
+        args.color = 0xff202080u;
+    } else if (memoryType.propertyFlags & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT) {
+      args.color = 0xff208080u;
+    } else {
+      args.color = 0xff804020u;
+    }
+
+    context->pushConstants(0, sizeof(args), &args);
+    context->draw(4, 1, 0, 0);
+  }
+
+
+
+
   HudCsThreadItem::HudCsThreadItem(const Rc<DxvkDevice>& device)
   : m_device(device) {
 
@@ -799,7 +1032,7 @@ namespace dxvk::hud {
         string = str::format(string, " (", computePercentage(), "%)");
 
       renderer.drawText(16.0f,
-        { position.x, renderer.surfaceSize().height / renderer.scale() - 20.0f },
+        { position.x, float(renderer.surfaceSize().height) / renderer.scale() - 20.0f },
         { 1.0f, 1.0f, 1.0f, 1.0f },
         string);
     }

--- a/src/dxvk/hud/dxvk_hud_item.h
+++ b/src/dxvk/hud/dxvk_hud_item.h
@@ -391,6 +391,58 @@ namespace dxvk::hud {
 
 
   /**
+   * \brief HUD item to display detailed memory allocation info
+   */
+  class HudMemoryDetailsItem : public HudItem {
+
+  public:
+
+    HudMemoryDetailsItem(const Rc<DxvkDevice>& device);
+
+    ~HudMemoryDetailsItem();
+
+    void update(dxvk::high_resolution_clock::time_point time);
+
+    HudPos render(
+            HudRenderer&      renderer,
+            HudPos            position);
+
+  private:
+
+    struct ShaderArgs {
+      HudPos pos;
+      HudPos size;
+      HudPos scale;
+      float opacity;
+      uint32_t color;
+      uint32_t maskIndex;
+      uint32_t pageCount;
+    };
+
+    Rc<DxvkDevice>                    m_device;
+    DxvkMemoryAllocationStats         m_stats;
+
+    Rc<DxvkShader>      m_vs;
+    Rc<DxvkShader>      m_fsBackground;
+    Rc<DxvkShader>      m_fsVisualize;
+
+    Rc<DxvkBuffer>      m_pageMaskBuffer;
+    Rc<DxvkBufferView>  m_pageMaskView;
+
+    void uploadChunkData(
+            HudRenderer&      renderer);
+
+    void drawChunk(
+            HudRenderer&      renderer,
+            HudPos            pos,
+            HudPos            size,
+      const VkMemoryType&     memoryType,
+      const DxvkMemoryChunkStats& stats) const;
+
+  };
+
+
+  /**
    * \brief HUD item to display CS thread statistics
    */
   class HudCsThreadItem : public HudItem {

--- a/src/dxvk/hud/dxvk_hud_renderer.cpp
+++ b/src/dxvk/hud/dxvk_hud_renderer.cpp
@@ -33,10 +33,10 @@ namespace dxvk::hud {
   
   
   void HudRenderer::beginFrame(
-          const Rc<DxvkContext>& context, 
-          VkExtent2D surfaceSize, 
-          float scale, 
-          float opacity) {
+    const Rc<DxvkContext>&  context,
+          VkExtent2D        surfaceSize, 
+          float             scale, 
+          float             opacity) {
     if (!m_initialized)
       this->initFontTexture(context);
 
@@ -128,7 +128,6 @@ namespace dxvk::hud {
         VK_FALSE, 0 };
       
       m_context->setInputAssemblyState(iaState);
-      m_context->setInputLayout(0, nullptr, 0, nullptr);
     }
   }
 
@@ -147,7 +146,6 @@ namespace dxvk::hud {
         VK_FALSE, 0 };
 
       m_context->setInputAssemblyState(iaState);
-      m_context->setInputLayout(0, nullptr, 0, nullptr);
     }
   }
 

--- a/src/dxvk/hud/dxvk_hud_renderer.h
+++ b/src/dxvk/hud/dxvk_hud_renderer.h
@@ -121,13 +121,22 @@ namespace dxvk::hud {
             HudPos            size,
             size_t            pointCount,
       const HudGraphPoint*    pointData);
-    
+
+    DxvkContext* getContext() {
+      m_mode = Mode::RenderNone;
+      return m_context.ptr();
+    }
+
     VkExtent2D surfaceSize() const {
       return m_surfaceSize;
     }
 
     float scale() const {
       return m_scale;
+    }
+
+    float opacity() const {
+      return m_opacity;
     }
     
   private:

--- a/src/dxvk/hud/shaders/hud_chunk_frag_background.frag
+++ b/src/dxvk/hud/shaders/hud_chunk_frag_background.frag
@@ -1,0 +1,23 @@
+#version 450
+
+#extension GL_GOOGLE_include_directive : require
+
+#include "hud_frag_common.glsl"
+
+layout(location = 0) out vec4 o_color;
+
+layout(push_constant)
+uniform push_data_t {
+  vec2 pos;
+  vec2 size;
+  vec2 scale;
+  float opacity;
+  uint color;
+  uint maskIndex;
+  uint pageCount;
+};
+
+void main() {
+  vec4 rgba = unpackUnorm4x8(color);
+  o_color = vec4(encodeOutput(rgba.rgb), rgba.a * opacity);
+}

--- a/src/dxvk/hud/shaders/hud_chunk_frag_visualize.frag
+++ b/src/dxvk/hud/shaders/hud_chunk_frag_visualize.frag
@@ -1,0 +1,65 @@
+#version 450
+
+#extension GL_GOOGLE_include_directive : require
+
+#include "hud_frag_common.glsl"
+
+layout(location = 0) in  vec2 v_coord;
+layout(location = 0) out vec4 o_color;
+
+layout(binding = 0, std430)
+readonly buffer mask_data_t {
+  uint masks[];
+};
+
+layout(push_constant)
+uniform push_data_t {
+  vec2 pos;
+  vec2 size;
+  vec2 scale;
+  float opacity;
+  uint color;
+  uint maskIndex;
+  uint pageCount;
+};
+
+void main() {
+  vec4 rgba = unpackUnorm4x8(color);
+
+  float dx = dFdx(v_coord.x * float(pageCount)) / 2.0f - 0.5f;
+
+  uvec2 pageRange = uvec2(clamp(
+    (v_coord.xx * float(pageCount)) + vec2(-dx, dx),
+    vec2(0.0), vec2(float(pageCount - 1u))));
+
+  uint bitsTotal = max(pageRange.y - pageRange.x, 1u);
+  uint bitsSet = 0u;
+
+  uint index = pageRange.x / 32u;
+  uint shift = pageRange.x % 32u;
+
+  if (shift + bitsTotal <= 32u) {
+    bitsSet = bitCount(bitfieldExtract(
+      masks[maskIndex + index], int(shift), int(bitsTotal)));
+  } else {
+    bitsSet = bitCount(masks[maskIndex + (index++)] >> shift);
+    uint bitsCounted = 32u - shift;
+
+    while (bitsCounted + 32u <= bitsTotal) {
+      bitsSet += bitCount(masks[maskIndex + (index++)]);
+      bitsCounted += 32u;
+    }
+
+    if (bitsCounted < bitsTotal) {
+      bitsSet += bitCount(bitfieldExtract(
+        masks[maskIndex + (index++)], 0, int(bitsTotal - bitsCounted)));
+    }
+  }
+
+  if (bitsSet == 0u)
+    discard;
+
+  float blendFactor = 0.5f * float(bitsSet) / max(float(bitsTotal), 1.0f);
+  o_color = vec4(mix(rgba.rgb, vec3(1.0f), blendFactor), rgba.a * opacity);
+  o_color.rgb = encodeOutput(o_color.rgb);
+}

--- a/src/dxvk/hud/shaders/hud_chunk_vert.vert
+++ b/src/dxvk/hud/shaders/hud_chunk_vert.vert
@@ -1,0 +1,25 @@
+#version 450
+
+layout(location = 0) out vec2 o_coord;
+
+layout(push_constant)
+uniform push_data_t {
+  vec2 pos;
+  vec2 size;
+  vec2 scale;
+  float opacity;
+  uint color;
+  uint maskIndex;
+  uint pageCount;
+};
+
+void main() {
+  vec2 coord = vec2(
+    float(gl_VertexIndex  & 1),
+    float(gl_VertexIndex >> 1));
+  o_coord = coord;
+
+  vec2 pixel_pos = pos + size * coord;
+  vec2 scaled_pos = 2.0f * scale * pixel_pos - 1.0f;
+  gl_Position = vec4(scaled_pos, 0.0f, 1.0f);
+}

--- a/src/dxvk/meson.build
+++ b/src/dxvk/meson.build
@@ -50,6 +50,10 @@ dxvk_shaders = files([
   'shaders/dxvk_unpack_d24s8.comp',
   'shaders/dxvk_unpack_d32s8.comp',
 
+  'hud/shaders/hud_chunk_frag_background.frag',
+  'hud/shaders/hud_chunk_frag_visualize.frag',
+  'hud/shaders/hud_chunk_vert.vert',
+
   'hud/shaders/hud_graph_frag.frag',
   'hud/shaders/hud_graph_vert.vert',
 

--- a/src/dxvk/meson.build
+++ b/src/dxvk/meson.build
@@ -59,6 +59,7 @@ dxvk_shaders = files([
 
 dxvk_src = [
   'dxvk_adapter.cpp',
+  'dxvk_allocator.cpp',
   'dxvk_barrier.cpp',
   'dxvk_buffer.cpp',
   'dxvk_cmdlist.cpp',

--- a/src/util/util_bit.h
+++ b/src/util/util_bit.h
@@ -152,6 +152,18 @@ namespace dxvk::bit {
     #endif
   }
 
+  inline uint32_t lzcnt(uint64_t n) {
+    #if defined(DXVK_ARCH_X86_64) && ((defined(_MSC_VER) && !defined(__clang__)) || defined(__LZCNT__))
+    return _lzcnt_u64(n);
+    #elif defined(DXVK_ARCH_X86_64) && (defined(__GNUC__) || defined(__clang__))
+    return n != 0 ? __builtin_clzll(n) : 64;
+    #else
+    uint32_t lo = uint32_t(n);
+    uint32_t hi = uint32_t(n >> 32u);
+    return hi ? lzcnt(hi) : lzcnt(lo) + 32u;
+    #endif
+  }
+
   template<typename T>
   uint32_t pack(T& dst, uint32_t& shift, T src, uint32_t count) {
     constexpr uint32_t Bits = 8 * sizeof(T);


### PR DESCRIPTION
First part of a massive rework. Not going to merge this until after 2.4.1, and this needs a lot of testing anyway, especially on Nvidia and in more memory-constrained scenarios.

## The problem
Currently, DXVK allocates video memory in chunks of up to 256 MiB, and uses an extremely basic per-chunk free list to allocate memory, employing a worst-fit strategy to suballocate memory from those chunks. The original reasoning here was that worst-fit tends to perform quite well with allocations of more or less the same size with respect to external fragmentation, and texture allocations generally satisfy that criterium.

However, this approach does come with drawbacks:
- The runtime complexity for **any** allocation is `O(n)`, with `n` being the total number of free ranges in all chunks of a memory type. Even serving small allocations can be slow in practice.
- Images generally have stricter alignment requirements than buffers. Satisfying those requirements when buffers and images are allocated from the same chunk can lead to extremely tiny free list entries, making the runtime issue worse.
- When there are lots of small allocations (e.g. buffers), worst-fit has the nasty tendency to subdivide chunks into equally sized partitions that may end up too small to service a larger texture allocation. We worked around this by creating separate chunks for small allocations, but this increases overall memory waste.

## The new allocator
We still use ≤256 MiB chunks, however the way we use this memory has completely changed:
- Instead of a per-chunk free list, we now have a global free list that includes **all** chunks allocated from each Vulkan memory type. Entries in this free list are ordered by size in descending order.
- The free list opetates at a 64 kiB granularity. This size was chosen because it satisfies the alignment requirement of most texture resources on current hardware, and allows us to use fast look-up tables with negligible system memory overhead.
- We use a best-fit allocation strategy to reduce external fragmentation. This tends to leave larger free areas available for larger texture resources while smaller buffers can fill in any gaps, and also leaves any empty chunk unused until it is either destroyed or required for an allocation.
- Allocations up to 32 kiB are padded to a power-of-two size and are serviced by a pool allocator, which itself operates on 64 kiB pages taken from the free list allocator. This comes at the cost of some internal fragmentation, but is very fast, which is important e.g. for D3D11 constant buffers.
- Separate chunk types are no longer used, which significantly reduces the amount of unused memory.

This new approach generally allows small allocations up to 64 kiB to be serviced in `O(1)` time, with a worst-case complexity of `O(n)` for larger allocations. Freeing memory is also `O(n)`, however in practice, the actual number of operations performed scales with allocation size in both cases.

## The new HUD item

`DXVK_HUD=allocations` was added to visualize suballocation behaviour. Note that the numbers may not match up with what the `memory` item shows, since this new item only accounts for chunk allocations, is based on Vulkan memory types rather than heaps, and counts allocated 64k pages rather than using an exact amount.

![Bildschirmfoto-661](https://github.com/user-attachments/assets/3456455b-201f-464c-b757-7c9888749f98)
*God of War (2018) after teleporting to various areas and running around a bunch* 

## Future plans
While the new allocator should already improve memory usage, the main motivation for this change is to allow more dynamic memory management in the future and finally fix issues such as #4118, or excessive HVV usage in Shadow of the Tomb Raider. Currently, we try to avoid frequent memory allocations due to performance concerns, but with the new allocator this should no longer ne necessary.

Another issue we should finally solve is related to buffer allocation lifetimes on Deferred Contexts. DXVK's default behaviour is technically incorrect and only happens to work in most games, with the `d3d11.dcSingleUseMode` option enabling a more correct but slow code path that is required for games which submit a D3D11 command list multiple times. The goal is to remove that option and support behaviour that is both correct and fast.

In the long term, the plan is to implement memory defragmentation and resource relocation to avoid slowdowns under memory pressure, but also to support use cases such as `DXGI_SWAP_EFFECT[_FLIP]_SEQUENTIAL`. Currently, the latter is unsupported because we cannot "rename" image resources. However, resource management will largely have to be rewritten as well for this to become possible.