### PR TITLE
[d3d8] Various Wine device tests fixes (Part 1)

### DIFF
--- a/src/d3d8/d3d8.def
+++ b/src/d3d8/d3d8.def
@@ -1,3 +1,6 @@
 LIBRARY D3D8.DLL
 EXPORTS
+  ValidatePixelShader @ 2
+  ValidateVertexShader @ 3
+
   Direct3DCreate8 @ 5

--- a/src/d3d8/d3d8.sym
+++ b/src/d3d8/d3d8.sym
@@ -1,5 +1,7 @@
 {
   global:
+    ValidatePixelShader;
+    ValidateVertexShader;
     Direct3DCreate8;
 
   local:

--- a/src/d3d8/d3d8_d3d9_util.h
+++ b/src/d3d8/d3d8_d3d9_util.h
@@ -81,7 +81,7 @@ namespace dxvk {
       if (unlikely(PresentationInterval != D3DPRESENT_INTERVAL_DEFAULT)) {
         // TODO: what does dx8 do if windowed app sets FullScreen_PresentationInterval?
         Logger::warn(str::format(
-          "D3D8 Application is windowed yet requested FullScreen_PresentationInterval ", PresentationInterval,
+          "D3D8: Application is windowed yet requested FullScreen_PresentationInterval ", PresentationInterval,
           " (should be D3DPRESENT_INTERVAL_DEFAULT). This will be ignored."));
       }
 

--- a/src/d3d8/d3d8_d3d9_util.h
+++ b/src/d3d8/d3d8_d3d9_util.h
@@ -58,7 +58,12 @@ namespace dxvk {
   }
 
   // (9<-8) D3DD3DPRESENT_PARAMETERS: Returns D3D9's params given an input for D3D8
-  inline d3d9::D3DPRESENT_PARAMETERS ConvertPresentParameters9(const D3DPRESENT_PARAMETERS* pParams) {
+  inline d3d9::D3DPRESENT_PARAMETERS ConvertPresentParameters9(D3DPRESENT_PARAMETERS* pParams) {
+    // A 0 back buffer count needs to be corrected and made visible to the D3D8 application as well
+    pParams->BackBufferCount = std::max(pParams->BackBufferCount, 1u);
+
+    if (pParams->BackBufferFormat == D3DFMT_UNKNOWN)
+      pParams->BackBufferFormat = D3DFMT_X8R8G8B8;
 
     d3d9::D3DPRESENT_PARAMETERS params;
     params.BackBufferWidth = pParams->BackBufferWidth;
@@ -68,7 +73,6 @@ namespace dxvk {
 
     params.MultiSampleType = d3d9::D3DMULTISAMPLE_TYPE(pParams->MultiSampleType);
     params.MultiSampleQuality = 0; // (D3D8: no MultiSampleQuality), TODO: get a value for this
-
 
     UINT PresentationInterval = pParams->FullScreen_PresentationInterval;
 

--- a/src/d3d8/d3d8_device.cpp
+++ b/src/d3d8/d3d8_device.cpp
@@ -219,7 +219,7 @@ namespace dxvk {
     );
 
     if (likely(SUCCEEDED(res)))
-      *ppSwapChain = ref(new D3D8SwapChain(this, std::move(pSwapChain9)));
+      *ppSwapChain = ref(new D3D8SwapChain(this, pPresentationParameters, std::move(pSwapChain9)));
 
     return res;
   }

--- a/src/d3d8/d3d8_device.cpp
+++ b/src/d3d8/d3d8_device.cpp
@@ -1402,7 +1402,10 @@ namespace dxvk {
       if (ShouldBatch())
         m_batcher->SetStream(StreamNumber, buffer, Stride);
 
-      m_streams[StreamNumber] = D3D8VBO {buffer, Stride};
+      m_streams[StreamNumber].buffer = buffer;
+      // The previous stride is preserved if pStreamData is NULL
+      if (likely(buffer != nullptr))
+        m_streams[StreamNumber].stride = Stride;
     }
 
     return res;

--- a/src/d3d8/d3d8_device.cpp
+++ b/src/d3d8/d3d8_device.cpp
@@ -887,14 +887,15 @@ namespace dxvk {
     if (pRenderTarget != nullptr) {
       D3D8Surface* surf = static_cast<D3D8Surface*>(pRenderTarget);
 
-      if (likely(m_renderTarget != surf)) {
-        StateChange();
-        res = GetD3D9()->SetRenderTarget(0, D3D8Surface::GetD3D9Nullable(surf));
+      // This will always be a state change and needs to be forwarded to
+      // D3D9, even when the same render target is set, as the viewport
+      // needs to be readjusted and reset.
+      StateChange();
+      res = GetD3D9()->SetRenderTarget(0, D3D8Surface::GetD3D9Nullable(surf));
 
-        if (unlikely(FAILED(res))) return res;
+      if (unlikely(FAILED(res))) return res;
 
-        m_renderTarget = surf;
-      }
+      m_renderTarget = surf;
     }
 
     // SetDepthStencilSurface is a separate call

--- a/src/d3d8/d3d8_device.cpp
+++ b/src/d3d8/d3d8_device.cpp
@@ -696,7 +696,7 @@ namespace dxvk {
       POINT dstPt = { dstRect.left, dstRect.top };
 
       auto unhandled = [&] {
-        Logger::warn(str::format("CopyRects: Hit unhandled case from src pool ", srcDesc.Pool, " to dst pool ", dstDesc.Pool));
+        Logger::warn(str::format("D3D8Device::CopyRects: Unhandled case from src pool ", srcDesc.Pool, " to dst pool ", dstDesc.Pool));
         return D3DERR_INVALIDCALL;
       };
 
@@ -704,7 +704,7 @@ namespace dxvk {
         if (FAILED(res)) {
           // Only a debug message because some games mess up CopyRects every frame in a way
           // that fails on native too but are perfectly fine with it.
-          Logger::debug(str::format("CopyRects: FAILED to copy from src pool ", srcDesc.Pool, " to dst pool ", dstDesc.Pool));
+          Logger::debug(str::format("D3D8Device::CopyRects: Failed to copy from src pool ", srcDesc.Pool, " to dst pool ", dstDesc.Pool));
         }
         return res;
       };
@@ -1014,7 +1014,7 @@ namespace dxvk {
         bool isOnePixelTaller = pViewport->Y + pViewport->Height == rtDesc.Height + 1;
 
         if (m_presentParams.Windowed && (isOnePixelWider || isOnePixelTaller)) {
-          Logger::debug("Viewport exceeds render target dimensions by one pixel");
+          Logger::debug("D3D8Device::SetViewport: Viewport exceeds render target dimensions by one pixel");
         } else {
           return D3DERR_INVALIDCALL;
         }
@@ -1097,8 +1097,8 @@ namespace dxvk {
     auto stateBlockIter = m_stateBlocks.find(Token);
 
     if (unlikely(stateBlockIter == m_stateBlocks.end())) {
-      Logger::err("Invalid token passed to CaptureStateBlock");
-      return D3DERR_INVALIDCALL;
+      Logger::warn(str::format("D3D8Device::CaptureStateBlock: Invalid token: ", std::hex, Token));
+      return D3D_OK;
     }
 
     return stateBlockIter->second.Capture();
@@ -1112,8 +1112,8 @@ namespace dxvk {
     auto stateBlockIter = m_stateBlocks.find(Token);
 
     if (unlikely(stateBlockIter == m_stateBlocks.end())) {
-      Logger::err("Invalid token passed to ApplyStateBlock");
-      return D3DERR_INVALIDCALL;
+      Logger::warn(str::format("D3D8Device::ApplyStateBlock: Invalid token: ", std::hex, Token));
+      return D3D_OK;
     }
 
     return stateBlockIter->second.Apply();
@@ -1129,8 +1129,8 @@ namespace dxvk {
     auto stateBlockIter = m_stateBlocks.find(Token);
 
     if (unlikely(stateBlockIter == m_stateBlocks.end())) {
-      Logger::err("Invalid token passed to DeleteStateBlock");
-      return D3DERR_INVALIDCALL;
+      Logger::warn(str::format("D3D8Device::DeleteStateBlock: Invalid token: ", std::hex, Token));
+      return D3D_OK;
     }
 
     m_stateBlocks.erase(stateBlockIter);
@@ -1444,7 +1444,7 @@ namespace dxvk {
       return m_recorder->SetIndices(pIndexData, BaseVertexIndex);
 
     if (unlikely(BaseVertexIndex > INT_MAX))
-      Logger::warn("BaseVertexIndex exceeds INT_MAX and will be clamped on use.");
+      Logger::warn("D3D8Device::SetIndices: BaseVertexIndex exceeds INT_MAX");
 
     // used by DrawIndexedPrimitive
     m_baseVertexIndex = BaseVertexIndex;
@@ -1672,14 +1672,14 @@ namespace dxvk {
     Handle = getShaderIndex(Handle);
 
     if (unlikely(Handle >= device->m_vertexShaders.size())) {
-      Logger::debug(str::format("getVertexShaderInfo: Invalid vertex shader index ", std::hex, Handle));
+      Logger::debug(str::format("D3D8: Invalid vertex shader index ", std::hex, Handle));
       return nullptr;
     }
 
     D3D8VertexShaderInfo& info = device->m_vertexShaders[Handle];
 
     if (unlikely(info.pVertexDecl == nullptr && info.pVertexShader == nullptr)) {
-      Logger::debug(str::format("getVertexShaderInfo: Application provided deleted vertex shader ", std::hex, Handle));
+      Logger::debug(str::format("D3D8: Application provided deleted vertex shader ", std::hex, Handle));
       return nullptr;
     }
 
@@ -1873,14 +1873,14 @@ namespace dxvk {
     Handle = getShaderIndex(Handle);
 
     if (unlikely(Handle >= device->m_pixelShaders.size())) {
-      Logger::debug(str::format("getPixelShaderPtr: Invalid pixel shader index ", std::hex, Handle));
+      Logger::debug(str::format("D3D8: Invalid pixel shader index ", std::hex, Handle));
       return nullptr;
     }
 
     d3d9::IDirect3DPixelShader9* pPixelShader = device->m_pixelShaders[Handle].ptr();
 
     if (unlikely(pPixelShader == nullptr)) {
-      Logger::debug(str::format("getPixelShaderPtr: Application provided deleted pixel shader ", std::hex, Handle));
+      Logger::debug(str::format("D3D8: Application provided deleted pixel shader ", std::hex, Handle));
       return nullptr;
     }
 

--- a/src/d3d8/d3d8_interface.h
+++ b/src/d3d8/d3d8_interface.h
@@ -63,12 +63,15 @@ namespace dxvk {
         D3DFORMAT   AdapterFormat,
         D3DFORMAT   BackBufferFormat,
         BOOL        bWindowed) {
+      // Ignore the bWindowed parameter when querying D3D9. D3D8 does
+      // identical validations between windowed and fullscreen modes, adhering
+      // to the stricter fullscreen adapter and back buffer format validations.
       return m_d3d9->CheckDeviceType(
           Adapter,
           (d3d9::D3DDEVTYPE)DevType,
           (d3d9::D3DFORMAT)AdapterFormat,
           (d3d9::D3DFORMAT)BackBufferFormat,
-          bWindowed
+          FALSE
       );
     }
 

--- a/src/d3d8/d3d8_main.cpp
+++ b/src/d3d8/d3d8_main.cpp
@@ -12,7 +12,45 @@ namespace dxvk {
   }
 }
 
-extern "C" {  
+extern "C" {
+
+  DLLEXPORT HRESULT __stdcall ValidatePixelShader(
+      const DWORD*     pixelshader,
+      const D3DCAPS8*  caps,
+      BOOL             boolValue,
+      char**           errorString) {
+    dxvk::Logger::warn("D3D8: ValidatePixelShader: Stub");
+
+    if (unlikely(pixelshader == nullptr))
+      return E_FAIL;
+
+    if (likely(errorString != nullptr)) {
+      const char* errorMessage = "";
+      *errorString = (char *) errorMessage;
+    }
+
+    return S_OK;
+  }
+
+  DLLEXPORT HRESULT __stdcall ValidateVertexShader(
+      const DWORD*     vertexShader,
+      const DWORD*     vertexDecl,
+      const D3DCAPS8*  caps,
+      BOOL             boolValue,
+      char**           errorString) {
+    dxvk::Logger::warn("D3D8: ValidateVertexShader: Stub");
+
+    if (unlikely(vertexShader == nullptr))
+      return E_FAIL;
+
+    if (likely(errorString != nullptr)) {
+      const char* errorMessage = "";
+      *errorString = (char *) errorMessage;
+    }
+
+    return S_OK;
+  }
+
   DLLEXPORT IDirect3D8* __stdcall Direct3DCreate8(UINT nSDKVersion) {
     dxvk::Logger::trace("Direct3DCreate8 called");
 
@@ -21,4 +59,5 @@ extern "C" {
 
     return pDirect3D;
   }
+
 }

--- a/src/d3d8/d3d8_main.cpp
+++ b/src/d3d8/d3d8_main.cpp
@@ -52,8 +52,6 @@ extern "C" {
   }
 
   DLLEXPORT IDirect3D8* __stdcall Direct3DCreate8(UINT nSDKVersion) {
-    dxvk::Logger::trace("Direct3DCreate8 called");
-
     IDirect3D8* pDirect3D = nullptr;
     dxvk::CreateD3D8(&pDirect3D);
 

--- a/src/d3d8/d3d8_shader.cpp
+++ b/src/d3d8/d3d8_shader.cpp
@@ -138,7 +138,7 @@ namespace dxvk {
     DWORD token;
 
     std::stringstream dbg;
-    dbg << "Vertex Declaration Tokens:\n\t";
+    dbg << "D3D8: Vertex Declaration Tokens:\n\t";
 
     WORD currentStream = 0;
     WORD currentOffset = 0;

--- a/src/d3d8/d3d8_state_block.h
+++ b/src/d3d8/d3d8_state_block.h
@@ -103,7 +103,9 @@ namespace dxvk {
 
     inline HRESULT SetStreamSource(UINT StreamNumber, IDirect3DVertexBuffer8* pStreamData, UINT Stride) {
       m_streams[StreamNumber].buffer = pStreamData;
-      m_streams[StreamNumber].stride = Stride;
+      // The previous stride is preserved if pStreamData is NULL
+      if (likely(pStreamData != nullptr))
+        m_streams[StreamNumber].stride = Stride;
       m_capture.streams.set(StreamNumber, true);
       return D3D_OK;
     }

--- a/src/d3d8/d3d8_state_block.h
+++ b/src/d3d8/d3d8_state_block.h
@@ -75,7 +75,7 @@ namespace dxvk {
       if (likely(m_stateBlock == nullptr)) {
         m_stateBlock = std::move(pStateBlock);
       } else {
-        Logger::err("D3D8StateBlock::SetD3D9 called when m_stateBlock has already been initialized");
+        Logger::err("D3D8StateBlock::SetD3D9: m_stateBlock has already been initialized");
       }
     }
 

--- a/src/d3d8/d3d8_texture.h
+++ b/src/d3d8/d3d8_texture.h
@@ -93,7 +93,7 @@ namespace dxvk {
       HRESULT res = D3DERR_INVALIDCALL;
       if constexpr (std::is_same_v<D3D8, IDirect3DTexture8>) {
         res = this->GetD3D9()->GetSurfaceLevel(Index, &ptr); 
-      } else if constexpr (std::is_same_v<D3D8, IDirect3DVolume8>) {
+      } else if constexpr (std::is_same_v<D3D8, IDirect3DVolumeTexture8>) {
         res = this->GetD3D9()->GetVolumeLevel(Index, &ptr);
       } else if constexpr (std::is_same_v<D3D8, IDirect3DCubeTexture8>) {
         res = this->GetD3D9()->GetCubeMapSurface(d3d9::D3DCUBEMAP_FACES(Index % CUBE_FACES), Index / CUBE_FACES, &ptr);

--- a/src/d3d9/d3d9_adapter.cpp
+++ b/src/d3d9/d3d9_adapter.cpp
@@ -186,6 +186,12 @@ namespace dxvk {
     if (pQualityLevels != nullptr)
       *pQualityLevels = 1;
 
+    if (unlikely(MultiSampleType > D3DMULTISAMPLE_16_SAMPLES))
+      return D3DERR_INVALIDCALL;
+
+    if (unlikely(SurfaceFormat == D3D9Format::Unknown))
+      return D3DERR_INVALIDCALL;
+
     auto dst = ConvertFormatUnfixed(SurfaceFormat);
     if (dst.FormatColor == VK_FORMAT_UNDEFINED)
       return D3DERR_NOTAVAILABLE;
@@ -194,7 +200,12 @@ namespace dxvk {
      && (SurfaceFormat == D3D9Format::D32_LOCKABLE
       || SurfaceFormat == D3D9Format::D32F_LOCKABLE
       || SurfaceFormat == D3D9Format::D16_LOCKABLE
-      || SurfaceFormat == D3D9Format::INTZ))
+      || SurfaceFormat == D3D9Format::INTZ
+      || SurfaceFormat == D3D9Format::DXT1
+      || SurfaceFormat == D3D9Format::DXT2
+      || SurfaceFormat == D3D9Format::DXT3
+      || SurfaceFormat == D3D9Format::DXT4
+      || SurfaceFormat == D3D9Format::DXT5))
       return D3DERR_NOTAVAILABLE;
 
     uint32_t sampleCount = std::max<uint32_t>(MultiSampleType, 1u);

--- a/src/d3d9/d3d9_common_texture.cpp
+++ b/src/d3d9/d3d9_common_texture.cpp
@@ -156,6 +156,16 @@ namespace dxvk {
 
     if (pDesc->Width == 0 || pDesc->Height == 0 || pDesc->Depth == 0)
       return D3DERR_INVALIDCALL;
+
+    // Native drivers won't allow the creation of DXT format
+    // textures that aren't aligned to block dimensions.
+    if (IsDXTFormat(pDesc->Format)) {
+      D3D9_FORMAT_BLOCK_SIZE blockSize = GetFormatBlockSize(pDesc->Format);
+
+      if ((blockSize.Width  && (pDesc->Width  & (blockSize.Width  - 1)))
+       || (blockSize.Height && (pDesc->Height & (blockSize.Height - 1))))
+        return D3DERR_INVALIDCALL;
+    }
     
     if (FAILED(DecodeMultiSampleType(pDevice->GetDXVKDevice(), pDesc->MultiSample, pDesc->MultisampleQuality, nullptr)))
       return D3DERR_INVALIDCALL;

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -3948,6 +3948,15 @@ namespace dxvk {
     if (unlikely(ppSurface == nullptr))
       return D3DERR_INVALIDCALL;
 
+    if (unlikely(MultiSample > D3DMULTISAMPLE_16_SAMPLES))
+      return D3DERR_INVALIDCALL;
+
+    uint32_t sampleCount = std::max<uint32_t>(MultiSample, 1u);
+
+    // Check if this is a power of two...
+    if (sampleCount & (sampleCount - 1))
+      return D3DERR_NOTAVAILABLE;
+
     D3D9_COMMON_TEXTURE_DESC desc;
     desc.Width              = Width;
     desc.Height             = Height;

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -531,7 +531,7 @@ namespace dxvk {
     if (unlikely(m_losableResourceCounter.load() != 0 && !IsExtended() && m_d3d9Options.countLosableResources)) {
       Logger::warn(str::format("Device reset failed because device still has alive losable resources: Device not reset. Remaining resources: ", m_losableResourceCounter.load()));
       m_deviceLostState = D3D9DeviceLostState::NotReset;
-      return D3DERR_INVALIDCALL;
+      return D3DERR_DEVICELOST;
     }
 
     HRESULT hr = ResetSwapChain(pPresentationParameters, nullptr);

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -8152,6 +8152,12 @@ namespace dxvk {
       "    - Windowed:           ", pPresentationParameters->Windowed ? "true" : "false", "\n",
       "    - Swap effect:        ", pPresentationParameters->SwapEffect, "\n"));
 
+    if (!pPresentationParameters->Windowed &&
+        (pPresentationParameters->BackBufferWidth  == 0
+      || pPresentationParameters->BackBufferHeight == 0)) {
+      return D3DERR_INVALIDCALL;
+    }
+
     if (backBufferFmt != D3D9Format::Unknown && !unlockedFormats) {
       if (!IsSupportedBackBufferFormat(backBufferFmt)) {
         Logger::err(str::format("D3D9DeviceEx::ResetSwapChain: Unsupported backbuffer format: ",

--- a/src/d3d9/d3d9_format.cpp
+++ b/src/d3d9/d3d9_format.cpp
@@ -439,6 +439,27 @@ namespace dxvk {
     }
   }
 
+  // Block size of formats that require some form of alignment
+  D3D9_FORMAT_BLOCK_SIZE GetFormatBlockSize(D3D9Format Format) {
+    switch (Format) {
+      case D3D9Format::DXT1:
+      case D3D9Format::DXT2:
+      case D3D9Format::DXT3:
+      case D3D9Format::DXT4:
+      case D3D9Format::DXT5:
+      case D3D9Format::ATI1:
+      case D3D9Format::ATI2:
+        return { 4, 4, 1 };
+
+      case D3D9Format::YUY2:
+      case D3D9Format::UYVY:
+        return { 2, 1, 1 };
+
+      default:
+        return {}; // Irrelevant or unknown block size
+    }
+  }
+
   D3D9VkFormatTable::D3D9VkFormatTable(
     const Rc<DxvkAdapter>& adapter,
     const D3D9Options&     options) {

--- a/src/d3d9/d3d9_format.h
+++ b/src/d3d9/d3d9_format.h
@@ -147,6 +147,12 @@ namespace dxvk {
     VkFormat             FormatSrgb     = VK_FORMAT_UNDEFINED;
   };
 
+  struct D3D9_FORMAT_BLOCK_SIZE {
+    uint8_t            Width  = 0;
+    uint8_t            Height = 0;
+    uint8_t            Depth  = 0;
+  };
+
   /**
    * \brief Format mapping
    * 
@@ -170,6 +176,8 @@ namespace dxvk {
   };
 
   D3D9_VK_FORMAT_MAPPING ConvertFormatUnfixed(D3D9Format Format);
+
+  D3D9_FORMAT_BLOCK_SIZE GetFormatBlockSize(D3D9Format Format);
 
   /**
    * \brief Format table
@@ -237,6 +245,14 @@ namespace dxvk {
       && format != D3D9Format::DXT3
       && format != D3D9Format::DXT4
       && format != D3D9Format::DXT5;
+  }
+
+  inline bool IsDXTFormat(D3D9Format format) {
+    return format == D3D9Format::DXT1
+        || format == D3D9Format::DXT2
+        || format == D3D9Format::DXT3
+        || format == D3D9Format::DXT4
+        || format == D3D9Format::DXT5;
   }
 
 }


### PR DESCRIPTION
Fixes a rather large portion (in terms of failures, at least) of Wine's D3D8 device tests.

The changes are:
- fixed a type derp on texture subresource lookup
- don't allow mix-matched adapter and buffer formats in windowed mode (apparently that's not a thing in D3D8)
- make some D3D8 present parameter validations visible to the calling application
- cache (and hold references to) all the back buffers tied to an additional swapchain
- various additional CheckDeviceMultiSampleType validations that native also does (~TODO: check these on D3D9 side directly also~ They indeed check out on D3D9 as well)
- failure of device resets due to invalid losable count should return D3DERR_DEVICELOST
- can't create a 0 x 0 backbuffer in fullscreen (but windowed mode works, absolutely lovely)
- D3D8 SetStreamSource won't update the stride if the buffer data is NULL (so the old one is retained)
- calls to SetRenderTarget should always be forwarded to D3D9, since they can affect the viewport
- stub ValidatePixelShader and ValidateVertexShader (needed mostly for Wine tests)
- textures/surfaces using DXT formats need to be checked for block alignment during creation