### PR TITLE
[d3d9] Adjust matrix inversion boundary

### DIFF
--- a/src/util/util_matrix.cpp
+++ b/src/util/util_matrix.cpp
@@ -205,7 +205,7 @@ namespace dxvk {
     Vector4 dot0    = { m[0] * row0 };
     float dot1      = (dot0.x + dot0.y) + (dot0.z + dot0.w);
 
-    if (unlikely(std::abs(dot1) <= 0.000001f)) {
+    if (unlikely(std::abs(dot1) <= std::numeric_limits<float>::min() * 10)) {
       return m;
     }
 


### PR DESCRIPTION
Let's be as precise as possible without breaking float boundaries.

Fixes #4340 and most likely the flickering problems in #4222. Also, what I thought was some shadow flickering on buildings in Act of War is also gone now.

I've also checked that the affected Wine test still passes.