### PR TITLE
Revert "[d3d8] Skip stride updates for null buffers in SetStreamSource"

### DIFF
--- a/src/d3d8/d3d8_device.cpp
+++ b/src/d3d8/d3d8_device.cpp
@@ -1403,10 +1403,7 @@ namespace dxvk {
       if (ShouldBatch())
         m_batcher->SetStream(StreamNumber, buffer, Stride);
 
-      m_streams[StreamNumber].buffer = buffer;
-      // The previous stride is preserved if pStreamData is NULL
-      if (likely(buffer != nullptr))
-        m_streams[StreamNumber].stride = Stride;
+      m_streams[StreamNumber] = D3D8VBO {buffer, Stride};
     }
 
     return res;

--- a/src/d3d8/d3d8_state_block.h
+++ b/src/d3d8/d3d8_state_block.h
@@ -103,9 +103,7 @@ namespace dxvk {
 
     inline HRESULT SetStreamSource(UINT StreamNumber, IDirect3DVertexBuffer8* pStreamData, UINT Stride) {
       m_streams[StreamNumber].buffer = pStreamData;
-      // The previous stride is preserved if pStreamData is NULL
-      if (likely(pStreamData != nullptr))
-        m_streams[StreamNumber].stride = Stride;
+      m_streams[StreamNumber].stride = Stride;
       m_capture.streams.set(StreamNumber, true);
       return D3D_OK;
     }


### PR DESCRIPTION
This reverts commit 8c54969552faa7f0bf8cce330ea820d55c68994b.