### PR TITLE
D3D11: Remove direct image mapping

### DIFF
--- a/dxvk.conf
+++ b/dxvk.conf
@@ -276,14 +276,6 @@
 # dxvk.zeroMappedMemory = False
 
 
-# Resource size limit for buffer-mapped dynamic images, in kilobytes.
-# A higher threshold may reduce memory usage and PCI-E bandwidth in
-# some games, but may also increase GPU synchronizations. Setting it
-# to -1 disables the feature.
-
-# d3d11.maxDynamicImageBufferSize = -1
-
-
 # Allocates dynamic resources with the given set of bind flags in
 # cached system memory rather than uncached memory or host-visible
 # VRAM, in order to allow fast readback from the CPU. This is only

--- a/dxvk.conf
+++ b/dxvk.conf
@@ -276,14 +276,6 @@
 # dxvk.zeroMappedMemory = False
 
 
-# Resource size limit for implicit discards, in kilobytes. For small staging
-# resources mapped with MAP_WRITE, DXVK will sometimes allocate new backing
-# storage in order to avoid GPU synchronization, so setting this too high
-# may cause memory issues, setting it to -1 disables the feature.
-
-# d3d11.maxImplicitDiscardSize = 256
-
-
 # Resource size limit for buffer-mapped dynamic images, in kilobytes.
 # A higher threshold may reduce memory usage and PCI-E bandwidth in
 # some games, but may also increase GPU synchronizations. Setting it

--- a/src/d3d11/d3d11_context_imm.cpp
+++ b/src/d3d11/d3d11_context_imm.cpp
@@ -17,7 +17,6 @@ namespace dxvk {
     const Rc<DxvkDevice>& Device)
   : D3D11CommonContext<D3D11ImmediateContext>(pParent, Device, 0, DxvkCsChunkFlag::SingleUse),
     m_csThread(Device, Device->createContext()),
-    m_maxImplicitDiscardSize(pParent->GetOptions()->maxImplicitDiscardSize),
     m_submissionFence(new sync::CallbackFence()),
     m_flushTracker(pParent->GetOptions()->reproducibleCommandStream),
     m_stagingBufferFence(new sync::Fence(0)),

--- a/src/d3d11/d3d11_context_imm.cpp
+++ b/src/d3d11/d3d11_context_imm.cpp
@@ -411,9 +411,6 @@ namespace dxvk {
           D3D11_MAP                   MapType,
           UINT                        MapFlags,
           D3D11_MAPPED_SUBRESOURCE*   pMappedResource) {
-    const Rc<DxvkImage>  mappedImage  = pResource->GetImage();
-    const Rc<DxvkBuffer> mappedBuffer = pResource->GetMappedBuffer(Subresource);
-
     auto mapMode = pResource->GetMapMode();
 
     if (pMappedResource)
@@ -443,9 +440,10 @@ namespace dxvk {
     uint64_t sequenceNumber = pResource->GetSequenceNumber(Subresource);
 
     auto formatInfo = lookupFormatInfo(packedFormat);
-    void* mapPtr;
 
     if (mapMode == D3D11_COMMON_TEXTURE_MAP_MODE_DIRECT) {
+      Rc<DxvkImage> mappedImage = pResource->GetImage();
+
       // Wait for the resource to become available. We do not
       // support image renaming, so stall on DISCARD instead.
       if (MapType == D3D11_MAP_WRITE_DISCARD)
@@ -455,11 +453,9 @@ namespace dxvk {
         if (!WaitForResource(*mappedImage, sequenceNumber, MapType, MapFlags))
           return DXGI_ERROR_WAS_STILL_DRAWING;
       }
-      
-      // Query the subresource's memory layout and hope that
-      // the application respects the returned pitch values.
-      mapPtr = mappedImage->mapPtr(0);
     } else {
+      Rc<DxvkBuffer> mappedBuffer = pResource->GetMappedBuffer(Subresource);
+
       constexpr uint32_t DoInvalidate = (1u << 0);
       constexpr uint32_t DoPreserve   = (1u << 1);
       constexpr uint32_t DoWait       = (1u << 2);
@@ -530,17 +526,17 @@ namespace dxvk {
         auto dstSlice = pResource->DiscardSlice(Subresource);
 
         auto srcPtr = srcSlice->mapPtr();
-        mapPtr = dstSlice->mapPtr();
+        auto dstPtr = dstSlice->mapPtr();
 
         EmitCs([
-          cImageBuffer      = mappedBuffer,
+          cImageBuffer      = std::move(mappedBuffer),
           cImageBufferSlice = std::move(dstSlice)
         ] (DxvkContext* ctx) mutable {
           ctx->invalidateBuffer(cImageBuffer, std::move(cImageBufferSlice));
         });
 
         if (doFlags & DoPreserve)
-          std::memcpy(mapPtr, srcPtr, bufferSize);
+          std::memcpy(dstPtr, srcPtr, bufferSize);
       } else {
         if (doFlags & DoWait) {
           // We cannot respect DO_NOT_WAIT for buffer-mapped resources since
@@ -552,8 +548,6 @@ namespace dxvk {
           if (!WaitForResource(*mappedBuffer, sequenceNumber, MapType, MapFlags))
             return DXGI_ERROR_WAS_STILL_DRAWING;
         }
-
-        mapPtr = pResource->GetMappedSlice(Subresource)->mapPtr();
       }
     }
 
@@ -562,7 +556,7 @@ namespace dxvk {
 
     if (pMappedResource) {
       auto layout = pResource->GetSubresourceLayout(formatInfo->aspectMask, Subresource);
-      pMappedResource->pData      = reinterpret_cast<char*>(mapPtr) + layout.Offset;
+      pMappedResource->pData      = pResource->GetMapPtr(Subresource, layout.Offset);
       pMappedResource->RowPitch   = layout.RowPitch;
       pMappedResource->DepthPitch = layout.DepthPitch;
     }

--- a/src/d3d11/d3d11_context_imm.cpp
+++ b/src/d3d11/d3d11_context_imm.cpp
@@ -341,6 +341,11 @@ namespace dxvk {
         ctx->invalidateBuffer(cBuffer, std::move(cBufferSlice));
       });
 
+      // Ignore small buffers here. These are often updated per
+      // draw and won't contribute much to memory waste anyway.
+      if (unlikely(bufferSize > DxvkPageAllocator::PageSize))
+        ThrottleDiscard(bufferSize);
+
       return S_OK;
     } else if (likely(MapType == D3D11_MAP_WRITE_NO_OVERWRITE)) {
       // Put this on a fast path without any extra checks since it's
@@ -360,7 +365,7 @@ namespace dxvk {
       auto buffer = pResource->GetBuffer();
       auto sequenceNumber = pResource->GetSequenceNumber();
 
-      if (MapType != D3D11_MAP_READ && !MapFlags && bufferSize <= m_maxImplicitDiscardSize) {
+      if (MapType != D3D11_MAP_READ && !MapFlags && bufferSize <= D3D11Initializer::MaxMemoryPerSubmission) {
         SynchronizeCsThread(sequenceNumber);
 
         bool hasWoAccess = buffer->isInUse(DxvkAccess::Write);
@@ -389,6 +394,8 @@ namespace dxvk {
         pMappedResource->pData      = dstPtr;
         pMappedResource->RowPitch   = bufferSize;
         pMappedResource->DepthPitch = bufferSize;
+
+        ThrottleDiscard(bufferSize);
         return S_OK;
       } else {
         if (!WaitForResource(*buffer, sequenceNumber, MapType, MapFlags)) {
@@ -493,11 +500,11 @@ namespace dxvk {
         // Need to synchronize thread to determine pending GPU accesses
         SynchronizeCsThread(sequenceNumber);
 
-        // Don't implicitly discard large buffers or buffers of images with
-        // multiple subresources, as that is likely to cause memory issues.
+        // Don't implicitly discard large very large resources
+        // since that might lead to memory issues.
         VkDeviceSize bufferSize = mappedBuffer->info().size;
 
-        if (bufferSize >= m_maxImplicitDiscardSize || pResource->CountSubresources() > 1) {
+        if (bufferSize > D3D11Initializer::MaxMemoryPerSubmission) {
           // Don't check access flags, WaitForResource will return
           // early anyway if the resource is currently in use
           doFlags = DoWait;
@@ -537,6 +544,8 @@ namespace dxvk {
 
         if (doFlags & DoPreserve)
           std::memcpy(dstPtr, srcPtr, bufferSize);
+
+        ThrottleDiscard(bufferSize);
       } else {
         if (doFlags & DoWait) {
           // We cannot respect DO_NOT_WAIT for buffer-mapped resources since
@@ -949,7 +958,7 @@ namespace dxvk {
       cSubmissionId     = submissionId,
       cSubmissionStatus = synchronizeSubmission ? &m_submitStatus : nullptr,
       cStagingFence     = m_stagingBufferFence,
-      cStagingMemory    = m_staging.getStatistics().allocatedTotal
+      cStagingMemory    = GetStagingMemoryStatistics().allocatedTotal
     ] (DxvkContext* ctx) {
       ctx->signal(cSubmissionFence, cSubmissionId);
       ctx->signal(cStagingFence, cStagingMemory);
@@ -971,6 +980,9 @@ namespace dxvk {
     // end up with a persistent allocation
     ResetStagingBuffer();
 
+    // Reset counter for discarded memory in flight
+    m_discardMemoryOnFlush = m_discardMemoryCounter;
+
     // Notify the device that the context has been flushed,
     // this resets some resource initialization heuristics.
     m_parent->NotifyContextFlush();
@@ -978,7 +990,7 @@ namespace dxvk {
 
 
   void D3D11ImmediateContext::ThrottleAllocation() {
-    DxvkStagingBufferStats stats = m_staging.getStatistics();
+    DxvkStagingBufferStats stats = GetStagingMemoryStatistics();
 
     VkDeviceSize stagingMemoryInFlight = stats.allocatedTotal - m_stagingBufferFence->value();
 
@@ -988,12 +1000,29 @@ namespace dxvk {
       // wait for the GPU to go fully idle in case of a large allocation.
       ExecuteFlush(GpuFlushType::ExplicitFlush, nullptr, false);
 
-      m_device->waitForFence(*m_stagingBufferFence, stats.allocatedTotal - stats.allocatedSinceLastReset - D3D11Initializer::MaxMemoryInFlight);
+      m_device->waitForFence(*m_stagingBufferFence, stats.allocatedTotal -
+        stats.allocatedSinceLastReset - D3D11Initializer::MaxMemoryInFlight);
     } else if (stats.allocatedSinceLastReset >= D3D11Initializer::MaxMemoryPerSubmission) {
       // Flush somewhat aggressively if there's a lot of memory in flight
       ExecuteFlush(GpuFlushType::ExplicitFlush, nullptr, false);
     }
   }
 
+
+  void D3D11ImmediateContext::ThrottleDiscard(
+          VkDeviceSize                Size) {
+    m_discardMemoryCounter += Size;
+
+    if (m_discardMemoryCounter - m_discardMemoryOnFlush >= D3D11Initializer::MaxMemoryPerSubmission)
+      ThrottleAllocation();
+  }
+
+
+  DxvkStagingBufferStats D3D11ImmediateContext::GetStagingMemoryStatistics() {
+    DxvkStagingBufferStats stats = m_staging.getStatistics();
+    stats.allocatedTotal += m_discardMemoryCounter;
+    stats.allocatedSinceLastReset += m_discardMemoryCounter - m_discardMemoryOnFlush;
+    return stats;
+  }
 
 }

--- a/src/d3d11/d3d11_context_imm.h
+++ b/src/d3d11/d3d11_context_imm.h
@@ -117,8 +117,6 @@ namespace dxvk {
 
     uint32_t                m_mappedImageCount = 0u;
 
-    VkDeviceSize            m_maxImplicitDiscardSize = 0ull;
-
     Rc<sync::CallbackFence> m_submissionFence;
     uint64_t                m_submissionId = 0ull;
     DxvkSubmitStatus        m_submitStatus;

--- a/src/d3d11/d3d11_context_imm.h
+++ b/src/d3d11/d3d11_context_imm.h
@@ -128,6 +128,9 @@ namespace dxvk {
 
     Rc<sync::Fence>         m_stagingBufferFence;
 
+    VkDeviceSize            m_discardMemoryCounter = 0u;
+    VkDeviceSize            m_discardMemoryOnFlush = 0u;
+
     D3D10Multithread        m_multithread;
     D3D11VideoContext       m_videoContext;
 
@@ -198,6 +201,11 @@ namespace dxvk {
             BOOL                        Synchronize);
 
     void ThrottleAllocation();
+
+    void ThrottleDiscard(
+            VkDeviceSize                Size);
+
+    DxvkStagingBufferStats GetStagingMemoryStatistics();
 
   };
   

--- a/src/d3d11/d3d11_device.cpp
+++ b/src/d3d11/d3d11_device.cpp
@@ -2435,11 +2435,7 @@ namespace dxvk {
       D3D11_COMMON_TEXTURE_SUBRESOURCE_LAYOUT layout = pTexture->GetSubresourceLayout(aspect, Subresource);
 
       // Compute actual map pointer, accounting for the region offset
-      VkDeviceSize mapOffset = pTexture->ComputeMappedOffset(Subresource, i, offset);
-
-      void* mapPtr = pTexture->GetMapMode() == D3D11_COMMON_TEXTURE_MAP_MODE_BUFFER
-        ? pTexture->GetMappedBuffer(Subresource)->mapPtr(mapOffset)
-        : image->mapPtr(mapOffset);
+      void* mapPtr = pTexture->GetMapPtr(Subresource, pTexture->ComputeMappedOffset(Subresource, i, offset));
 
       if constexpr (std::is_const<Void>::value) {
         // WriteToSubresource

--- a/src/d3d11/d3d11_initializer.cpp
+++ b/src/d3d11/d3d11_initializer.cpp
@@ -177,7 +177,7 @@ namespace dxvk {
           }
 
           if (mapMode != D3D11_COMMON_TEXTURE_MAP_MODE_NONE) {
-            util::packImageData(pTexture->GetMappedBuffer(index)->mapPtr(0),
+            util::packImageData(pTexture->GetMapPtr(index, 0),
               pInitialData[index].pSysMem, pInitialData[index].SysMemPitch, pInitialData[index].SysMemSlicePitch,
               0, 0, pTexture->GetVkImageType(), mipLevelExtent, 1, formatInfo, formatInfo->aspectMask);
           }
@@ -215,8 +215,8 @@ namespace dxvk {
 
       if (mapMode != D3D11_COMMON_TEXTURE_MAP_MODE_NONE) {
         for (uint32_t i = 0; i < pTexture->CountSubresources(); i++) {
-          auto buffer = pTexture->GetMappedBuffer(i);
-          std::memset(buffer->mapPtr(0), 0, buffer->info().size);
+          auto layout = pTexture->GetSubresourceLayout(formatInfo->aspectMask, i);
+          std::memset(pTexture->GetMapPtr(i, layout.Offset), 0, layout.Size);
         }
       }
     }

--- a/src/d3d11/d3d11_initializer.cpp
+++ b/src/d3d11/d3d11_initializer.cpp
@@ -205,9 +205,7 @@ namespace dxvk {
         EmitCs([
           cImage = std::move(image)
         ] (DxvkContext* ctx) {
-          ctx->initImage(cImage,
-            cImage->getAvailableSubresources(),
-            VK_IMAGE_LAYOUT_UNDEFINED);
+          ctx->initImage(cImage, cImage->getAvailableSubresources());
         });
       }
 

--- a/src/d3d11/d3d11_options.cpp
+++ b/src/d3d11/d3d11_options.cpp
@@ -36,11 +36,6 @@ namespace dxvk {
     // Clamp LOD bias so that people don't abuse this in unintended ways
     this->samplerLodBias = dxvk::fclamp(this->samplerLodBias, -2.0f, 1.0f);
 
-    int32_t maxImplicitDiscardSize = config.getOption<int32_t>("d3d11.maxImplicitDiscardSize", 256);
-    this->maxImplicitDiscardSize = maxImplicitDiscardSize >= 0
-      ? VkDeviceSize(maxImplicitDiscardSize) << 10
-      : VkDeviceSize(~0ull);
-
     int32_t maxDynamicImageBufferSize = config.getOption<int32_t>("d3d11.maxDynamicImageBufferSize", -1);
     this->maxDynamicImageBufferSize = maxDynamicImageBufferSize >= 0
       ? VkDeviceSize(maxDynamicImageBufferSize) << 10

--- a/src/d3d11/d3d11_options.cpp
+++ b/src/d3d11/d3d11_options.cpp
@@ -36,11 +36,6 @@ namespace dxvk {
     // Clamp LOD bias so that people don't abuse this in unintended ways
     this->samplerLodBias = dxvk::fclamp(this->samplerLodBias, -2.0f, 1.0f);
 
-    int32_t maxDynamicImageBufferSize = config.getOption<int32_t>("d3d11.maxDynamicImageBufferSize", -1);
-    this->maxDynamicImageBufferSize = maxDynamicImageBufferSize >= 0
-      ? VkDeviceSize(maxDynamicImageBufferSize) << 10
-      : VkDeviceSize(~0ull);
-
     auto cachedDynamicResources = config.getOption<std::string>("d3d11.cachedDynamicResources", std::string());
 
     if (IsAPITracingDXGI()) {

--- a/src/d3d11/d3d11_options.h
+++ b/src/d3d11/d3d11_options.h
@@ -80,9 +80,6 @@ namespace dxvk {
     /// a higher value. May help with frame timing issues.
     int32_t maxFrameLatency;
 
-    /// Limit discardable resource size
-    VkDeviceSize maxImplicitDiscardSize;
-
     /// Limit size of buffer-mapped images
     VkDeviceSize maxDynamicImageBufferSize;
 

--- a/src/d3d11/d3d11_options.h
+++ b/src/d3d11/d3d11_options.h
@@ -80,9 +80,6 @@ namespace dxvk {
     /// a higher value. May help with frame timing issues.
     int32_t maxFrameLatency;
 
-    /// Limit size of buffer-mapped images
-    VkDeviceSize maxDynamicImageBufferSize;
-
     /// Defer surface creation until first present call. This
     /// fixes issues with games that create multiple swap chains
     /// for a single window that may interfere with each other.

--- a/src/d3d11/d3d11_swapchain.cpp
+++ b/src/d3d11/d3d11_swapchain.cpp
@@ -653,11 +653,8 @@ namespace dxvk {
     m_parent->GetContext()->InjectCs([
       cImages = std::move(images)
     ] (DxvkContext* ctx) {
-      for (size_t i = 0; i < cImages.size(); i++) {
-        ctx->initImage(cImages[i],
-          cImages[i]->getAvailableSubresources(),
-          VK_IMAGE_LAYOUT_UNDEFINED);
-      }
+      for (size_t i = 0; i < cImages.size(); i++)
+        ctx->initImage(cImages[i], cImages[i]->getAvailableSubresources());
     });
   }
 

--- a/src/d3d11/d3d11_texture.cpp
+++ b/src/d3d11/d3d11_texture.cpp
@@ -41,7 +41,6 @@ namespace dxvk {
                               | VK_ACCESS_TRANSFER_WRITE_BIT;
     imageInfo.tiling          = VK_IMAGE_TILING_OPTIMAL;
     imageInfo.layout          = VK_IMAGE_LAYOUT_GENERAL;
-    imageInfo.initialLayout   = VK_IMAGE_LAYOUT_UNDEFINED;
     imageInfo.shared          = vkImage != VK_NULL_HANDLE;
 
     // Normalise hSharedhandle to INVALID_HANDLE_VALUE to allow passing in nullptr

--- a/src/d3d11/d3d11_texture.h
+++ b/src/d3d11/d3d11_texture.h
@@ -24,7 +24,6 @@ namespace dxvk {
   enum D3D11_COMMON_TEXTURE_MAP_MODE {
     D3D11_COMMON_TEXTURE_MAP_MODE_NONE,     ///< Not mapped
     D3D11_COMMON_TEXTURE_MAP_MODE_BUFFER,   ///< Mapped through buffer
-    D3D11_COMMON_TEXTURE_MAP_MODE_DIRECT,   ///< Directly mapped to host mem
     D3D11_COMMON_TEXTURE_MAP_MODE_STAGING,  ///< Buffer only, no image
   };
   
@@ -313,19 +312,9 @@ namespace dxvk {
      * \param [in] Offset Offset derived from the subresource layout
      */
     void* GetMapPtr(uint32_t Subresource, size_t Offset) const {
-      switch (m_mapMode) {
-        case D3D11_COMMON_TEXTURE_MAP_MODE_DIRECT:
-          return m_image->mapPtr(Offset);
-
-        case D3D11_COMMON_TEXTURE_MAP_MODE_BUFFER:
-        case D3D11_COMMON_TEXTURE_MAP_MODE_STAGING:
-          return reinterpret_cast<char*>(m_buffers[Subresource].slice->mapPtr()) + Offset;
-
-        case D3D11_COMMON_TEXTURE_MAP_MODE_NONE:
-          return nullptr;
-      }
-
-      return nullptr;
+      return (m_mapMode != D3D11_COMMON_TEXTURE_MAP_MODE_NONE)
+        ? reinterpret_cast<char*>(m_buffers[Subresource].slice->mapPtr()) + Offset
+        : nullptr;
     }
 
     /**

--- a/src/d3d11/d3d11_texture.h
+++ b/src/d3d11/d3d11_texture.h
@@ -304,6 +304,31 @@ namespace dxvk {
     }
 
     /**
+     * \brief Queries map pointer of the raw image
+     *
+     * If the image is mapped directly, the returned pointer will
+     * point directly to the image, otherwise it will point to a
+     * buffer that contains image data.
+     * \param [in] Subresource Subresource index
+     * \param [in] Offset Offset derived from the subresource layout
+     */
+    void* GetMapPtr(uint32_t Subresource, size_t Offset) const {
+      switch (m_mapMode) {
+        case D3D11_COMMON_TEXTURE_MAP_MODE_DIRECT:
+          return m_image->mapPtr(Offset);
+
+        case D3D11_COMMON_TEXTURE_MAP_MODE_BUFFER:
+        case D3D11_COMMON_TEXTURE_MAP_MODE_STAGING:
+          return reinterpret_cast<char*>(m_buffers[Subresource].slice->mapPtr()) + Offset;
+
+        case D3D11_COMMON_TEXTURE_MAP_MODE_NONE:
+          return nullptr;
+      }
+
+      return nullptr;
+    }
+
+    /**
      * \brief Adds a dirty region
      *
      * This region will be updated on Unmap.

--- a/src/d3d9/d3d9_initializer.cpp
+++ b/src/d3d9/d3d9_initializer.cpp
@@ -101,9 +101,7 @@ namespace dxvk {
     EmitCs([
       cImage = std::move(image)
     ] (DxvkContext* ctx) {
-      ctx->initImage(cImage,
-        cImage->getAvailableSubresources(),
-        VK_IMAGE_LAYOUT_UNDEFINED);
+      ctx->initImage(cImage, cImage->getAvailableSubresources());
     });
 
     ThrottleAllocationLocked();

--- a/src/d3d9/d3d9_swapchain.cpp
+++ b/src/d3d9/d3d9_swapchain.cpp
@@ -1120,11 +1120,8 @@ namespace dxvk {
     m_parent->InjectCs([
       cImages = std::move(images)
     ] (DxvkContext* ctx) {
-      for (size_t i = 0; i < cImages.size(); i++) {
-        ctx->initImage(cImages[i],
-          cImages[i]->getAvailableSubresources(),
-          VK_IMAGE_LAYOUT_UNDEFINED);
-      }
+      for (size_t i = 0; i < cImages.size(); i++)
+        ctx->initImage(cImages[i], cImages[i]->getAvailableSubresources());
     });
 
     return D3D_OK;

--- a/src/dxvk/dxvk_context.h
+++ b/src/dxvk/dxvk_context.h
@@ -898,12 +898,10 @@ namespace dxvk {
      * Only safe to call if the image is not in use by the GPU.
      * \param [in] image The image to initialize
      * \param [in] subresources Image subresources
-     * \param [in] initialLayout Initial image layout
      */
     void initImage(
       const Rc<DxvkImage>&            image,
-      const VkImageSubresourceRange&  subresources,
-            VkImageLayout             initialLayout);
+      const VkImageSubresourceRange&  subresources);
 
     /**
      * \brief Initializes sparse image

--- a/src/dxvk/dxvk_image.cpp
+++ b/src/dxvk/dxvk_image.cpp
@@ -71,17 +71,6 @@ namespace dxvk {
   }
 
 
-  VkSubresourceLayout DxvkImage::querySubresourceLayout(
-    const VkImageSubresource& subresource) const {
-    VkSubresourceLayout result = { };
-
-    m_vkd->vkGetImageSubresourceLayout(m_vkd->device(),
-      m_imageInfo.image, &subresource, &result);
-
-    return result;
-  }
-
-
   HANDLE DxvkImage::sharedHandle() const {
     HANDLE handle = INVALID_HANDLE_VALUE;
 

--- a/src/dxvk/dxvk_image.cpp
+++ b/src/dxvk/dxvk_image.cpp
@@ -296,7 +296,7 @@ namespace dxvk {
     info.tiling = m_info.tiling;
     info.usage = m_info.usage | usageInfo.usage;
     info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
-    info.initialLayout = m_info.initialLayout;
+    info.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
 
     return info;
   }

--- a/src/dxvk/dxvk_image.h
+++ b/src/dxvk/dxvk_image.h
@@ -493,17 +493,6 @@ namespace dxvk {
     bool canRelocate() const;
 
     /**
-     * \brief Queries memory layout of a subresource
-     *
-     * Can be used to retrieve the exact pointer to a
-     * subresource of a mapped image with linear tiling.
-     * \param [in] subresource The image subresource
-     * \returns Memory layout of that subresource
-     */
-    VkSubresourceLayout querySubresourceLayout(
-      const VkImageSubresource& subresource) const;
-
-    /**
      * \brief Create a new shared handle to dedicated memory backing the image
      * \returns The shared handle with the type given by DxvkSharedHandleInfo::type
      */

--- a/src/dxvk/dxvk_image.h
+++ b/src/dxvk/dxvk_image.h
@@ -52,9 +52,6 @@ namespace dxvk {
     /// Common image layout
     VkImageLayout layout = VK_IMAGE_LAYOUT_UNDEFINED;
 
-    // Initial image layout
-    VkImageLayout initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-
     // Image is used by multiple contexts so it needs
     // to be in its default layout after each submission
     VkBool32 shared = VK_FALSE;
@@ -585,8 +582,8 @@ namespace dxvk {
     /**
      * \brief Tracks subresource initialization
      *
-     * Initialization happens when transitioning the image
-     * away from \c PREINITIALIZED or \c UNDEFINED layouts.
+     * Initialization happens when transitioning
+     * the image away from \c UNDEFINED layouts.
      * \param [in] subresources Subresource range
      */
     void trackInitialization(

--- a/src/dxvk/dxvk_swapchain_blitter.cpp
+++ b/src/dxvk/dxvk_swapchain_blitter.cpp
@@ -366,7 +366,6 @@ namespace dxvk {
       imageInfo.access = VK_ACCESS_2_TRANSFER_WRITE_BIT | VK_ACCESS_SHADER_READ_BIT;
       imageInfo.tiling = VK_IMAGE_TILING_OPTIMAL;
       imageInfo.layout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
-      imageInfo.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
 
       m_gammaImage = m_device->createImage(imageInfo,
         VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);

--- a/src/dxvk/hud/dxvk_hud_item.cpp
+++ b/src/dxvk/hud/dxvk_hud_item.cpp
@@ -1096,7 +1096,7 @@ namespace dxvk::hud {
       }
 
       // Render descriptive text
-      std::string headline = str::format("Mem type ", i, " [", type.properties.heapIndex, "]: ",
+      std::string headline = str::format("Mem type ", (i - 1), " [", type.properties.heapIndex, "]: ",
         type.chunkCount, " chunk", type.chunkCount != 1u ? "s" : "", " (", (stats.memoryAllocated >> 20u), " MB, ",
         ((stats.memoryUsed >= (1u << 20u)) ? stats.memoryUsed >> 20 : stats.memoryUsed >> 10),
         (stats.memoryUsed >= (1u << 20u) ? " MB" : " kB"), " used)");

--- a/src/dxvk/hud/dxvk_hud_renderer.cpp
+++ b/src/dxvk/hud/dxvk_hud_renderer.cpp
@@ -347,7 +347,6 @@ namespace dxvk::hud {
                            | VK_ACCESS_SHADER_READ_BIT;
     fontTextureInfo.tiling = VK_IMAGE_TILING_OPTIMAL;
     fontTextureInfo.layout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
-    fontTextureInfo.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
 
     m_fontTexture = m_device->createImage(fontTextureInfo, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
 

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -291,10 +291,6 @@ namespace dxvk {
     { R"(\\AoE2DE_s\.exe$)", {{
       { "d3d11.cachedDynamicResources",     "a"    },
     }} },
-    /* Total War: Warhammer III                   */
-    { R"(\\Warhammer3\.exe$)", {{
-      { "d3d11.maxDynamicImageBufferSize",  "4096" },
-    }} },
     /* Assassin's Creed 3 and 4                   */
     { R"(\\ac(3|4bf)[sm]p\.exe$)", {{
       { "d3d11.cachedDynamicResources",     "a"    },

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -101,7 +101,6 @@ namespace dxvk {
      * set of resources multiple times per frame. */
     { R"(\\QuantumBreak\.exe$)", {{
       { "d3d11.zeroInitWorkgroupMemory",    "True" },
-      { "d3d11.maxImplicitDiscardSize",     "-1"   },
     }} },
     /* Anno 2205: Random crashes with state cache */
     { R"(\\anno2205\.exe$)", {{


### PR DESCRIPTION
Supercedes #4413.

There are numerous problems with trying to use`VK_IMAGE_TILING_LINEAR` and exposing that directly to the app:
- It's an extremely poorly tested code path. We only ever enabled it for Warhammer 3 and some feature that nobody uses.
- The performance hit from using the suboptimal tiling mode is very difficult to predict.
- Driver support for linear tiling is extremely inconsistent, which makes testing it a nightmare.
- Games are broken and ignore `D3D11_MAPPED_SUBRESOURCE::RowPitch`, expecting it to be tightly packed anyway.
- There were numerous bugs in our implementation.

This **will** regress Warhammer 3 performance. A possible workaround might be to put the staging buffer in host-visible VRAM, at least on ReBAR systems. Ultimately, the game really just shouldn't be doing what it's doing.