### PR TITLE
[d3d8] Wine device tests fixes (Part 2) - LockRect/LockBox

### DIFF
--- a/src/d3d9/d3d9_common_texture.cpp
+++ b/src/d3d9/d3d9_common_texture.cpp
@@ -182,7 +182,13 @@ namespace dxvk {
     constexpr DWORD incompatibleUsages = D3DUSAGE_RENDERTARGET | D3DUSAGE_DEPTHSTENCIL;
     if (pDesc->Pool != D3DPOOL_DEFAULT && (pDesc->Usage & incompatibleUsages))
       return D3DERR_INVALIDCALL;
-    
+
+    // Volume textures in D3DPOOL_SCRATCH must not have DYNAMIC usage
+    if (ResourceType == D3DRTYPE_VOLUMETEXTURE
+      && pDesc->Pool == D3DPOOL_SCRATCH
+      && (pDesc->Usage & D3DUSAGE_DYNAMIC))
+      return D3DERR_INVALIDCALL;
+
     // Use the maximum possible mip level count if the supplied
     // mip level count is either unspecified (0) or invalid
     const uint32_t maxMipLevelCount = pDesc->MultiSample <= D3DMULTISAMPLE_NONMASKABLE

--- a/src/d3d9/d3d9_common_texture.cpp
+++ b/src/d3d9/d3d9_common_texture.cpp
@@ -160,7 +160,7 @@ namespace dxvk {
     // Native drivers won't allow the creation of DXT format
     // textures that aren't aligned to block dimensions.
     if (IsDXTFormat(pDesc->Format)) {
-      D3D9_FORMAT_BLOCK_SIZE blockSize = GetFormatBlockSize(pDesc->Format);
+      D3D9_FORMAT_BLOCK_SIZE blockSize = GetFormatAlignedBlockSize(pDesc->Format);
 
       if ((blockSize.Width  && (pDesc->Width  & (blockSize.Width  - 1)))
        || (blockSize.Height && (pDesc->Height & (blockSize.Height - 1))))

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -687,10 +687,10 @@ namespace dxvk {
     desc.IsAttachmentOnly   = FALSE;
     // Docs:
     // Textures placed in the D3DPOOL_DEFAULT pool cannot be locked
-    // unless they are dynamic textures or they are private, FOURCC, driver formats.
+    // unless they are dynamic textures. Volume textures do not
+    // exempt private, FOURCC, driver formats from these checks.
     desc.IsLockable         = Pool != D3DPOOL_DEFAULT
-                            || (Usage & D3DUSAGE_DYNAMIC)
-                            || IsVendorFormat(EnumerateFormat(Format));
+                            || (Usage & D3DUSAGE_DYNAMIC);
 
     if (FAILED(D3D9CommonTexture::NormalizeTextureProperties(this, D3DRTYPE_VOLUMETEXTURE, &desc)))
       return D3DERR_INVALIDCALL;

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -4658,7 +4658,7 @@ namespace dxvk {
 
     if (unlikely(pBox != nullptr)) {
       D3DRESOURCETYPE type = pResource->GetType();
-      D3D9_FORMAT_BLOCK_SIZE blockSize = GetFormatBlockSize(desc.Format);
+      D3D9_FORMAT_BLOCK_SIZE blockSize = GetFormatAlignedBlockSize(desc.Format);
 
       bool isBlockAlignedFormat = blockSize.Width > 0 && blockSize.Height > 0;
       bool isNotLeftAligned   = pBox->Left   && (pBox->Left   & (blockSize.Width  - 1));

--- a/src/d3d9/d3d9_format.cpp
+++ b/src/d3d9/d3d9_format.cpp
@@ -440,7 +440,7 @@ namespace dxvk {
   }
 
   // Block size of formats that require some form of alignment
-  D3D9_FORMAT_BLOCK_SIZE GetFormatBlockSize(D3D9Format Format) {
+  D3D9_FORMAT_BLOCK_SIZE GetFormatAlignedBlockSize(D3D9Format Format) {
     switch (Format) {
       case D3D9Format::DXT1:
       case D3D9Format::DXT2:

--- a/src/d3d9/d3d9_format.h
+++ b/src/d3d9/d3d9_format.h
@@ -177,7 +177,7 @@ namespace dxvk {
 
   D3D9_VK_FORMAT_MAPPING ConvertFormatUnfixed(D3D9Format Format);
 
-  D3D9_FORMAT_BLOCK_SIZE GetFormatBlockSize(D3D9Format Format);
+  D3D9_FORMAT_BLOCK_SIZE GetFormatAlignedBlockSize(D3D9Format Format);
 
   /**
    * \brief Format table

--- a/src/d3d9/d3d9_surface.cpp
+++ b/src/d3d9/d3d9_surface.cpp
@@ -124,7 +124,33 @@ namespace dxvk {
       return D3DERR_INVALIDCALL;
 
     D3DBOX box;
-    if (pRect != nullptr) {
+
+    if (unlikely(pRect != nullptr)) {
+      D3DRESOURCETYPE type = m_texture->GetType();
+      auto& desc = *(m_texture->Desc());
+      D3D9_FORMAT_BLOCK_SIZE blockSize = GetFormatBlockSize(desc.Format);
+
+      bool isBlockAlignedFormat = blockSize.Width > 0 && blockSize.Height > 0;
+
+      // The boundaries of pRect are validated for D3DPOOL_DEFAULT surfaces
+      // with formats which need to be block aligned (mip 0), surfaces created via
+      // CreateImageSurface and D3D8 cube textures outside of D3DPOOL_DEFAULT
+      if ((m_mipLevel == 0 && isBlockAlignedFormat && desc.Pool == D3DPOOL_DEFAULT)
+       || (desc.Pool == D3DPOOL_SYSTEMMEM && type == D3DRTYPE_SURFACE)
+       || (m_texture->Device()->IsD3D8Compatible() &&
+           desc.Pool != D3DPOOL_DEFAULT   && type == D3DRTYPE_CUBETEXTURE)) {
+        // Negative coordinates
+        if (pRect->left < 0 || pRect->right  < 0
+         || pRect->top  < 0 || pRect->bottom < 0
+        // Negative or zero length dimensions
+         || pRect->right  - pRect->left <= 0
+         || pRect->bottom - pRect->top  <= 0
+        // Exceeding surface dimensions
+         || static_cast<UINT>(pRect->right)  > desc.Width
+         || static_cast<UINT>(pRect->bottom) > desc.Height)
+          return D3DERR_INVALIDCALL;
+      }
+
       box.Left   = pRect->left;
       box.Right  = pRect->right;
       box.Top    = pRect->top;

--- a/src/d3d9/d3d9_surface.cpp
+++ b/src/d3d9/d3d9_surface.cpp
@@ -135,7 +135,7 @@ namespace dxvk {
 
     if (unlikely(pRect != nullptr)) {
       auto& desc = *(m_texture->Desc());
-      D3D9_FORMAT_BLOCK_SIZE blockSize = GetFormatBlockSize(desc.Format);
+      D3D9_FORMAT_BLOCK_SIZE blockSize = GetFormatAlignedBlockSize(desc.Format);
 
       bool isBlockAlignedFormat = blockSize.Width > 0 && blockSize.Height > 0;
 

--- a/src/d3d9/d3d9_surface.cpp
+++ b/src/d3d9/d3d9_surface.cpp
@@ -124,9 +124,16 @@ namespace dxvk {
       return D3DERR_INVALIDCALL;
 
     D3DBOX box;
+    D3DRESOURCETYPE type = m_texture->GetType();
+
+    if (m_texture->Device()->IsD3D8Compatible() && type != D3DRTYPE_TEXTURE) {
+      // D3D8 LockRect clears any existing content present in
+      // pLockedRect for anything beside D3DRTYPE_TEXTURE surfaces
+      pLockedRect->pBits = nullptr;
+      pLockedRect->Pitch = 0;
+    }
 
     if (unlikely(pRect != nullptr)) {
-      D3DRESOURCETYPE type = m_texture->GetType();
       auto& desc = *(m_texture->Desc());
       D3D9_FORMAT_BLOCK_SIZE blockSize = GetFormatBlockSize(desc.Format);
 
@@ -167,6 +174,8 @@ namespace dxvk {
       &lockedBox,
       pRect != nullptr ? &box : nullptr,
       Flags);
+
+    if (FAILED(hr)) return hr;
 
     pLockedRect->pBits = lockedBox.pBits;
     pLockedRect->Pitch = lockedBox.RowPitch;

--- a/src/d3d9/d3d9_volume.cpp
+++ b/src/d3d9/d3d9_volume.cpp
@@ -97,12 +97,29 @@ namespace dxvk {
     if (unlikely(pLockedBox == nullptr))
       return D3DERR_INVALIDCALL;
 
-    return m_parent->LockImage(
+    if (m_texture->Device()->IsD3D8Compatible()) {
+      // D3D8 LockBox clears any existing content present in pLockedBox
+      pLockedBox->pBits = nullptr;
+      pLockedBox->RowPitch = 0;
+      pLockedBox->SlicePitch = 0;
+    }
+
+    D3DLOCKED_BOX lockedBox;
+
+    HRESULT hr = m_parent->LockImage(
       m_texture,
       m_face, m_mipLevel,
-      pLockedBox,
+      &lockedBox,
       pBox,
       Flags);
+
+    if (FAILED(hr)) return hr;
+
+    pLockedBox->pBits      = lockedBox.pBits;
+    pLockedBox->RowPitch   = lockedBox.RowPitch;
+    pLockedBox->SlicePitch = lockedBox.SlicePitch;
+
+    return hr;
   }
 
 

--- a/src/d3d9/d3d9_volume.cpp
+++ b/src/d3d9/d3d9_volume.cpp
@@ -104,6 +104,20 @@ namespace dxvk {
       pLockedBox->SlicePitch = 0;
     }
 
+    if (unlikely(pBox != nullptr)) {
+      auto& desc = *(m_texture->Desc());
+
+      // Negative or zero length dimensions
+      if ( static_cast<LONG>(pBox->Right)  - static_cast<LONG>(pBox->Left)  <= 0
+        || static_cast<LONG>(pBox->Bottom) - static_cast<LONG>(pBox->Top)   <= 0
+        || static_cast<LONG>(pBox->Back)   - static_cast<LONG>(pBox->Front) <= 0
+      // Exceeding surface dimensions
+        || pBox->Right  > desc.Width
+        || pBox->Bottom > desc.Height
+        || pBox->Back   > desc.Depth)
+        return D3DERR_INVALIDCALL;
+    }
+
     D3DLOCKED_BOX lockedBox;
 
     HRESULT hr = m_parent->LockImage(


### PR DESCRIPTION
Built on top of #4320, I'm now expanding and hoping to fix (most) of the Wine tests dealing with surface locks (LockRect/LockBox validations).

Work so far:
- d3d8/9 seem to validate the boundaries of the locking rectangle for D3DPOOL_DEFAULT surfaces with formats that need to be block aligned, surfaces created via `CreateImageSurface` and cube textures outside of D3DPOOL_DEFAULT (the last one being specific to D3D8). ~If only it were so simple, though. Essentially **all** validation are done on surfaces or subsurfaces of textures so we need some way to determine the origin of a surface. To that end I've added a `D3DRESOURCETYPE` Type variable part of `D3D9_COMMON_TEXTURE_DESC`.~
- a ~very highly cursed~ alignment lock check for block aligned formats, ~performed only on direct calls to IDirect3DSurface9->LockRect()~. Turns out this is only performed on the first mip level, which makes a whole lot more sense and isn't hyper-cursed.
- a similar validation on volume textures with block aligned formats
- added general format volume texture validations on creation and locking (there seems to be some pool and flag specific behavior here)
- handled D3D8-specific LockRect/LockBox pLockedRect/pLockedBox clearing behavior, together with sanitizing return values on LockImage failures