### PR TITLE
Memory budget stuff

### DIFF
--- a/src/dxvk/dxvk_memory.cpp
+++ b/src/dxvk/dxvk_memory.cpp
@@ -1665,6 +1665,7 @@ namespace dxvk {
       result.memoryUsed += type.stats.memoryUsed;
     }
 
+    result.memoryBudget = m_memHeaps[heap].memoryBudget;
     return result;
   }
 

--- a/src/dxvk/dxvk_memory.h
+++ b/src/dxvk/dxvk_memory.h
@@ -36,6 +36,7 @@ namespace dxvk {
   struct DxvkMemoryStats {
     VkDeviceSize memoryAllocated = 0;
     VkDeviceSize memoryUsed      = 0;
+    VkDeviceSize memoryBudget    = 0;
   };
 
 

--- a/src/dxvk/dxvk_memory.h
+++ b/src/dxvk/dxvk_memory.h
@@ -138,6 +138,7 @@ namespace dxvk {
   struct DxvkMemoryHeap {
     uint32_t          index         = 0u;
     uint32_t          memoryTypes   = 0u;
+    VkDeviceSize      memoryBudget  = 0u;
     VkMemoryHeap      properties    = { };
   };
 
@@ -1238,6 +1239,8 @@ namespace dxvk {
 
     uint32_t findGlobalBufferMemoryTypeMask(
             VkBufferUsageFlags    usage) const;
+
+    void updateMemoryHeapBudgets();
 
     void runWorker();
 

--- a/src/dxvk/hud/dxvk_hud_item.cpp
+++ b/src/dxvk/hud/dxvk_hud_item.cpp
@@ -591,7 +591,9 @@ namespace dxvk::hud {
 
       uint64_t memUsedMib = m_heaps[i].memoryUsed >> 20;
       uint64_t memAllocatedMib = m_heaps[i].memoryAllocated >> 20;
-      uint64_t percentage = (100 * m_heaps[i].memoryAllocated) / m_memory.memoryHeaps[i].size;
+      uint64_t percentage = m_heaps[i].memoryBudget
+        ? (100u * m_heaps[i].memoryAllocated) / m_heaps[i].memoryBudget
+        : 0u;
 
       std::string label = str::format(isDeviceLocal ? "Vidmem" : "Sysmem", " heap ", i, ": ");
       std::string text  = str::format(std::setfill(' '), std::setw(5), memAllocatedMib, " MB (", percentage, "%) ",


### PR DESCRIPTION
Does two very simple things:
- decide whether to nuke empty chunks based on the budget rather than heap size,
- show the used memory percetage relative to the reported budget too.

Not too interesting right now, but I want to use this to work out how useful the budget value actually is for decision making on different platforms / drivers, especially on Deck.