### PR TITLE
[util] Add Secret World Legends config and move Far Cry 2

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -982,6 +982,11 @@ namespace dxvk {
     { R"(\\FEAR(MP|XP|XP2)?\.exe$)", {{
       { "d3d9.maxFrameRate",                 "360" },
     }} },
+    /* Secret World Legends - d3d9 mode only sees  *
+     * 512MB vram locking higher graphics presets  */
+    { R"(\\SecretWorldLegends\.exe$)", {{
+      { "d3d9.memoryTrackTest",              "True" },
+    }} },
 
     /**********************************************/
     /* D3D8 GAMES                                 */

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -71,14 +71,6 @@ namespace dxvk {
       { "d3d11.dcSingleUseMode",            "False" },
       { "d3d11.cachedDynamicResources",     "vi"   },
     }} },
-    /* Far Cry 2: Set vendor ID to Nvidia to avoid
-     * vegetation artifacts on Intel, and set
-     * apitrace mode to True to improve perf on all
-     * hardware.                                  */
-    { R"(\\(FarCry2|farcry2game)\.exe$)", {{
-      { "d3d9.customVendorId",              "10de" },
-      { "d3d9.cachedDynamicBuffers",        "True" },
-    }} },
     /* Far Cry 3: Assumes clear(0.5) on an UNORM  *
      * format to result in 128 on AMD and 127 on  *
      * Nvidia. We assume that the Vulkan drivers  *
@@ -986,6 +978,14 @@ namespace dxvk {
      * 512MB vram locking higher graphics presets  */
     { R"(\\SecretWorldLegends\.exe$)", {{
       { "d3d9.memoryTrackTest",              "True" },
+    }} },
+    /* Far Cry 2: Set vendor ID to Nvidia to      *
+     * avoid vegetation artifacts on Intel, and   *
+     * set apitrace mode to True to improve perf  *
+     * on all hardware.                           */
+    { R"(\\(FarCry2|farcry2game)\.exe$)", {{
+      { "d3d9.customVendorId",              "10de" },
+      { "d3d9.cachedDynamicBuffers",        "True" },
     }} },
 
     /**********************************************/


### PR DESCRIPTION
Otherwise d3d9 mode thinks we only have 512MB vram which will lock the higher graphics presets.

~~I opted to put this in the d3d11 section as going by the Far Cry 2 config I assume we sort the games by their highest supported dxvk renderer (d3d12 not included).~~ See comment below