### PR TITLE
Fixes for building with clang-cl and wine headers.

### DIFF
--- a/src/d3d8/d3d8_device.cpp
+++ b/src/d3d8/d3d8_device.cpp
@@ -973,21 +973,21 @@ namespace dxvk {
           float    Z,
           DWORD    Stencil) {
     StateChange();
-    return GetD3D9()->Clear(Count, pRects, Flags, Color, Z, Stencil);
+    return GetD3D9()->Clear(Count, reinterpret_cast<const d3d9::D3DRECT *>(pRects), Flags, Color, Z, Stencil);
   }
 
   HRESULT STDMETHODCALLTYPE D3D8Device::SetTransform(D3DTRANSFORMSTATETYPE State, const D3DMATRIX* pMatrix) {
     StateChange();
-    return GetD3D9()->SetTransform(d3d9::D3DTRANSFORMSTATETYPE(State), pMatrix);
+    return GetD3D9()->SetTransform(d3d9::D3DTRANSFORMSTATETYPE(State), reinterpret_cast<const d3d9::D3DMATRIX *>(pMatrix));
   }
 
   HRESULT STDMETHODCALLTYPE D3D8Device::GetTransform(D3DTRANSFORMSTATETYPE State, D3DMATRIX* pMatrix) {
-    return GetD3D9()->GetTransform(d3d9::D3DTRANSFORMSTATETYPE(State), pMatrix);
+    return GetD3D9()->GetTransform(d3d9::D3DTRANSFORMSTATETYPE(State), reinterpret_cast<d3d9::D3DMATRIX *>(pMatrix));
   }
 
   HRESULT STDMETHODCALLTYPE D3D8Device::MultiplyTransform(D3DTRANSFORMSTATETYPE TransformState, const D3DMATRIX* pMatrix) {
     StateChange();
-    return GetD3D9()->MultiplyTransform(d3d9::D3DTRANSFORMSTATETYPE(TransformState), pMatrix);
+    return GetD3D9()->MultiplyTransform(d3d9::D3DTRANSFORMSTATETYPE(TransformState), reinterpret_cast<const d3d9::D3DMATRIX *>(pMatrix));
   }
 
   HRESULT STDMETHODCALLTYPE D3D8Device::SetViewport(const D3DVIEWPORT8* pViewport) {

--- a/src/d3d8/d3d8_include.h
+++ b/src/d3d8/d3d8_include.h
@@ -181,9 +181,6 @@ namespace d3d9 {
 #define D3DDEVINFOID_VCACHE            4
 #endif
 
-// MinGW headers are broken. Who'dve guessed?
-#ifndef _MSC_VER
-
 // Missing from d3d8types.h
 #ifndef D3DDEVINFOID_RESOURCEMANAGER
 #define D3DDEVINFOID_RESOURCEMANAGER    5
@@ -197,7 +194,7 @@ namespace d3d9 {
 #define D3DPRESENT_RATE_UNLIMITED       0x7FFFFFFF
 #endif
 
-#else // _MSC_VER
+#ifdef _MSC_VER
 
 // These are enum typedefs in the MinGW headers, but not defined by Microsoft
 #define D3DVSDT_TYPE     DWORD

--- a/src/dxvk/dxvk_memory.h
+++ b/src/dxvk/dxvk_memory.h
@@ -12,7 +12,7 @@
 namespace dxvk {
   
   class DxvkMemoryAllocator;
-  class DxvkMemoryChunk;
+  struct DxvkMemoryChunk;
   class DxvkSparsePageTable;
   class DxvkSharedAllocationCache;
   class DxvkResourceAllocation;

--- a/src/wsi/win32/wsi_monitor_win32.cpp
+++ b/src/wsi/win32/wsi_monitor_win32.cpp
@@ -227,7 +227,7 @@ namespace dxvk::wsi {
     // Get the device name of the monitor.
     MONITORINFOEXW monInfo;
     monInfo.cbSize = sizeof(monInfo);
-    if (!::GetMonitorInfoW(hMonitor, &monInfo)) {
+    if (!::GetMonitorInfoW(hMonitor, reinterpret_cast<MONITORINFO*>(&monInfo))) {
       Logger::err("getMonitorDevicePath: Failed to get monitor info.");
       return {};
     }


### PR DESCRIPTION
A couple of compilation failures found while experimenting with clang msvc mode.