### PR TITLE
[d3d9] Silence unhandled render state D3DRS_ADAPTIVETESS_Y

### DIFF
--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -2463,6 +2463,9 @@ namespace dxvk {
           m_flags.set(D3D9DeviceFlag::DirtyFFVertexShader);
           break;
 
+        case D3DRS_ADAPTIVETESS_Y:
+          break;
+
         case D3DRS_ADAPTIVETESS_X:
         case D3DRS_ADAPTIVETESS_Z:
         case D3DRS_ADAPTIVETESS_W:


### PR DESCRIPTION
This doesn't fix anything besides getting rid of a warning but @WinterSnowfall said it would be good to add it so it isn't potentially missed whenever TruForm support is worked on.
