### PR TITLE
[dxvk] Fix HUD memory chunk colors on UMA

### DIFF
--- a/src/dxvk/hud/dxvk_hud_item.cpp
+++ b/src/dxvk/hud/dxvk_hud_item.cpp
@@ -846,11 +846,11 @@ namespace dxvk::hud {
     args.pos = pos;
     args.size = size;
 
-    if (!(memoryType.propertyFlags & VK_MEMORY_HEAP_DEVICE_LOCAL_BIT)) {
+    if (memoryType.propertyFlags & VK_MEMORY_PROPERTY_HOST_CACHED_BIT) {
+        args.color = 0xff208020u;
+    } else if (!(memoryType.propertyFlags & VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT)) {
       if (!stats.mapped)
         args.color = 0xff202020u;
-      else if (memoryType.propertyFlags & VK_MEMORY_PROPERTY_HOST_CACHED_BIT)
-        args.color = 0xff208020u;
       else
         args.color = 0xff202080u;
     } else if (stats.mapped) {


### PR DESCRIPTION
Correctly colors CACHED memory on UMA as well. Also fixed a VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT derp.