### PR TITLE
[d3d9] Add ID3D9InteropBuffer for vertex buffers, index buffers, surfaces, and volumes

### DIFF
--- a/src/d3d9/d3d9_buffer.cpp
+++ b/src/d3d9/d3d9_buffer.cpp
@@ -1,4 +1,5 @@
 #include "d3d9_buffer.h"
+#include "d3d9_interfaces.h"
 
 namespace dxvk {
 
@@ -26,6 +27,11 @@ namespace dxvk {
      || riid == __uuidof(IDirect3DResource9)
      || riid == __uuidof(IDirect3DVertexBuffer9)) {
       *ppvObject = ref(this);
+      return S_OK;
+    }
+
+    if (riid == __uuidof(ID3D9VkInteropBuffer)) {
+      *ppvObject = ref(m_buffer.GetVkInterop());
       return S_OK;
     }
 
@@ -86,6 +92,11 @@ namespace dxvk {
      || riid == __uuidof(IDirect3DResource9)
      || riid == __uuidof(IDirect3DIndexBuffer9)) {
       *ppvObject = ref(this);
+      return S_OK;
+    }
+
+    if (riid == __uuidof(ID3D9VkInteropBuffer)) {
+      *ppvObject = ref(m_buffer.GetVkInterop());
       return S_OK;
     }
 

--- a/src/d3d9/d3d9_buffer.h
+++ b/src/d3d9/d3d9_buffer.h
@@ -15,7 +15,7 @@ namespace dxvk {
             D3D9DeviceEx*      pDevice,
       const D3D9_BUFFER_DESC*  pDesc)
     : D3D9Resource<Type...> (pDevice),
-      m_buffer              (pDevice, pDesc) {
+      m_buffer              (this, pDevice, pDesc) {
 
     }
 

--- a/src/d3d9/d3d9_common_buffer.cpp
+++ b/src/d3d9/d3d9_common_buffer.cpp
@@ -6,10 +6,12 @@
 namespace dxvk {
 
   D3D9CommonBuffer::D3D9CommonBuffer(
+          IUnknown*          pInterface,
           D3D9DeviceEx*      pDevice,
     const D3D9_BUFFER_DESC*  pDesc)
-    : m_parent ( pDevice ), m_desc ( *pDesc ),
-      m_mapMode(DetermineMapMode(pDevice->GetOptions())) {
+    : m_parent (pDevice), m_desc (*pDesc)
+    , m_mapMode(DetermineMapMode(pDevice->GetOptions()))
+    , m_d3d9Interop(pInterface, this) {
     m_buffer = CreateBuffer();
     if (m_mapMode == D3D9_COMMON_BUFFER_MAP_MODE_BUFFER)
       m_stagingBuffer = CreateStagingBuffer();

--- a/src/d3d9/d3d9_common_buffer.h
+++ b/src/d3d9/d3d9_common_buffer.h
@@ -5,6 +5,7 @@
 
 #include "d3d9_device_child.h"
 #include "d3d9_format.h"
+#include "d3d9_interop.h"
 
 namespace dxvk {
 
@@ -75,6 +76,7 @@ namespace dxvk {
   public:
 
     D3D9CommonBuffer(
+                IUnknown*      pInterface,
             D3D9DeviceEx*      pDevice,
       const D3D9_BUFFER_DESC*  pDesc);
 
@@ -210,6 +212,8 @@ namespace dxvk {
       return m_desc.Pool == D3DPOOL_SYSTEMMEM && (m_desc.Usage & D3DUSAGE_DYNAMIC) != 0;
     }
 
+    ID3D9VkInteropBuffer* GetVkInterop() { return &m_d3d9Interop; }
+
   private:
 
     Rc<DxvkBuffer> CreateBuffer() const;
@@ -243,6 +247,8 @@ namespace dxvk {
     uint32_t                    m_lockCount = 0;
 
     uint64_t                    m_seq = 0ull;
+
+    D3D9VkInteropBuffer         m_d3d9Interop;
 
   };
 

--- a/src/d3d9/d3d9_common_texture.cpp
+++ b/src/d3d9/d3d9_common_texture.cpp
@@ -16,7 +16,9 @@ namespace dxvk {
     const D3D9_COMMON_TEXTURE_DESC* pDesc,
           D3DRESOURCETYPE           ResourceType,
           HANDLE*                   pSharedHandle)
-    : m_device(pDevice), m_desc(*pDesc), m_type(ResourceType), m_d3d9Interop(pInterface, this) {
+    : m_device(pDevice), m_desc(*pDesc), m_type(ResourceType)
+    , m_d3d9Interop(pInterface, this)
+    , m_d3d9BufferInterop(pInterface, this) {
     if (m_desc.Format == D3D9Format::Unknown)
       m_desc.Format = (m_desc.Usage & D3DUSAGE_DEPTHSTENCIL)
                     ? D3D9Format::D24X8

--- a/src/d3d9/d3d9_common_texture.h
+++ b/src/d3d9/d3d9_common_texture.h
@@ -487,6 +487,7 @@ namespace dxvk {
     void CreateBuffer(bool Initialize);
 
     ID3D9VkInteropTexture* GetVkInterop() { return &m_d3d9Interop; }
+    ID3D9VkInteropBuffer* GetVkBufferInterop() { return &m_d3d9BufferInterop; }
 
   private:
 
@@ -537,6 +538,7 @@ namespace dxvk {
     std::array<D3DBOX, 6>         m_dirtyBoxes;
 
     D3D9VkInteropTexture          m_d3d9Interop;
+    D3D9VkInteropBuffer           m_d3d9BufferInterop;
 
     Rc<DxvkImage> CreatePrimaryImage(D3DRESOURCETYPE ResourceType, bool TryOffscreenRT, HANDLE* pSharedHandle) const;
 

--- a/src/d3d9/d3d9_interfaces.h
+++ b/src/d3d9/d3d9_interfaces.h
@@ -33,8 +33,8 @@ ID3D9VkInteropInterface : public IUnknown {
 /**
  * \brief D3D9 texture interface for Vulkan interop
  * 
- * Provides access to the backing resource of a
- * D3D9 texture or surface.
+ * Provides access to the backing image of a
+ * D3D9 texture, surface, or volume.
  */
 MIDL_INTERFACE("d56344f5-8d35-46fd-806d-94c351b472c1")
 ID3D9VkInteropTexture : public IUnknown {

--- a/src/d3d9/d3d9_interfaces.h
+++ b/src/d3d9/d3d9_interfaces.h
@@ -74,6 +74,33 @@ ID3D9VkInteropTexture : public IUnknown {
           VkImageCreateInfo*    pInfo) = 0;
 };
 
+enum D3D9VkBufferType {
+  D3D9_VK_BUFFER_TYPE_MAPPING,
+  D3D9_VK_BUFFER_TYPE_STAGING,
+  D3D9_VK_BUFFER_TYPE_REAL
+};
+
+/**
+ * \brief D3D9 buffer interface for Vulkan interop
+ *
+ * Provides access to the backing buffer of a D3D9
+ * vertex buffer, index buffer, surface, or volume.
+ */
+MIDL_INTERFACE("6db73b95-ab03-4909-9f4e-5d42a29fe995")
+ID3D9VkInteropBuffer : public IUnknown {
+  /**
+   * \brief Retrieves buffer info
+   *
+   * Retrieves both the buffer handle as well as the buffer's
+   * properties. Any of the given pointers may be \c nullptr.
+   * 
+   * \returns \c S_OK on success, or \c D3DERR_INVALIDCALL
+   */
+  virtual HRESULT STDMETHODCALLTYPE GetBufferInfo(
+          D3D9VkBufferType Type,
+          VkBuffer* pStagingBuffer,
+          VkBufferCreateInfo* pStagingBufferInfo) = 0;
+};
 
 /**
  * \brief D3D9 image description
@@ -264,6 +291,7 @@ ID3D9VkExtSwapchain : public IUnknown {
 #ifndef _MSC_VER
 __CRT_UUID_DECL(ID3D9VkInteropInterface,   0x3461a81b,0xce41,0x485b,0xb6,0xb5,0xfc,0xf0,0x8b,0xa6,0xa6,0xbd);
 __CRT_UUID_DECL(ID3D9VkInteropTexture,     0xd56344f5,0x8d35,0x46fd,0x80,0x6d,0x94,0xc3,0x51,0xb4,0x72,0xc1);
+__CRT_UUID_DECL(ID3D9VkInteropBuffer,      0x6db73b95,0xab03,0x4909,0x9f,0x4e,0x5d,0x42,0xa2,0x9f,0xe9,0x95);
 __CRT_UUID_DECL(ID3D9VkInteropDevice,      0x2eaa4b89,0x0107,0x4bdb,0x87,0xf7,0x0f,0x54,0x1c,0x49,0x3c,0xe0);
 __CRT_UUID_DECL(ID3D9VkExtSwapchain,       0x13776e93,0x4aa9,0x430a,0xa4,0xec,0xfe,0x9e,0x28,0x11,0x81,0xd5);
 #endif

--- a/src/d3d9/d3d9_interop.h
+++ b/src/d3d9/d3d9_interop.h
@@ -7,6 +7,7 @@ namespace dxvk {
 
   class D3D9InterfaceEx;
   class D3D9CommonTexture;
+  class D3D9CommonBuffer;
   class D3D9DeviceEx;
   struct D3D9_COMMON_TEXTURE_DESC;
 
@@ -68,6 +69,41 @@ namespace dxvk {
   private:
 
     IUnknown*          m_interface;
+    D3D9CommonTexture* m_texture;
+
+  };
+
+  class D3D9VkInteropBuffer final : public ID3D9VkInteropBuffer {
+
+  public:
+
+    D3D9VkInteropBuffer(
+      IUnknown* pInterface,
+      D3D9CommonBuffer* pBuffer);
+
+    D3D9VkInteropBuffer(
+      IUnknown* pInterface,
+      D3D9CommonTexture* pTexture);
+
+    ~D3D9VkInteropBuffer();
+
+    ULONG STDMETHODCALLTYPE AddRef();
+
+    ULONG STDMETHODCALLTYPE Release();
+
+    HRESULT STDMETHODCALLTYPE QueryInterface(
+      REFIID                riid,
+      void** ppvObject);
+
+    HRESULT STDMETHODCALLTYPE GetBufferInfo(
+      D3D9VkBufferType Type,
+      VkBuffer* pHandle,
+      VkBufferCreateInfo* pInfo);
+
+  private:
+
+    IUnknown* m_interface;
+    D3D9CommonBuffer* m_buffer;
     D3D9CommonTexture* m_texture;
 
   };

--- a/src/d3d9/d3d9_surface.cpp
+++ b/src/d3d9/d3d9_surface.cpp
@@ -88,6 +88,11 @@ namespace dxvk {
       return S_OK;
     }
 
+    if (riid == __uuidof(ID3D9VkInteropBuffer)) {
+      *ppvObject = ref(m_texture->GetVkBufferInterop());
+      return S_OK;
+    }
+
     if (logQueryInterfaceError(__uuidof(IDirect3DSurface9), riid)) {
       Logger::warn("D3D9Surface::QueryInterface: Unknown interface query");
       Logger::warn(str::format(riid));

--- a/src/d3d9/d3d9_volume.cpp
+++ b/src/d3d9/d3d9_volume.cpp
@@ -65,6 +65,11 @@ namespace dxvk {
       return S_OK;
     }
 
+    if (riid == __uuidof(ID3D9VkInteropTexture)) {
+      *ppvObject = ref(m_texture->GetVkInterop());
+      return S_OK;
+    }
+
     if (riid == __uuidof(ID3D9VkInteropBuffer)) {
       *ppvObject = ref(m_texture->GetVkBufferInterop());
       return S_OK;

--- a/src/d3d9/d3d9_volume.cpp
+++ b/src/d3d9/d3d9_volume.cpp
@@ -65,6 +65,11 @@ namespace dxvk {
       return S_OK;
     }
 
+    if (riid == __uuidof(ID3D9VkInteropBuffer)) {
+      *ppvObject = ref(m_texture->GetVkBufferInterop());
+      return S_OK;
+    }
+
     if (logQueryInterfaceError(__uuidof(IDirect3DVolume9), riid)) {
       Logger::warn("D3D9Volume::QueryInterface: Unknown interface query");
       Logger::warn(str::format(riid));

--- a/src/dxvk/dxvk_buffer.h
+++ b/src/dxvk/dxvk_buffer.h
@@ -182,6 +182,14 @@ namespace dxvk {
     const DxvkBufferCreateInfo& info() const {
       return m_info;
     }
+
+    /**
+     * \brief Sharing mode info
+     * \returns Sharing mode info
+     */
+    const DxvkSharingModeInfo& sharingModeInfo() const {
+      return m_sharingMode;
+    }
     
     /**
      * \brief Memory type flags


### PR DESCRIPTION
Exposes everything that has a DxvkBuffer to have its underlying VkBuffer(s) accessed the same way that VkImages can already be accessed for textures. Also extends ID3D9InteropTexture to be returned by volumes in addition to textures and surfaces. Interfacing with vertex buffers, index buffers, and volumes are essential features for interop.