### PR TITLE
[d3d8] Stub DebugSetMute to fix C&C:Generals performance

### DIFF
--- a/src/d3d8/d3d8.def
+++ b/src/d3d8/d3d8.def
@@ -2,5 +2,5 @@ LIBRARY D3D8.DLL
 EXPORTS
   ValidatePixelShader @ 2
   ValidateVertexShader @ 3
-
+  DebugSetMute @ 4
   Direct3DCreate8 @ 5

--- a/src/d3d8/d3d8.sym
+++ b/src/d3d8/d3d8.sym
@@ -2,6 +2,7 @@
   global:
     ValidatePixelShader;
     ValidateVertexShader;
+    DebugSetMute;
     Direct3DCreate8;
 
   local:

--- a/src/d3d8/d3d8_main.cpp
+++ b/src/d3d8/d3d8_main.cpp
@@ -51,6 +51,10 @@ extern "C" {
     return S_OK;
   }
 
+  DLLEXPORT void __stdcall DebugSetMute() {
+    dxvk::Logger::debug("D3D8: DebugSetMute: Stub");
+  }
+
   DLLEXPORT IDirect3D8* __stdcall Direct3DCreate8(UINT nSDKVersion) {
     IDirect3D8* pDirect3D = nullptr;
     dxvk::CreateD3D8(&pDirect3D);


### PR DESCRIPTION
This has to be like the dumbest thing ever, but C&C: Generals is spamming calls to DebugSetMute() *every frame* whenever the slowdowns occur. Stubbing it makes it not choke. Fixes #4112.