### PR TITLE
[d3d9] Hold reference to DLL in D3D9Interface

### DIFF
--- a/src/d3d9/d3d9_interface.cpp
+++ b/src/d3d9/d3d9_interface.cpp
@@ -28,6 +28,11 @@ namespace dxvk {
     // We can't match up by names on Linux/Wine as they don't match at all
     // like on Windows, so this is our best option.
 #ifdef _WIN32
+    // Windows reference counts DLLs per process.
+    // Hold a reference to the DLL to make sure the application cannot unload it before properly cleaning up.
+    // This works around a crash in the Skyrim Launcher.
+    m_dllHandle = LoadLibrary("d3d9.dll");
+
     if (m_d3d9Options.enumerateByDisplays) {
       DISPLAY_DEVICEA device = { };
       device.cb = sizeof(device);
@@ -72,6 +77,10 @@ namespace dxvk {
 
   D3D9InterfaceEx::~D3D9InterfaceEx() {
     g_dxvkInstance.release();
+
+#ifdef _WIN32
+  FreeLibrary(m_dllHandle);
+#endif
   }
 
 

--- a/src/d3d9/d3d9_interface.h
+++ b/src/d3d9/d3d9_interface.h
@@ -151,6 +151,10 @@ namespace dxvk {
 
     D3D9VkInteropInterface        m_d3d9Interop;
 
+#ifdef _WIN32
+    HMODULE                       m_dllHandle;
+#endif
+
   };
 
 }


### PR DESCRIPTION
Skyrims Launcher manually loads d3d9.dll and then forgets to release a D3D9Device (and thus a D3D9Interface) before manually unloading the DLL.
This leads to a crash on the new memory worker thread because that wakes itself every second. It never gets stopped so it tries to run after the DLL got unloaded.

My original plan was to maintain a global list of D3D9Device* pointers and then iterate over the remaining ones in 
`DLL_PROCESS_DETACH` inside `DllMain()` and keep calling `Release` until the reference count hits 0. Unfortunately this approach deadlocks inside `Thread::join` which is called by a bunch of destructors because `DllMain` runs inside a global loader lock.

During my attempts at getting the approach above to work I came across the fact that Windows reference counts DLLs:
> The system maintains a per-process reference count on all loaded modules. Calling LoadLibrary increments the reference count. Calling the [FreeLibrary](https://learn.microsoft.com/en-us/windows/desktop/api/libloaderapi/nf-libloaderapi-freelibrary) or [FreeLibraryAndExitThread](https://learn.microsoft.com/en-us/windows/desktop/api/libloaderapi/nf-libloaderapi-freelibraryandexitthread) function decrements the reference count. The system unloads a module when its reference count reaches zero or when the process terminates (regardless of the reference count). 

So I propose we keep a reference to d3d9.dll inside D3D9Interface which in turn gets kept alive by D3D9Device.
So the library cannot be unloaded before the application has released all references to both D3D9Device and D3D9Interface objects.

I think this is nicely un-invasive considering how cursed this problem is. On top of that, this DLL reference count gets ignored when the process exits, so hopefully it's not gonna cause any major issues. (famous last words)