### PR TITLE
Fix various image invalidation issues

### DIFF
--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -82,6 +82,7 @@ namespace dxvk {
   
   Rc<DxvkCommandList> DxvkContext::endRecording() {
     this->endCurrentCommands();
+    this->relocateQueuedResources();
 
     if (m_descriptorPool->shouldSubmit(false)) {
       m_cmd->trackDescriptorPool(m_descriptorPool, m_descriptorManager);
@@ -102,8 +103,6 @@ namespace dxvk {
 
 
   void DxvkContext::flushCommandList(DxvkSubmitStatus* status) {
-    relocateQueuedResources();
-
     m_device->submitCommandList(
       this->endRecording(), status);
     
@@ -6565,8 +6564,6 @@ namespace dxvk {
     // If there are any resources to relocate, we have to stall the transfer
     // queue so that subsequent resource uploads do not overlap with resource
     // copies on the graphics timeline.
-    this->spillRenderPass(true);
-
     relocateResources(
       bufferInfos.size(), bufferInfos.data(),
       imageInfos.size(), imageInfos.data());

--- a/src/dxvk/dxvk_context.h
+++ b/src/dxvk/dxvk_context.h
@@ -936,9 +936,6 @@ namespace dxvk {
      * backing resource. This allows the host to access
      * the buffer while the GPU is still accessing the
      * original backing resource.
-     * 
-     * \warning If the buffer is used by another context,
-     * invalidating it will result in undefined behaviour.
      * \param [in] buffer The buffer to invalidate
      * \param [in] slice New buffer slice
      */
@@ -962,8 +959,6 @@ namespace dxvk {
      * \brief Invalidates image content
      *
      * Replaces the backing storage of an image.
-     * \warning If the image is used by another context,
-     * invalidating it will result in undefined behaviour.
      * \param [in] buffer The buffer to invalidate
      * \param [in] slice New buffer slice
      */
@@ -975,8 +970,6 @@ namespace dxvk {
      * \brief Invalidates image content and add usage flag
      *
      * Replaces the backing storage of an image.
-     * \warning If the image is used by another context,
-     * invalidating it will result in undefined behaviour.
      * \param [in] buffer The buffer to invalidate
      * \param [in] slice New buffer slice
      * \param [in] usageInfo Added usage info


### PR DESCRIPTION
Spotted some issues while investigating #4395:
- We shouldn't emit hundreds of `VkImageMemoryBarrier2`s during defrag when most of them don't even do a layout transition
  This doesn't affect correctness, but makes renderdoc captures less painful to look at and saves some CPU cycles.
- Doing defrag where we did it was technically correct, but hard to reason about *why* it was correct.
- Image invalidation for sequential swap chains image recreation was essentially broken and wouldn't ensure that the images involved were actually transitioned back to the correct layout. This is a real bug, but not related to defrag.