### PR TITLE
[util] Set forceSamplerTypeSpecConstants for Alpha Protocol

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -979,13 +979,17 @@ namespace dxvk {
     { R"(\\SecretWorldLegends\.exe$)", {{
       { "d3d9.memoryTrackTest",              "True" },
     }} },
-    /* Far Cry 2: Set vendor ID to Nvidia to      *
-     * avoid vegetation artifacts on Intel, and   *
-     * set apitrace mode to True to improve perf  *
-     * on all hardware.                           */
+    /* Far Cry 2: Set vendor ID to Nvidia to       *
+     * avoid vegetation artifacts on Intel, and    *
+     * set apitrace mode to True to improve perf   *
+     * on all hardware.                            */
     { R"(\\(FarCry2|farcry2game)\.exe$)", {{
       { "d3d9.customVendorId",              "10de" },
       { "d3d9.cachedDynamicBuffers",        "True" },
+    }} },
+    /* Alpha Protocol - Rids unwanted reflections  */
+    { R"(\\APGame\.exe$)", {{
+      { "d3d9.forceSamplerTypeSpecConstants", "True" },
     }} },
 
     /**********************************************/


### PR DESCRIPTION
Some objects like metal containers will have unwanted reflection when they shouldn't otherwise.


<details>
  <summary>Screenshots</summary>
  
Without the config
![image](https://github.com/user-attachments/assets/b4af0fa3-bc7b-4f1b-b727-58595705490e)

With the config. Matches wined3d and native (latter confirmed via YouTube)
![image](https://github.com/user-attachments/assets/024f7885-464b-4b62-8e1a-d6b3ddabe036)
</details>


There was some talk of maybe just doing this by default so this PR also acts as a reminder issue.