### PR TITLE
[d3d9] Fix software cursor reset and transitions

### DIFF
--- a/src/d3d9/d3d9_cursor.h
+++ b/src/d3d9/d3d9_cursor.h
@@ -8,10 +8,12 @@ namespace dxvk {
    * \brief D3D9 Software Cursor
    */
   struct D3D9_SOFTWARE_CURSOR {
-    UINT Width = 0;
+    UINT Width  = 0;
     UINT Height = 0;
     UINT X = 0;
     UINT Y = 0;
+    bool DrawCursor  = false;
+    bool ResetCursor = false;
   };
 
   constexpr uint32_t HardwareCursorWidth      = 32u;
@@ -36,6 +38,10 @@ namespace dxvk {
 #endif
 
     void ResetCursor();
+
+    void ResetHardwareCursor();
+
+    void ResetSoftwareCursor();
 
     void UpdateCursor(int X, int Y);
 

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -3917,11 +3917,22 @@ namespace dxvk {
 
       D3D9_SOFTWARE_CURSOR* pSoftwareCursor = m_cursor.GetSoftwareCursor();
 
-      UINT cursorWidth  = m_cursor.IsCursorVisible() ? pSoftwareCursor->Width : 0;
-      UINT cursorHeight = m_cursor.IsCursorVisible() ? pSoftwareCursor->Height : 0;
+      UINT cursorWidth  = pSoftwareCursor->DrawCursor ? pSoftwareCursor->Width : 0;
+      UINT cursorHeight = pSoftwareCursor->DrawCursor ? pSoftwareCursor->Height : 0;
 
       m_implicitSwapchain->SetCursorPosition(pSoftwareCursor->X, pSoftwareCursor->Y,
                                              cursorWidth, cursorHeight);
+
+      // Once a hardware cursor has been set or the device has been reset,
+      // we need to ensure that we render a 0-sized rectangle first, and
+      // only then fully clear the software cursor.
+      if (unlikely(pSoftwareCursor->ResetCursor)) {
+        pSoftwareCursor->Width = 0;
+        pSoftwareCursor->Height = 0;
+        pSoftwareCursor->X = 0;
+        pSoftwareCursor->Y = 0;
+        pSoftwareCursor->ResetCursor = false;
+      }
     }
 
     return m_implicitSwapchain->Present(


### PR DESCRIPTION
Turns out @doitsujin's prophecy of games switching between software and hardware cursor has come true. Ironically it's with a game that apparently doesn't showcase its full cursor capabilities with WineD3D, namely Act of War.

I was never aware it had animated cursors, because WineD3D just shows the default cursor permanently throughout the game, whereas we now properly animate it depending on the situation. The animations end up on the software cursor path, while the default game cursor ends up on the hardware path.

Since we still need to render the software cursor as a 0-sized rect (to hide it in the backend) even on such a switch switch,  I had to add a bit of extra lifecycle tracking in the struct, however it does work as expected now.