### PR TITLE
[d3d8] GetInfo rework and various assorted fixes

### DIFF
--- a/src/d3d8/d3d8_device.cpp
+++ b/src/d3d8/d3d8_device.cpp
@@ -528,10 +528,6 @@ namespace dxvk {
     HRESULT res = D3D_OK;
     D3DLOCKED_RECT srcLocked, dstLocked;
 
-    // CopyRects cannot perform format conversions.
-    if (srcDesc.Format != dstDesc.Format)
-      return D3DERR_INVALIDCALL;
-
     bool compressed = isDXT(srcDesc.Format);
 
     res = src->LockRect(&srcLocked, &srcRect, D3DLOCK_READONLY);
@@ -647,10 +643,8 @@ namespace dxvk {
 
     // This method cannot be applied to surfaces whose formats
     // are classified as depth stencil formats.
-    if (unlikely(isDepthStencilFormat(D3DFORMAT(srcDesc.Format)) ||
-                 isDepthStencilFormat(D3DFORMAT(dstDesc.Format)))) {
+    if (unlikely(isDepthStencilFormat(D3DFORMAT(srcDesc.Format))))
       return D3DERR_INVALIDCALL;
-    }
 
     StateChange();
 

--- a/src/d3d8/d3d8_device.cpp
+++ b/src/d3d8/d3d8_device.cpp
@@ -18,7 +18,7 @@ namespace dxvk {
 
   static constexpr DWORD getShaderIndex(DWORD Handle) {
     if ((Handle & D3DFVF_RESERVED0) != 0) {
-      return (Handle & ~(D3DFVF_RESERVED0)) >> 1;
+      return ((Handle & ~(D3DFVF_RESERVED0)) >> 1) - 1;
     } else {
       return Handle;
     }
@@ -1648,7 +1648,7 @@ namespace dxvk {
 
     if (likely(SUCCEEDED(res))) {
       // Set bit to indicate this is not an FVF
-      *pHandle = getShaderHandle(m_vertexShaders.size() - 1);
+      *pHandle = getShaderHandle(m_vertexShaders.size());
     }
 
     return res;
@@ -1849,7 +1849,7 @@ namespace dxvk {
     if (likely(SUCCEEDED(res))) {
       m_pixelShaders.push_back(pPixelShader);
       // Still set the shader bit, to prevent conflicts with NULL.
-      *pHandle = getShaderHandle(m_pixelShaders.size() - 1);
+      *pHandle = getShaderHandle(m_pixelShaders.size());
     }
 
     return res;

--- a/src/d3d8/d3d8_device.cpp
+++ b/src/d3d8/d3d8_device.cpp
@@ -106,11 +106,12 @@ namespace dxvk {
         }
 
         break;
-      case D3DDEVINFOID_RESOURCEMANAGER:
-        // May not be implemented by D9VK.
+
+      case D3DDEVINFOID_RESOURCEMANAGER: // Not yet implemented by D9VK.
         res = GetD3D9()->CreateQuery(d3d9::D3DQUERYTYPE_RESOURCEMANAGER, &pQuery);
         break;
-      case D3DDEVINFOID_VERTEXSTATS:
+
+      case D3DDEVINFOID_VERTEXSTATS: // Not yet implemented by D9VK.
         res = GetD3D9()->CreateQuery(d3d9::D3DQUERYTYPE_VERTEXSTATS, &pQuery);
         break;
 
@@ -119,26 +120,20 @@ namespace dxvk {
         return E_FAIL;
     }
 
-    if (unlikely(FAILED(res)))
-      goto done;
-    
-    // Immediately issue the query.
-    // D3D9 will begin it automatically before ending.
-    res = pQuery->Issue(D3DISSUE_END);
-    if (unlikely(FAILED(res))) {
-      goto done;
-    }
-
-    // TODO: Will immediately issuing the query without doing any API calls
-    // actually yield meaingful results? And should we flush or let it mellow?
-    res = pQuery->GetData(pDevInfoStruct, DevInfoStructSize, D3DGETDATA_FLUSH);
-
-  done:
-    if (unlikely(FAILED(res))) {
+    if (FAILED(res)) {
       if (res == D3DERR_NOTAVAILABLE) // unsupported
         return E_FAIL;
       else // any unknown error
         return S_FALSE;
+    }
+
+    if (pQuery != nullptr) {
+      // Immediately issue the query. D3D9 will begin it automatically before ending.
+      pQuery->Issue(D3DISSUE_END);
+      // TODO: Will immediately issuing the query actually yield meaingful results?
+      // Only relevant once RESOURCEMANAGER or VERTEXSTATS are implemented by D9VK,
+      // since VCACHE queries will immediately return data during this call.
+      res = pQuery->GetData(pDevInfoStruct, DevInfoStructSize, D3DGETDATA_FLUSH);
     }
 
     return res;

--- a/src/d3d8/d3d8_device.h
+++ b/src/d3d8/d3d8_device.h
@@ -405,9 +405,11 @@ namespace dxvk {
         m_backBuffers[i] = new D3D8Surface(this, std::move(pSurface9));
       }
 
-      Com<d3d9::IDirect3DSurface9> pStencil9 = nullptr;
-      GetD3D9()->GetDepthStencilSurface(&pStencil9);
-      m_autoDepthStencil = new D3D8Surface(this, std::move(pStencil9));
+      Com<d3d9::IDirect3DSurface9> pStencil9;
+      // This call will fail if the D3D9 device is created without
+      // the EnableAutoDepthStencil presentation parameter set to TRUE.
+      HRESULT res = GetD3D9()->GetDepthStencilSurface(&pStencil9);
+      m_autoDepthStencil = FAILED(res) ? nullptr : new D3D8Surface(this, std::move(pStencil9));
 
       m_renderTarget = m_backBuffers[0];
       m_depthStencil = m_autoDepthStencil;

--- a/src/d3d9/d3d9_common_texture.cpp
+++ b/src/d3d9/d3d9_common_texture.cpp
@@ -19,7 +19,7 @@ namespace dxvk {
     : m_device(pDevice), m_desc(*pDesc), m_type(ResourceType), m_d3d9Interop(pInterface, this) {
     if (m_desc.Format == D3D9Format::Unknown)
       m_desc.Format = (m_desc.Usage & D3DUSAGE_DEPTHSTENCIL)
-                    ? D3D9Format::D32
+                    ? D3D9Format::D24X8
                     : D3D9Format::X8R8G8B8;
 
     m_exposedMipLevels = m_desc.MipLevels;


### PR DESCRIPTION
I've reworked our implementation of GetInfo() to more closely follow what d9vk is doing, namely:
- `pQuery->Issue()` will never fail in d9vk (and even if can fail according to spec, we shouldn't care much, as `pQuery->GetData()` would also then fail).
- `D3DDEVINFOID_RESOURCEMANAGER` and `D3DDEVINFOID_VERTEXSTATS`, though technically supported by d3d8 are not implemented in d9vk. D3D9's `CreateQuery()` will always return `D3DERR_NOTAVAILABLE` for both as it stands, thus we shouldn't really speculate on the outcome (removed the "unlikely" hint).
- According to specs, D3D9 `GetData()` should always be called with `D3DGETDATA_FLUSH` for the queries that D3D8 supports.
- D3D9 `GetData()` returns are inline with what `GetInfo()` should return if it reaches that point.

The above allows us to get rid of the goto and restructure the flow a bit.

Also as part of this PR I've changed some `CopyRects` behavior:
- removed format difference check from `copyTextureBuffers`, since this is now done globally on `CopyRects` calls, as per spec.
- `CopyRects` depth stencil checks are done after the format difference checks, so there's no need to check both src and dest.
