### PR TITLE
[util] Include Prince of Persia main executable

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -965,7 +965,7 @@ namespace dxvk {
     }} },
     /* Prince of Persia (2008) - Can get stuck     *
      * during loading at very high fps             */
-    { R"(\\PrinceOfPersia_Launcher\.exe$)", {{
+    { R"(\\Prince( of Persia|OfPersia_Launcher)\.exe$)", {{
       { "d3d9.maxFrameRate",                 "240" },
     }} },
     /* F.E.A.R 1 & expansions                      *


### PR DESCRIPTION
The GOG edition uses `Prince of Persia.exe` as the main executable name, although it also has the launcher.

It will similarly hang on loading screens without a framecap.