### PR TITLE
[d3d9] Make proper use of X/YHotSpot for software cursors

### DIFF
--- a/src/d3d9/d3d9_cursor.cpp
+++ b/src/d3d9/d3d9_cursor.cpp
@@ -41,8 +41,8 @@ namespace dxvk {
     POINT currentPos = { };
     ::GetCursorPos(&currentPos);
 
-    m_sCursor.X = static_cast<UINT>(currentPos.x);
-    m_sCursor.Y = static_cast<UINT>(currentPos.y);
+    m_sCursor.X = static_cast<int32_t>(currentPos.x) - m_sCursor.XHotSpot;
+    m_sCursor.Y = static_cast<int32_t>(currentPos.y) - m_sCursor.YHotSpot;
   }
 
 
@@ -97,8 +97,8 @@ namespace dxvk {
 
     m_sCursor.Width       = Width;
     m_sCursor.Height      = Height;
-    m_sCursor.X           = XHotSpot;
-    m_sCursor.Y           = YHotSpot;
+    m_sCursor.XHotSpot    = XHotSpot;
+    m_sCursor.YHotSpot    = YHotSpot;
     m_sCursor.ResetCursor = false;
 
     ShowCursor(m_visible);

--- a/src/d3d9/d3d9_cursor.h
+++ b/src/d3d9/d3d9_cursor.h
@@ -10,8 +10,10 @@ namespace dxvk {
   struct D3D9_SOFTWARE_CURSOR {
     UINT Width  = 0;
     UINT Height = 0;
-    UINT X = 0;
-    UINT Y = 0;
+    UINT XHotSpot = 0;
+    UINT YHotSpot = 0;
+    int32_t X = 0;
+    int32_t Y = 0;
     bool DrawCursor  = false;
     bool ResetCursor = false;
   };

--- a/src/d3d9/d3d9_swapchain.cpp
+++ b/src/d3d9/d3d9_swapchain.cpp
@@ -758,8 +758,8 @@ namespace dxvk {
   }
 
 
-  void D3D9SwapChainEx::SetCursorPosition(UINT X, UINT Y, UINT Width, UINT Height) {
-      VkOffset2D cursorPosition = { int32_t(X), int32_t(Y) };
+  void D3D9SwapChainEx::SetCursorPosition(int32_t X, int32_t Y, UINT Width, UINT Height) {
+      VkOffset2D cursorPosition = { X, Y };
       VkExtent2D cursorSize     = { uint32_t(Width), uint32_t(Height) };
 
       VkRect2D   cursorRect     = { cursorPosition, cursorSize };

--- a/src/d3d9/d3d9_swapchain.h
+++ b/src/d3d9/d3d9_swapchain.h
@@ -120,7 +120,7 @@ namespace dxvk {
 
     void SetCursorTexture(UINT Width, UINT Height, uint8_t* pCursorBitmap);
 
-    void SetCursorPosition(UINT X, UINT Y, UINT Width, UINT Height);
+    void SetCursorPosition(int32_t X, int32_t Y, UINT Width, UINT Height);
 
     HRESULT SetDialogBoxMode(bool bEnableDialogs);
 


### PR DESCRIPTION
Apparently only now it dawned on me that XHotSpot/YHotSpot are not in fact initial cursor positions, rather where the cursor pointer tip should be set within the bitmap coordinates :man_facepalming:. That means all the bitmap clipping & processing I was doing is rather superfluous, and in retrospect the new approach makes a lot more sense.

Anyway, this fixes some snapping on cursor bitmap transitions that I noticed and shouldn't be there. Now everything is properly aligned vs hotspot coordinates, as the application expects it to be.

This also means we frequently end up rendering the bitmap rectangle outside of the screen when the cursor is near screen edges, so that backend viewport-based positioning wasn't a bad idea after all :wink:.