### PR TITLE
[d3d9] Implement a software cursor

### DIFF
--- a/src/d3d9/d3d9_cursor.cpp
+++ b/src/d3d9/d3d9_cursor.cpp
@@ -40,6 +40,10 @@ namespace dxvk {
 
 
   BOOL D3D9Cursor::ShowCursor(BOOL bShow) {
+    // Cursor visibility remains unchanged (typically FALSE) if the cursor isn't set.
+    if (unlikely(m_hCursor == nullptr && m_sCursor.Width == 0 && m_sCursor.Height == 0))
+      return m_visible;
+
     if (likely(m_hCursor != nullptr))
       ::SetCursor(bShow ? m_hCursor : nullptr);
     

--- a/src/d3d9/d3d9_cursor.cpp
+++ b/src/d3d9/d3d9_cursor.cpp
@@ -6,6 +6,21 @@
 namespace dxvk {
 
 #ifdef _WIN32
+  void D3D9Cursor::ResetCursor() {
+    ShowCursor(FALSE);
+
+    if (likely(m_hCursor != nullptr)) {
+      ::DestroyCursor(m_hCursor);
+      m_hCursor = nullptr;
+    } else {
+      m_sCursor.Width = 0;
+      m_sCursor.Height = 0;
+      m_sCursor.X = 0;
+      m_sCursor.Y = 0;
+    }
+  }
+
+
   void D3D9Cursor::UpdateCursor(int X, int Y) {
     POINT currentPos = { };
     if (::GetCursorPos(&currentPos) && currentPos == POINT{ X, Y })
@@ -15,17 +30,31 @@ namespace dxvk {
   }
 
 
+  void D3D9Cursor::RefreshSoftwareCursorPosition() {
+    POINT currentPos = { };
+    ::GetCursorPos(&currentPos);
+
+    m_sCursor.X = static_cast<UINT>(currentPos.x);
+    m_sCursor.Y = static_cast<UINT>(currentPos.y);
+  }
+
+
   BOOL D3D9Cursor::ShowCursor(BOOL bShow) {
     if (likely(m_hCursor != nullptr))
       ::SetCursor(bShow ? m_hCursor : nullptr);
-    else
-      Logger::debug("D3D9Cursor::ShowCursor: Software cursor not implemented.");
     
     return std::exchange(m_visible, bShow);
   }
 
 
   HRESULT D3D9Cursor::SetHardwareCursor(UINT XHotSpot, UINT YHotSpot, const CursorBitmap& bitmap) {
+    if (unlikely(IsSoftwareCursor())) {
+      m_sCursor.Width = 0;
+      m_sCursor.Height = 0;
+      m_sCursor.X = 0;
+      m_sCursor.Y = 0;
+    }
+
     CursorMask mask;
     std::memset(mask, ~0, sizeof(mask));
 
@@ -48,9 +77,40 @@ namespace dxvk {
 
     return D3D_OK;
   }
+
+
+  HRESULT D3D9Cursor::SetSoftwareCursor(UINT Width, UINT Height, UINT XHotSpot, UINT YHotSpot) {
+    // Make sure to hide the win32 cursor
+    ::SetCursor(nullptr);
+
+    if (unlikely(m_hCursor != nullptr)) {
+      ::DestroyCursor(m_hCursor);
+      m_hCursor = nullptr;
+    }
+
+    m_sCursor.Width  = Width;
+    m_sCursor.Height = Height;
+    m_sCursor.X      = XHotSpot;
+    m_sCursor.Y      = YHotSpot;
+
+    ShowCursor(m_visible);
+
+    return D3D_OK;
+  }
+
 #else
+  void D3D9Cursor::ResetCursor() {
+    Logger::warn("D3D9Cursor::ResetCursor: Not supported on current platform.");
+  }
+
+
   void D3D9Cursor::UpdateCursor(int X, int Y) {
     Logger::warn("D3D9Cursor::UpdateCursor: Not supported on current platform.");
+  }
+
+
+  void D3D9Cursor::RefreshSoftwareCursorPosition() {
+    Logger::warn("D3D9Cursor::RefreshSoftwareCursorPosition: Not supported on current platform.");
   }
 
 
@@ -62,6 +122,12 @@ namespace dxvk {
 
   HRESULT D3D9Cursor::SetHardwareCursor(UINT XHotSpot, UINT YHotSpot, const CursorBitmap& bitmap) {
     Logger::warn("D3D9Cursor::SetHardwareCursor: Not supported on current platform.");
+
+    return D3D_OK;
+  }
+
+  HRESULT D3D9Cursor::SetSoftwareCursor(UINT Width, UINT Height, UINT XHotSpot, UINT YHotSpot) {
+    Logger::warn("D3D9Cursor::SetSoftwareCursor: Not supported on current platform.");
 
     return D3D_OK;
   }

--- a/src/d3d9/d3d9_cursor.h
+++ b/src/d3d9/d3d9_cursor.h
@@ -4,15 +4,25 @@
 
 namespace dxvk {
 
-  constexpr uint32_t HardwareCursorWidth     = 32u;
-  constexpr uint32_t HardwareCursorHeight    = 32u;
+  /**
+   * \brief D3D9 Software Cursor
+   */
+  struct D3D9_SOFTWARE_CURSOR {
+    UINT Width = 0;
+    UINT Height = 0;
+    UINT X = 0;
+    UINT Y = 0;
+  };
+
+  constexpr uint32_t HardwareCursorWidth      = 32u;
+  constexpr uint32_t HardwareCursorHeight     = 32u;
   constexpr uint32_t HardwareCursorFormatSize = 4u;
   constexpr uint32_t HardwareCursorPitch      = HardwareCursorWidth * HardwareCursorFormatSize;
 
   // Format Size of 4 bytes (ARGB)
   using CursorBitmap = uint8_t[HardwareCursorHeight * HardwareCursorPitch];
   // Monochrome mask (1 bit)
-  using CursorMask = uint8_t[HardwareCursorHeight * HardwareCursorWidth / 8];
+  using CursorMask   = uint8_t[HardwareCursorHeight * HardwareCursorWidth / 8];
 
   class D3D9Cursor {
 
@@ -25,18 +35,37 @@ namespace dxvk {
     }
 #endif
 
+    void ResetCursor();
+
     void UpdateCursor(int X, int Y);
+
+    void RefreshSoftwareCursorPosition();
 
     BOOL ShowCursor(BOOL bShow);
 
     HRESULT SetHardwareCursor(UINT XHotSpot, UINT YHotSpot, const CursorBitmap& bitmap);
 
+    HRESULT SetSoftwareCursor(UINT Width, UINT Height, UINT XHotSpot, UINT YHotSpot);
+
+    D3D9_SOFTWARE_CURSOR* GetSoftwareCursor() {
+      return &m_sCursor;
+    }
+
+    BOOL IsSoftwareCursor() const {
+      return m_sCursor.Width > 0 && m_sCursor.Height > 0;
+    }
+
+    BOOL IsCursorVisible() const {
+      return m_visible;
+    }
+
   private:
 
-    BOOL    m_visible       = FALSE;
+    BOOL                  m_visible   = FALSE;
+    D3D9_SOFTWARE_CURSOR  m_sCursor;
 
 #ifdef _WIN32
-    HCURSOR m_hCursor       = nullptr;
+    HCURSOR               m_hCursor   = nullptr;
 #endif
 
   };

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -345,9 +345,19 @@ namespace dxvk {
     uint32_t inputWidth  = cursorTex->Desc()->Width;
     uint32_t inputHeight = cursorTex->Desc()->Height;
 
-    // Always use a hardware cursor when windowed.
+    // Check if surface dimensions are powers of two.
+    if ((inputWidth  && (inputWidth  & (inputWidth  - 1)))
+     || (inputHeight && (inputHeight & (inputHeight - 1))))
+      return D3DERR_INVALIDCALL;
+
     D3DPRESENT_PARAMETERS params;
     m_implicitSwapchain->GetPresentParameters(&params);
+
+    if (inputWidth  > params.BackBufferWidth
+     || inputHeight > params.BackBufferHeight)
+      return D3DERR_INVALIDCALL;
+
+    // Always use a hardware cursor when windowed.
     bool hwCursor  = params.Windowed;
 
     // Always use a hardware cursor w/h <= 32 px

--- a/src/d3d9/d3d9_swapchain.cpp
+++ b/src/d3d9/d3d9_swapchain.cpp
@@ -748,6 +748,32 @@ namespace dxvk {
   }
 
 
+  void D3D9SwapChainEx::SetCursorTexture(UINT Width, UINT Height, uint8_t* pCursorBitmap) {
+      VkExtent2D cursorSize = { uint32_t(Width), uint32_t(Height) };
+
+      m_blitter->setCursorTexture(
+        cursorSize,
+        VK_FORMAT_B8G8R8A8_UNORM,
+        (void *) pCursorBitmap);
+  }
+
+
+  void D3D9SwapChainEx::SetCursorPosition(UINT X, UINT Y, UINT Width, UINT Height) {
+      VkOffset2D cursorPosition = { int32_t(X), int32_t(Y) };
+      VkExtent2D cursorSize     = { uint32_t(Width), uint32_t(Height) };
+
+      VkRect2D   cursorRect     = { cursorPosition, cursorSize };
+
+      m_parent->EmitCs([
+        cBlitter = m_blitter,
+        cRect    = cursorRect
+      ] (DxvkContext* ctx) {
+        cBlitter->setCursorPos(
+          cRect);
+      });
+  }
+
+
   HRESULT D3D9SwapChainEx::SetDialogBoxMode(bool bEnableDialogs) {
     D3D9DeviceLock lock = m_parent->LockDevice();
 

--- a/src/d3d9/d3d9_swapchain.h
+++ b/src/d3d9/d3d9_swapchain.h
@@ -118,6 +118,10 @@ namespace dxvk {
 
     void    Invalidate(HWND hWindow);
 
+    void SetCursorTexture(UINT Width, UINT Height, uint8_t* pCursorBitmap);
+
+    void SetCursorPosition(UINT X, UINT Y, UINT Width, UINT Height);
+
     HRESULT SetDialogBoxMode(bool bEnableDialogs);
 
     D3D9Surface* GetBackBuffer(UINT iBackBuffer);


### PR DESCRIPTION
Probably not an entirely sound approach, but it's a start. I believe we'll actually need to draw the cursor onto the final image ourselves, before the HUD. Some processing on the cursor bitmap surface that a game provides also needs to be done, because it needs to be trimmed to the bounding dimensions of pixels that contain color data and then blended.

I'm fine if @K0bin wants to pick up and reuse some of what I've done here, since the `d3d9_cursor.cpp/h` additions should be sound.

As is, the implementation is fully functional and sets/shows/hides a software cursor properly. However, the cursor surface is very unceremoniously sent onto the final backbuffer using StretchRect(). I had sort of hoped that would simply work, but alas.

As always, Dungeon Siege 2 is the game to test this with. (Fixes #3020).