### PR TITLE
Properly reference-count queries and events

### DIFF
--- a/src/d3d11/d3d11_query.h
+++ b/src/d3d11/d3d11_query.h
@@ -103,8 +103,8 @@ namespace dxvk {
 
     D3D11_VK_QUERY_STATE m_state;
     
-    std::array<Rc<DxvkGpuQuery>, MaxGpuQueries> m_query;
-    std::array<Rc<DxvkGpuEvent>, MaxGpuEvents>  m_event;
+    std::array<Rc<DxvkQuery>, MaxGpuQueries> m_query;
+    std::array<Rc<DxvkEvent>, MaxGpuEvents>  m_event;
 
     D3D10Query m_d3d10;
 

--- a/src/d3d9/d3d9_query.h
+++ b/src/d3d9/d3d9_query.h
@@ -74,8 +74,8 @@ namespace dxvk {
 
     D3D9_VK_QUERY_STATE m_state;
 
-    std::array<Rc<DxvkGpuQuery>, MaxGpuQueries> m_query;
-    std::array<Rc<DxvkGpuEvent>, MaxGpuEvents>  m_event;
+    std::array<Rc<DxvkQuery>, MaxGpuQueries> m_query;
+    std::array<Rc<DxvkEvent>, MaxGpuEvents>  m_event;
 
     uint32_t m_stallMask = 0;
     bool     m_stallFlag = false;

--- a/src/dxvk/dxvk_cmdlist.cpp
+++ b/src/dxvk/dxvk_cmdlist.cpp
@@ -368,9 +368,6 @@ namespace dxvk {
     // that are no longer in use
     m_resources.reset();
 
-    // Return query and event handles
-    m_gpuQueryTracker.reset();
-
     // Less important stuff
     m_signalTracker.reset();
     m_statCounters.reset();

--- a/src/dxvk/dxvk_cmdlist.cpp
+++ b/src/dxvk/dxvk_cmdlist.cpp
@@ -370,7 +370,6 @@ namespace dxvk {
 
     // Return query and event handles
     m_gpuQueryTracker.reset();
-    m_gpuEventTracker.reset();
 
     // Less important stuff
     m_signalTracker.reset();

--- a/src/dxvk/dxvk_cmdlist.h
+++ b/src/dxvk/dxvk_cmdlist.h
@@ -284,17 +284,10 @@ namespace dxvk {
       m_resources.trackSampler(sampler);
     }
 
-    /**
-     * \brief Tracks a GPU event
-     * 
-     * The event will be returned to its event pool
-     * after the command buffer has finished executing.
-     * \param [in] handle Event handle
-     */
-    void trackGpuEvent(DxvkGpuEventHandle handle) {
-      m_gpuEventTracker.trackEvent(handle);
+    void trackEvent(Rc<DxvkGpuEvent>&& event) {
+      m_resources.trackEvent(std::move(event));
     }
-    
+
     /**
      * \brief Tracks a GPU query
      * 
@@ -1082,7 +1075,6 @@ namespace dxvk {
 
     DxvkLifetimeTracker       m_resources;
     DxvkSignalTracker         m_signalTracker;
-    DxvkGpuEventTracker       m_gpuEventTracker;
     DxvkGpuQueryTracker       m_gpuQueryTracker;
     DxvkStatCounters          m_statCounters;
 

--- a/src/dxvk/dxvk_cmdlist.h
+++ b/src/dxvk/dxvk_cmdlist.h
@@ -288,17 +288,10 @@ namespace dxvk {
       m_resources.trackEvent(std::move(event));
     }
 
-    /**
-     * \brief Tracks a GPU query
-     * 
-     * The query handle will be returned to its allocator
-     * after the command buffer has finished executing.
-     * \param [in] handle Event handle
-     */
-    void trackGpuQuery(DxvkGpuQueryHandle handle) {
-      m_gpuQueryTracker.trackQuery(handle);
+    void trackQuery(Rc<DxvkGpuQuery>&& query) {
+      m_resources.trackQuery(std::move(query));
     }
-    
+
     /**
      * \brief Tracks a graphics pipeline
      * \param [in] pipeline Pipeline
@@ -1075,7 +1068,6 @@ namespace dxvk {
 
     DxvkLifetimeTracker       m_resources;
     DxvkSignalTracker         m_signalTracker;
-    DxvkGpuQueryTracker       m_gpuQueryTracker;
     DxvkStatCounters          m_statCounters;
 
     DxvkCommandSubmission     m_commandSubmission;

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -126,12 +126,12 @@ namespace dxvk {
   }
 
   
-  void DxvkContext::beginQuery(const Rc<DxvkGpuQuery>& query) {
+  void DxvkContext::beginQuery(const Rc<DxvkQuery>& query) {
     m_queryManager.enableQuery(m_cmd, query);
   }
 
 
-  void DxvkContext::endQuery(const Rc<DxvkGpuQuery>& query) {
+  void DxvkContext::endQuery(const Rc<DxvkQuery>& query) {
     m_queryManager.disableQuery(m_cmd, query);
   }
   
@@ -2467,7 +2467,7 @@ namespace dxvk {
   }
 
 
-  void DxvkContext::signalGpuEvent(const Rc<DxvkGpuEvent>& event) {
+  void DxvkContext::signalGpuEvent(const Rc<DxvkEvent>& event) {
     this->spillRenderPass(true);
     
     DxvkGpuEventHandle handle = m_common->eventPool().allocEvent();
@@ -2556,7 +2556,7 @@ namespace dxvk {
   }
   
   
-  void DxvkContext::writeTimestamp(const Rc<DxvkGpuQuery>& query) {
+  void DxvkContext::writeTimestamp(const Rc<DxvkQuery>& query) {
     m_queryManager.writeTimestamp(m_cmd, query);
   }
 

--- a/src/dxvk/dxvk_context.h
+++ b/src/dxvk/dxvk_context.h
@@ -101,14 +101,14 @@ namespace dxvk {
      * \param [in] query The query to end
      */
     void beginQuery(
-      const Rc<DxvkGpuQuery>&   query);
+      const Rc<DxvkQuery>&      query);
     
     /**
      * \brief Ends generating query data
      * \param [in] query The query to end
      */
     void endQuery(
-      const Rc<DxvkGpuQuery>&   query);
+      const Rc<DxvkQuery>&      query);
     
     /**
      * \brief Sets render targets
@@ -1299,14 +1299,14 @@ namespace dxvk {
      * \param [in] event The event
      */
     void signalGpuEvent(
-      const Rc<DxvkGpuEvent>&   event);
+      const Rc<DxvkEvent>&      event);
     
     /**
      * \brief Writes to a timestamp query
      * \param [in] query The timestamp query
      */
     void writeTimestamp(
-      const Rc<DxvkGpuQuery>&   query);
+      const Rc<DxvkQuery>&      query);
     
     /**
      * \brief Queues a signal

--- a/src/dxvk/dxvk_device.cpp
+++ b/src/dxvk/dxvk_device.cpp
@@ -138,16 +138,16 @@ namespace dxvk {
   }
 
 
-  Rc<DxvkGpuEvent> DxvkDevice::createGpuEvent() {
-    return new DxvkGpuEvent(m_vkd);
+  Rc<DxvkEvent> DxvkDevice::createGpuEvent() {
+    return new DxvkEvent(m_vkd);
   }
 
 
-  Rc<DxvkGpuQuery> DxvkDevice::createGpuQuery(
+  Rc<DxvkQuery> DxvkDevice::createGpuQuery(
           VkQueryType           type,
           VkQueryControlFlags   flags,
           uint32_t              index) {
-    return new DxvkGpuQuery(m_vkd, type, flags, index);
+    return new DxvkQuery(m_vkd, type, flags, index);
   }
 
 

--- a/src/dxvk/dxvk_device.cpp
+++ b/src/dxvk/dxvk_device.cpp
@@ -139,7 +139,7 @@ namespace dxvk {
 
 
   Rc<DxvkEvent> DxvkDevice::createGpuEvent() {
-    return new DxvkEvent(m_vkd);
+    return new DxvkEvent(this);
   }
 
 

--- a/src/dxvk/dxvk_device.cpp
+++ b/src/dxvk/dxvk_device.cpp
@@ -147,7 +147,7 @@ namespace dxvk {
           VkQueryType           type,
           VkQueryControlFlags   flags,
           uint32_t              index) {
-    return new DxvkQuery(m_vkd, type, flags, index);
+    return new DxvkQuery(this, type, flags, index);
   }
 
 

--- a/src/dxvk/dxvk_device.h
+++ b/src/dxvk/dxvk_device.h
@@ -288,7 +288,7 @@ namespace dxvk {
      * \brief Creates a GPU event
      * \returns New GPU event
      */
-    Rc<DxvkGpuEvent> createGpuEvent();
+    Rc<DxvkEvent> createGpuEvent();
 
     /**
      * \brief Creates a query
@@ -298,7 +298,7 @@ namespace dxvk {
      * \param [in] index Query index
      * \returns New query
      */
-    Rc<DxvkGpuQuery> createGpuQuery(
+    Rc<DxvkQuery> createGpuQuery(
             VkQueryType           type,
             VkQueryControlFlags   flags,
             uint32_t              index);

--- a/src/dxvk/dxvk_gpu_event.cpp
+++ b/src/dxvk/dxvk_gpu_event.cpp
@@ -3,17 +3,17 @@
 
 namespace dxvk {
 
-  DxvkGpuEvent::DxvkGpuEvent(const Rc<vk::DeviceFn>& vkd)
+  DxvkEvent::DxvkEvent(const Rc<vk::DeviceFn>& vkd)
   : m_vkd(vkd) { }
 
 
-  DxvkGpuEvent::~DxvkGpuEvent() {
+  DxvkEvent::~DxvkEvent() {
     if (m_handle.pool && m_handle.event)
       m_handle.pool->freeEvent(m_handle.event);
   }
 
 
-  DxvkGpuEventStatus DxvkGpuEvent::test() const {
+  DxvkGpuEventStatus DxvkEvent::test() const {
     if (!m_handle.event)
       return DxvkGpuEventStatus::Invalid;
     
@@ -28,7 +28,7 @@ namespace dxvk {
   }
 
 
-  DxvkGpuEventHandle DxvkGpuEvent::reset(DxvkGpuEventHandle handle) {
+  DxvkGpuEventHandle DxvkEvent::reset(DxvkGpuEventHandle handle) {
     m_vkd->vkResetEvent(m_vkd->device(), handle.event);
     return std::exchange(m_handle, handle);
   }

--- a/src/dxvk/dxvk_gpu_event.cpp
+++ b/src/dxvk/dxvk_gpu_event.cpp
@@ -3,34 +3,76 @@
 
 namespace dxvk {
 
-  DxvkEvent::DxvkEvent(const Rc<vk::DeviceFn>& vkd)
-  : m_vkd(vkd) { }
+  DxvkGpuEvent::DxvkGpuEvent(
+          DxvkGpuEventPool*           parent)
+  : m_pool(parent) {
+    auto vk = m_pool->m_vkd;
 
+    VkEventCreateInfo info = { VK_STRUCTURE_TYPE_EVENT_CREATE_INFO };
+    VkResult vr = vk->vkCreateEvent(vk->device(), &info, nullptr, &m_event);
 
-  DxvkEvent::~DxvkEvent() {
-    if (m_handle.pool && m_handle.event)
-      m_handle.pool->freeEvent(m_handle.event);
+    if (vr != VK_SUCCESS)
+      throw DxvkError(str::format("Failed to create event: ", vr));
   }
 
 
-  DxvkGpuEventStatus DxvkEvent::test() const {
-    if (!m_handle.event)
+  DxvkGpuEvent::~DxvkGpuEvent() {
+    auto vk = m_pool->m_vkd;
+    vk->vkDestroyEvent(vk->device(), m_event, nullptr);
+  }
+
+
+  void DxvkGpuEvent::free() {
+    m_pool->freeEvent(this);
+  }
+
+
+
+  DxvkEvent::DxvkEvent(const Rc<DxvkDevice>& device)
+  : m_device(device) { }
+
+
+  DxvkEvent::~DxvkEvent() {
+
+  }
+
+
+  DxvkGpuEventStatus DxvkEvent::test() {
+    std::lock_guard lock(m_mutex);
+
+    if (m_status == VK_EVENT_SET)
+      return DxvkGpuEventStatus::Signaled;
+
+    if (!m_gpuEvent)
       return DxvkGpuEventStatus::Invalid;
-    
-    VkResult status = m_vkd->vkGetEventStatus(
-      m_vkd->device(), m_handle.event);
-    
-    switch (status) {
-      case VK_EVENT_SET:    return DxvkGpuEventStatus::Signaled;
-      case VK_EVENT_RESET:  return DxvkGpuEventStatus::Pending;
-      default:              return DxvkGpuEventStatus::Invalid;
+
+    // Query current event status and recycle
+    // it as soon as a signal is observed.
+    auto vk = m_device->vkd();
+
+    m_status = vk->vkGetEventStatus(
+      vk->device(), m_gpuEvent->handle());
+
+    switch (m_status) {
+      case VK_EVENT_SET:
+        m_gpuEvent = nullptr;
+        return DxvkGpuEventStatus::Signaled;
+
+      case VK_EVENT_RESET:
+        return DxvkGpuEventStatus::Pending;
+
+      default:
+        return DxvkGpuEventStatus::Invalid;
     }
   }
 
 
-  DxvkGpuEventHandle DxvkEvent::reset(DxvkGpuEventHandle handle) {
-    m_vkd->vkResetEvent(m_vkd->device(), handle.event);
-    return std::exchange(m_handle, handle);
+  void DxvkEvent::assignGpuEvent(
+          Rc<DxvkGpuEvent>             event) {
+    std::lock_guard lock(m_mutex);
+
+    m_gpuEvent = std::move(event);
+    m_status = VK_NOT_READY;
   }
 
 
@@ -41,61 +83,31 @@ namespace dxvk {
 
 
   DxvkGpuEventPool::~DxvkGpuEventPool() {
-    for (VkEvent ev : m_events)
-      m_vkd->vkDestroyEvent(m_vkd->device(), ev, nullptr);
+    for (auto e : m_freeEvents)
+      delete e;
   }
 
   
-  DxvkGpuEventHandle DxvkGpuEventPool::allocEvent() {
-    VkEvent event = VK_NULL_HANDLE;
+  Rc<DxvkGpuEvent> DxvkGpuEventPool::allocEvent() {
+    std::lock_guard lock(m_mutex);
 
-    { std::lock_guard<dxvk::mutex> lock(m_mutex);
-      
-      if (m_events.size() > 0) {
-        event = m_events.back();
-        m_events.pop_back();
-      }
+    Rc<DxvkGpuEvent> event;
+
+    if (m_freeEvents.empty()) {
+      event = new DxvkGpuEvent(this);
+    } else {
+      event = m_freeEvents.back();
+      m_freeEvents.pop_back();
     }
 
-    if (!event) {
-      VkEventCreateInfo info = { VK_STRUCTURE_TYPE_EVENT_CREATE_INFO };
-
-      VkResult status = m_vkd->vkCreateEvent(
-        m_vkd->device(), &info, nullptr, &event);
-      
-      if (status != VK_SUCCESS) {
-        Logger::err("DXVK: Failed to create GPU event");
-        return DxvkGpuEventHandle();
-      }
-    }
-
-    return { this, event };
+    m_vkd->vkResetEvent(m_vkd->device(), event->handle());
+    return event;
   }
 
 
-  void DxvkGpuEventPool::freeEvent(VkEvent event) {
-    std::lock_guard<dxvk::mutex> lock(m_mutex);
-    m_events.push_back(event);
-  }
-
-
-
-
-  DxvkGpuEventTracker::DxvkGpuEventTracker() { }
-  DxvkGpuEventTracker::~DxvkGpuEventTracker() { }
-
-
-  void DxvkGpuEventTracker::trackEvent(DxvkGpuEventHandle handle) {
-    if (handle.pool && handle.event)
-      m_handles.push_back(handle);
-  }
-
-
-  void DxvkGpuEventTracker::reset() {
-    for (const auto& h : m_handles)
-      h.pool->freeEvent(h.event);
-    
-    m_handles.clear();
+  void DxvkGpuEventPool::freeEvent(DxvkGpuEvent* event) {
+    std::lock_guard lock(m_mutex);
+    m_freeEvents.push_back(event);
   }
 
 }

--- a/src/dxvk/dxvk_gpu_event.h
+++ b/src/dxvk/dxvk_gpu_event.h
@@ -42,12 +42,12 @@ namespace dxvk {
    * the application to check whether a specific
    * command has completed execution.
    */
-  class DxvkGpuEvent : public DxvkResource {
+  class DxvkEvent : public DxvkResource {
 
   public:
 
-    DxvkGpuEvent(const Rc<vk::DeviceFn>& vkd);
-    ~DxvkGpuEvent();
+    DxvkEvent(const Rc<vk::DeviceFn>& vkd);
+    ~DxvkEvent();
 
     /**
      * \brief Retrieves event status

--- a/src/dxvk/dxvk_gpu_event.h
+++ b/src/dxvk/dxvk_gpu_event.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <atomic>
 #include <vector>
 
 #include "dxvk_resource.h"
@@ -29,9 +30,50 @@ namespace dxvk {
    * as a pointer to the pool that the event
    * was allocated from.
    */
-  struct DxvkGpuEventHandle {
-    DxvkGpuEventPool* pool  = nullptr;
-    VkEvent           event = VK_NULL_HANDLE;
+  class DxvkGpuEvent {
+
+  public:
+
+    explicit DxvkGpuEvent(
+            DxvkGpuEventPool*           parent);
+
+    ~DxvkGpuEvent();
+
+    /**
+     * \brief Increments ref count
+     */
+    void incRef() {
+      m_refs.fetch_add(1u, std::memory_order_acquire);
+    }
+
+    /**
+     * \brief Decrements ref count
+     *
+     * Returns event to the pool if no further
+     * references exist for this event.
+     */
+    void decRef() {
+      if (m_refs.fetch_sub(1u, std::memory_order_release) == 1u)
+        free();
+    }
+
+    /**
+     * \brief Queries event handle
+     * \returns Event handle
+     */
+    VkEvent handle() const {
+      return m_event;
+    }
+
+  private:
+
+    DxvkGpuEventPool*     m_pool  = nullptr;
+    VkEvent               m_event = VK_NULL_HANDLE;
+
+    std::atomic<uint32_t> m_refs  = { 0u };
+
+    void free();
+
   };
 
 
@@ -42,12 +84,28 @@ namespace dxvk {
    * the application to check whether a specific
    * command has completed execution.
    */
-  class DxvkEvent : public DxvkResource {
-
+  class DxvkEvent {
+    friend class DxvkContext;
   public:
 
-    DxvkEvent(const Rc<vk::DeviceFn>& vkd);
+    DxvkEvent(const Rc<DxvkDevice>& device);
     ~DxvkEvent();
+
+    /**
+     * \brief Increments reference count
+     */
+    force_inline void incRef() {
+      m_refCount.fetch_add(1u, std::memory_order_acquire);
+    }
+
+    /**
+     * \brief Decrements reference count
+     * Frees the event as necessary.
+     */
+    force_inline void decRef() {
+      if (m_refCount.fetch_sub(1u, std::memory_order_release) == 1u)
+        delete this;
+    }
 
     /**
      * \brief Retrieves event status
@@ -56,24 +114,20 @@ namespace dxvk {
      * recorded intro a command buffer.
      * \returns Event status
      */
-    DxvkGpuEventStatus test() const;
-
-    /**
-     * \brief Resets event
-     * 
-     * Assigns a new Vulkan event to this event
-     * object and replaces the old one. The old
-     * event should be freed as soon as the GPU
-     * stops using it.
-     * \param [in] handle New GPU event handle
-     * \returns Old GPU event handle
-     */
-    DxvkGpuEventHandle reset(DxvkGpuEventHandle handle);
+    DxvkGpuEventStatus test();
 
   private:
 
-    Rc<vk::DeviceFn>   m_vkd;
-    DxvkGpuEventHandle m_handle;
+    std::atomic<uint32_t> m_refCount = { 0u };
+
+    sync::Spinlock    m_mutex;
+    VkResult          m_status = VK_NOT_READY;
+
+    Rc<DxvkDevice>    m_device;
+    Rc<DxvkGpuEvent>  m_gpuEvent;
+
+    void assignGpuEvent(
+            Rc<DxvkGpuEvent>            event);
 
   };
 
@@ -85,7 +139,7 @@ namespace dxvk {
    * a way to create and recycle Vulkan events.
    */
   class DxvkGpuEventPool {
-  
+    friend class DxvkGpuEvent;
   public:
 
     DxvkGpuEventPool(const DxvkDevice* device);
@@ -99,55 +153,21 @@ namespace dxvk {
      * state of the event is undefined.
      * \returns An event handle
      */
-    DxvkGpuEventHandle allocEvent();
+    Rc<DxvkGpuEvent> allocEvent();
 
     /**
      * \brief Recycles an event
      * 
-     * \param [in] handle Event to free
+     * \param [in] event Event object to free
      */
-    void freeEvent(VkEvent event);
+    void freeEvent(DxvkGpuEvent* event);
 
   private:
 
-    Rc<vk::DeviceFn>     m_vkd;
-    dxvk::mutex          m_mutex;
-    std::vector<VkEvent> m_events;
+    Rc<vk::DeviceFn>            m_vkd;
 
-  };
-
-
-  /**
-   * \brief GPU event tracker
-   * 
-   * Stores events currently accessed by the
-   * GPU, and returns them to the event pool
-   * once they are no longer in use.
-   */
-  class DxvkGpuEventTracker {
-
-  public:
-
-    DxvkGpuEventTracker();
-    ~DxvkGpuEventTracker();
-
-    /**
-     * \brief Tracks an event
-     * \param [in] handle Event to track
-     */
-    void trackEvent(DxvkGpuEventHandle handle);
-
-    /**
-     * \brief Resets event tracker
-     * 
-     * Releases all tracked events back
-     * to the respective event pool
-     */
-    void reset();
-
-  private:
-
-    std::vector<DxvkGpuEventHandle> m_handles;
+    dxvk::mutex                 m_mutex;
+    std::vector<DxvkGpuEvent*>  m_freeEvents;
 
   };
 

--- a/src/dxvk/dxvk_gpu_query.cpp
+++ b/src/dxvk/dxvk_gpu_query.cpp
@@ -1,4 +1,4 @@
-#include <algorithm>
+#include <utility>
 
 #include "dxvk_cmdlist.h"
 #include "dxvk_device.h"
@@ -6,25 +6,25 @@
 
 namespace dxvk {
 
+  void DxvkGpuQuery::free() {
+    m_allocator->freeQuery(this);
+  }
+
+
+
+
   DxvkQuery::DxvkQuery(
-    const Rc<vk::DeviceFn>&   vkd,
-          VkQueryType         type,
-          VkQueryControlFlags flags,
-          uint32_t            index)
-  : m_vkd(vkd), m_type(type), m_flags(flags),
-    m_index(index), m_ended(false) {
-    
+    const Rc<DxvkDevice>&             device,
+          VkQueryType                 type,
+          VkQueryControlFlags         flags,
+          uint32_t                    index)
+  : m_device(device), m_type(type), m_flags(flags), m_index(index) {
+
   }
   
   
   DxvkQuery::~DxvkQuery() {
-    for (size_t i = 0; i < m_handles.size(); i++)
-      m_handles[i].allocator->freeQuery(m_handles[i]);
-  }
 
-
-  bool DxvkQuery::isIndexed() const {
-    return m_type == VK_QUERY_TYPE_TRANSFORM_FEEDBACK_STREAM_EXT;
   }
 
 
@@ -34,12 +34,14 @@ namespace dxvk {
     // Callers must ensure that no begin call is pending when
     // calling this. Given that, once the query is ended, we
     // know that no other thread will access query state.
-    if (!m_ended.load(std::memory_order_acquire))
+    std::lock_guard lock(m_mutex);
+
+    if (!m_ended)
       return DxvkGpuQueryStatus::Invalid;
 
     // Accumulate query data from all available queries
-    DxvkGpuQueryStatus status = this->accumulateQueryData();
-    
+    DxvkGpuQueryStatus status = accumulateQueryDataLocked();
+
     // Treat non-precise occlusion queries as available
     // if we already know the result will be non-zero
     if ((status == DxvkGpuQueryStatus::Pending)
@@ -56,64 +58,61 @@ namespace dxvk {
   }
 
 
-  void DxvkQuery::begin(const Rc<DxvkCommandList>& cmd) {
-    // Not useful to enforce a memory order here since
-    // only the false->true transition is defined.
-    m_ended.store(false, std::memory_order_relaxed);
-
-    // Ideally we should have no queries left at this point,
-    // if we do, lifetime-track them with the command list.
-    for (size_t i = 0; i < m_handles.size(); i++)
-      cmd->trackGpuQuery(m_handles[i]);
-
-    m_handles.clear();
-
-    // Reset accumulated query data
-    m_queryData = DxvkQueryData();
+  void DxvkQuery::begin() {
+    std::lock_guard lock(m_mutex);
+    m_queries.clear();
+    m_queryData = { };
+    m_ended = false;
   }
 
-  
+
   void DxvkQuery::end() {
-    // Ensure that all prior writes are made available
-    m_ended.store(true, std::memory_order_release);
+    std::lock_guard lock(m_mutex);
+    m_ended = true;
   }
 
 
-  void DxvkQuery::addQueryHandle(const DxvkGpuQueryHandle& handle) {
+  void DxvkQuery::addGpuQuery(Rc<DxvkGpuQuery> query) {
     // Already accumulate available queries here in case
     // we already allocated a large number of queries
-    if (m_handles.size() >= m_handles.MinCapacity)
-      this->accumulateQueryData();
+    std::lock_guard lock(m_mutex);
 
-    m_handles.push_back(handle);
+    if (m_queries.size() >= m_queries.MinCapacity)
+      accumulateQueryDataLocked();
+
+    m_queries.push_back(std::move(query));
   }
 
 
-  DxvkGpuQueryStatus DxvkQuery::accumulateQueryDataForHandle(
-    const DxvkGpuQueryHandle& handle) {
+  DxvkGpuQueryStatus DxvkQuery::accumulateQueryDataForGpuQueryLocked(
+    const Rc<DxvkGpuQuery>&           query) {
+    auto vk = m_device->vkd();
+
     DxvkQueryData tmpData = { };
 
     // Try to copy query data to temporary structure
-    VkResult result = m_vkd->vkGetQueryPoolResults(m_vkd->device(),
-      handle.queryPool, handle.queryId, 1,
+    std::pair<VkQueryPool, uint32_t> handle = query->getQuery();
+
+    VkResult result = vk->vkGetQueryPoolResults(
+      vk->device(), handle.first, handle.second, 1,
       sizeof(DxvkQueryData), &tmpData,
       sizeof(DxvkQueryData), VK_QUERY_RESULT_64_BIT);
-    
+
     if (result == VK_NOT_READY)
       return DxvkGpuQueryStatus::Pending;
     else if (result != VK_SUCCESS)
       return DxvkGpuQueryStatus::Failed;
-    
+
     // Add numbers to the destination structure
     switch (m_type) {
       case VK_QUERY_TYPE_OCCLUSION:
         m_queryData.occlusion.samplesPassed += tmpData.occlusion.samplesPassed;
         break;
-      
+
       case VK_QUERY_TYPE_TIMESTAMP:
         m_queryData.timestamp.time = tmpData.timestamp.time;
         break;
-      
+
       case VK_QUERY_TYPE_PIPELINE_STATISTICS:
         m_queryData.statistic.iaVertices       += tmpData.statistic.iaVertices;
         m_queryData.statistic.iaPrimitives     += tmpData.statistic.iaPrimitives;
@@ -142,7 +141,7 @@ namespace dxvk {
   }
 
 
-  DxvkGpuQueryStatus DxvkQuery::accumulateQueryData() {
+  DxvkGpuQueryStatus DxvkQuery::accumulateQueryDataLocked() {
     DxvkGpuQueryStatus status = DxvkGpuQueryStatus::Available;
 
     // Process available queries and return them to the
@@ -150,8 +149,8 @@ namespace dxvk {
     // number of Vulkan queries in flight.
     size_t queriesAvailable = 0;
 
-    while (queriesAvailable < m_handles.size()) {
-      status = this->accumulateQueryDataForHandle(m_handles[queriesAvailable]);
+    while (queriesAvailable < m_queries.size()) {
+      status = accumulateQueryDataForGpuQueryLocked(m_queries[queriesAvailable]);
 
       if (status != DxvkGpuQueryStatus::Available)
         break;
@@ -160,13 +159,10 @@ namespace dxvk {
     }
 
     if (queriesAvailable) {
-      for (size_t i = 0; i < queriesAvailable; i++)
-        m_handles[i].allocator->freeQuery(m_handles[i]);
+      for (size_t i = queriesAvailable; i < m_queries.size(); i++)
+        m_queries[i - queriesAvailable] = m_queries[i];
 
-      for (size_t i = queriesAvailable; i < m_handles.size(); i++)
-        m_handles[i - queriesAvailable] = m_handles[i];
-
-      m_handles.resize(m_handles.size() - queriesAvailable);
+      m_queries.resize(m_queries.size() - queriesAvailable);
     }
 
     return status;
@@ -176,11 +172,10 @@ namespace dxvk {
   
   
   DxvkGpuQueryAllocator::DxvkGpuQueryAllocator(
-          DxvkDevice*         device,
-          VkQueryType         queryType,
-          uint32_t            queryPoolSize)
+          DxvkDevice*                 device,
+          VkQueryType                 queryType,
+          uint32_t                    queryPoolSize)
   : m_device        (device),
-    m_vkd           (device->vkd()),
     m_queryType     (queryType),
     m_queryPoolSize (queryPoolSize) {
 
@@ -188,35 +183,34 @@ namespace dxvk {
 
   
   DxvkGpuQueryAllocator::~DxvkGpuQueryAllocator() {
-    for (VkQueryPool pool : m_pools) {
-      m_vkd->vkDestroyQueryPool(
-        m_vkd->device(), pool, nullptr);
+    auto vk = m_device->vkd();
+
+    for (auto& p : m_pools) {
+      vk->vkDestroyQueryPool(vk->device(), p.pool, nullptr);
+      delete[] p.queries;
     }
   }
 
   
-  DxvkGpuQueryHandle DxvkGpuQueryAllocator::allocQuery() {
+  Rc<DxvkGpuQuery> DxvkGpuQueryAllocator::allocQuery() {
     std::lock_guard<dxvk::mutex> lock(m_mutex);
 
-    if (m_handles.size() == 0)
-      this->createQueryPool();
+    if (!m_free)
+      createQueryPool();
 
-    if (m_handles.size() == 0)
-      return DxvkGpuQueryHandle();
-    
-    DxvkGpuQueryHandle result = m_handles.back();
-    m_handles.pop_back();
-    return result;
+    return std::exchange(m_free, m_free->m_next);
   }
 
 
-  void DxvkGpuQueryAllocator::freeQuery(DxvkGpuQueryHandle handle) {
+  void DxvkGpuQueryAllocator::freeQuery(DxvkGpuQuery* query) {
     std::lock_guard<dxvk::mutex> lock(m_mutex);
-    m_handles.push_back(handle);
+    query->m_next = std::exchange(m_free, query);
   }
 
-  
+
   void DxvkGpuQueryAllocator::createQueryPool() {
+    auto vk = m_device->vkd();
+
     VkQueryPoolCreateInfo info = { VK_STRUCTURE_TYPE_QUERY_POOL_CREATE_INFO };
     info.queryType  = m_queryType;
     info.queryCount = m_queryPoolSize;
@@ -238,15 +232,26 @@ namespace dxvk {
 
     VkQueryPool queryPool = VK_NULL_HANDLE;
 
-    if (m_vkd->vkCreateQueryPool(m_vkd->device(), &info, nullptr, &queryPool)) {
+    if (vk->vkCreateQueryPool(vk->device(), &info, nullptr, &queryPool)) {
       Logger::err(str::format("DXVK: Failed to create query pool (", m_queryType, "; ", m_queryPoolSize, ")"));
       return;
     }
 
-    m_pools.push_back(queryPool);
+    auto& pool = m_pools.emplace_back();
+    pool.pool = queryPool;
+    pool.queries = new DxvkGpuQuery [m_queryPoolSize];
 
-    for (uint32_t i = 0; i < m_queryPoolSize; i++)
-      m_handles.push_back({ this, queryPool, i });
+    for (uint32_t i = 0; i < m_queryPoolSize; i++) {
+      auto& query = pool.queries[i];
+      query.m_allocator = this;
+      query.m_pool = queryPool;
+      query.m_index = i;
+
+      if (i + 1u < m_queryPoolSize)
+        query.m_next = &pool.queries[i + 1u];
+    }
+
+    m_free = &pool.queries[0u];
   }
 
 
@@ -266,7 +271,7 @@ namespace dxvk {
   }
 
   
-  DxvkGpuQueryHandle DxvkGpuQueryPool::allocQuery(VkQueryType type) {
+  Rc<DxvkGpuQuery> DxvkGpuQueryPool::allocQuery(VkQueryType type) {
     switch (type) {
       case VK_QUERY_TYPE_OCCLUSION:
         return m_occlusion.allocQuery();
@@ -278,7 +283,7 @@ namespace dxvk {
         return m_xfbStream.allocQuery();
       default:
         Logger::err(str::format("DXVK: Unhandled query type: ", type));
-        return DxvkGpuQueryHandle();
+        return nullptr;
     }
   }
 
@@ -286,7 +291,7 @@ namespace dxvk {
 
 
   DxvkGpuQueryManager::DxvkGpuQueryManager(DxvkGpuQueryPool& pool)
-  : m_pool(&pool), m_activeTypes(0) {
+  : m_pool(&pool) {
 
   }
 
@@ -299,51 +304,55 @@ namespace dxvk {
   void DxvkGpuQueryManager::enableQuery(
     const Rc<DxvkCommandList>&  cmd,
     const Rc<DxvkQuery>&        query) {
-    query->begin(cmd);
+    query->begin();
 
-    m_activeQueries.push_back(query);
+    uint32_t index = getQueryTypeIndex(query->type(), query->index());
+
+    m_activeQueries[index].queries.push_back(query);
 
     if (m_activeTypes & getQueryTypeBit(query->type()))
-      beginSingleQuery(cmd, query);
+      restartQueries(cmd, query->type(), query->index());
   }
 
   
   void DxvkGpuQueryManager::disableQuery(
     const Rc<DxvkCommandList>&  cmd,
     const Rc<DxvkQuery>&        query) {
-    auto iter = std::find(
-      m_activeQueries.begin(),
-      m_activeQueries.end(),
-      query);
-    
-    if (iter != m_activeQueries.end()) {
-      if (m_activeTypes & getQueryTypeBit((*iter)->type()))
-        endSingleQuery(cmd, query);
-      m_activeQueries.erase(iter);
-      
-      query->end();
+    uint32_t index = getQueryTypeIndex(query->type(), query->index());
+
+    for (auto& q : m_activeQueries[index].queries) {
+      if (q == query) {
+        q = std::move(m_activeQueries[index].queries.back());
+        m_activeQueries[index].queries.pop_back();
+        break;
+      }
     }
+
+    if (m_activeTypes & getQueryTypeBit(query->type()))
+      restartQueries(cmd, query->type(), query->index());
+
+    query->end();
   }
 
 
   void DxvkGpuQueryManager::writeTimestamp(
     const Rc<DxvkCommandList>&  cmd,
     const Rc<DxvkQuery>&        query) {
-    DxvkGpuQueryHandle handle = m_pool->allocQuery(query->type());
-    
-    query->begin(cmd);
-    query->addQueryHandle(handle);
+    Rc<DxvkGpuQuery> q = m_pool->allocQuery(query->type());
+
+    query->begin();
+    query->addGpuQuery(q);
     query->end();
 
-    cmd->resetQuery(
-      handle.queryPool,
-      handle.queryId);
-    
+    std::pair<VkQueryPool, uint32_t> handle = q->getQuery();
+
+    cmd->resetQuery(handle.first, handle.second);
+
     cmd->cmdWriteTimestamp(DxvkCmdBuffer::ExecBuffer,
       VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
-      handle.queryPool, handle.queryId);
-    
-    cmd->trackResource<DxvkAccess::None>(query);
+      handle.first, handle.second);
+
+    cmd->trackQuery(std::move(q));
   }
 
 
@@ -352,9 +361,11 @@ namespace dxvk {
           VkQueryType           type) {
     m_activeTypes |= getQueryTypeBit(type);
 
-    for (size_t i = 0; i < m_activeQueries.size(); i++) {
-      if (m_activeQueries[i]->type() == type)
-        beginSingleQuery(cmd, m_activeQueries[i]);
+    if (likely(type != VK_QUERY_TYPE_TRANSFORM_FEEDBACK_STREAM_EXT)) {
+      restartQueries(cmd, type, 0);
+    } else {
+      for (uint32_t i = 0; i < 4; i++)
+        restartQueries(cmd, type, i);
     }
   }
 
@@ -364,88 +375,76 @@ namespace dxvk {
           VkQueryType           type) {
     m_activeTypes &= ~getQueryTypeBit(type);
 
-    for (size_t i = 0; i < m_activeQueries.size(); i++) {
-      if (m_activeQueries[i]->type() == type)
-        endSingleQuery(cmd, m_activeQueries[i]);
-    }
-  }
-
-
-  void DxvkGpuQueryManager::beginSingleQuery(
-    const Rc<DxvkCommandList>&  cmd,
-    const Rc<DxvkQuery>&        query) {
-    DxvkGpuQueryHandle handle = m_pool->allocQuery(query->type());
-    
-    cmd->resetQuery(
-      handle.queryPool,
-      handle.queryId);
-    
-    if (query->isIndexed()) {
-      cmd->cmdBeginQueryIndexed(
-        handle.queryPool,
-        handle.queryId,
-        query->flags(),
-        query->index());
+    if (likely(type != VK_QUERY_TYPE_TRANSFORM_FEEDBACK_STREAM_EXT)) {
+      restartQueries(cmd, type, 0);
     } else {
-      cmd->cmdBeginQuery(
-        handle.queryPool,
-        handle.queryId,
-        query->flags());
+      for (uint32_t i = 0; i < 4; i++)
+        restartQueries(cmd, type, i);
     }
-    
-    query->addQueryHandle(handle);
   }
 
 
-  void DxvkGpuQueryManager::endSingleQuery(
+  void DxvkGpuQueryManager::restartQueries(
     const Rc<DxvkCommandList>&  cmd,
-    const Rc<DxvkQuery>&        query) {
-    DxvkGpuQueryHandle handle = query->handle();
-    
-    if (query->isIndexed()) {
-      cmd->cmdEndQueryIndexed(
-        handle.queryPool,
-        handle.queryId,
-        query->index());
-    } else {
-      cmd->cmdEndQuery(
-        handle.queryPool,
-        handle.queryId);
+          VkQueryType           type,
+          uint32_t              index) {
+    auto& array = m_activeQueries[getQueryTypeIndex(type, index)];
+
+    // End active GPU query for the given type and index
+    if (array.gpuQuery) {
+      auto handle = array.gpuQuery->getQuery();
+
+      if (type == VK_QUERY_TYPE_TRANSFORM_FEEDBACK_STREAM_EXT)
+        cmd->cmdEndQueryIndexed(handle.first, handle.second, index);
+      else
+        cmd->cmdEndQuery(handle.first, handle.second);
+
+      array.gpuQuery = nullptr;
     }
 
-    cmd->trackResource<DxvkAccess::None>(query);
+    // If the query type is still active, allocate, reset and begin
+    // a new GPU query and assign it to all virtual queries.
+    if ((m_activeTypes & getQueryTypeBit(type)) && !array.queries.empty()) {
+      array.gpuQuery = m_pool->allocQuery(type);
+      auto handle = array.gpuQuery->getQuery();
+
+      // If any active occlusion query has the precise flag set, we need
+      // to respect it, otherwise just use a regular occlusion query.
+      VkQueryControlFlags flags = 0u;
+
+      for (const auto& q : array.queries) {
+        flags |= q->flags();
+        q->addGpuQuery(array.gpuQuery);
+      }
+
+      // Actually reset and begin the query
+      cmd->resetQuery(handle.first, handle.second);
+
+      if (type == VK_QUERY_TYPE_TRANSFORM_FEEDBACK_STREAM_EXT)
+        cmd->cmdBeginQueryIndexed(handle.first, handle.second, flags, index);
+      else
+        cmd->cmdBeginQuery(handle.first, handle.second, flags);
+
+      cmd->trackQuery(Rc<DxvkGpuQuery>(array.gpuQuery));
+    }
   }
-  
-  
+
+
   uint32_t DxvkGpuQueryManager::getQueryTypeBit(
           VkQueryType           type) {
+    return 1u << getQueryTypeIndex(type, 0u);
+  }
+
+
+  uint32_t DxvkGpuQueryManager::getQueryTypeIndex(
+          VkQueryType           type,
+          uint32_t              index) {
     switch (type) {
-      case VK_QUERY_TYPE_OCCLUSION:                     return 0x01;
-      case VK_QUERY_TYPE_PIPELINE_STATISTICS:           return 0x02;
-      case VK_QUERY_TYPE_TIMESTAMP:                     return 0x04;
-      case VK_QUERY_TYPE_TRANSFORM_FEEDBACK_STREAM_EXT: return 0x08;
-      default:                                          return 0;
+      case VK_QUERY_TYPE_OCCLUSION:                     return 0u;
+      case VK_QUERY_TYPE_PIPELINE_STATISTICS:           return 1u;
+      case VK_QUERY_TYPE_TRANSFORM_FEEDBACK_STREAM_EXT: return 2u + index;
+      default:                                          return 0u;
     }
-  }
-
-
-
-
-  DxvkGpuQueryTracker::DxvkGpuQueryTracker() { }
-  DxvkGpuQueryTracker::~DxvkGpuQueryTracker() { }
-  
-
-  void DxvkGpuQueryTracker::trackQuery(DxvkGpuQueryHandle handle) {
-    if (handle.queryPool)
-      m_handles.push_back(handle);
-  }
-
-
-  void DxvkGpuQueryTracker::reset() {
-    for (DxvkGpuQueryHandle handle : m_handles)
-      handle.allocator->freeQuery(handle);
-    
-    m_handles.clear();
   }
 
 }

--- a/src/dxvk/dxvk_gpu_query.h
+++ b/src/dxvk/dxvk_gpu_query.h
@@ -2,6 +2,7 @@
 
 #include <atomic>
 #include <mutex>
+#include <list>
 #include <vector>
 
 #include "../util/util_small_vector.h"
@@ -103,30 +104,82 @@ namespace dxvk {
    * query pools have to be reset on the GPU,
    * this also comes with a reset event.
    */
-  struct DxvkGpuQueryHandle {
-    DxvkGpuQueryAllocator* allocator  = nullptr;
-    VkQueryPool            queryPool  = VK_NULL_HANDLE;
-    uint32_t               queryId    = 0;
+  class DxvkGpuQuery {
+    friend class DxvkGpuQueryAllocator;
+  public:
+
+    /**
+     * \brief Increments query reference count
+     */
+    force_inline void incRef() {
+      m_refCount.fetch_add(1u, std::memory_order_acquire);
+    }
+
+    /**
+     * \brief Decrements query reference count
+     * Returns the query to its allocator if necessary.
+     */
+    force_inline void decRef() {
+      if (m_refCount.fetch_sub(1u, std::memory_order_release) == 1u)
+        free();
+    }
+
+    /**
+     * \brief Retrieves query pool and index
+     * \returns Query pool handle and query index
+     */
+    std::pair<VkQueryPool, uint32_t> getQuery() const {
+      return std::make_pair(m_pool, m_index);
+    }
+
+  private:
+
+    DxvkGpuQueryAllocator*  m_allocator = nullptr;
+    DxvkGpuQuery*           m_next      = nullptr;
+
+    VkQueryPool             m_pool      = VK_NULL_HANDLE;
+    uint32_t                m_index     = 0u;
+
+    std::atomic<uint32_t>   m_refCount  = { 0u };
+
+    void free();
+
   };
 
 
   /**
-   * \brief Query object
-   * 
-   * Manages Vulkan queries that are sub-allocated
-   * from larger query pools 
+   * \brief Virtual query object
+   *
+   * References an arbitrary number of Vulkan queries to
+   * get feedback from the GPU. Vulkan queries can be used
+   * by multiple virtual queries in case of overlap.
    */
-  class DxvkQuery : public DxvkResource {
-
+  class DxvkQuery {
+    friend class DxvkGpuQueryManager;
   public:
 
     DxvkQuery(
-      const Rc<vk::DeviceFn>&   vkd,
-            VkQueryType         type,
-            VkQueryControlFlags flags,
-            uint32_t            index);
+      const Rc<DxvkDevice>&             device,
+            VkQueryType                 type,
+            VkQueryControlFlags         flags,
+            uint32_t                    index);
     
     ~DxvkQuery();
+
+    /**
+     * \brief Increments reference count
+     */
+    force_inline void incRef() {
+      m_refCount.fetch_add(1u, std::memory_order_acquire);
+    }
+
+    /**
+     * \brief Decrements reference count
+     */
+    force_inline void decRef() {
+      if (m_refCount.fetch_sub(1u, std::memory_order_release) == 1u)
+        delete this;
+    }
 
     /**
      * \brief Query type
@@ -145,20 +198,6 @@ namespace dxvk {
     }
 
     /**
-     * \brief Retrieves current handle
-     * 
-     * Note that the query handle will change
-     * when calling \ref addQueryHandle.
-     * \returns Current query handle
-     */
-    DxvkGpuQueryHandle handle() const {
-      if (m_handles.empty())
-        return DxvkGpuQueryHandle();
-
-      return m_handles.back();
-    }
-
-    /**
      * \brief Query index
      * 
      * Only valid for indexed query types.
@@ -169,12 +208,6 @@ namespace dxvk {
     uint32_t index() const {
       return m_index;
     }
-
-    /**
-     * \brief Checks whether query is indexed
-     * \returns \c true for indexed query types
-     */
-    bool isIndexed() const;
 
     /**
      * \brief Retrieves query data
@@ -192,52 +225,42 @@ namespace dxvk {
 
     /**
      * \brief Begins query
-     * 
-     * Moves all current query handles to the given
-     * command list and sets the query into active
-     * state. No data can be retrieved while the
-     * query is active.
-     * \param [in] cmd Command list
+     *
+     * Invalidates previously retrieved data.
      */
-    void begin(
-      const Rc<DxvkCommandList>& cmd);
+    void begin();
 
     /**
      * \brief Ends query
-     * 
+     *
      * Sets query into pending state. Calling
      * \c getData is legal after calling this.
      */
     void end();
 
-    /**
-     * \brief Adds a query handle to the query
-     * 
-     * The given query handle shall be used when
-     * retrieving query data. A query can have
-     * multiple handles attached.
-     * \param [in] handle The query handle
-     */
-    void addQueryHandle(
-      const DxvkGpuQueryHandle& handle);
-
   private:
 
-    Rc<vk::DeviceFn>    m_vkd;
+    std::atomic<uint32_t> m_refCount = { 0u };
 
-    VkQueryType         m_type;
-    VkQueryControlFlags m_flags;
-    uint32_t            m_index;
-    std::atomic<bool>   m_ended;
+    Rc<DxvkDevice>      m_device;
 
+    VkQueryType         m_type  = VK_QUERY_TYPE_MAX_ENUM;
+    VkQueryControlFlags m_flags = 0u;
+    uint32_t            m_index = 0u;
+    bool                m_ended = false;
+
+    sync::Spinlock      m_mutex;
     DxvkQueryData       m_queryData = { };
 
-    small_vector<DxvkGpuQueryHandle, 8> m_handles;
-    
-    DxvkGpuQueryStatus accumulateQueryDataForHandle(
-      const DxvkGpuQueryHandle& handle);
+    small_vector<Rc<DxvkGpuQuery>, 8> m_queries;
 
-    DxvkGpuQueryStatus accumulateQueryData();
+    DxvkGpuQueryStatus accumulateQueryDataForGpuQueryLocked(
+      const Rc<DxvkGpuQuery>&           query);
+
+    DxvkGpuQueryStatus accumulateQueryDataLocked();
+
+    void addGpuQuery(
+            Rc<DxvkGpuQuery>            query);
 
   };
 
@@ -253,42 +276,46 @@ namespace dxvk {
   public:
 
     DxvkGpuQueryAllocator(
-            DxvkDevice*         device,
-            VkQueryType         queryType,
-            uint32_t            queryPoolSize);
-    
+            DxvkDevice*                 device,
+            VkQueryType                 queryType,
+            uint32_t                    queryPoolSize);
+
     ~DxvkGpuQueryAllocator();
 
     /**
      * \brief Allocates a query
      * 
-     * If possible, this returns a free query
-     * from an existing query pool. Otherwise,
-     * a new query pool will be created.
+     * If possible, this returns a free query from an existing
+     * query pool. Otherwise, a new query pool will be created.
      * \returns Query handle
      */
-    DxvkGpuQueryHandle allocQuery();
+    Rc<DxvkGpuQuery> allocQuery();
 
     /**
      * \brief Recycles a query
      * 
-     * Returns a query back to the allocator
-     * so that it can be reused. The query
-     * must not be in pending state.
-     * \param [in] handle Query to reset
+     * Returns a query back to the allocator so that it can be
+     * reused. The query must not be in pending state.
+     * \param [in] query Query object to recycle
      */
-    void freeQuery(DxvkGpuQueryHandle handle);
+    void freeQuery(
+            DxvkGpuQuery*               query);
 
   private:
 
-    DxvkDevice*       m_device;
-    Rc<vk::DeviceFn>  m_vkd;
-    VkQueryType       m_queryType;
-    uint32_t          m_queryPoolSize;
-    
-    dxvk::mutex                     m_mutex;
-    std::vector<DxvkGpuQueryHandle> m_handles;
-    std::vector<VkQueryPool>        m_pools;
+    struct Pool {
+      VkQueryPool   pool    = VK_NULL_HANDLE;
+      DxvkGpuQuery* queries = nullptr;
+    };
+
+    DxvkDevice*       m_device        = nullptr;
+    VkQueryType       m_queryType     = VK_QUERY_TYPE_MAX_ENUM;
+    uint32_t          m_queryPoolSize = 0u;
+
+    dxvk::mutex       m_mutex;
+    std::list<Pool>   m_pools;
+
+    DxvkGpuQuery*     m_free = nullptr;
 
     void createQueryPool();
 
@@ -315,7 +342,7 @@ namespace dxvk {
      * \param [in] type Query type
      * \returns Handle to the allocated query
      */
-    DxvkGpuQueryHandle allocQuery(VkQueryType type);
+    Rc<DxvkGpuQuery> allocQuery(VkQueryType type);
 
   private:
 
@@ -334,7 +361,7 @@ namespace dxvk {
    * and assigns Vulkan queries to them as needed.
    */
   class DxvkGpuQueryManager {
-
+    constexpr static uint32_t MaxQueryTypes = 6u;
   public:
 
     DxvkGpuQueryManager(DxvkGpuQueryPool& pool);
@@ -402,54 +429,28 @@ namespace dxvk {
 
   private:
 
-    DxvkGpuQueryPool*             m_pool;
-    uint32_t                      m_activeTypes;
-    std::vector<Rc<DxvkQuery>> m_activeQueries;
+    struct QuerySet {
+      Rc<DxvkGpuQuery>            gpuQuery;
+      std::vector<Rc<DxvkQuery>>  queries;
+    };
 
-    void beginSingleQuery(
-      const Rc<DxvkCommandList>&  cmd,
-      const Rc<DxvkQuery>&        query);
+    DxvkGpuQueryPool*             m_pool        = nullptr;
+    uint32_t                      m_activeTypes = 0u;
 
-    void endSingleQuery(
+    std::array<QuerySet, MaxQueryTypes> m_activeQueries = { };
+
+    void restartQueries(
       const Rc<DxvkCommandList>&  cmd,
-      const Rc<DxvkQuery>&        query);
-    
+            VkQueryType           type,
+            uint32_t              index);
+
     static uint32_t getQueryTypeBit(
             VkQueryType           type);
 
-  };
-
-
-  /**
-   * \brief Query tracker
-   * 
-   * Returns queries to their allocators after
-   * the command buffer has finished executing.
-   */
-  class DxvkGpuQueryTracker {
-
-  public:
-
-    DxvkGpuQueryTracker();
-    ~DxvkGpuQueryTracker();
-    
-    /**
-     * \param Tracks a query
-     * \param [in] handle Query handle
-     */
-    void trackQuery(DxvkGpuQueryHandle handle);
-
-    /**
-     * \brief Recycles all tracked handles
-     * 
-     * Releases all tracked query handles
-     * to their respective query allocator.
-     */
-    void reset();
-
-  private:
-
-    std::vector<DxvkGpuQueryHandle> m_handles;
+    static uint32_t getQueryTypeIndex(
+            VkQueryType           type,
+            uint32_t              index);
 
   };
+
 }

--- a/src/dxvk/dxvk_gpu_query.h
+++ b/src/dxvk/dxvk_gpu_query.h
@@ -116,17 +116,17 @@ namespace dxvk {
    * Manages Vulkan queries that are sub-allocated
    * from larger query pools 
    */
-  class DxvkGpuQuery : public DxvkResource {
+  class DxvkQuery : public DxvkResource {
 
   public:
 
-    DxvkGpuQuery(
+    DxvkQuery(
       const Rc<vk::DeviceFn>&   vkd,
             VkQueryType         type,
             VkQueryControlFlags flags,
             uint32_t            index);
     
-    ~DxvkGpuQuery();
+    ~DxvkQuery();
 
     /**
      * \brief Query type
@@ -351,7 +351,7 @@ namespace dxvk {
      */
     void enableQuery(
       const Rc<DxvkCommandList>&  cmd,
-      const Rc<DxvkGpuQuery>&     query);
+      const Rc<DxvkQuery>&        query);
     
     /**
      * \brief Disables a query
@@ -363,7 +363,7 @@ namespace dxvk {
      */
     void disableQuery(
       const Rc<DxvkCommandList>&  cmd,
-      const Rc<DxvkGpuQuery>&     query);
+      const Rc<DxvkQuery>&        query);
     
     /**
      * \brief Signals a time stamp query
@@ -374,7 +374,7 @@ namespace dxvk {
      */
     void writeTimestamp(
       const Rc<DxvkCommandList>&  cmd,
-      const Rc<DxvkGpuQuery>&     query);
+      const Rc<DxvkQuery>&        query);
 
     /**
      * \brief Begins queries of a given type
@@ -404,15 +404,15 @@ namespace dxvk {
 
     DxvkGpuQueryPool*             m_pool;
     uint32_t                      m_activeTypes;
-    std::vector<Rc<DxvkGpuQuery>> m_activeQueries;
+    std::vector<Rc<DxvkQuery>> m_activeQueries;
 
     void beginSingleQuery(
       const Rc<DxvkCommandList>&  cmd,
-      const Rc<DxvkGpuQuery>&     query);
+      const Rc<DxvkQuery>&        query);
 
     void endSingleQuery(
       const Rc<DxvkCommandList>&  cmd,
-      const Rc<DxvkGpuQuery>&     query);
+      const Rc<DxvkQuery>&        query);
     
     static uint32_t getQueryTypeBit(
             VkQueryType           type);

--- a/src/dxvk/dxvk_lifetime.cpp
+++ b/src/dxvk/dxvk_lifetime.cpp
@@ -10,6 +10,7 @@ namespace dxvk {
     m_resources.clear();
     m_allocations.clear();
     m_samplers.clear();
+    m_events.clear();
   }
   
 }

--- a/src/dxvk/dxvk_lifetime.cpp
+++ b/src/dxvk/dxvk_lifetime.cpp
@@ -11,6 +11,7 @@ namespace dxvk {
     m_allocations.clear();
     m_samplers.clear();
     m_events.clear();
+    m_queries.clear();
   }
   
 }

--- a/src/dxvk/dxvk_lifetime.h
+++ b/src/dxvk/dxvk_lifetime.h
@@ -3,6 +3,7 @@
 #include <vector>
 
 #include "dxvk_gpu_event.h"
+#include "dxvk_gpu_query.h"
 #include "dxvk_resource.h"
 #include "dxvk_sampler.h"
 
@@ -125,6 +126,14 @@ namespace dxvk {
     }
 
     /**
+     * \brief Adds a query to track
+     * \param [in] query The query to track
+     */
+    void trackQuery(Rc<DxvkGpuQuery>&& query) {
+      m_queries.push_back(std::move(query));
+    }
+
+    /**
      * \brief Adds a resource to track
      * \param [in] res The resource to track
      */
@@ -152,6 +161,7 @@ namespace dxvk {
 
     std::vector<Rc<DxvkSampler>> m_samplers;
     std::vector<Rc<DxvkGpuEvent>> m_events;
+    std::vector<Rc<DxvkGpuQuery>> m_queries;
 
     std::vector<DxvkLifetime<DxvkResource>> m_resources;
     std::vector<DxvkLifetime<DxvkResourceAllocation>> m_allocations;

--- a/src/dxvk/dxvk_lifetime.h
+++ b/src/dxvk/dxvk_lifetime.h
@@ -2,6 +2,7 @@
 
 #include <vector>
 
+#include "dxvk_gpu_event.h"
 #include "dxvk_resource.h"
 #include "dxvk_sampler.h"
 
@@ -116,6 +117,14 @@ namespace dxvk {
     }
 
     /**
+     * \brief Adds an event to track
+     * \param [in] res The event to track
+     */
+    void trackEvent(Rc<DxvkGpuEvent>&& event) {
+      m_events.push_back(std::move(event));
+    }
+
+    /**
      * \brief Adds a resource to track
      * \param [in] res The resource to track
      */
@@ -142,6 +151,7 @@ namespace dxvk {
   private:
 
     std::vector<Rc<DxvkSampler>> m_samplers;
+    std::vector<Rc<DxvkGpuEvent>> m_events;
 
     std::vector<DxvkLifetime<DxvkResource>> m_resources;
     std::vector<DxvkLifetime<DxvkResourceAllocation>> m_allocations;


### PR DESCRIPTION
TL;DR finally figured out what some weird validation errors were about, we would sometimes use the same Vulkan query twice in a row for some really strange reason. There was also another long-standing issue where a D3D11 app overlapping scoped queries of the same type would lead to invalid Vulkan usage, this rework should fix both.

~~Only ran this through wine tests so far, edge cases definitely require testing, hence the draft.~~

Did more testing now, seems to work even in scary edge cases. Fixes #2698.