### PR TITLE
[d3d9] Order modes descending by refresh rate

### DIFF
--- a/src/d3d9/d3d9_adapter.cpp
+++ b/src/d3d9/d3d9_adapter.cpp
@@ -817,8 +817,9 @@ namespace dxvk {
         m_modes.push_back(mode);
     }
 
-    // Sort display modes by width, height and refresh rate,
-    // in that order. Some games rely on correct ordering.
+    // Sort display modes by width, height and refresh rate (descending), in that order.
+    // Some games rely on correct ordering, e.g. Prince of Persia (2008) expects the highest
+    // refresh rate to be listed first for a particular resolution.
     std::sort(m_modes.begin(), m_modes.end(),
       [](const D3DDISPLAYMODEEX& a, const D3DDISPLAYMODEEX& b) {
         if (a.Width < b.Width)   return true;
@@ -827,7 +828,7 @@ namespace dxvk {
         if (a.Height < b.Height) return true;
         if (a.Height > b.Height) return false;
         
-        return a.RefreshRate < b.RefreshRate;
+        return b.RefreshRate < a.RefreshRate;
     });
   }
 


### PR DESCRIPTION
Fixes #4288. Not the shadows, those are fine. The game does however pick the first (lowest ordinal) mode for a particular resolution. 

Since we were ordering them ascending by refresh rates, this has the potential to end up on 24 Hz. The game offers no means of manually selecting refresh rates. Which is why I suspect the reporter of the issue gets stuck on 50 Hz, being on AMD (see below output sample).

Behavior on native drivers is as follows:
- Nvidia:

>     D3DFMT_X8R8G8B8 1920 x 1080 @ 60 Hz
>     D3DFMT_X8R8G8B8 1920 x 1080 @ 59 Hz
>     D3DFMT_X8R8G8B8 1920 x 1080 @ 50 Hz
>     D3DFMT_X8R8G8B8 1920 x 1080 @ 120 Hz
>     D3DFMT_X8R8G8B8 1920 x 1080 @ 100 Hz

- AMD:

>     D3DFMT_X8R8G8B8 1920 x 1080 @ 50 Hz
>     D3DFMT_X8R8G8B8 1920 x 1080 @ 59 Hz
>     D3DFMT_X8R8G8B8 1920 x 1080 @ 60 Hz
>     D3DFMT_X8R8G8B8 1920 x 1080 @ 100 Hz
>     D3DFMT_X8R8G8B8 1920 x 1080 @ 120 Hz

- Intel:

>     D3DFMT_R5G6B5 1920 x 1080 @ 60 Hz
>     D3DFMT_R5G6B5 1920 x 1080 @ 48 Hz

- WineD3D:

>     D3DFMT_R5G6B5 1920 x 1080 @ 75 Hz
>     D3DFMT_R5G6B5 1920 x 1080 @ 60 Hz
>     D3DFMT_R5G6B5 1920 x 1080 @ 60 Hz
>     D3DFMT_R5G6B5 1920 x 1080 @ 50 Hz

These were collected on different systems, but you get the idea. Fun fact: Intel doesn't even order by height & width ascending, rather puts the current resolution first, and then "sticks to the plan".

I guess this would need some regression testing, but at some point we'll have to decide if we just want to YOLO it and see if any of the 99.999 d3d9 games out there are affected.