### PR TITLE
[d3d9] Ignore modes with refresh rates under 60 Hz

### DIFF
--- a/dxvk.conf
+++ b/dxvk.conf
@@ -333,6 +333,19 @@
 # d3d9.reproducibleCommandStream = False
 
 
+# Low Refresh Rate Support
+#
+# List modes with refresh rates lower than 60 Hz. Note that this
+# was typically uncommon in the D3D8/D3D9 era, and some games will
+# automatically select the first listed mode for a particular
+# resolution, expecting it to be equal to 60 Hz.
+#
+# Supported values:
+# - True/False
+
+# d3d9.lowRefreshRateSupport = False
+
+
 # Sets number of pipeline compiler threads.
 # 
 # If the graphics pipeline library feature is enabled, the given

--- a/src/d3d9/d3d9_adapter.cpp
+++ b/src/d3d9/d3d9_adapter.cpp
@@ -796,6 +796,7 @@ namespace dxvk {
     uint32_t modeIndex = 0;
 
     const auto forcedRatio = Ratio<DWORD>(options.forceAspectRatio);
+    const wsi::WsiRational sixtyHertz = wsi::WsiRational{ 60, 1 };
 
     while (wsi::getDisplayMode(wsi::getDefaultMonitor(), modeIndex++, &devMode)) {
       // Skip interlaced modes altogether
@@ -807,6 +808,10 @@ namespace dxvk {
         continue;
 
       if (!forcedRatio.undefined() && Ratio<DWORD>(devMode.width, devMode.height) != forcedRatio)
+        continue;
+
+      // Skip modes with refresh rates lower than 60 Hz
+      if (!options.lowRefreshRateSupport && devMode.refreshRate < sixtyHertz)
         continue;
 
       D3DDISPLAYMODEEX mode = ConvertDisplayMode(devMode);

--- a/src/d3d9/d3d9_options.cpp
+++ b/src/d3d9/d3d9_options.cpp
@@ -77,6 +77,7 @@ namespace dxvk {
     this->clampNegativeLodBias          = config.getOption<bool>        ("d3d9.clampNegativeLodBias",          false);
     this->countLosableResources         = config.getOption<bool>        ("d3d9.countLosableResources",         true);
     this->reproducibleCommandStream     = config.getOption<bool>        ("d3d9.reproducibleCommandStream",     false);
+    this->lowRefreshRateSupport         = config.getOption<bool>        ("d3d9.lowRefreshRateSupport",         false);
 
     // D3D8 options
     this->drefScaling                   = config.getOption<int32_t>     ("d3d8.scaleDref",                     0);

--- a/src/d3d9/d3d9_options.h
+++ b/src/d3d9/d3d9_options.h
@@ -156,6 +156,9 @@ namespace dxvk {
     /// can negatively affect performance.
     bool reproducibleCommandStream;
 
+    /// List modes with refresh rates lower than 60 Hz.
+    bool lowRefreshRateSupport;
+
     /// Enable depth texcoord Z (Dref) scaling (D3D8 quirk)
     int32_t drefScaling;
   };

--- a/src/wsi/wsi_monitor.h
+++ b/src/wsi/wsi_monitor.h
@@ -18,6 +18,11 @@ namespace dxvk::wsi {
     uint32_t denominator;
   };
 
+  inline bool operator < (const WsiRational& left, const WsiRational& right) {
+    return static_cast<uint64_t>(left.numerator)   * right.denominator
+         < static_cast<uint64_t>(left.denominator) * right.numerator;
+  }
+
   /**
    * \brief Display mode
    */


### PR DESCRIPTION
Also fixes #4288. Still not the shadows, they're fine.

An alternative to #4414, and IMHO a better way to address the problem the game has, while keeping with ascending ordering, which seems to have been respected on Windows XP at least, is to simply ignore modes with refresh rates under 60 Hz.

I've taken the liberty of adding a config option to revert to the old behavior, for purists, but the filtering gets enabled by default.