### PR TITLE
Further optimize certain copies

### DIFF
--- a/src/dxvk/dxvk_barrier.cpp
+++ b/src/dxvk/dxvk_barrier.cpp
@@ -474,7 +474,6 @@ namespace dxvk {
       return;
 
     list->cmdPipelineBarrier(m_cmdBuffer, &depInfo);
-    list->addStatCtr(DxvkStatCounter::CmdBarrierCount, 1u);
 
     m_memoryBarrier.srcStageMask = 0u;
     m_memoryBarrier.srcAccessMask = 0u;

--- a/src/dxvk/dxvk_cmdlist.cpp
+++ b/src/dxvk/dxvk_cmdlist.cpp
@@ -225,6 +225,9 @@ namespace dxvk {
       }
 
       // Execute transfer command buffer, if any
+      if (cmd.usedFlags.test(DxvkCmdBuffer::SdmaBarriers))
+        m_commandSubmission.executeCommandBuffer(cmd.cmdBuffers[uint32_t(DxvkCmdBuffer::SdmaBarriers)]);
+
       if (cmd.usedFlags.test(DxvkCmdBuffer::SdmaBuffer))
         m_commandSubmission.executeCommandBuffer(cmd.cmdBuffers[uint32_t(DxvkCmdBuffer::SdmaBuffer)]);
 
@@ -249,6 +252,9 @@ namespace dxvk {
       }
 
       // Submit graphics commands
+      if (cmd.usedFlags.test(DxvkCmdBuffer::InitBarriers))
+        m_commandSubmission.executeCommandBuffer(cmd.cmdBuffers[uint32_t(DxvkCmdBuffer::InitBarriers)]);
+
       if (cmd.usedFlags.test(DxvkCmdBuffer::InitBuffer))
         m_commandSubmission.executeCommandBuffer(cmd.cmdBuffers[uint32_t(DxvkCmdBuffer::InitBuffer)]);
 
@@ -391,7 +397,7 @@ namespace dxvk {
 
 
   VkCommandBuffer DxvkCommandList::allocateCommandBuffer(DxvkCmdBuffer type) {
-    return type == DxvkCmdBuffer::SdmaBuffer
+    return type == DxvkCmdBuffer::SdmaBuffer || type == DxvkCmdBuffer::SdmaBarriers
       ? m_transferPool->getCommandBuffer()
       : m_graphicsPool->getCommandBuffer();
   }

--- a/src/dxvk/dxvk_cmdlist.h
+++ b/src/dxvk/dxvk_cmdlist.h
@@ -47,7 +47,9 @@ namespace dxvk {
   enum class DxvkCmdBuffer : uint32_t {
     ExecBuffer,
     InitBuffer,
+    InitBarriers,
     SdmaBuffer,
+    SdmaBarriers,
 
     Count
   };

--- a/src/dxvk/dxvk_cmdlist.h
+++ b/src/dxvk/dxvk_cmdlist.h
@@ -425,6 +425,7 @@ namespace dxvk {
     void cmdBeginRendering(
       const VkRenderingInfo*        pRenderingInfo) {
       m_cmd.execCommands = true;
+      m_statCounters.addCtr(DxvkStatCounter::CmdRenderPassCount, 1);
 
       m_vkd->vkCmdBeginRendering(getCmdBuffer(), pRenderingInfo);
     }
@@ -633,6 +634,7 @@ namespace dxvk {
             uint32_t                y,
             uint32_t                z) {
       m_cmd.execCommands |= cmdBuffer == DxvkCmdBuffer::ExecBuffer;
+      m_statCounters.addCtr(DxvkStatCounter::CmdDispatchCalls, 1);
 
       m_vkd->vkCmdDispatch(getCmdBuffer(cmdBuffer), x, y, z);
     }
@@ -643,6 +645,7 @@ namespace dxvk {
             VkBuffer                buffer,
             VkDeviceSize            offset) {
       m_cmd.execCommands |= cmdBuffer == DxvkCmdBuffer::ExecBuffer;
+      m_statCounters.addCtr(DxvkStatCounter::CmdDispatchCalls, 1);
 
       m_vkd->vkCmdDispatchIndirect(getCmdBuffer(cmdBuffer), buffer, offset);
     }
@@ -653,6 +656,8 @@ namespace dxvk {
             uint32_t                instanceCount,
             uint32_t                firstVertex,
             uint32_t                firstInstance) {
+      m_statCounters.addCtr(DxvkStatCounter::CmdDrawCalls, 1);
+
       m_vkd->vkCmdDraw(getCmdBuffer(),
         vertexCount, instanceCount,
         firstVertex, firstInstance);
@@ -664,6 +669,8 @@ namespace dxvk {
             VkDeviceSize            offset,
             uint32_t                drawCount,
             uint32_t                stride) {
+      m_statCounters.addCtr(DxvkStatCounter::CmdDrawCalls, 1);
+
       m_vkd->vkCmdDrawIndirect(getCmdBuffer(),
         buffer, offset, drawCount, stride);
     }
@@ -676,6 +683,8 @@ namespace dxvk {
             VkDeviceSize            countOffset,
             uint32_t                maxDrawCount,
             uint32_t                stride) {
+      m_statCounters.addCtr(DxvkStatCounter::CmdDrawCalls, 1);
+
       m_vkd->vkCmdDrawIndirectCount(getCmdBuffer(),
         buffer, offset, countBuffer, countOffset, maxDrawCount, stride);
     }
@@ -687,6 +696,8 @@ namespace dxvk {
             uint32_t                firstIndex,
             int32_t                 vertexOffset,
             uint32_t                firstInstance) {
+      m_statCounters.addCtr(DxvkStatCounter::CmdDrawCalls, 1);
+
       m_vkd->vkCmdDrawIndexed(getCmdBuffer(),
         indexCount, instanceCount,
         firstIndex, vertexOffset,
@@ -699,6 +710,8 @@ namespace dxvk {
             VkDeviceSize            offset,
             uint32_t                drawCount,
             uint32_t                stride) {
+      m_statCounters.addCtr(DxvkStatCounter::CmdDrawCalls, 1);
+
       m_vkd->vkCmdDrawIndexedIndirect(getCmdBuffer(),
         buffer, offset, drawCount, stride);
     }
@@ -711,6 +724,8 @@ namespace dxvk {
             VkDeviceSize            countOffset,
             uint32_t                maxDrawCount,
             uint32_t                stride) {
+      m_statCounters.addCtr(DxvkStatCounter::CmdDrawCalls, 1);
+
       m_vkd->vkCmdDrawIndexedIndirectCount(getCmdBuffer(),
         buffer, offset, countBuffer, countOffset, maxDrawCount, stride);
     }
@@ -723,6 +738,8 @@ namespace dxvk {
             VkDeviceSize            counterBufferOffset,
             uint32_t                counterOffset,
             uint32_t                vertexStride) {
+      m_statCounters.addCtr(DxvkStatCounter::CmdDrawCalls, 1);
+
       m_vkd->vkCmdDrawIndirectByteCountEXT(getCmdBuffer(),
         instanceCount, firstInstance, counterBuffer,
         counterBufferOffset, counterOffset, vertexStride);
@@ -777,6 +794,7 @@ namespace dxvk {
             DxvkCmdBuffer           cmdBuffer,
       const VkDependencyInfo*       dependencyInfo) {
       m_cmd.execCommands |= cmdBuffer == DxvkCmdBuffer::ExecBuffer;
+      m_statCounters.addCtr(DxvkStatCounter::CmdBarrierCount, 1);
 
       m_vkd->vkCmdPipelineBarrier2(getCmdBuffer(cmdBuffer), dependencyInfo);
     }

--- a/src/dxvk/dxvk_cmdlist.h
+++ b/src/dxvk/dxvk_cmdlist.h
@@ -287,17 +287,17 @@ namespace dxvk {
      */
     template<typename T>
     void track(Rc<T>&& object, DxvkAccess access) {
-      m_objectTracker.track<DxvkResourceRef>(std::move(object), access);
+      m_objectTracker.track<DxvkResourceRef>(std::move(object), access, m_trackingId);
     }
 
     template<typename T>
     void track(const Rc<T>& object, DxvkAccess access) {
-      m_objectTracker.track<DxvkResourceRef>(object.ptr(), access);
+      m_objectTracker.track<DxvkResourceRef>(object.ptr(), access, m_trackingId);
     }
 
     template<typename T>
     void track(T* object, DxvkAccess access) {
-      m_objectTracker.track<DxvkResourceRef>(object, access);
+      m_objectTracker.track<DxvkResourceRef>(object, access, m_trackingId);
     }
 
     /**
@@ -1061,6 +1061,11 @@ namespace dxvk {
       m_descriptorPools.push_back({ pool, manager });
     }
 
+
+    void setTrackingId(uint64_t id) {
+      m_trackingId = id;
+    }
+
   private:
     
     DxvkDevice*               m_device;
@@ -1073,6 +1078,7 @@ namespace dxvk {
     DxvkCommandSubmissionInfo m_cmd;
 
     PresenterSync             m_wsiSemaphores = { };
+    uint64_t                  m_trackingId = 0u;
 
     DxvkObjectTracker         m_objectTracker;
     DxvkSignalTracker         m_signalTracker;

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -827,8 +827,6 @@ namespace dxvk {
       m_queryManager.endQueries(m_cmd,
         VK_QUERY_TYPE_PIPELINE_STATISTICS);
     }
-    
-    m_cmd->addStatCtr(DxvkStatCounter::CmdDispatchCalls, 1);
   }
   
   
@@ -864,8 +862,6 @@ namespace dxvk {
       
       this->trackDrawBuffer();
     }
-    
-    m_cmd->addStatCtr(DxvkStatCounter::CmdDispatchCalls, 1);
   }
   
   
@@ -879,8 +875,6 @@ namespace dxvk {
         vertexCount, instanceCount,
         firstVertex, firstInstance);
     }
-    
-    m_cmd->addStatCtr(DxvkStatCounter::CmdDrawCalls, 1);
   }
   
   
@@ -896,8 +890,6 @@ namespace dxvk {
         descriptor.buffer.offset + offset,
         count, stride);
     }
-    
-    m_cmd->addStatCtr(DxvkStatCounter::CmdDrawCalls, 1);
   }
   
   
@@ -917,8 +909,6 @@ namespace dxvk {
         cntDescriptor.buffer.offset + countOffset,
         maxCount, stride);
     }
-    
-    m_cmd->addStatCtr(DxvkStatCounter::CmdDrawCalls, 1);
   }
   
   
@@ -934,8 +924,6 @@ namespace dxvk {
         firstIndex, vertexOffset,
         firstInstance);
     }
-    
-    m_cmd->addStatCtr(DxvkStatCounter::CmdDrawCalls, 1);
   }
   
   
@@ -951,8 +939,6 @@ namespace dxvk {
         descriptor.buffer.offset + offset,
         count, stride);
     }
-    
-    m_cmd->addStatCtr(DxvkStatCounter::CmdDrawCalls, 1);
   }
   
   
@@ -972,8 +958,6 @@ namespace dxvk {
         cntDescriptor.buffer.offset + countOffset,
         maxCount, stride);
     }
-    
-    m_cmd->addStatCtr(DxvkStatCounter::CmdDrawCalls, 1);
   }
   
   
@@ -990,8 +974,6 @@ namespace dxvk {
         counterBias,
         counterDivisor);
     }
-
-    m_cmd->addStatCtr(DxvkStatCounter::CmdDrawCalls, 1);
   }
 
 
@@ -4749,8 +4731,6 @@ namespace dxvk {
 
     for (uint32_t i = 0; i < framebufferInfo.numAttachments(); i++)
       m_cmd->track(framebufferInfo.getAttachment(i).view->image(), DxvkAccess::Write);
-
-    m_cmd->addStatCtr(DxvkStatCounter::CmdRenderPassCount, 1);
   }
   
   
@@ -6224,7 +6204,6 @@ namespace dxvk {
     depInfo.pMemoryBarriers = &barrier;
 
     m_cmd->cmdPipelineBarrier(DxvkCmdBuffer::ExecBuffer, &depInfo);
-    m_cmd->addStatCtr(DxvkStatCounter::CmdBarrierCount, 1);
   }
 
 
@@ -6404,7 +6383,6 @@ namespace dxvk {
     }
 
     m_cmd->cmdPipelineBarrier(DxvkCmdBuffer::ExecBuffer, &depInfo);
-    m_cmd->addStatCtr(DxvkStatCounter::CmdBarrierCount, 1);
 
     // Set up post-copy barriers
     depInfo = { VK_STRUCTURE_TYPE_DEPENDENCY_INFO };
@@ -6547,7 +6525,6 @@ namespace dxvk {
     }
 
     m_cmd->cmdPipelineBarrier(DxvkCmdBuffer::ExecBuffer, &depInfo);
-    m_cmd->addStatCtr(DxvkStatCounter::CmdBarrierCount, 1);
   }
 
 
@@ -6671,8 +6648,6 @@ namespace dxvk {
     depInfo.pMemoryBarriers = &barrier;
 
     m_cmd->cmdPipelineBarrier(DxvkCmdBuffer::InitBuffer, &depInfo);
-    m_cmd->addStatCtr(DxvkStatCounter::CmdBarrierCount, 1);
-
     return m_zeroBuffer;
   }
   
@@ -6772,7 +6747,6 @@ namespace dxvk {
       depInfo.pImageMemoryBarriers = m_imageLayoutTransitions.data();
 
       m_cmd->cmdPipelineBarrier(cmdBuffer, &depInfo);
-      m_cmd->addStatCtr(DxvkStatCounter::CmdBarrierCount, 1u);
     } else {
       // If we're recording into an out-of-order command buffer, batch
       // layout transitions into a dedicated command buffer in order to

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -1383,6 +1383,8 @@ namespace dxvk {
     Rc<DxvkResourceAllocation> prevAllocation = buffer->assignStorage(std::move(slice));
     m_cmd->track(std::move(prevAllocation));
 
+    buffer->resetTracking();
+
     // We also need to update all bindings that the buffer
     // may be bound to either directly or through views.
     VkBufferUsageFlags usage = buffer->info().usage &
@@ -1475,6 +1477,8 @@ namespace dxvk {
 
     if (usageInfo.stableGpuAddress)
       m_common->memoryManager().lockResourceGpuAddress(image->storage());
+
+    image->resetTracking();
   }
 
 
@@ -6712,6 +6716,8 @@ namespace dxvk {
 
     m_state.gp.pipeline = nullptr;
     m_state.cp.pipeline = nullptr;
+
+    m_cmd->setTrackingId(++m_trackingId);
   }
 
 

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -1492,7 +1492,7 @@ namespace dxvk {
     // Check if we need to insert a barrier and update image properties
     bool isAccessAndLayoutCompatible = (image->info().stages & usageInfo.stages) == usageInfo.stages
                                     && (image->info().access & usageInfo.access) == usageInfo.access
-                                    && (usageInfo.layout && image->info().layout == usageInfo.layout);
+                                    && (!usageInfo.layout || image->info().layout == usageInfo.layout);
 
     // If everything matches already, no need to do anything. Only ensure
     // that the stable adress bit is respected if set for the first time.

--- a/src/dxvk/dxvk_context.h
+++ b/src/dxvk/dxvk_context.h
@@ -1383,6 +1383,8 @@ namespace dxvk {
     
     Rc<DxvkDevice>          m_device;
     DxvkObjects*            m_common;
+
+    uint64_t                m_trackingId = 0u;
     
     Rc<DxvkCommandList>     m_cmd;
     Rc<DxvkBuffer>          m_zeroBuffer;

--- a/src/dxvk/dxvk_context.h
+++ b/src/dxvk/dxvk_context.h
@@ -29,7 +29,8 @@ namespace dxvk {
    * recorded.
    */
   class DxvkContext : public RcObject {
-
+    constexpr static VkDeviceSize MaxDiscardSizeInRp = 256u << 10u;
+    constexpr static VkDeviceSize MaxDiscardSize     =  16u << 10u;
   public:
     
     DxvkContext(const Rc<DxvkDevice>& device);
@@ -1902,6 +1903,22 @@ namespace dxvk {
 
     DxvkBarrierBatch& getBarrierBatch(
             DxvkCmdBuffer             cmdBuffer);
+
+    bool prepareOutOfOrderTransfer(
+      const Rc<DxvkBuffer>&           buffer,
+            VkDeviceSize              offset,
+            VkDeviceSize              size,
+            DxvkAccess                access);
+
+    bool prepareOutOfOrderTransfer(
+      const Rc<DxvkBufferView>&       bufferView,
+            VkDeviceSize              offset,
+            VkDeviceSize              size,
+            DxvkAccess                access);
+
+    bool prepareOutOfOrderTransfer(
+      const Rc<DxvkImage>&            image,
+            DxvkAccess                access);
 
     template<typename Pred>
     bool checkResourceBarrier(

--- a/src/dxvk/dxvk_context.h
+++ b/src/dxvk/dxvk_context.h
@@ -1398,7 +1398,9 @@ namespace dxvk {
     Rc<DxvkDescriptorPool>  m_descriptorPool;
     Rc<DxvkDescriptorManager> m_descriptorManager;
 
+    DxvkBarrierBatch        m_sdmaAcquires;
     DxvkBarrierBatch        m_sdmaBarriers;
+    DxvkBarrierBatch        m_initAcquires;
     DxvkBarrierBatch        m_initBarriers;
     DxvkBarrierBatch        m_execBarriers;
     DxvkBarrierTracker      m_barrierTracker;


### PR DESCRIPTION
Now that we only have one single `DxvkContext`, we can be a bit more aggressive about pulling copies into the init command buffer in order to reduce barrier and/or render pass counts in some cases, ideally without discarding the destination resource.

Previously, we would only do this on full buffer uploads, this new code covers image uploads and actual GPU->GPU buffer copies as well.

An alternative implementation would work based on barrier tracking and be more granular, but since that's **much** more expensive I don't think it's warranted, especially since the issue we're trying to solve isn't all that common to begin with.

There's probably more we can do here (moving image ClearUAV perhaps, or at least related barriers), need to investigate.