### PR TITLE
Rework GPU synchronization

### DIFF
--- a/src/dxvk/dxvk_cmdlist.cpp
+++ b/src/dxvk/dxvk_cmdlist.cpp
@@ -174,18 +174,6 @@ namespace dxvk {
     const auto& graphicsQueue = m_device->queues().graphics;
     const auto& transferQueue = m_device->queues().transfer;
 
-    VkSemaphoreCreateInfo semaphoreInfo = { VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO };
-
-    if (m_vkd->vkCreateSemaphore(m_vkd->device(), &semaphoreInfo, nullptr, &m_bindSemaphore)
-     || m_vkd->vkCreateSemaphore(m_vkd->device(), &semaphoreInfo, nullptr, &m_postSemaphore)
-     || m_vkd->vkCreateSemaphore(m_vkd->device(), &semaphoreInfo, nullptr, &m_sdmaSemaphore))
-      throw DxvkError("DxvkCommandList: Failed to create semaphore");
-
-    VkFenceCreateInfo fenceInfo = { VK_STRUCTURE_TYPE_FENCE_CREATE_INFO };
-
-    if (m_vkd->vkCreateFence(m_vkd->device(), &fenceInfo, nullptr, &m_fence))
-      throw DxvkError("DxvkCommandList: Failed to create fence");
-
     m_graphicsPool = new DxvkCommandPool(device, graphicsQueue.queueFamily);
 
     if (transferQueue.queueFamily != graphicsQueue.queueFamily)
@@ -197,16 +185,12 @@ namespace dxvk {
   
   DxvkCommandList::~DxvkCommandList() {
     this->reset();
-
-    m_vkd->vkDestroySemaphore(m_vkd->device(), m_bindSemaphore, nullptr);
-    m_vkd->vkDestroySemaphore(m_vkd->device(), m_postSemaphore, nullptr);
-    m_vkd->vkDestroySemaphore(m_vkd->device(), m_sdmaSemaphore, nullptr);
-
-    m_vkd->vkDestroyFence(m_vkd->device(), m_fence, nullptr);
   }
   
   
-  VkResult DxvkCommandList::submit() {
+  VkResult DxvkCommandList::submit(
+    const DxvkTimelineSemaphores&       semaphores,
+          DxvkTimelineSemaphoreValues&  timelines) {
     VkResult status = VK_SUCCESS;
 
     const auto& graphics = m_device->queues().graphics;
@@ -236,18 +220,16 @@ namespace dxvk {
       if (sparseBind) {
         // Sparse binding needs to serialize command execution, so wait
         // for any prior submissions, then block any subsequent ones
-        m_commandSubmission.signalSemaphore(m_bindSemaphore, 0, VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT);
+        sparseBind->waitSemaphore(semaphores.graphics, timelines.graphics);
+        sparseBind->waitSemaphore(semaphores.transfer, timelines.transfer);
 
-        if ((status = m_commandSubmission.submit(m_device, graphics.queueHandle)))
-          return status;
-
-        sparseBind->waitSemaphore(m_bindSemaphore, 0);
-        sparseBind->signalSemaphore(m_postSemaphore, 0);
+        sparseBind->signalSemaphore(semaphores.graphics, ++timelines.graphics);
 
         if ((status = sparseBind->submit(m_device, sparse.queueHandle)))
           return status;
 
-        m_commandSubmission.waitSemaphore(m_postSemaphore, 0, VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT);
+        m_commandSubmission.waitSemaphore(semaphores.graphics,
+          timelines.graphics, VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT);
       }
 
       // Submit transfer commands as necessary
@@ -257,12 +239,14 @@ namespace dxvk {
       // If we had either a transfer command or a semaphore wait, submit to the
       // transfer queue so that all subsequent commands get stalled as necessary.
       if (m_device->hasDedicatedTransferQueue() && !m_commandSubmission.isEmpty()) {
-        m_commandSubmission.signalSemaphore(m_sdmaSemaphore, 0, VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT);
+        m_commandSubmission.signalSemaphore(semaphores.transfer,
+          ++timelines.transfer, VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT);
 
         if ((status = m_commandSubmission.submit(m_device, transfer.queueHandle)))
           return status;
 
-        m_commandSubmission.waitSemaphore(m_sdmaSemaphore, 0, VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT);
+        m_commandSubmission.waitSemaphore(semaphores.transfer,
+          timelines.transfer, VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT);
       }
 
       // We promise to never do weird stuff to WSI images on
@@ -291,14 +275,25 @@ namespace dxvk {
           m_commandSubmission.signalSemaphore(m_wsiSemaphores.present,
             0, VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT);
         }
-
-        // Signal synchronization fence on final submission
-        m_commandSubmission.signalFence(m_fence);
       }
+
+      m_commandSubmission.signalSemaphore(semaphores.graphics,
+        ++timelines.graphics, VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT);
 
       // Finally, submit all graphics commands of the current submission
       if ((status = m_commandSubmission.submit(m_device, graphics.queueHandle)))
         return status;
+
+      // If there are WSI semaphores involved, do another submit only
+      // containing a timeline semaphore signal so that we can be sure
+      // that they are safe to use afterwards.
+      if ((m_wsiSemaphores.present || m_wsiSemaphores.acquire) && isLast) {
+        m_commandSubmission.signalSemaphore(semaphores.graphics,
+          ++timelines.graphics, VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT);
+
+        if ((status = m_commandSubmission.submit(m_device, graphics.queueHandle)))
+          return status;
+      }
     }
 
     return VK_SUCCESS;
@@ -358,11 +353,6 @@ namespace dxvk {
   }
 
   
-  VkResult DxvkCommandList::synchronizeFence() {
-    return m_vkd->vkWaitForFences(m_vkd->device(), 1, &m_fence, VK_TRUE, ~0ull);
-  }
-
-
   void DxvkCommandList::reset() {
     // Free resources and other objects
     // that are no longer in use
@@ -395,10 +385,6 @@ namespace dxvk {
     // Reset actual command buffers and pools
     m_graphicsPool->reset();
     m_transferPool->reset();
-
-    // Reset fence
-    if (m_vkd->vkResetFences(m_vkd->device(), 1, &m_fence))
-      Logger::err("DxvkCommandList: Failed to reset fence");
   }
 
 

--- a/src/dxvk/dxvk_cmdlist.h
+++ b/src/dxvk/dxvk_cmdlist.h
@@ -19,6 +19,26 @@
 namespace dxvk {
   
   /**
+   * \brief Timeline semaphore pair
+   *
+   * One semaphore for each queue.
+   */
+  struct DxvkTimelineSemaphores {
+    VkSemaphore graphics = VK_NULL_HANDLE;
+    VkSemaphore transfer = VK_NULL_HANDLE;
+  };
+
+
+  /**
+   * \brief Timeline semaphore values
+   */
+  struct DxvkTimelineSemaphoreValues {
+    uint64_t graphics = 0u;
+    uint64_t transfer = 0u;
+  };
+
+
+  /**
    * \brief Command buffer flags
    * 
    * A set of flags used to specify which of
@@ -195,9 +215,14 @@ namespace dxvk {
     
     /**
      * \brief Submits command list
+     *
+     * \param [in] semaphores Timeline semaphore pair
+     * \param [in] timelines Timeline semaphore values
      * \returns Submission status
      */
-    VkResult submit();
+    VkResult submit(
+      const DxvkTimelineSemaphores&       semaphores,
+            DxvkTimelineSemaphoreValues&  timelines);
     
     /**
      * \brief Stat counters
@@ -340,12 +365,6 @@ namespace dxvk {
     void setWsiSemaphores(const PresenterSync& wsiSemaphores) {
       m_wsiSemaphores = wsiSemaphores;
     }
-
-    /**
-     * \brief Synchronizes with command list fence
-     * \returns Return value of vkWaitForFences call
-     */
-    VkResult synchronizeFence();
 
     /**
      * \brief Resets the command list
@@ -1046,11 +1065,6 @@ namespace dxvk {
     
     Rc<DxvkCommandPool>       m_graphicsPool;
     Rc<DxvkCommandPool>       m_transferPool;
-
-    VkSemaphore               m_bindSemaphore = VK_NULL_HANDLE;
-    VkSemaphore               m_postSemaphore = VK_NULL_HANDLE;
-    VkSemaphore               m_sdmaSemaphore = VK_NULL_HANDLE;
-    VkFence                   m_fence         = VK_NULL_HANDLE;
 
     DxvkCommandSubmissionInfo m_cmd;
 

--- a/src/dxvk/dxvk_presenter.h
+++ b/src/dxvk/dxvk_presenter.h
@@ -66,17 +66,19 @@ namespace dxvk {
    * image acquisition.
    */
   struct PresenterSync {
-    VkSemaphore acquire;
-    VkSemaphore present;
+    VkSemaphore acquire = VK_NULL_HANDLE;
+    VkSemaphore present = VK_NULL_HANDLE;
+    VkFence fence = VK_NULL_HANDLE;
+    VkBool32 fenceSignaled = VK_FALSE;
   };
 
   /**
    * \brief Queued frame
    */
   struct PresenterFrame {
-    uint64_t          frameId;
-    VkPresentModeKHR  mode;
-    VkResult          result;
+    uint64_t          frameId = 0u;
+    VkPresentModeKHR  mode    = VK_PRESENT_MODE_FIFO_KHR;
+    VkResult          result  = VK_NOT_READY;
   };
 
   /**
@@ -293,6 +295,9 @@ namespace dxvk {
     void destroySwapchain();
 
     void destroySurface();
+
+    void waitForSwapchainFence(
+            PresenterSync&            sync);
 
     void runFrameThread();
 

--- a/src/dxvk/dxvk_queue.h
+++ b/src/dxvk/dxvk_queue.h
@@ -60,6 +60,26 @@ namespace dxvk {
 
 
   /**
+   * \brief Timeline semaphore pair
+   *
+   * One semaphore for each queue.
+   */
+  struct DxvkTimelineSemaphores {
+    VkSemaphore graphics = VK_NULL_HANDLE;
+    VkSemaphore transfer = VK_NULL_HANDLE;
+  };
+
+
+  /**
+   * \brief Timeline semaphore values
+   */
+  struct DxvkTimelineSemaphoreValues {
+    uint64_t graphics = 0u;
+    uint64_t transfer = 0u;
+  };
+
+
+  /**
    * \brief Submission queue
    */
   class DxvkSubmissionQueue {
@@ -178,6 +198,9 @@ namespace dxvk {
 
     DxvkDevice*                 m_device;
     DxvkQueueCallback           m_callback;
+
+    DxvkTimelineSemaphores      m_semaphores;
+    DxvkTimelineSemaphoreValues m_timelines;
 
     std::atomic<VkResult>       m_lastError = { VK_SUCCESS };
     

--- a/src/dxvk/dxvk_queue.h
+++ b/src/dxvk/dxvk_queue.h
@@ -56,26 +56,7 @@ namespace dxvk {
     DxvkSubmitStatus*   status;
     DxvkSubmitInfo      submit;
     DxvkPresentInfo     present;
-  };
-
-
-  /**
-   * \brief Timeline semaphore pair
-   *
-   * One semaphore for each queue.
-   */
-  struct DxvkTimelineSemaphores {
-    VkSemaphore graphics = VK_NULL_HANDLE;
-    VkSemaphore transfer = VK_NULL_HANDLE;
-  };
-
-
-  /**
-   * \brief Timeline semaphore values
-   */
-  struct DxvkTimelineSemaphoreValues {
-    uint64_t graphics = 0u;
-    uint64_t transfer = 0u;
+    DxvkTimelineSemaphoreValues timelines;
   };
 
 


### PR DESCRIPTION
Part of #4378, but I'd like to get this extensively tested (and merged) first.

TL;DR Nvidia hangs when submitting a binary semaphore wait without any command buffers attached, even though this *should* be legal and we haven't seen any validation errors. Switching to timeline semaphores works around the issue and makes the whole synchronization thing easier to reason about in general.

We've tried this some two years ago already, but it didn't end up working because timeline semaphores were broken on 32-bit Proton. Things have moved on a little though and I hope that it works out this time, because otherwise we have a big problem.

Another thing that this does is introduce the use of present fences if `VK_EXT_swapchain_maintenance1` is supported. This shouldn't functionally change anything, but silences some sporaic validation errors and is kind of neeed for correctness anyway, it's just scary because anything synchronization-related can cause bugs, hangs, crashes and whatnot.