### PR TITLE
Work around Vindictus constant buffer breakage

### DIFF
--- a/dxvk.conf
+++ b/dxvk.conf
@@ -267,6 +267,15 @@
 # d3d11.zeroWorkgroupMemory = False
 
 
+# Clears mapped memory to zero when suballocated memory is freed. This will
+# drastically increase CPU overhead and should only be used as a last resort
+# if a game does not properly initialize mapped buffers on its own.
+#
+# Supported values: True, False
+
+# dxvk.zeroMappedMemory = False
+
+
 # Resource size limit for implicit discards, in kilobytes. For small staging
 # resources mapped with MAP_WRITE, DXVK will sometimes allocate new backing
 # storage in order to avoid GPU synchronization, so setting this too high

--- a/src/dxvk/dxvk_memory.h
+++ b/src/dxvk/dxvk_memory.h
@@ -465,12 +465,23 @@ namespace dxvk {
    * \brief Resource allocation flags
    */
   enum class DxvkAllocationFlag : uint32_t {
+    /// Allocation owns the given VkDeviceMemory allocation
+    /// and is not suballocated from an existing chunk.
     OwnsMemory  = 0,
+    /// Allocation owns a dedicated VkBuffer object rather
+    /// than the global buffer for the parent chunk, if any.
     OwnsBuffer  = 1,
+    /// Allocation owns a VkImage object.
     OwnsImage   = 2,
+    /// Allocation can use an allocation cache.
     CanCache    = 3,
+    /// Allocation can be relocated for defragmentation.
     CanMove     = 4,
+    /// Allocation is imported from an external API.
     Imported    = 5,
+    /// Memory must be cleared to zero when the allocation
+    /// is freed. Only used to work around app bugs.
+    ClearOnFree = 6,
   };
 
   using DxvkAllocationFlags = Flags<DxvkAllocationFlag>;

--- a/src/dxvk/dxvk_options.cpp
+++ b/src/dxvk/dxvk_options.cpp
@@ -13,6 +13,7 @@ namespace dxvk {
     hud                   = config.getOption<std::string>("dxvk.hud", "");
     tearFree              = config.getOption<Tristate>("dxvk.tearFree",               Tristate::Auto);
     hideIntegratedGraphics = config.getOption<bool>   ("dxvk.hideIntegratedGraphics", false);
+    zeroMappedMemory      = config.getOption<bool>    ("dxvk.zeroMappedMemory",       false);
     deviceFilter          = config.getOption<std::string>("dxvk.deviceFilter",        "");
   }
 

--- a/src/dxvk/dxvk_options.h
+++ b/src/dxvk/dxvk_options.h
@@ -42,6 +42,9 @@ namespace dxvk {
     // incorrectly assume monitor layouts.
     bool hideIntegratedGraphics = false;
 
+    /// Clears all mapped memory to zero.
+    bool zeroMappedMemory = false;
+
     // Device name
     std::string deviceFilter;
   };

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -404,9 +404,12 @@ namespace dxvk {
     { R"(\\GRW\.exe$)", {{
       { "d3d11.dcSingleUseMode",            "False" },
     }} },
-    /* Vindictus d3d11 CPU bound perf             */
+    /* Vindictus d3d11 CPU bound perf, and work   *
+     * around the game not properly initializing  *
+     * some of its constant buffers after discard */
     { R"(\\Vindictus(_x64)?\.exe$)", {{
       { "d3d11.cachedDynamicResources",     "cr"   },
+      { "dxvk.zeroMappedMemory",            "True" },
     }} },
     /* Riders Republic - Statically linked AMDAGS */
     { R"(\\RidersRepublic(_BE)?\.exe$)", {{

--- a/src/util/util_bit.h
+++ b/src/util/util_bit.h
@@ -183,6 +183,37 @@ namespace dxvk::bit {
     return shift > Bits ? shift - Bits : 0;
   }
 
+
+  /**
+   * \brief Clears cache lines of memory
+   *
+   * Uses non-temporal stores. The memory region offset
+   * and size are assumed to be aligned to 64 bytes.
+   * \param [in] mem Memory region to clear
+   * \param [in] size Number of bytes to clear
+   */
+  inline void bclear(void* mem, size_t size) {
+    #if defined(DXVK_ARCH_X86) && (defined(__GNUC__) || defined(__clang__) || defined(_MSC_VER))
+    auto zero = _mm_setzero_si128();
+
+    #if defined(__clang__)
+    #pragma nounroll
+    #elif defined(__GNUC__)
+    #pragma GCC unroll 0
+    #endif
+    for (size_t i = 0; i < size; i += 64u) {
+      auto* ptr = reinterpret_cast<__m128i*>(mem) + i / sizeof(zero);
+      _mm_stream_si128(ptr + 0u, zero);
+      _mm_stream_si128(ptr + 1u, zero);
+      _mm_stream_si128(ptr + 2u, zero);
+      _mm_stream_si128(ptr + 3u, zero);
+    }
+    #else
+    std::memset(mem, 0, size);
+    #endif
+  }
+
+
   /**
    * \brief Compares two aligned structs bit by bit
    *


### PR DESCRIPTION
I hate everything about this, The game has some 432-byte constant buffer that it constantly `DISCARD`s but doesn't really bother writing to, yet it accesses the uninitialized data in the shader.

Before the memory rework, this was sort-of fine because per-buffer allocations were more or less set in stone, we'd grab some memory, clear it and then just reuse those regions, so any data not written at all would remain zeroed. The new allocator however allocates fresh memory on every `MAP_WRITE_DISCARD`, which means the memory we return to the app might have been used for a different purpose before and can contain stale data.

This workaround essentially zeroes all mapped memory allocations when they are freed. While this mostly happens on a worker thread, it is **very** CPU-intensive and slow, but I don't see any better ways to fix this game.

Fixes #4405.