### PR TITLE
[d3d9] Add texture/image interop to volumes

### DIFF
--- a/src/d3d9/d3d9_interfaces.h
+++ b/src/d3d9/d3d9_interfaces.h
@@ -33,8 +33,8 @@ ID3D9VkInteropInterface : public IUnknown {
 /**
  * \brief D3D9 texture interface for Vulkan interop
  * 
- * Provides access to the backing resource of a
- * D3D9 texture or surface.
+ * Provides access to the backing image of a
+ * D3D9 texture, surface, or volume.
  */
 MIDL_INTERFACE("d56344f5-8d35-46fd-806d-94c351b472c1")
 ID3D9VkInteropTexture : public IUnknown {

--- a/src/d3d9/d3d9_volume.cpp
+++ b/src/d3d9/d3d9_volume.cpp
@@ -65,6 +65,11 @@ namespace dxvk {
       return S_OK;
     }
 
+    if (riid == __uuidof(ID3D9VkInteropTexture)) {
+      *ppvObject = ref(m_texture->GetVkInterop());
+      return S_OK;
+    }
+
     if (logQueryInterfaceError(__uuidof(IDirect3DVolume9), riid)) {
       Logger::warn("D3D9Volume::QueryInterface: Unknown interface query");
       Logger::warn(str::format(riid));


### PR DESCRIPTION
In the spirit of #4193, this extends ID3D9VkInteropTexture so that it can be used for volumes in addition to surfaces and textures. I don't expect this to create any new issues here since a volume is just a surface with depth and we already expose this for surfaces and textures.