### PR TITLE
[d3d8] Various Wine state block tests fixes

### DIFF
--- a/src/d3d8/d3d8_device.cpp
+++ b/src/d3d8/d3d8_device.cpp
@@ -53,6 +53,9 @@ namespace dxvk {
 
     m_bridge->SetAPIName("D3D8");
     m_bridge->SetD3D8CompatibilityMode(true);
+    // The default value of D3DRS_POINTSIZE_MIN in D3D8 is 0.0f,
+    // whereas it's initialized to 1.0f in D3D9 by default
+    GetD3D9()->SetRenderState(d3d9::D3DRS_POINTSIZE_MIN, bit::cast<DWORD>(0.0f));
 
     ResetState();
     RecreateBackBuffersAndAutoDepthStencil();

--- a/src/d3d8/d3d8_device.cpp
+++ b/src/d3d8/d3d8_device.cpp
@@ -1089,10 +1089,13 @@ namespace dxvk {
 
     if (likely(SUCCEEDED(res))) {
       m_token++;
-      m_stateBlocks.emplace(std::piecewise_construct,
-                            std::forward_as_tuple(m_token),
-                            std::forward_as_tuple(this, Type, pStateBlock9.ref()));
+      auto stateBlockIterPair = m_stateBlocks.emplace(std::piecewise_construct,
+                                                      std::forward_as_tuple(m_token),
+                                                      std::forward_as_tuple(this, Type, pStateBlock9.ref()));
       *pToken = m_token;
+
+      // D3D8 state blocks automatically capture state on creation.
+      stateBlockIterPair.first->second.Capture();
     }
 
     return res;

--- a/src/d3d8/d3d8_device.cpp
+++ b/src/d3d8/d3d8_device.cpp
@@ -1400,6 +1400,9 @@ namespace dxvk {
     if (unlikely(StreamNumber >= d8caps::MAX_STREAMS))
       return D3DERR_INVALIDCALL;
 
+    if (unlikely(ShouldRecord()))
+      return m_recorder->SetStreamSource(StreamNumber, pStreamData, Stride);
+
     D3D8VertexBuffer* buffer = static_cast<D3D8VertexBuffer*>(pStreamData);
     HRESULT res = GetD3D9()->SetStreamSource(StreamNumber, D3D8VertexBuffer::GetD3D9Nullable(buffer), 0, Stride);
 

--- a/src/d3d8/d3d8_state_block.cpp
+++ b/src/d3d8/d3d8_state_block.cpp
@@ -13,6 +13,13 @@ HRESULT dxvk::D3D8StateBlock::Capture() {
       m_textures[stage] = m_device->m_textures[stage].ptr();
   }
 
+  for (DWORD stream = 0; stream < m_streams.size(); stream++) {
+    if (m_capture.streams.get(stream)) {
+      m_streams[stream].buffer = m_device->m_streams[stream].buffer.ptr();
+      m_streams[stream].stride = m_device->m_streams[stream].stride;
+    }
+  }
+
   if (m_capture.indices) {
     m_baseVertexIndex = m_device->m_baseVertexIndex;
     m_indices = m_device->m_indices.ptr();
@@ -36,6 +43,11 @@ HRESULT dxvk::D3D8StateBlock::Apply() {
   for (DWORD stage = 0; stage < m_textures.size(); stage++) {
     if (m_capture.textures.get(stage))
       m_device->SetTexture(stage, m_textures[stage]);
+  }
+
+  for (DWORD stream = 0; stream < m_streams.size(); stream++) {
+    if (m_capture.streams.get(stream))
+      m_device->SetStreamSource(stream, m_streams[stream].buffer, m_streams[stream].stride);
   }
 
   if (m_capture.indices)

--- a/src/d3d8/d3d8_state_block.h
+++ b/src/d3d8/d3d8_state_block.h
@@ -16,6 +16,7 @@ namespace dxvk {
     bool swvp     : 1;
 
     bit::bitset<d8caps::MAX_TEXTURE_STAGES> textures;
+    bit::bitset<d8caps::MAX_STREAMS>        streams;
 
     D3D8StateCapture()
       : vs(false)
@@ -24,6 +25,7 @@ namespace dxvk {
       , swvp(false) {
       // Ensure all bits are initialized to false
       textures.clearAll();
+      streams.clearAll();
     }
   };
 
@@ -54,9 +56,11 @@ namespace dxvk {
         m_capture.indices = true;
         m_capture.swvp    = true;
         m_capture.textures.setAll();
+        m_capture.streams.setAll();
       }
 
       m_textures.fill(nullptr);
+      m_streams.fill(D3D8VBOP());
     }
 
     ~D3D8StateBlock() {}
@@ -97,6 +101,13 @@ namespace dxvk {
       return D3D_OK;
     }
 
+    inline HRESULT SetStreamSource(UINT StreamNumber, IDirect3DVertexBuffer8* pStreamData, UINT Stride) {
+      m_streams[StreamNumber].buffer = pStreamData;
+      m_streams[StreamNumber].stride = Stride;
+      m_capture.streams.set(StreamNumber, true);
+      return D3D_OK;
+    }
+
     inline HRESULT SetIndices(IDirect3DIndexBuffer8* pIndexData, UINT BaseVertexIndex) {
       m_indices         = pIndexData;
       m_baseVertexIndex = BaseVertexIndex;
@@ -115,6 +126,11 @@ namespace dxvk {
     Com<d3d9::IDirect3DStateBlock9> m_stateBlock;
     D3DSTATEBLOCKTYPE               m_type;
 
+    struct D3D8VBOP {
+      IDirect3DVertexBuffer8*       buffer = nullptr;
+      UINT                          stride = 0;
+    };
+
   private: // State Data //
 
     D3D8StateCapture m_capture;
@@ -123,6 +139,7 @@ namespace dxvk {
     DWORD m_pixelShader;  // ps
 
     std::array<IDirect3DBaseTexture8*, d8caps::MAX_TEXTURE_STAGES>  m_textures; // textures
+    std::array<D3D8VBOP, d8caps::MAX_STREAMS>                       m_streams; // stream data
 
     IDirect3DIndexBuffer8*  m_indices = nullptr;  // indices
     UINT                    m_baseVertexIndex;    // indices

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -7900,7 +7900,7 @@ namespace dxvk {
     rs[D3DRS_POINTSCALE_B]               = bit::cast<DWORD>(0.0f);
     rs[D3DRS_POINTSCALE_C]               = bit::cast<DWORD>(0.0f);
     rs[D3DRS_POINTSIZE]                  = bit::cast<DWORD>(1.0f);
-    rs[D3DRS_POINTSIZE_MIN]              = bit::cast<DWORD>(1.0f);
+    rs[D3DRS_POINTSIZE_MIN]              = m_isD3D8Compatible ? bit::cast<DWORD>(0.0f) : bit::cast<DWORD>(1.0f);
     rs[D3DRS_POINTSIZE_MAX]              = bit::cast<DWORD>(limits.pointSizeRange[1]);
     UpdatePushConstant<D3D9RenderStateItem::PointSize>();
     UpdatePushConstant<D3D9RenderStateItem::PointSizeMin>();


### PR DESCRIPTION
Fixes all of Wine's D3D8 state block tests.

In short:
- fixed the default value of the D3DRS_POINTSIZE_MIN render state being 0.0f in D3D8 (this was changed to 1.0f in D3D9)
- capture VB stream state as part of D3D8 state blocks
- automatically capture state on state block creation via CreateStateBlock()

Master:
`0020:stateblock: 9283 tests executed (0 marked as todo, 0 as flaky, 108 failures), 0 skipped.`

This PR:
`0020:stateblock: 9283 tests executed (0 marked as todo, 0 as flaky, 0 failures), 0 skipped.`
