### PR TITLE
Memory defragmentation

### DIFF
--- a/dxvk.conf
+++ b/dxvk.conf
@@ -388,6 +388,20 @@
 # dxvk.trackPipelineLifetime = Auto
 
 
+# Controls memory defragmentation
+#
+# By default, DXVK will try to defragment video memory if there is a
+# significant amount of memory wasted, or if the allocation budget of
+# the application is exceeded. This option is provided solely for
+# debug purposes.
+#
+# Supported values:
+# - True: Enable defragmentation
+# - False: Disable defragmentation
+
+# dxvk.enableMemoryDefrag = True
+
+
 # Sets enabled HUD elements
 # 
 # Behaves like the DXVK_HUD environment variable if the

--- a/src/dxvk/dxvk_allocator.cpp
+++ b/src/dxvk/dxvk_allocator.cpp
@@ -32,6 +32,13 @@ namespace dxvk {
     while (index--) {
       PageRange entry = m_freeList[index];
 
+      // The chunk index is the same regardless of alignment.
+      // Skip chunk if it does not accept new allocations.
+      uint32_t chunkIndex = entry.index >> ChunkPageBits;
+
+      if (unlikely(m_chunks[chunkIndex].disabled))
+        continue;
+
       if (likely(!(entry.index & (alignment - 1u)))) {
         // If the current free range is sufficiently aligned, we can use
         // it as-is and simply modify the remaining free list entry.
@@ -42,7 +49,6 @@ namespace dxvk {
 
         insertFreeRange(entry, index);
 
-        uint32_t chunkIndex = pageIndex >> ChunkPageBits;
         m_chunks[chunkIndex].pagesUsed += count;
         return pageIndex;
       } else {
@@ -68,7 +74,6 @@ namespace dxvk {
         if (nextRange.count)
           insertFreeRange(nextRange, -1);
 
-        uint32_t chunkIndex = pageIndex >> ChunkPageBits;
         m_chunks[chunkIndex].pagesUsed += count;
 
         return pageIndex;
@@ -163,6 +168,7 @@ namespace dxvk {
     chunk.pageCount = size / PageSize;
     chunk.pagesUsed = 0u;
     chunk.nextChunk = -1;
+    chunk.disabled = false;
 
     PageRange pageRange = { };
     pageRange.index = uint32_t(chunkIndex) << ChunkPageBits;
@@ -179,6 +185,7 @@ namespace dxvk {
     chunk.pageCount = 0u;
     chunk.pagesUsed = 0u;
     chunk.nextChunk = std::exchange(m_freeChunk, int32_t(chunkIndex));
+    chunk.disabled = true;
 
     uint32_t pageIndex = chunkIndex << ChunkPageBits;
 
@@ -187,6 +194,30 @@ namespace dxvk {
     pageRange.count = 0;
 
     insertFreeRange(pageRange, m_freeListLutByPage[pageIndex]);
+  }
+
+
+  void DxvkPageAllocator::killChunk(uint32_t chunkIndex) {
+    m_chunks[chunkIndex].disabled = true;
+  }
+
+
+  void DxvkPageAllocator::reviveChunk(uint32_t chunkIndex) {
+    m_chunks[chunkIndex].disabled = false;
+  }
+
+
+  uint32_t DxvkPageAllocator::reviveChunks() {
+    uint32_t count = 0u;
+
+    for (uint32_t i = 0; i < m_chunks.size(); i++) {
+      if (m_chunks[i].pageCount && m_chunks[i].disabled) {
+        m_chunks[i].disabled = false;
+        count += 1u;
+      }
+    }
+
+    return count;
   }
 
 

--- a/src/dxvk/dxvk_allocator.h
+++ b/src/dxvk/dxvk_allocator.h
@@ -76,6 +76,16 @@ namespace dxvk {
     }
 
     /**
+     * \brief Checks whether a chunk is alive
+     *
+     * \param [in] chunkIndex Chunk index
+     * \returns \c true if chunk can be used
+     */
+    bool chunkIsAvailable(uint32_t chunkIndex) const {
+      return !m_chunks.at(chunkIndex).disabled;
+    }
+
+    /**
      * \brief Allocates given number of bytes from the pool
      *
      * \param [in] size Allocation size, in bytes
@@ -132,6 +142,31 @@ namespace dxvk {
     void removeChunk(uint32_t chunkIndex);
 
     /**
+     * \brief Disables a chunk
+     *
+     * Makes an entire chunk unavailable for subsequent allocations.
+     * This can be useful when moving allocations out of that chunk
+     * in an attempt to free some memory.
+     * \param [in] chunkIndex Chunk index
+     */
+    void killChunk(uint32_t chunkIndex);
+
+    /**
+     * \brief Re-enables a chunk
+     *
+     * Makes all disabled chunks available for allocations again.
+     * Should be used before allocating new chunk memory.
+     * \param [in] chunkIndex Chunk index
+     */
+    void reviveChunk(uint32_t chunkIndex);
+
+    /**
+     * \brief Re-enables all disabled chunks
+     * \returns Number of chunks re-enabled
+     */
+    uint32_t reviveChunks();
+
+    /**
      * \brief Queries page allocation mask
      *
      * Should be used for informational purposes only. Retrieves
@@ -149,6 +184,7 @@ namespace dxvk {
       uint32_t  pageCount = 0u;
       uint32_t  pagesUsed = 0u;
       int32_t   nextChunk = -1;
+      bool      disabled  = false;
     };
 
     struct PageRange {

--- a/src/dxvk/dxvk_buffer.cpp
+++ b/src/dxvk/dxvk_buffer.cpp
@@ -35,7 +35,8 @@ namespace dxvk {
     m_properties    (memFlags),
     m_shaderStages  (util::shaderStages(createInfo.stages)),
     m_sharingMode   (device->getSharingMode()),
-    m_info          (createInfo) {
+    m_info          (createInfo),
+    m_stableAddress (true) {
     m_allocator->registerResource(this);
 
     DxvkAllocationInfo allocationInfo = { };
@@ -58,7 +59,6 @@ namespace dxvk {
 
   bool DxvkBuffer::canRelocate() const {
     return !m_bufferInfo.mapPtr && !m_stableAddress
-        && !m_storage->flags().test(DxvkAllocationFlag::Imported)
         && !(m_info.flags & VK_BUFFER_CREATE_SPARSE_BINDING_BIT);
   }
 

--- a/src/dxvk/dxvk_buffer.cpp
+++ b/src/dxvk/dxvk_buffer.cpp
@@ -77,5 +77,27 @@ namespace dxvk {
   DxvkSparsePageTable* DxvkBuffer::getSparsePageTable() {
     return m_storage->getSparsePageTable();
   }
+
+
+  Rc<DxvkResourceAllocation> DxvkBuffer::relocateStorage(
+          DxvkAllocationModes         mode) {
+    // The resource may become non-relocatable even after we allocate new
+    // backing storage, but if it already is then don't waste memory.
+    if (!canRelocate())
+      return nullptr;
+
+    DxvkAllocationInfo allocationInfo = { };
+    allocationInfo.resourceCookie = cookie();
+    allocationInfo.properties = m_properties;
+    allocationInfo.mode = mode;
+
+    VkBufferCreateInfo info = { VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO };
+    info.flags = m_info.flags;
+    info.usage = m_info.usage;
+    info.size = m_info.size;
+    m_sharingMode.fill(info);
+
+    return m_allocator->createBufferResource(info, allocationInfo, nullptr);
+  }
   
 }

--- a/src/dxvk/dxvk_buffer.cpp
+++ b/src/dxvk/dxvk_buffer.cpp
@@ -17,6 +17,8 @@ namespace dxvk {
     m_shaderStages  (util::shaderStages(createInfo.stages)),
     m_sharingMode   (device->getSharingMode()),
     m_info          (createInfo) {
+    m_allocator->registerResource(this);
+
     // Create and assign actual buffer resource
     assignStorage(allocateStorage());
   }
@@ -34,6 +36,8 @@ namespace dxvk {
     m_shaderStages  (util::shaderStages(createInfo.stages)),
     m_sharingMode   (device->getSharingMode()),
     m_info          (createInfo) {
+    m_allocator->registerResource(this);
+
     DxvkAllocationInfo allocationInfo = { };
     allocationInfo.resourceCookie = cookie();
 
@@ -48,7 +52,7 @@ namespace dxvk {
 
 
   DxvkBuffer::~DxvkBuffer() {
-
+    m_allocator->unregisterResource(this);
   }
 
 

--- a/src/dxvk/dxvk_buffer.cpp
+++ b/src/dxvk/dxvk_buffer.cpp
@@ -34,13 +34,16 @@ namespace dxvk {
     m_shaderStages  (util::shaderStages(createInfo.stages)),
     m_sharingMode   (device->getSharingMode()),
     m_info          (createInfo) {
+    DxvkAllocationInfo allocationInfo = { };
+    allocationInfo.resourceCookie = cookie();
+
     VkBufferCreateInfo info = { VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO };
     info.flags = m_info.flags;
     info.usage = m_info.usage;
     info.size = m_info.size;
     m_sharingMode.fill(info);
 
-    assignStorage(allocator.importBufferResource(info, importInfo));
+    assignStorage(allocator.importBufferResource(info, allocationInfo, importInfo));
   }
 
 

--- a/src/dxvk/dxvk_buffer.h
+++ b/src/dxvk/dxvk_buffer.h
@@ -397,6 +397,15 @@ namespace dxvk {
      */
     DxvkSparsePageTable* getSparsePageTable();
 
+    /**
+     * \brief Allocates new backing storage with constraints
+     *
+     * \param [in] mode Allocation mode flags
+     * \returns Operation status and allocation
+     */
+    Rc<DxvkResourceAllocation> relocateStorage(
+            DxvkAllocationModes         mode);
+
   private:
 
     Rc<vk::DeviceFn>            m_vkd;

--- a/src/dxvk/dxvk_buffer.h
+++ b/src/dxvk/dxvk_buffer.h
@@ -312,13 +312,16 @@ namespace dxvk {
      * \returns The new buffer slice
      */
     Rc<DxvkResourceAllocation> allocateStorage(DxvkLocalAllocationCache* cache) {
+      DxvkAllocationInfo allocationInfo = { };
+      allocationInfo.properties = m_properties;
+
       VkBufferCreateInfo info = { VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO };
       info.flags = m_info.flags;
       info.usage = m_info.usage;
       info.size = m_info.size;
       m_sharingMode.fill(info);
 
-      return m_allocator->createBufferResource(info, m_properties, cache);
+      return m_allocator->createBufferResource(info, allocationInfo, cache);
     }
 
     /**

--- a/src/dxvk/dxvk_buffer.h
+++ b/src/dxvk/dxvk_buffer.h
@@ -313,6 +313,7 @@ namespace dxvk {
      */
     Rc<DxvkResourceAllocation> allocateStorage(DxvkLocalAllocationCache* cache) {
       DxvkAllocationInfo allocationInfo = { };
+      allocationInfo.resourceCookie = cookie();
       allocationInfo.properties = m_properties;
 
       VkBufferCreateInfo info = { VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO };

--- a/src/dxvk/dxvk_cmdlist.cpp
+++ b/src/dxvk/dxvk_cmdlist.cpp
@@ -211,9 +211,9 @@ namespace dxvk {
 
       if (isFirst) {
         // Wait for per-command list semaphores on first submission
-        for (const auto& entry : m_waitSemaphores) {
-          m_commandSubmission.waitSemaphore(entry.fence->handle(),
-            entry.value, VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT);
+        for (size_t i = 0; i < m_waitSemaphores.size(); i++) {
+          m_commandSubmission.waitSemaphore(m_waitSemaphores[i].fence->handle(),
+            m_waitSemaphores[i].value, VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT);
         }
       }
 
@@ -265,9 +265,9 @@ namespace dxvk {
 
       if (isLast) {
         // Signal per-command list semaphores on the final submission
-        for (const auto& entry : m_signalSemaphores) {
-          m_commandSubmission.signalSemaphore(entry.fence->handle(),
-            entry.value, VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT);
+        for (size_t i = 0; i < m_signalSemaphores.size(); i++) {
+          m_commandSubmission.signalSemaphore(m_signalSemaphores[i].fence->handle(),
+            m_signalSemaphores[i].value, VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT);
         }
 
         // Signal WSI semaphore on the final submission

--- a/src/dxvk/dxvk_cmdlist.h
+++ b/src/dxvk/dxvk_cmdlist.h
@@ -129,10 +129,10 @@ namespace dxvk {
 
   private:
 
-    VkFence                                m_fence = VK_NULL_HANDLE;
-    std::vector<VkSemaphoreSubmitInfo>     m_semaphoreWaits;
-    std::vector<VkSemaphoreSubmitInfo>     m_semaphoreSignals;
-    std::vector<VkCommandBufferSubmitInfo> m_commandBuffers;
+    VkFence                                     m_fence = VK_NULL_HANDLE;
+    small_vector<VkSemaphoreSubmitInfo, 4>      m_semaphoreWaits;
+    small_vector<VkSemaphoreSubmitInfo, 4>      m_semaphoreSignals;
+    small_vector<VkCommandBufferSubmitInfo, 4>  m_commandBuffers;
 
   };
 
@@ -1076,11 +1076,11 @@ namespace dxvk {
 
     DxvkCommandSubmission     m_commandSubmission;
 
-    std::vector<DxvkFenceValuePair> m_waitSemaphores;
-    std::vector<DxvkFenceValuePair> m_signalSemaphores;
+    small_vector<DxvkFenceValuePair, 4> m_waitSemaphores;
+    small_vector<DxvkFenceValuePair, 4> m_signalSemaphores;
 
-    std::vector<DxvkCommandSubmissionInfo> m_cmdSubmissions;
-    std::vector<DxvkSparseBindSubmission>  m_cmdSparseBinds;
+    small_vector<DxvkCommandSubmissionInfo, 4> m_cmdSubmissions;
+    small_vector<DxvkSparseBindSubmission, 4>  m_cmdSparseBinds;
     
     std::vector<std::pair<
       Rc<DxvkDescriptorPool>,

--- a/src/dxvk/dxvk_cmdlist.h
+++ b/src/dxvk/dxvk_cmdlist.h
@@ -145,6 +145,7 @@ namespace dxvk {
    */
   struct DxvkCommandSubmissionInfo {
     DxvkCmdBufferFlags  usedFlags   = 0;
+    VkBool32            syncSdma    = VK_FALSE;
     VkCommandBuffer     execBuffer  = VK_NULL_HANDLE;
     VkCommandBuffer     initBuffer  = VK_NULL_HANDLE;
     VkCommandBuffer     sdmaBuffer  = VK_NULL_HANDLE;
@@ -364,6 +365,17 @@ namespace dxvk {
      */
     void setWsiSemaphores(const PresenterSync& wsiSemaphores) {
       m_wsiSemaphores = wsiSemaphores;
+    }
+
+    /**
+     * \brief Sets flag to stall transfer queue
+     *
+     * If set, the current submission will submit a semaphore
+     * wait to the transfer queue in order to stall subsequent
+     * submissions. Necessary in case of resource relocations.
+     */
+    void setSubmissionBarrier() {
+      m_cmd.syncSdma = VK_TRUE;
     }
 
     /**

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -6498,7 +6498,8 @@ namespace dxvk {
 
 
   void DxvkContext::relocateQueuedResources() {
-    auto resourceList = m_common->memoryManager().pollRelocationList();
+    constexpr static uint32_t MaxRelocationsPerSubmission = 128u;
+    auto resourceList = m_common->memoryManager().pollRelocationList(MaxRelocationsPerSubmission);
 
     if (resourceList.empty())
       return;

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -6498,8 +6498,13 @@ namespace dxvk {
 
 
   void DxvkContext::relocateQueuedResources() {
+    // Limit the number and size of resources to process per submission to
+    // something reasonable. We don't know if we are transferring over PCIe.
     constexpr static uint32_t MaxRelocationsPerSubmission = 128u;
-    auto resourceList = m_common->memoryManager().pollRelocationList(MaxRelocationsPerSubmission);
+    constexpr static uint32_t MaxRelocatedMemoryPerSubmission = 16u << 20;
+
+    auto resourceList = m_common->memoryManager().pollRelocationList(
+      MaxRelocationsPerSubmission, MaxRelocatedMemoryPerSubmission);
 
     if (resourceList.empty())
       return;

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -6356,6 +6356,7 @@ namespace dxvk {
     }
 
     m_cmd->cmdPipelineBarrier(DxvkCmdBuffer::ExecBuffer, &depInfo);
+    m_cmd->addStatCtr(DxvkStatCounter::CmdBarrierCount, 1);
 
     imageBarriers.clear();
 
@@ -6490,6 +6491,7 @@ namespace dxvk {
     }
 
     m_cmd->cmdPipelineBarrier(DxvkCmdBuffer::ExecBuffer, &depInfo);
+    m_cmd->addStatCtr(DxvkStatCounter::CmdBarrierCount, 1);
   }
 
 

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -1587,7 +1587,7 @@ namespace dxvk {
     DxvkImageUsageInfo usage = usageInfo;
     usage.flags |= createFlags;
 
-    auto storage = image->allocateStorageWithUsage(usage);
+    auto storage = image->allocateStorageWithUsage(usage, 0u);
 
     DxvkRelocateImageInfo relocateInfo;
     relocateInfo.image = image;

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -6291,32 +6291,55 @@ namespace dxvk {
       const auto& info = imageInfos[i];
       auto oldStorage = info.image->storage();
 
-      VkImageMemoryBarrier2 dstBarrier = { VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER_2 };
-      dstBarrier.srcStageMask = info.image->info().stages;
-      dstBarrier.srcAccessMask = info.image->info().access;
-      dstBarrier.dstStageMask = info.image->info().stages;
-      dstBarrier.dstAccessMask = info.image->info().access;
-      dstBarrier.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-      dstBarrier.newLayout = info.image->pickLayout(VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
-      dstBarrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-      dstBarrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-      dstBarrier.image = info.storage->getImageInfo().image;
-      dstBarrier.subresourceRange = info.image->getAvailableSubresources();
+      // The source image may only be partially initialized. Ignore any subresources
+      // that aren't, but try to do process as much in one go as possible.
+      VkImageSubresourceRange availableSubresources = info.image->getAvailableSubresources();
 
-      VkImageMemoryBarrier2 srcBarrier = { VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER_2 };
-      srcBarrier.srcStageMask = info.image->info().stages;
-      srcBarrier.srcAccessMask = info.image->info().access;
-      srcBarrier.dstStageMask = info.image->info().stages;
-      srcBarrier.dstAccessMask = info.image->info().access;
-      srcBarrier.oldLayout = info.image->info().layout;
-      srcBarrier.newLayout = info.image->pickLayout(VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL);
-      srcBarrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-      srcBarrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-      srcBarrier.image = oldStorage->getImageInfo().image;
-      srcBarrier.subresourceRange = info.image->getAvailableSubresources();
+      uint32_t mipStep = info.image->isInitialized(availableSubresources)
+        ? availableSubresources.levelCount : 1u;
 
-      imageBarriers.push_back(dstBarrier);
-      imageBarriers.push_back(srcBarrier);
+      for (uint32_t m = 0; m < availableSubresources.levelCount; m += mipStep) {
+        VkImageSubresourceRange subresourceRange = availableSubresources;
+        subresourceRange.baseMipLevel = m;
+        subresourceRange.levelCount = mipStep;
+
+        uint32_t layerStep = info.image->isInitialized(subresourceRange)
+          ? availableSubresources.layerCount : 1u;
+
+        for (uint32_t l = 0; l < availableSubresources.layerCount; l += layerStep) {
+          subresourceRange.baseArrayLayer = l;
+          subresourceRange.layerCount = layerStep;
+
+          if (info.image->isInitialized(subresourceRange)) {
+            VkImageMemoryBarrier2 dstBarrier = { VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER_2 };
+            dstBarrier.srcStageMask = info.image->info().stages;
+            dstBarrier.srcAccessMask = info.image->info().access;
+            dstBarrier.dstStageMask = info.image->info().stages;
+            dstBarrier.dstAccessMask = info.image->info().access;
+            dstBarrier.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+            dstBarrier.newLayout = info.image->pickLayout(VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
+            dstBarrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+            dstBarrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+            dstBarrier.image = info.storage->getImageInfo().image;
+            dstBarrier.subresourceRange = subresourceRange;
+
+            VkImageMemoryBarrier2 srcBarrier = { VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER_2 };
+            srcBarrier.srcStageMask = info.image->info().stages;
+            srcBarrier.srcAccessMask = info.image->info().access;
+            srcBarrier.dstStageMask = info.image->info().stages;
+            srcBarrier.dstAccessMask = info.image->info().access;
+            srcBarrier.oldLayout = info.image->info().layout;
+            srcBarrier.newLayout = info.image->pickLayout(VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL);
+            srcBarrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+            srcBarrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+            srcBarrier.image = oldStorage->getImageInfo().image;
+            srcBarrier.subresourceRange = subresourceRange;
+
+            imageBarriers.push_back(dstBarrier);
+            imageBarriers.push_back(srcBarrier);
+          }
+        }
+      }
     }
 
     // Submit all pending barriers in one go
@@ -6369,6 +6392,8 @@ namespace dxvk {
       DxvkResourceImageInfo dstInfo = info.storage->getImageInfo();
       DxvkResourceImageInfo srcInfo = oldStorage->getImageInfo();
 
+      VkImageSubresourceRange availableSubresources = info.image->getAvailableSubresources();
+
       // Iterate over all subresources and compute copy regions. We need
       // one region per mip or plane, so size the local array accordingly.
       small_vector<VkImageCopy2, 16> imageRegions;
@@ -6382,23 +6407,54 @@ namespace dxvk {
 
       for (uint32_t p = 0; p < planeCount; p++) {
         for (uint32_t m = 0; m < info.image->info().mipLevels; m++) {
-          VkImageCopy2 region = { VK_STRUCTURE_TYPE_IMAGE_COPY_2 };
-          region.dstSubresource.aspectMask = formatInfo->aspectMask;
-          region.dstSubresource.mipLevel = m;
-          region.dstSubresource.baseArrayLayer = 0;
-          region.dstSubresource.layerCount = info.image->info().numLayers;
-          region.srcSubresource = region.dstSubresource;
-          region.extent = info.image->mipLevelExtent(m);
+          VkImageSubresourceRange subresourceRange = availableSubresources;
+          subresourceRange.baseMipLevel = m;
+          subresourceRange.levelCount = 1u;
 
-          if (formatInfo->flags.test(DxvkFormatFlag::MultiPlane)) {
-            region.dstSubresource.aspectMask = vk::getPlaneAspect(p);
-            region.srcSubresource.aspectMask = vk::getPlaneAspect(p);
+          uint32_t layerStep = info.image->isInitialized(subresourceRange)
+            ? subresourceRange.layerCount : 1u;
 
-            region.extent.width /= formatInfo->planes[p].blockSize.width;
-            region.extent.height /= formatInfo->planes[p].blockSize.height;
+          for (uint32_t l = 0; l < subresourceRange.layerCount; l += layerStep) {
+            subresourceRange.baseArrayLayer = l;
+            subresourceRange.layerCount = layerStep;
+
+            if (info.image->isInitialized(subresourceRange)) {
+              VkImageCopy2 region = { VK_STRUCTURE_TYPE_IMAGE_COPY_2 };
+              region.dstSubresource.aspectMask = formatInfo->aspectMask;
+              region.dstSubresource.mipLevel = m;
+              region.dstSubresource.baseArrayLayer = l;
+              region.dstSubresource.layerCount = layerStep;
+              region.srcSubresource = region.dstSubresource;
+              region.extent = info.image->mipLevelExtent(m);
+
+              if (formatInfo->flags.test(DxvkFormatFlag::MultiPlane)) {
+                region.dstSubresource.aspectMask = vk::getPlaneAspect(p);
+                region.srcSubresource.aspectMask = vk::getPlaneAspect(p);
+
+                region.extent.width /= formatInfo->planes[p].blockSize.width;
+                region.extent.height /= formatInfo->planes[p].blockSize.height;
+              }
+
+              imageRegions.push_back(region);
+
+              // Emit image barrier for this region. We could in theory transition the
+              // entire image in one go as long as all subresources are initialized,
+              // but there is usually no reason to do so.
+              VkImageMemoryBarrier2 dstBarrier = { VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER_2 };
+              dstBarrier.srcStageMask = info.image->info().stages;
+              dstBarrier.srcAccessMask = info.image->info().access;
+              dstBarrier.dstStageMask = info.image->info().stages;
+              dstBarrier.dstAccessMask = info.image->info().access;
+              dstBarrier.oldLayout = info.image->pickLayout(VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
+              dstBarrier.newLayout = info.image->info().layout;
+              dstBarrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+              dstBarrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+              dstBarrier.image = info.storage->getImageInfo().image;
+              dstBarrier.subresourceRange = vk::makeSubresourceRange(region.dstSubresource),
+
+              imageBarriers.push_back(dstBarrier);
+            }
           }
-
-          imageRegions.push_back(region);
         }
       }
 
@@ -6413,22 +6469,7 @@ namespace dxvk {
       m_cmd->cmdCopyImage(DxvkCmdBuffer::ExecBuffer, &copy);
       m_cmd->track(info.image, DxvkAccess::Write);
 
-      // Invalidate image and emit post-copy barrier to use the correct layout
       invalidateImageWithUsage(info.image, Rc<DxvkResourceAllocation>(info.storage), info.usageInfo);
-
-      VkImageMemoryBarrier2 dstBarrier = { VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER_2 };
-      dstBarrier.srcStageMask = info.image->info().stages;
-      dstBarrier.srcAccessMask = info.image->info().access;
-      dstBarrier.dstStageMask = info.image->info().stages;
-      dstBarrier.dstAccessMask = info.image->info().access;
-      dstBarrier.oldLayout = info.image->pickLayout(VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
-      dstBarrier.newLayout = info.image->info().layout;
-      dstBarrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-      dstBarrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-      dstBarrier.image = info.storage->getImageInfo().image;
-      dstBarrier.subresourceRange = info.image->getAvailableSubresources();
-
-      imageBarriers.push_back(dstBarrier);
     }
 
     // Submit post-copy barriers

--- a/src/dxvk/dxvk_context.h
+++ b/src/dxvk/dxvk_context.h
@@ -1757,6 +1757,8 @@ namespace dxvk {
             size_t                    imageCount,
       const DxvkRelocateImageInfo*    imageInfos);
 
+    void relocateQueuedResources();
+
     Rc<DxvkSampler> createBlitSampler(
             VkFilter                  filter);
 

--- a/src/dxvk/dxvk_device.cpp
+++ b/src/dxvk/dxvk_device.cpp
@@ -113,14 +113,6 @@ namespace dxvk {
 
     return result;
   }
-
-
-  DxvkDeviceOptions DxvkDevice::options() const {
-    DxvkDeviceOptions options;
-    options.maxNumDynamicUniformBuffers = m_properties.core.properties.limits.maxDescriptorSetUniformBuffersDynamic;
-    options.maxNumDynamicStorageBuffers = m_properties.core.properties.limits.maxDescriptorSetStorageBuffersDynamic;
-    return options;
-  }
   
   
   Rc<DxvkCommandList> DxvkDevice::createCommandList() {

--- a/src/dxvk/dxvk_device.h
+++ b/src/dxvk/dxvk_device.h
@@ -29,13 +29,6 @@ namespace dxvk {
   
   class DxvkInstance;
 
-  /**
-   * \brief Device options
-   */
-  struct DxvkDeviceOptions {
-    uint32_t maxNumDynamicUniformBuffers = 0;
-    uint32_t maxNumDynamicStorageBuffers = 0;
-  };
 
   /**
    * \brief Device performance hints
@@ -252,12 +245,6 @@ namespace dxvk {
      * \returns Supported shader pipeline stages
      */
     VkPipelineStageFlags getShaderPipelineStages() const;
-    
-    /**
-     * \brief Retrieves device options
-     * \returns Device options
-     */
-    DxvkDeviceOptions options() const;
 
     /**
      * \brief Retrieves performance hints

--- a/src/dxvk/dxvk_image.cpp
+++ b/src/dxvk/dxvk_image.cpp
@@ -173,8 +173,11 @@ namespace dxvk {
       sharedImportWin32.handle = m_info.sharing.handle;
     }
 
+    DxvkAllocationInfo allocationInfo = { };
+    allocationInfo.properties = m_properties;
+
     return m_allocator->createImageResource(imageInfo,
-      m_properties, sharedMemoryInfo);
+      allocationInfo, sharedMemoryInfo);
   }
 
 

--- a/src/dxvk/dxvk_image.cpp
+++ b/src/dxvk/dxvk_image.cpp
@@ -183,6 +183,7 @@ namespace dxvk {
     DxvkAllocationInfo allocationInfo = { };
     allocationInfo.resourceCookie = cookie();
     allocationInfo.properties = m_properties;
+    allocationInfo.mode = mode;
 
     return m_allocator->createImageResource(imageInfo,
       allocationInfo, sharedMemoryInfo);

--- a/src/dxvk/dxvk_image.cpp
+++ b/src/dxvk/dxvk_image.cpp
@@ -45,7 +45,8 @@ namespace dxvk {
     m_allocator     (&memAlloc),
     m_properties    (memFlags),
     m_shaderStages  (util::shaderStages(createInfo.stages)),
-    m_info          (createInfo) {
+    m_info          (createInfo),
+    m_stableAddress (true) {
     m_allocator->registerResource(this);
 
     copyFormatList(createInfo.viewFormatCount, createInfo.viewFormats);
@@ -66,7 +67,6 @@ namespace dxvk {
 
   bool DxvkImage::canRelocate() const {
     return !m_imageInfo.mapPtr && !m_shared && !m_stableAddress
-        && !m_storage->flags().test(DxvkAllocationFlag::Imported)
         && !(m_info.flags & VK_IMAGE_CREATE_SPARSE_BINDING_BIT);
   }
 

--- a/src/dxvk/dxvk_image.cpp
+++ b/src/dxvk/dxvk_image.cpp
@@ -47,8 +47,11 @@ namespace dxvk {
     copyFormatList(createInfo.viewFormatCount, createInfo.viewFormats);
 
     // Create backing storage for existing image resource
+    DxvkAllocationInfo allocationInfo = { };
+    allocationInfo.resourceCookie = cookie();
+
     VkImageCreateInfo imageInfo = getImageCreateInfo(DxvkImageUsageInfo());
-    assignStorage(m_allocator->importImageResource(imageInfo, imageHandle));
+    assignStorage(m_allocator->importImageResource(imageInfo, allocationInfo, imageHandle));
   }
 
 
@@ -174,6 +177,7 @@ namespace dxvk {
     }
 
     DxvkAllocationInfo allocationInfo = { };
+    allocationInfo.resourceCookie = cookie();
     allocationInfo.properties = m_properties;
 
     return m_allocator->createImageResource(imageInfo,

--- a/src/dxvk/dxvk_image.cpp
+++ b/src/dxvk/dxvk_image.cpp
@@ -14,6 +14,8 @@ namespace dxvk {
     m_properties    (memFlags),
     m_shaderStages  (util::shaderStages(createInfo.stages)),
     m_info          (createInfo) {
+    m_allocator->registerResource(this);
+
     copyFormatList(createInfo.viewFormatCount, createInfo.viewFormats);
 
     // Always enable depth-stencil attachment usage for depth-stencil
@@ -44,6 +46,8 @@ namespace dxvk {
     m_properties    (memFlags),
     m_shaderStages  (util::shaderStages(createInfo.stages)),
     m_info          (createInfo) {
+    m_allocator->registerResource(this);
+
     copyFormatList(createInfo.viewFormatCount, createInfo.viewFormats);
 
     // Create backing storage for existing image resource
@@ -56,7 +60,7 @@ namespace dxvk {
 
 
   DxvkImage::~DxvkImage() {
-
+    m_allocator->unregisterResource(this);
   }
 
 

--- a/src/dxvk/dxvk_image.cpp
+++ b/src/dxvk/dxvk_image.cpp
@@ -108,6 +108,15 @@ namespace dxvk {
   }
 
 
+  Rc<DxvkResourceAllocation> DxvkImage::relocateStorage(
+          DxvkAllocationModes         mode) {
+    if (!canRelocate())
+      return nullptr;
+
+    return allocateStorageWithUsage(DxvkImageUsageInfo(), mode);
+  }
+
+
   Rc<DxvkImageView> DxvkImage::createView(
     const DxvkImageViewKey& info) {
     std::unique_lock lock(m_viewMutex);
@@ -120,11 +129,13 @@ namespace dxvk {
 
 
   Rc<DxvkResourceAllocation> DxvkImage::allocateStorage() {
-    return allocateStorageWithUsage(DxvkImageUsageInfo());
+    return allocateStorageWithUsage(DxvkImageUsageInfo(), 0u);
   }
 
 
-  Rc<DxvkResourceAllocation> DxvkImage::allocateStorageWithUsage(const DxvkImageUsageInfo& usageInfo) {
+  Rc<DxvkResourceAllocation> DxvkImage::allocateStorageWithUsage(
+    const DxvkImageUsageInfo&         usageInfo,
+          DxvkAllocationModes         mode) {
     const DxvkFormatInfo* formatInfo = lookupFormatInfo(m_info.format);
     small_vector<VkFormat, 4> localViewFormats;
 

--- a/src/dxvk/dxvk_image.h
+++ b/src/dxvk/dxvk_image.h
@@ -516,6 +516,15 @@ namespace dxvk {
     DxvkSparsePageTable* getSparsePageTable();
 
     /**
+     * \brief Allocates new backing storage with constraints
+     *
+     * \param [in] mode Allocation mode flags
+     * \returns Operation status and allocation
+     */
+    Rc<DxvkResourceAllocation> relocateStorage(
+            DxvkAllocationModes         mode);
+
+    /**
      * \brief Creates image resource
      *
      * The returned image can be used as backing storage.
@@ -529,10 +538,12 @@ namespace dxvk {
      * Creates new backing storage with additional usage flags
      * enabled. Useful to expand on usage flags after creation.
      * \param [in] usage Usage flags to add
+     * \param [in] mode Allocation constraints
      * \returns New underlying image resource
      */
     Rc<DxvkResourceAllocation> allocateStorageWithUsage(
-      const DxvkImageUsageInfo&       usage);
+      const DxvkImageUsageInfo&         usage,
+            DxvkAllocationModes         mode);
 
     /**
      * \brief Assigns backing storage to the image

--- a/src/dxvk/dxvk_memory.cpp
+++ b/src/dxvk/dxvk_memory.cpp
@@ -1603,6 +1603,7 @@ namespace dxvk {
       chunkStats.pageMaskOffset = stats.pageMasks.size();
       chunkStats.pageCount = pool.pageAllocator.pageCount(i);
       chunkStats.mapped = &pool == &type.mappedPool;
+      chunkStats.active = pool.pageAllocator.chunkIsAvailable(i);
 
       size_t maskCount = (chunkStats.pageCount + 31u) / 32u;
       stats.pageMasks.resize(chunkStats.pageMaskOffset + maskCount);

--- a/src/dxvk/dxvk_memory.cpp
+++ b/src/dxvk/dxvk_memory.cpp
@@ -2221,7 +2221,7 @@ namespace dxvk {
 
 
   void DxvkMemoryAllocator::performTimedTasks() {
-    static constexpr auto Interval = std::chrono::seconds(1u);
+    static constexpr auto Interval = std::chrono::milliseconds(500u);
 
     // This function shouldn't be called concurrently, so checking and
     // updating the deadline is fine without taking the global lock

--- a/src/dxvk/dxvk_memory.cpp
+++ b/src/dxvk/dxvk_memory.cpp
@@ -524,7 +524,7 @@ namespace dxvk {
       int64_t address = selectedPool.alloc(size, requirements.alignment);
 
       if (likely(address >= 0))
-        return createAllocation(type, selectedPool, address, size);
+        return createAllocation(type, selectedPool, address, size, allocationInfo);
 
       // If the memory type is host-visible, try to find an existing chunk
       // in the other memory pool of the memory type and move over.
@@ -549,7 +549,7 @@ namespace dxvk {
           address = selectedPool.alloc(size, requirements.alignment);
 
           if (likely(address >= 0))
-            return createAllocation(type, selectedPool, address, size);
+            return createAllocation(type, selectedPool, address, size, allocationInfo);
         }
       }
 
@@ -572,7 +572,7 @@ namespace dxvk {
           continue;
 
         mapDeviceMemory(memory, allocationInfo.properties);
-        return createAllocation(type, memory);
+        return createAllocation(type, memory, allocationInfo);
       }
 
       // Try to allocate a new chunk that is large enough to hold
@@ -584,7 +584,7 @@ namespace dxvk {
 
       if (allocateChunkInPool(type, selectedPool, allocationInfo.properties, size, desiredSize)) {
         address = selectedPool.alloc(size, requirements.alignment);
-        return createAllocation(type, selectedPool, address, size);
+        return createAllocation(type, selectedPool, address, size, allocationInfo);
       }
     }
 
@@ -606,7 +606,7 @@ namespace dxvk {
 
       if (likely(memory.memory != VK_NULL_HANDLE)) {
         mapDeviceMemory(memory, allocationInfo.properties);
-        return createAllocation(type, memory);
+        return createAllocation(type, memory, allocationInfo);
       }
     }
 
@@ -716,7 +716,9 @@ namespace dxvk {
         logMemoryStats();
       }
     } else {
-      allocation = createAllocation(new DxvkSparsePageTable(m_device, createInfo, buffer));
+      allocation = createAllocation(
+        new DxvkSparsePageTable(m_device, createInfo, buffer),
+        allocationInfo);
     }
 
     if (!allocation) {
@@ -853,7 +855,7 @@ namespace dxvk {
           allocation->m_sparsePageTable = pageTable.release();
       } else {
         // Just need a page table, but no memory
-        allocation = createAllocation(pageTable.release());
+        allocation = createAllocation(pageTable.release(), allocationInfo);
       }
     }
 
@@ -928,9 +930,11 @@ namespace dxvk {
 
   Rc<DxvkResourceAllocation> DxvkMemoryAllocator::importBufferResource(
     const VkBufferCreateInfo&         createInfo,
+    const DxvkAllocationInfo&         allocationInfo,
     const DxvkBufferImportInfo&       importInfo) {
     Rc<DxvkResourceAllocation> allocation = m_allocationPool.create(this, nullptr);
     allocation->m_flags.set(DxvkAllocationFlag::Imported);
+    allocation->m_resourceCookie = allocation->m_resourceCookie;
     allocation->m_size = createInfo.size;
     allocation->m_mapPtr = importInfo.mapPtr;
     allocation->m_buffer = importInfo.buffer;
@@ -945,9 +949,11 @@ namespace dxvk {
 
   Rc<DxvkResourceAllocation> DxvkMemoryAllocator::importImageResource(
     const VkImageCreateInfo&          createInfo,
+    const DxvkAllocationInfo&         allocationInfo,
           VkImage                     imageHandle) {
     Rc<DxvkResourceAllocation> allocation = m_allocationPool.create(this, nullptr);
     allocation->m_flags.set(DxvkAllocationFlag::Imported);
+    allocation->m_resourceCookie = allocation->m_resourceCookie;
     allocation->m_image = imageHandle;
 
     return allocation;
@@ -1103,7 +1109,8 @@ namespace dxvk {
           DxvkMemoryType&       type,
           DxvkMemoryPool&       pool,
           VkDeviceSize          address,
-          VkDeviceSize          size) {
+          VkDeviceSize          size,
+    const DxvkAllocationInfo&   allocationInfo) {
     type.stats.memoryUsed += size;
 
     uint32_t chunkIndex = address >> DxvkPageAllocator::ChunkAddressBits;
@@ -1114,6 +1121,7 @@ namespace dxvk {
     VkDeviceSize offset = address & DxvkPageAllocator::ChunkAddressMask;
 
     auto allocation = m_allocationPool.create(this, &type);
+    allocation->m_resourceCookie = allocationInfo.resourceCookie;
     allocation->m_memory = chunk.memory.memory;
     allocation->m_address = address;
     allocation->m_size = size;
@@ -1133,8 +1141,10 @@ namespace dxvk {
 
 
   DxvkResourceAllocation* DxvkMemoryAllocator::createAllocation(
-          DxvkSparsePageTable*  sparsePageTable) {
+          DxvkSparsePageTable*  sparsePageTable,
+    const DxvkAllocationInfo&   allocationInfo) {
     auto allocation = m_allocationPool.create(this, nullptr);
+    allocation->m_resourceCookie = allocationInfo.resourceCookie;
     allocation->m_sparsePageTable = sparsePageTable;
 
     return allocation;
@@ -1143,7 +1153,8 @@ namespace dxvk {
 
   DxvkResourceAllocation* DxvkMemoryAllocator::createAllocation(
           DxvkMemoryType&       type,
-    const DxvkDeviceMemory&     memory) {
+    const DxvkDeviceMemory&     memory,
+    const DxvkAllocationInfo&   allocationInfo) {
     type.stats.memoryUsed += memory.size;
 
     auto allocation = m_allocationPool.create(this, &type);
@@ -1152,6 +1163,7 @@ namespace dxvk {
     if (memory.buffer)
       allocation->m_flags.set(DxvkAllocationFlag::OwnsBuffer);
 
+    allocation->m_resourceCookie = allocationInfo.resourceCookie;
     allocation->m_memory = memory.memory;
     allocation->m_address = DedicatedChunkAddress;
     allocation->m_size = memory.size;
@@ -1440,7 +1452,8 @@ namespace dxvk {
 
         // Add allocation to the list and mark it as cacheable,
         // so it will get recycled as-is after use.
-        allocation = createAllocation(memoryType, memoryPool, address, allocationSize);
+        allocation = createAllocation(memoryType, memoryPool,
+          address, allocationSize, DxvkAllocationInfo());
         allocation->m_flags.set(DxvkAllocationFlag::Cacheable);
 
         if (tail) {

--- a/src/dxvk/dxvk_memory.cpp
+++ b/src/dxvk/dxvk_memory.cpp
@@ -2283,13 +2283,15 @@ namespace dxvk {
         m_memTypes[i].sharedCache->cleanupUnusedFromLockedAllocator(currentTime);
     }
 
-    // Periodically defragment device-local memory types. We cannot
-    // do anything about mapped allocations since we rely on pointer
-    // stability there.
-    for (uint32_t i = 0; i < m_memTypeCount; i++) {
-      if (m_memTypes[i].properties.propertyFlags & VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT) {
-        moveDefragChunk(m_memTypes[i]);
-        pickDefragChunk(m_memTypes[i]);
+    if (m_device->config().enableMemoryDefrag) {
+      // Periodically defragment device-local memory types. We cannot
+      // do anything about mapped allocations since we rely on pointer
+      // stability there.
+      for (uint32_t i = 0; i < m_memTypeCount; i++) {
+        if (m_memTypes[i].properties.propertyFlags & VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT) {
+          moveDefragChunk(m_memTypes[i]);
+          pickDefragChunk(m_memTypes[i]);
+        }
       }
     }
   }

--- a/src/dxvk/dxvk_memory.cpp
+++ b/src/dxvk/dxvk_memory.cpp
@@ -1121,6 +1121,10 @@ namespace dxvk {
     VkDeviceSize offset = address & DxvkPageAllocator::ChunkAddressMask;
 
     auto allocation = m_allocationPool.create(this, &type);
+
+    if (!(allocationInfo.properties & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT) && allocationInfo.resourceCookie)
+      allocation->m_flags.set(DxvkAllocationFlag::CanMove);
+
     allocation->m_resourceCookie = allocationInfo.resourceCookie;
     allocation->m_memory = chunk.memory.memory;
     allocation->m_address = address;
@@ -1163,6 +1167,9 @@ namespace dxvk {
     if (memory.buffer)
       allocation->m_flags.set(DxvkAllocationFlag::OwnsBuffer);
 
+    if (!(allocationInfo.properties & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT) && allocationInfo.resourceCookie)
+      allocation->m_flags.set(DxvkAllocationFlag::CanMove);
+
     allocation->m_resourceCookie = allocationInfo.resourceCookie;
     allocation->m_memory = memory.memory;
     allocation->m_address = DedicatedChunkAddress;
@@ -1188,7 +1195,7 @@ namespace dxvk {
 
   void DxvkMemoryAllocator::freeAllocation(
           DxvkResourceAllocation* allocation) {
-    if (allocation->m_flags.test(DxvkAllocationFlag::Cacheable)) {
+    if (allocation->m_flags.test(DxvkAllocationFlag::CanCache)) {
       // Return cacheable allocations to the shared cache
       allocation->destroyBufferViews();
 
@@ -1454,7 +1461,7 @@ namespace dxvk {
         // so it will get recycled as-is after use.
         allocation = createAllocation(memoryType, memoryPool,
           address, allocationSize, DxvkAllocationInfo());
-        allocation->m_flags.set(DxvkAllocationFlag::Cacheable);
+        allocation->m_flags.set(DxvkAllocationFlag::CanCache);
 
         if (tail) {
           tail->m_nextCached = allocation;

--- a/src/dxvk/dxvk_memory.cpp
+++ b/src/dxvk/dxvk_memory.cpp
@@ -1848,6 +1848,20 @@ namespace dxvk {
   }
 
 
+  void DxvkMemoryAllocator::registerResource(
+          DxvkPagedResource*          resource) {
+    std::lock_guard lock(m_resourceMutex);
+    m_resourceMap.emplace(resource->cookie(), resource);
+  }
+
+
+  void DxvkMemoryAllocator::unregisterResource(
+          DxvkPagedResource*          resource) {
+    std::lock_guard lock(m_resourceMutex);
+    m_resourceMap.erase(resource->cookie());
+  }
+
+
   VkDeviceAddress DxvkMemoryAllocator::getBufferDeviceAddress(VkBuffer buffer) const {
     auto vk = m_device->vkd();
 

--- a/src/dxvk/dxvk_memory.cpp
+++ b/src/dxvk/dxvk_memory.cpp
@@ -596,6 +596,21 @@ namespace dxvk {
       if (likely(address >= 0))
         return createAllocation(type, selectedPool, address, size, allocationInfo);
 
+      // If we're not allowed to allocate additional device memory, move on.
+      // Also do not try to revive any chunks marked for defragmentation since
+      // that would defeat the purpose.
+      if (allocationInfo.mode.test(DxvkAllocationMode::NoAllocation))
+        continue;
+
+      // Otherwise, if there are any chunks marked for defragmentation, stop
+      // that process and use any available memory for new allocations.
+      if (selectedPool.pageAllocator.reviveChunks()) {
+        address = selectedPool.alloc(size, requirements.alignment);
+
+        if (address >= 0)
+          return createAllocation(type, selectedPool, address, size, allocationInfo);
+      }
+
       // If the memory type is host-visible, try to find an existing chunk
       // in the other memory pool of the memory type and move over.
       if (type.properties.propertyFlags & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT) {
@@ -622,10 +637,6 @@ namespace dxvk {
             return createAllocation(type, selectedPool, address, size, allocationInfo);
         }
       }
-
-      // If we're not allowed to allocate device memory, move on.
-      if (allocationInfo.mode.test(DxvkAllocationMode::NoAllocation))
-        continue;
 
       // If the allocation is very large, use a dedicated allocation instead
       // of creating a new chunk. This way we avoid excessive fragmentation,
@@ -2048,6 +2059,149 @@ namespace dxvk {
   }
 
 
+  void DxvkMemoryAllocator::moveDefragChunk(
+          DxvkMemoryType&       type) {
+    auto& pool = type.devicePool;
+
+    // Ensure that we only process each chunk once
+    uint32_t chunkIndex = std::exchange(pool.nextDefragChunk, ~0u);
+
+    if (chunkIndex >= pool.chunks.size())
+      return;
+
+    // If the chunk has been revived in the meantime, we need
+    // the memory and should not relocate any resources
+    if (pool.pageAllocator.chunkIsAvailable(chunkIndex))
+      return;
+
+    DxvkAllocationModes mode(
+      DxvkAllocationMode::NoAllocation,
+      DxvkAllocationMode::NoFallback);
+
+    // Iterate over the chunk's allocation list and look up resources
+    std::unique_lock lock(m_resourceMutex);
+
+    for (auto a = pool.chunks[chunkIndex].allocationList; a; a = a->m_nextInChunk) {
+      if (!a->m_flags.test(DxvkAllocationFlag::CanMove))
+        continue;
+
+      // If we can't find the resource by its cookie, it has probably
+      // already been destroyed. This is fine since the allocation will
+      // likely get freed soon anyway.
+      auto entry = m_resourceMap.find(a->m_resourceCookie);
+
+      if (entry == m_resourceMap.end())
+        continue;
+
+      // Same if there are no external references. There is a small chance
+      // that we pick up a newly created resource here that has no public
+      // references yet, but skipping that will not affect correctness.
+      auto resource = entry->second->tryAcquire();
+
+      if (!resource)
+        continue;
+
+      // Acquired the resource, add it to the relocation list.
+      m_relocations.addResource(std::move(resource), mode);
+    }
+  }
+
+
+  void DxvkMemoryAllocator::pickDefragChunk(
+          DxvkMemoryType&       type) {
+    auto& pool = type.devicePool;
+
+    // Only engage defragmentation at all if we have a significant
+    // amount of memory wasted, or if we're under memory pressure.
+    auto heapStats = getMemoryStats(type.heap->index);
+
+    if (heapStats.memoryAllocated <= heapStats.memoryBudget) {
+      uint32_t pagesTotal = 0u;
+      uint32_t pagesUsed = 0u;
+
+      for (uint32_t i = 0; i < pool.chunks.size(); i++) {
+        uint32_t used = pool.pageAllocator.pagesUsed(i);
+
+        if (used) {
+          pagesUsed += used;
+          pagesTotal += pool.pageAllocator.pageCount(i);
+        }
+      }
+
+      uint32_t pagesPerChunk = pool.nextChunkSize / DxvkPageAllocator::PageSize;
+
+      if (pagesUsed + pagesUsed / 8u + pagesPerChunk >= pagesTotal)
+        return;
+    }
+
+    // Find live chunk with the lowest number of pages used. Skip
+    // empty chunks since the goal here is to turn a used chunk
+    // into an empty one.
+    uint32_t chunkIndex = 0u;
+    uint32_t chunkPages = 0u;
+
+    for (uint32_t i = 0; i < pool.chunks.size(); i++) {
+      // Mark any empty chunk as dead for now as well so that we don't
+      // keep moving resources between multiple otherwise unused chunks
+      uint32_t pagesUsed = pool.pageAllocator.pagesUsed(i);
+
+      if (!pagesUsed) {
+        pool.pageAllocator.killChunk(i);
+        continue;
+      }
+
+      // If there's a non-empty chunk already marked as dead and we haven't
+      // finished moving resources around yet, killing another chunk would
+      // do more harm than good so wait for that to finish first.
+      if (!pool.pageAllocator.chunkIsAvailable(i)) {
+        if (!m_relocations.empty())
+          return;
+        continue;
+      }
+
+      if (!chunkPages || pagesUsed < chunkPages) {
+        chunkIndex = i;
+        chunkPages = pagesUsed;
+      }
+    }
+
+    if (!chunkPages)
+      return;
+
+    // Check if the remaining chunks in the pool have sufficient free space.
+    // This is not a strong guarantee that relocation will succeed, but the
+    // chance is reasonably high.
+    uint32_t freePages = 0u;
+
+    for (uint32_t i = 0; i < pool.chunks.size(); i++) {
+      uint32_t pagesUsed = pool.pageAllocator.pagesUsed(i);
+      uint32_t pageCount = pool.pageAllocator.pageCount(i);
+
+      if (pagesUsed && pool.pageAllocator.chunkIsAvailable(i) && i != chunkIndex)
+        freePages += pageCount - pagesUsed;
+    }
+
+    if (2u * freePages < 3u * chunkPages)
+      return;
+
+    // We only want one non-empty dead chunk at a time in order to prevent
+    // situations where defragmation locks itself up in a suboptimal state.
+    // If we already have a dead chunk with a resource that cannot be moved,
+    // revive it and mark the newly selected one instead so that it can be
+    // moved into the previously dead chunk.
+    for (uint32_t i = 0; i < pool.chunks.size(); i++) {
+      if (!pool.pageAllocator.chunkIsAvailable(i) && pool.pageAllocator.pagesUsed(i))
+        pool.pageAllocator.reviveChunk(i);
+    }
+
+    // Mark the chunk as dead. If it does not subsequently get reactivated
+    // because the game is loading more resources, the next worker iteration
+    // will queue all live resources for relocation.
+    pool.pageAllocator.killChunk(chunkIndex);
+    pool.nextDefragChunk = chunkIndex;
+  }
+
+
   void DxvkMemoryAllocator::performTimedTasks() {
     static constexpr auto Interval = std::chrono::seconds(1u);
 
@@ -2083,6 +2237,16 @@ namespace dxvk {
     for (uint32_t i = 0; i < m_memTypeCount; i++) {
       if (m_memTypes[i].sharedCache)
         m_memTypes[i].sharedCache->cleanupUnusedFromLockedAllocator(currentTime);
+    }
+
+    // Periodically defragment device-local memory types. We cannot
+    // do anything about mapped allocations since we rely on pointer
+    // stability there.
+    for (uint32_t i = 0; i < m_memTypeCount; i++) {
+      if (m_memTypes[i].properties.propertyFlags & VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT) {
+        moveDefragChunk(m_memTypes[i]);
+        pickDefragChunk(m_memTypes[i]);
+      }
     }
   }
 

--- a/src/dxvk/dxvk_memory.cpp
+++ b/src/dxvk/dxvk_memory.cpp
@@ -469,16 +469,24 @@ namespace dxvk {
   }
 
 
-  std::vector<DxvkRelocationEntry> DxvkRelocationList::poll() {
+  std::vector<DxvkRelocationEntry> DxvkRelocationList::poll(uint32_t count) {
     std::lock_guard lock(m_mutex);
 
     std::vector<DxvkRelocationEntry> result;
-    result.reserve(m_entries.size());
+    count = std::min(count, uint32_t(m_entries.size()));
 
-    for (const auto& p : m_entries)
-      result.push_back({ p.first, p.second });
+    if (!count)
+      return result;
 
-    m_entries.clear();
+    result.reserve(count);
+
+    for (uint32_t i = 0; i < count; i++) {
+      auto iter = m_entries.begin();
+
+      result.push_back({ iter->first, iter->second });
+      m_entries.erase(iter);
+    }
+
     return result;
   }
 

--- a/src/dxvk/dxvk_memory.h
+++ b/src/dxvk/dxvk_memory.h
@@ -995,11 +995,13 @@ namespace dxvk {
     /**
      * \brief Retrieves list of resources to move
      *
-     * Clears the internally stored list. Any
-     * duplicate entries will be removed.
+     * Removes items from the internally stored list.
+     * Any duplicate entries will be removed.
+     * \param [in] count Number of entries to return
      * \returns List of resources to move
      */
-    std::vector<DxvkRelocationEntry> poll();
+    std::vector<DxvkRelocationEntry> poll(
+            uint32_t                    count);
 
     /**
      * \brief Adds relocation entry to the list
@@ -1240,10 +1242,12 @@ namespace dxvk {
 
     /**
      * \brief Polls relocation list
+     *
+     * \param [in] count Desired entry count
      * \returns Relocation entries
      */
-    auto pollRelocationList() {
-      return m_relocations.poll();
+    auto pollRelocationList(uint32_t count) {
+      return m_relocations.poll(count);
     }
 
   private:

--- a/src/dxvk/dxvk_memory.h
+++ b/src/dxvk/dxvk_memory.h
@@ -928,6 +928,23 @@ namespace dxvk {
 
 
   /**
+   * \brief Allocation modes
+   */
+  enum class DxvkAllocationMode : uint32_t {
+    /// If set, the allocation will fail if video memory is
+    /// full rather than falling back to system memory.
+    NoFallback      = 0,
+    /// If set, the allocation will only succeed if it
+    /// can be suballocated from an existing chunk.
+    NoAllocation    = 1,
+
+    eFlagEnum
+  };
+
+  using DxvkAllocationModes = Flags<DxvkAllocationMode>;
+
+
+  /**
    * \brief Allocation properties
    */
   struct DxvkAllocationInfo {
@@ -935,6 +952,8 @@ namespace dxvk {
     uint64_t resourceCookie = 0u;
     /// Desired memory property flags
     VkMemoryPropertyFlags properties = 0u;
+    /// Allocation mode flags
+    DxvkAllocationModes mode = 0u;
   };
 
 

--- a/src/dxvk/dxvk_memory.h
+++ b/src/dxvk/dxvk_memory.h
@@ -608,7 +608,7 @@ namespace dxvk {
     DxvkMemoryAllocator*        m_allocator = nullptr;
     DxvkMemoryType*             m_type = nullptr;
 
-    DxvkResourceAllocation*     m_next = nullptr;
+    DxvkResourceAllocation*     m_nextCached = nullptr;
 
     void destroyBufferViews();
 

--- a/src/dxvk/dxvk_memory.h
+++ b/src/dxvk/dxvk_memory.h
@@ -196,6 +196,8 @@ namespace dxvk {
     uint16_t pageCount = 0u;
     /// Whether this chunk is mapped
     bool mapped = false;
+    /// Whether this chunk is active
+    bool active = false;
   };
 
 

--- a/src/dxvk/dxvk_memory.h
+++ b/src/dxvk/dxvk_memory.h
@@ -998,20 +998,24 @@ namespace dxvk {
      * Removes items from the internally stored list.
      * Any duplicate entries will be removed.
      * \param [in] count Number of entries to return
+     * \param [in] size Maximum total resource size
      * \returns List of resources to move
      */
     std::vector<DxvkRelocationEntry> poll(
-            uint32_t                    count);
+            uint32_t                    count,
+            VkDeviceSize                size);
 
     /**
      * \brief Adds relocation entry to the list
      *
      * \param [in] resource Resource to add
      * \param [in] mode Allocation mode
+     * \param [in] size Allocation size
      */
     void addResource(
             Rc<DxvkPagedResource>&&     resource,
-            DxvkAllocationModes         mode);
+            DxvkAllocationModes         mode,
+            VkDeviceSize                size);
 
     /**
      * \brief Clears list
@@ -1028,9 +1032,14 @@ namespace dxvk {
 
   private:
 
+    struct Entry {
+      DxvkAllocationModes mode = 0u;
+      VkDeviceSize        size = 0u;
+    };
+
     dxvk::mutex                               m_mutex;
     std::unordered_map<Rc<DxvkPagedResource>,
-      DxvkAllocationModes, RcHash>            m_entries;
+      Entry, RcHash>                          m_entries;
 
   };
 
@@ -1243,11 +1252,12 @@ namespace dxvk {
     /**
      * \brief Polls relocation list
      *
-     * \param [in] count Desired entry count
+     * \param [in] count Maximum resource count
+     * \param [in] size Maximum total size
      * \returns Relocation entries
      */
-    auto pollRelocationList(uint32_t count) {
-      return m_relocations.poll(count);
+    auto pollRelocationList(uint32_t count, VkDeviceSize size) {
+      return m_relocations.poll(count, size);
     }
 
   private:

--- a/src/dxvk/dxvk_memory.h
+++ b/src/dxvk/dxvk_memory.h
@@ -82,6 +82,8 @@ namespace dxvk {
     high_resolution_clock::time_point unusedTime = { };
     /// Unordered list of resources suballocated from this chunk.
     DxvkResourceAllocation* allocationList = nullptr;
+    /// Chunk cookie
+    uint32_t chunkCookie = 0u;
 
     void addAllocation(DxvkResourceAllocation* allocation);
     void removeAllocation(DxvkResourceAllocation* allocation);
@@ -109,6 +111,8 @@ namespace dxvk {
     VkDeviceSize nextChunkSize = MinChunkSize;
     /// Maximum chunk size for the memory pool. Hard limit.
     VkDeviceSize maxChunkSize = MaxChunkSize;
+    /// Next chunk cookie, used to order chunks in statistics
+    uint32_t nextChunkCookie = 0u;
 
     force_inline int64_t alloc(uint64_t size, uint64_t align) {
       if (size <= DxvkPoolAllocator::MaxSize)
@@ -198,6 +202,8 @@ namespace dxvk {
     bool mapped = false;
     /// Whether this chunk is active
     bool active = false;
+    /// Chunk cookie
+    uint32_t cookie = 0u;
   };
 
 

--- a/src/dxvk/dxvk_memory.h
+++ b/src/dxvk/dxvk_memory.h
@@ -16,6 +16,7 @@ namespace dxvk {
   class DxvkSparsePageTable;
   class DxvkSharedAllocationCache;
   class DxvkResourceAllocation;
+  class DxvkPagedResource;
 
   /**
    * \brief Memory stats
@@ -1118,6 +1119,22 @@ namespace dxvk {
             VkMemoryRequirements2&  memoryRequirements) const;
 
     /**
+     * \brief Registers a paged resource with cookie
+     *
+     * Useful when the allocator needs to track resources.
+     * \param [in] resource Resource to add
+     */
+    void registerResource(
+            DxvkPagedResource*          resource);
+
+    /**
+     * \brief Unregisters a paged resource
+     * \param [in] resource Resource to remove
+     */
+    void unregisterResource(
+            DxvkPagedResource*          resource);
+
+    /**
      * \brief Performs clean-up tasks
      *
      * Intended to be called periodically by a worker thread in order
@@ -1152,6 +1169,10 @@ namespace dxvk {
     alignas(CACHE_LINE_SIZE)
     high_resolution_clock::time_point m_taskDeadline = { };
     std::array<DxvkMemoryStats, VK_MAX_MEMORY_HEAPS> m_adapterHeapStats = { };
+
+    alignas(CACHE_LINE_SIZE)
+    dxvk::mutex               m_resourceMutex;
+    std::unordered_map<uint64_t, DxvkPagedResource*> m_resourceMap;
 
     DxvkDeviceMemory allocateDeviceMemory(
             DxvkMemoryType&       type,

--- a/src/dxvk/dxvk_memory.h
+++ b/src/dxvk/dxvk_memory.h
@@ -448,8 +448,9 @@ namespace dxvk {
     OwnsMemory  = 0,
     OwnsBuffer  = 1,
     OwnsImage   = 2,
-    Cacheable   = 3,
-    Imported    = 4,
+    CanCache    = 3,
+    CanMove     = 4,
+    Imported    = 5,
   };
 
   using DxvkAllocationFlags = Flags<DxvkAllocationFlag>;

--- a/src/dxvk/dxvk_memory.h
+++ b/src/dxvk/dxvk_memory.h
@@ -15,6 +15,7 @@ namespace dxvk {
   class DxvkMemoryChunk;
   class DxvkSparsePageTable;
   class DxvkSharedAllocationCache;
+  class DxvkResourceAllocation;
 
   /**
    * \brief Memory stats
@@ -78,6 +79,11 @@ namespace dxvk {
     /// Time when the chunk has been marked as unused. Must
     /// be set to 0 when allocating memory from the chunk
     high_resolution_clock::time_point unusedTime = { };
+    /// Unordered list of resources suballocated from this chunk.
+    DxvkResourceAllocation* allocationList = nullptr;
+
+    void addAllocation(DxvkResourceAllocation* allocation);
+    void removeAllocation(DxvkResourceAllocation* allocation);
   };
 
   
@@ -466,6 +472,7 @@ namespace dxvk {
   class alignas(CACHE_LINE_SIZE) DxvkResourceAllocation {
     friend DxvkMemoryAllocator;
 
+    friend struct DxvkMemoryChunk;
     friend class DxvkLocalAllocationCache;
     friend class DxvkSharedAllocationCache;
   public:
@@ -611,6 +618,9 @@ namespace dxvk {
 
     DxvkResourceAllocation*     m_nextCached = nullptr;
 
+    DxvkResourceAllocation*     m_prevInChunk = nullptr;
+    DxvkResourceAllocation*     m_nextInChunk = nullptr;
+
     void destroyBufferViews();
 
     void free();
@@ -620,8 +630,6 @@ namespace dxvk {
     }
 
   };
-
-  static_assert(sizeof(DxvkResourceAllocation) == 2u * CACHE_LINE_SIZE);
 
 
   /**

--- a/src/dxvk/dxvk_memory.h
+++ b/src/dxvk/dxvk_memory.h
@@ -918,6 +918,15 @@ namespace dxvk {
 
 
   /**
+   * \brief Allocation properties
+   */
+  struct DxvkAllocationInfo {
+    /// Desired memory property flags
+    VkMemoryPropertyFlags properties = 0u;
+  };
+
+
+  /**
    * \brief Memory allocator
    * 
    * Allocates device memory for Vulkan resources.
@@ -952,27 +961,27 @@ namespace dxvk {
      * not required. Very large resources may still be placed in
      * a dedicated allocation.
      * \param [in] requirements Memory requirements
+     * \param [in] allocationInfo Allocation info
      * \param [in] properties Memory property flags. Some of
      *    these may be ignored in case of memory pressure.
      * \returns Allocated memory
      */
     Rc<DxvkResourceAllocation> allocateMemory(
       const VkMemoryRequirements&             requirements,
-            VkMemoryPropertyFlags             properties);
+      const DxvkAllocationInfo&               allocationInfo);
 
     /**
      * \brief Allocates memory for a resource
      *
      * Will always create a dedicated allocation.
      * \param [in] requirements Memory requirements
-     * \param [in] properties Memory property flags. Some of
-     *    these may be ignored in case of memory pressure.
+     * \param [in] allocationInfo Allocation info
      * \param [in] next Further memory properties
      * \returns Allocated memory
      */
     Rc<DxvkResourceAllocation> allocateDedicatedMemory(
       const VkMemoryRequirements&             requirements,
-            VkMemoryPropertyFlags             properties,
+      const DxvkAllocationInfo&               allocationInfo,
       const void*                             next);
 
     /**
@@ -981,26 +990,26 @@ namespace dxvk {
      * Will make use of global buffers whenever possible, but
      * may fall back to creating a dedicated Vulkan buffer.
      * \param [in] createInfo Buffer create info
-     * \param [in] properties Memory property flags
+     * \param [in] allocationInfo Allocation properties
      * \param [in] allocationCache Optional allocation cache
      * \returns Buffer resource
      */
     Rc<DxvkResourceAllocation> createBufferResource(
       const VkBufferCreateInfo&         createInfo,
-            VkMemoryPropertyFlags       properties,
+      const DxvkAllocationInfo&         allocationInfo,
             DxvkLocalAllocationCache*   allocationCache);
 
     /**
      * \brief Creates image resource
      *
      * \param [in] createInfo Image create info
-     * \param [in] properties Memory property flags
+     * \param [in] allocationInfo Allocation properties
      * \param [in] next External memory properties
      * \returns Image resource
      */
     Rc<DxvkResourceAllocation> createImageResource(
       const VkImageCreateInfo&          createInfo,
-            VkMemoryPropertyFlags       properties,
+      const DxvkAllocationInfo&         allocationInfo,
       const void*                       next);
 
     /**

--- a/src/dxvk/dxvk_memory.h
+++ b/src/dxvk/dxvk_memory.h
@@ -921,6 +921,8 @@ namespace dxvk {
    * \brief Allocation properties
    */
   struct DxvkAllocationInfo {
+    /// Virtual resource cookie for the allocation
+    uint64_t resourceCookie = 0u;
     /// Desired memory property flags
     VkMemoryPropertyFlags properties = 0u;
   };
@@ -1040,6 +1042,7 @@ namespace dxvk {
      */
     Rc<DxvkResourceAllocation> importBufferResource(
       const VkBufferCreateInfo&         createInfo,
+      const DxvkAllocationInfo&         allocationInfo,
       const DxvkBufferImportInfo&       importInfo);
 
     /**
@@ -1051,6 +1054,7 @@ namespace dxvk {
      */
     Rc<DxvkResourceAllocation> importImageResource(
       const VkImageCreateInfo&          createInfo,
+      const DxvkAllocationInfo&         allocationInfo,
             VkImage                     imageHandle);
 
     /**
@@ -1195,14 +1199,17 @@ namespace dxvk {
             DxvkMemoryType&       type,
             DxvkMemoryPool&       pool,
             VkDeviceSize          address,
-            VkDeviceSize          size);
+            VkDeviceSize          size,
+      const DxvkAllocationInfo&   allocationInfo);
 
     DxvkResourceAllocation* createAllocation(
             DxvkMemoryType&       type,
-      const DxvkDeviceMemory&     memory);
+      const DxvkDeviceMemory&     memory,
+      const DxvkAllocationInfo&   allocationInfo);
 
     DxvkResourceAllocation* createAllocation(
-            DxvkSparsePageTable*  sparsePageTable);
+            DxvkSparsePageTable*  sparsePageTable,
+      const DxvkAllocationInfo&   allocationInfo);
 
     bool refillAllocationCache(
             DxvkLocalAllocationCache* cache,

--- a/src/dxvk/dxvk_memory.h
+++ b/src/dxvk/dxvk_memory.h
@@ -113,6 +113,8 @@ namespace dxvk {
     VkDeviceSize maxChunkSize = MaxChunkSize;
     /// Next chunk cookie, used to order chunks in statistics
     uint32_t nextChunkCookie = 0u;
+    /// Next chunk to relocate for defragmentation
+    uint32_t nextDefragChunk = ~0u;
 
     force_inline int64_t alloc(uint64_t size, uint64_t align) {
       if (size <= DxvkPoolAllocator::MaxSize)
@@ -1014,6 +1016,14 @@ namespace dxvk {
      */
     void clear();
 
+    /**
+     * \brief Checks whether resource list is empty
+     * \returns \c true if the list is empty
+     */
+    bool empty() {
+      return m_entries.empty();
+    }
+
   private:
 
     dxvk::mutex                               m_mutex;
@@ -1376,6 +1386,12 @@ namespace dxvk {
 
     void updateMemoryHeapStats(
             uint32_t              heapIndex);
+
+    void moveDefragChunk(
+            DxvkMemoryType&       type);
+
+    void pickDefragChunk(
+            DxvkMemoryType&       type);
 
     void performTimedTasksLocked(
             high_resolution_clock::time_point currentTime);

--- a/src/dxvk/dxvk_memory.h
+++ b/src/dxvk/dxvk_memory.h
@@ -84,6 +84,9 @@ namespace dxvk {
     DxvkResourceAllocation* allocationList = nullptr;
     /// Chunk cookie
     uint32_t chunkCookie = 0u;
+    /// Whether defragmentation can be performed on this chunk.
+    /// Only relevant for chunks in non-mappable device memory.
+    VkBool32 canMove = true;
 
     void addAllocation(DxvkResourceAllocation* allocation);
     void removeAllocation(DxvkResourceAllocation* allocation);
@@ -1239,6 +1242,15 @@ namespace dxvk {
      */
     void unregisterResource(
             DxvkPagedResource*          resource);
+
+    /**
+     * \brief Locks an allocation in place
+     *
+     * Ensures that the resource is marked as immovable so
+     * that defragmentation won't attempt to relocate it.
+     */
+    void lockResourceGpuAddress(
+      const Rc<DxvkResourceAllocation>& allocation);
 
     /**
      * \brief Performs clean-up tasks

--- a/src/dxvk/dxvk_options.cpp
+++ b/src/dxvk/dxvk_options.cpp
@@ -5,6 +5,7 @@ namespace dxvk {
   DxvkOptions::DxvkOptions(const Config& config) {
     enableDebugUtils      = config.getOption<bool>    ("dxvk.enableDebugUtils",       false);
     enableStateCache      = config.getOption<bool>    ("dxvk.enableStateCache",       true);
+    enableMemoryDefrag    = config.getOption<bool>    ("dxvk.enableMemoryDefrag",     true);
     numCompilerThreads    = config.getOption<int32_t> ("dxvk.numCompilerThreads",     0);
     enableGraphicsPipelineLibrary = config.getOption<Tristate>("dxvk.enableGraphicsPipelineLibrary", Tristate::Auto);
     trackPipelineLifetime = config.getOption<Tristate>("dxvk.trackPipelineLifetime",  Tristate::Auto);

--- a/src/dxvk/dxvk_options.h
+++ b/src/dxvk/dxvk_options.h
@@ -9,35 +9,38 @@ namespace dxvk {
     DxvkOptions(const Config& config);
 
     /// Enable debug utils
-    bool enableDebugUtils;
+    bool enableDebugUtils = false;
 
     /// Enable state cache
-    bool enableStateCache;
+    bool enableStateCache = true;
+
+    /// Enable memory defragmentation
+    bool enableMemoryDefrag = true;
 
     /// Number of compiler threads
     /// when using the state cache
-    int32_t numCompilerThreads;
+    int32_t numCompilerThreads = 0;
 
     /// Enable graphics pipeline library
-    Tristate enableGraphicsPipelineLibrary;
+    Tristate enableGraphicsPipelineLibrary = Tristate::Auto;
 
     /// Enables pipeline lifetime tracking
-    Tristate trackPipelineLifetime;
+    Tristate trackPipelineLifetime = Tristate::Auto;
 
     /// Shader-related options
-    Tristate useRawSsbo;
+    Tristate useRawSsbo = Tristate::Auto;
 
     /// HUD elements
     std::string hud;
 
     /// Forces swap chain into MAILBOX (if true)
     /// or FIFO_RELAXED (if false) present mode
-    Tristate tearFree;
+    Tristate tearFree = Tristate::Auto;
 
     // Hides integrated GPUs if dedicated GPUs are
     // present. May be necessary for some games that
     // incorrectly assume monitor layouts.
-    bool hideIntegratedGraphics;
+    bool hideIntegratedGraphics = false;
 
     // Device name
     std::string deviceFilter;

--- a/src/dxvk/dxvk_sparse.cpp
+++ b/src/dxvk/dxvk_sparse.cpp
@@ -7,6 +7,9 @@
 
 namespace dxvk {
 
+  std::atomic<uint64_t> DxvkPagedResource::s_cookie = { 0u };
+
+
   DxvkPagedResource::~DxvkPagedResource() {
 
   }

--- a/src/dxvk/dxvk_sparse.h
+++ b/src/dxvk/dxvk_sparse.h
@@ -522,6 +522,21 @@ namespace dxvk {
      */
     virtual DxvkSparsePageTable* getSparsePageTable() = 0;
 
+    /**
+     * \brief Allocates new backing storage with constraints
+     *
+     * \param [in] mode Allocation mode flags to control behaviour.
+     *    When relocating the resource to a preferred memory type,
+     *    \c NoFallback should be set, when defragmenting device
+     *    memory then \c NoAllocation should also be set.
+     * \returns \c true in the first field if the operation is
+     *    considered successful, i.e. if an new backing allocation
+     *    was successfully created or is unnecessary. The second
+     *    field will contain the new allocation itself.
+     */
+    virtual Rc<DxvkResourceAllocation> relocateStorage(
+            DxvkAllocationModes         mode) = 0;
+
   private:
 
     std::atomic<uint64_t> m_useCount = { 0u };

--- a/src/dxvk/dxvk_sparse.h
+++ b/src/dxvk/dxvk_sparse.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <atomic>
 #include <map>
 
 #include "dxvk_access.h"
@@ -434,7 +435,18 @@ namespace dxvk {
 
   public:
 
+    DxvkPagedResource()
+    : m_cookie(++s_cookie) { }
+
     virtual ~DxvkPagedResource();
+
+    /**
+     * \brief Queries resource cookie
+     * \returns Resource cookie
+     */
+    uint64_t cookie() const {
+      return m_cookie;
+    }
 
     /**
      * \brief Increments reference count
@@ -513,10 +525,13 @@ namespace dxvk {
   private:
 
     std::atomic<uint64_t> m_useCount = { 0u };
+    uint64_t              m_cookie = { 0u };
 
     static constexpr uint64_t getIncrement(DxvkAccess access) {
       return uint64_t(1u) << (uint32_t(access) * 20u);
     }
+
+    static std::atomic<uint64_t> s_cookie;
 
   };
 

--- a/src/dxvk/dxvk_swapchain_blitter.cpp
+++ b/src/dxvk/dxvk_swapchain_blitter.cpp
@@ -417,6 +417,7 @@ namespace dxvk {
     depInfo.pImageMemoryBarriers = &barrier;
 
     ctx.cmd->cmdPipelineBarrier(DxvkCmdBuffer::ExecBuffer, &depInfo);
+    image->trackInitialization(barrier.subresourceRange);
 
     DxvkBufferSliceHandle bufferSlice = buffer->getSliceHandle();
 

--- a/src/dxvk/hud/dxvk_hud_item.cpp
+++ b/src/dxvk/hud/dxvk_hud_item.cpp
@@ -1122,8 +1122,11 @@ namespace dxvk::hud {
     draw.w = size.x;
     draw.h = size.y;
     draw.pageMask = chunk.pageMaskOffset;
-    draw.pageCount = chunk.pageCount;
+    draw.pageCountAndActiveBit = chunk.pageCount;
     draw.color = color;
+
+    if (chunk.active)
+      draw.pageCountAndActiveBit |= 1u << 15;
   }
 
 

--- a/src/dxvk/hud/dxvk_hud_item.h
+++ b/src/dxvk/hud/dxvk_hud_item.h
@@ -540,7 +540,7 @@ namespace dxvk::hud {
       int16_t w;
       int16_t h;
       uint16_t pageMask;
-      uint16_t pageCount;
+      uint16_t pageCountAndActiveBit;
       uint32_t color;
     };
 

--- a/src/dxvk/hud/dxvk_hud_renderer.cpp
+++ b/src/dxvk/hud/dxvk_hud_renderer.cpp
@@ -427,6 +427,7 @@ namespace dxvk::hud {
     depInfo.pImageMemoryBarriers = &imageBarrier;
 
     ctx.cmd->cmdPipelineBarrier(DxvkCmdBuffer::InitBuffer, &depInfo);
+    m_fontTexture->trackInitialization(imageBarrier.subresourceRange);
 
     VkBufferCopy2 bufferRegion = { VK_STRUCTURE_TYPE_BUFFER_COPY_2 };
     bufferRegion.srcOffset = uploadSlice.offset;

--- a/src/dxvk/hud/shaders/hud_chunk_frag_background.frag
+++ b/src/dxvk/hud/shaders/hud_chunk_frag_background.frag
@@ -11,10 +11,20 @@ uniform push_data_t {
   float scale;
 };
 
+layout(location = 0) flat in uint v_active;
+
 layout(location = 0) out vec4 o_color;
 
 void main() {
   o_color = vec4(0.0f, 0.0f, 0.0f, 0.75f);
+
+  if (v_active == 0u) {
+    uvec2 pos = uvec2(gl_FragCoord.xy);
+
+    if (((pos.x + pos.y) & 7u) < 2u)
+      o_color.xyz = vec3(0.25f);
+  }
+
   o_color.a *= opacity;
   o_color = linear_to_output(o_color);
 }

--- a/src/dxvk/hud/shaders/hud_chunk_frag_visualize.frag
+++ b/src/dxvk/hud/shaders/hud_chunk_frag_visualize.frag
@@ -9,6 +9,7 @@ layout(location = 0) in  vec2 v_coord;
 layout(location = 1, component = 0) flat in uint v_color;
 layout(location = 1, component = 1) flat in uint v_mask_index;
 layout(location = 1, component = 2) flat in uint v_page_count;
+layout(location = 1, component = 3) flat in uint v_active;
 
 layout(location = 0) out vec4 o_color;
 

--- a/src/dxvk/hud/shaders/hud_chunk_vert_background.vert
+++ b/src/dxvk/hud/shaders/hud_chunk_vert_background.vert
@@ -26,6 +26,8 @@ vec2 unpack_u16(uint v) {
   return vec2(float(lo >> 16), float(hi >> 16));
 }
 
+layout(location = 0) out uint o_active;
+
 void main() {
   draw_info_t draw = draw_infos[gl_InstanceIndex];
 
@@ -43,5 +45,6 @@ void main() {
   vec2 pixel_pos = pos + size * coord + (2.0f * coord - 1.0f);
   vec2 scaled_pos = 2.0f * (pixel_pos / surface_size_f) - 1.0f;
 
+  o_active = bitfieldExtract(draw.packed_range, 31, 1);
   gl_Position = vec4(scaled_pos, 0.0f, 1.0f);
 }

--- a/src/dxvk/hud/shaders/hud_chunk_vert_visualize.vert
+++ b/src/dxvk/hud/shaders/hud_chunk_vert_visualize.vert
@@ -24,6 +24,7 @@ layout(location = 0) out vec2 o_coord;
 layout(location = 1, component = 0) out uint o_color;
 layout(location = 1, component = 1) out uint o_mask_index;
 layout(location = 1, component = 2) out uint o_page_count;
+layout(location = 1, component = 3) out uint o_active;
 
 vec2 unpack_u16(uint v) {
   // Inputs may be signed
@@ -42,7 +43,8 @@ void main() {
   o_coord = coord;
   o_color = draw.color;
   o_mask_index = bitfieldExtract(draw.packed_range,  0, 16);
-  o_page_count = bitfieldExtract(draw.packed_range, 16, 16);
+  o_page_count = bitfieldExtract(draw.packed_range, 16, 15);
+  o_active = bitfieldExtract(draw.packed_range, 31, 1);
 
   vec2 surface_size_f = vec2(surface_size) / scale;
 

--- a/src/util/util_small_vector.h
+++ b/src/util/util_small_vector.h
@@ -133,9 +133,9 @@ namespace dxvk {
     }
 
     template<typename... Args>
-    void emplace_back(Args... args) {
+    T& emplace_back(Args... args) {
       reserve(m_size + 1);
-      new (ptr(m_size++)) T(std::forward<Args>(args)...);
+      return *(new (ptr(m_size++)) T(std::forward<Args>(args)...));
     }
 
     void erase(size_t idx) {


### PR DESCRIPTION
Builds on all the reworks from the past couple of weeks to implement memory defragmentation.

## Things still to do
- [x] Get rid of the format conversion context in the D3D9 front-end. **Some D3D9 games may break before this is solved.** (#4388)
- [x] Put a limit on the number of resources to relocate at once, processing thousands in one go isn't free and might lead to frame time spikes.
- [x] Only consider chunk allocations rather than the entire heap when deciding whether to defrag at all.
- [x] Fix some useless error messages when we can't relocate a resource
- [x] Work around some Nvidia driver bug which causes all apps to hang as soon as defragmentation happens (#4380)
- [x] Test this a whole bunch

## What this does
As described in #4280, our memory allocator works on chunks of 256MB that are allocated from the system. The goal here is to make more efficient use of these chunks and *actually* return memory back to the system if we have a lot of unused memory sitting around. This is especially important under memory pressure (even more so on Nvidia due to the need of dedicated allocations for e.g. render targets), or if the app in question isn't actually a game but rather a launcher that temporarily eats over 1GB of VRAM but frees most of it when getting minimized.

As an example, Metaphor ReFantazio (the demo version in this case) allocates over 4GB of memory right at the start, just to free most of it right away. Because some small allocations are scattered all across the memory chunks, we still need to keep the full 4.6GB of memory around:
![Bildschirmfoto-696](https://github.com/user-attachments/assets/32f1492b-fffd-46bc-addc-10b2390cc2a1)

With defragmentation, we get a lot closer to what the game is actively using:
![Bildschirmfoto-697](https://github.com/user-attachments/assets/aee15cca-3bfc-4826-8e91-2bd397531a6c)

This **only** affects VRAM allocations that are not mapped into CPU address space. For CPU-accessible memory we require pointer stability, so moving those around dynamically is not feasible - that said, most mapped allocations are short-lived anyway so the problem usually solves itself.

The algorithm used here is very simple, we periodically look at the chunk that has the lowest amount of memory used and try to move those resources to existing chunks, while preventing the allocator from reusing that chunk until the memory is *actually needed*. This way, we essentially produce empty chunks which can subsequently be freed. While not optimal in any way, this generally seems to work well in practice.

## What this does not (yet) do
We don't migrate any resources between VRAM and system memory yet. This is planned as a future PR and will likely be necessary in order to make Unity Engine games work better on cards with less than 12GB of VRAM (e.g. #4118).

This also means that if we do currently allocate a resource in system memory, we **will not** move it back to VRAM even if enough space would be available, so performance in those games is still going to be an issue.