### PR TITLE
[dxgi] Delay qualifying foreground loss as occlusion

### DIFF
--- a/src/wsi/win32/wsi_platform_win32.h
+++ b/src/wsi/win32/wsi_platform_win32.h
@@ -7,6 +7,9 @@
 namespace dxvk::wsi {
 
   class Win32WsiDriver : public WsiDriver {
+  private:
+    uint64_t m_lastForegroundTimestamp = 0;
+
   public:
     // Platform
     virtual std::vector<const char *> getInstanceExtensions();

--- a/src/wsi/win32/wsi_window_win32.cpp
+++ b/src/wsi/win32/wsi_window_win32.cpp
@@ -193,6 +193,7 @@ namespace dxvk::wsi {
       rect.left, rect.top, rect.right - rect.left, rect.bottom - rect.top,
       SWP_FRAMECHANGED | SWP_SHOWWINDOW | SWP_NOACTIVATE);
 
+    m_lastForegroundTimestamp = 0;
     return true;
   }
 
@@ -260,7 +261,12 @@ namespace dxvk::wsi {
 
 
   bool Win32WsiDriver::isOccluded(HWND hWindow) {
-    return ::GetForegroundWindow() != hWindow;
+    if (::GetForegroundWindow() == hWindow)
+    {
+      m_lastForegroundTimestamp = GetTickCount64();
+      return false;
+    }
+    return m_lastForegroundTimestamp && GetTickCount64() - m_lastForegroundTimestamp > 100;
   }
 
 


### PR DESCRIPTION
That fixes a regression with Yakuza 0 introduced by commit ed9ffa6584dfb49a630df4d8cd7ec7fe29b1f23b (after which commit the game hangs with black screen on start).

There are actually two manifestations of essentially the same problem. 

1. The initial hang on start happens after the game sets fullscreen mode through dxgi and then calls GetFullscreenState which kicks off fullscreen state and retuns no fullscreen status. This is unexpected, game seems to refuse to do anything after this. What happens here is that the game didn't make the window visible yet before SetFullscreenState, it is only becoming visible in the course of configuring fullscreen mode (here on Windows WS_VISIBLE attributed is still not set while window is fullscreen and visible, but this is unrelated and unfixable in dxvk in isolation). The process of window gaining focus has some delay. Window manager ultimately controls the focus, so Wine doesn't make a window foreground for WINAPI until WM sends corresponding X events. That doesn't happen immediately and the delay may be quite big until the window is fully mapped, displayed and only then we get a focus event and mark the window as foreground. So GetFullscreenState called right after SetFullscreenState sees that the window is not foreground and kicks off fullscreen mode. If solving just initial fullscreen setting (by checking that our window ever had focus at all before concuding that it is occluded) fixes the hang on start, but then at any alt tab the same happens: after kicking off fullscreen the game seems very unhappy and refuses to do any presentation or window management.
2. How the game is supposed to work, is that upon receiving WM_KILLFOCUS it sets windowed mode itself and minimizes the window. WM_KILLFOCUS is apparently supposed to arrive before GetFullscreenState() will kick off fullscreen mode. I think here plays the role that using GetForegroundWindow for detecting "occlusion" status is a workaround, some delays for focusing events may also affect this sequence. I doubt it is possible to fully correctly solve without having Windows-like WSI and window management not intergating host's native WM.

The added delay to react on foreground loss should hopefully solve the issues with transition process in p. 2. A separate check for yet-nevet-foreground window is still needed for p. 1., ~100ms may be by far not enough for that process to settle at list in this case when the window is getting mapped during fullscreening.