### PR TITLE
D3D11: Improve direct image mapping v2

### DIFF
--- a/dxvk.conf
+++ b/dxvk.conf
@@ -276,14 +276,6 @@
 # dxvk.zeroMappedMemory = False
 
 
-# Resource size limit for buffer-mapped dynamic images, in kilobytes.
-# A higher threshold may reduce memory usage and PCI-E bandwidth in
-# some games, but may also increase GPU synchronizations. Setting it
-# to -1 disables the feature.
-
-# d3d11.maxDynamicImageBufferSize = -1
-
-
 # Allocates dynamic resources with the given set of bind flags in
 # cached system memory rather than uncached memory or host-visible
 # VRAM, in order to allow fast readback from the CPU. This is only

--- a/src/d3d11/d3d11_buffer.cpp
+++ b/src/d3d11/d3d11_buffer.cpp
@@ -97,8 +97,8 @@ namespace dxvk {
         m_11on12.Resource->Map(0, nullptr, &importInfo.mapPtr);
 
       m_buffer = m_parent->GetDXVKDevice()->importBuffer(info, importInfo, GetMemoryFlags());
+      m_cookie = m_buffer->cookie();
       m_mapPtr = m_buffer->mapPtr(0);
-
       m_mapMode = DetermineMapMode(m_buffer->memFlags());
     } else if (!(pDesc->MiscFlags & D3D11_RESOURCE_MISC_TILE_POOL)) {
       VkMemoryPropertyFlags memoryFlags = GetMemoryFlags();
@@ -107,11 +107,13 @@ namespace dxvk {
       // Create the buffer and set the entire buffer slice as mapped,
       // so that we only have to update it when invalidating the buffer
       m_buffer = m_parent->GetDXVKDevice()->createBuffer(info, memoryFlags);
+      m_cookie = m_buffer->cookie();
       m_mapPtr = m_buffer->mapPtr(0);
     } else {
       m_sparseAllocator = m_parent->GetDXVKDevice()->createSparsePageAllocator();
       m_sparseAllocator->setCapacity(info.size / SparseMemoryPageSize);
 
+      m_cookie = 0u;
       m_mapPtr = nullptr;
       m_mapMode = D3D11_COMMON_BUFFER_MAP_MODE_NONE;
     }

--- a/src/d3d11/d3d11_buffer.h
+++ b/src/d3d11/d3d11_buffer.h
@@ -77,6 +77,10 @@ namespace dxvk {
       return m_mapMode;
     }
 
+    uint64_t GetCookie() const {
+      return m_cookie;
+    }
+
     Rc<DxvkBuffer> GetBuffer() const {
       return m_buffer;
     }
@@ -183,6 +187,8 @@ namespace dxvk {
     D3D11_COMMON_BUFFER_MAP_MODE  m_mapMode;
     
     Rc<DxvkBuffer>                m_buffer;
+    uint64_t                      m_cookie = 0u;
+
     Rc<DxvkBuffer>                m_soCounter;
     Rc<DxvkSparsePageAllocator>   m_sparseAllocator;
     uint64_t                      m_seq = 0ull;

--- a/src/d3d11/d3d11_context.cpp
+++ b/src/d3d11/d3d11_context.cpp
@@ -3950,8 +3950,8 @@ namespace dxvk {
 
     // It is possible for any of the given images to be a staging image with
     // no actual image, so we need to account for all possibilities here.
-    bool dstIsImage = pDstTexture->GetMapMode() != D3D11_COMMON_TEXTURE_MAP_MODE_STAGING;
-    bool srcIsImage = pSrcTexture->GetMapMode() != D3D11_COMMON_TEXTURE_MAP_MODE_STAGING;
+    bool dstIsImage = pDstTexture->HasImage();
+    bool srcIsImage = pSrcTexture->HasImage();
 
     if (dstIsImage && srcIsImage) {
       EmitCs([
@@ -5196,7 +5196,7 @@ namespace dxvk {
           VkOffset3D                        DstOffset,
           VkExtent3D                        DstExtent,
           DxvkBufferSlice                   StagingBuffer) {
-    bool dstIsImage = pDstTexture->GetMapMode() != D3D11_COMMON_TEXTURE_MAP_MODE_STAGING;
+    bool dstIsImage = pDstTexture->HasImage();
 
     uint32_t dstSubresource = D3D11CalcSubresource(pDstSubresource->mipLevel,
       pDstSubresource->arrayLayer, pDstTexture->Desc()->MipLevels);

--- a/src/d3d11/d3d11_context_def.cpp
+++ b/src/d3d11/d3d11_context_def.cpp
@@ -292,17 +292,16 @@ namespace dxvk {
           D3D11_MAPPED_SUBRESOURCE*     pMappedResource) {
     D3D11CommonTexture* pTexture = GetCommonTexture(pResource);
     
-    if (unlikely(pTexture->GetMapMode() == D3D11_COMMON_TEXTURE_MAP_MODE_NONE)) {
-      Logger::err("D3D11: Cannot map a device-local image");
-      pMappedResource->pData = nullptr;
-      return E_INVALIDARG;
-    }
-
     if (unlikely(Subresource >= pTexture->CountSubresources())) {
       pMappedResource->pData = nullptr;
       return E_INVALIDARG;
     }
-    
+
+    if (unlikely(pTexture->Desc()->Usage != D3D11_USAGE_DYNAMIC)) {
+      pMappedResource->pData = nullptr;
+      return E_INVALIDARG;
+    }
+
     VkFormat packedFormat = pTexture->GetPackedFormat();
     auto formatInfo = lookupFormatInfo(packedFormat);
     auto layout = pTexture->GetSubresourceLayout(formatInfo->aspectMask, Subresource);

--- a/src/d3d11/d3d11_context_def.h
+++ b/src/d3d11/d3d11_context_def.h
@@ -8,17 +8,8 @@
 namespace dxvk {
   
   struct D3D11DeferredContextMapEntry {
-    D3D11DeferredContextMapEntry() { }
-    D3D11DeferredContextMapEntry(
-            ID3D11Resource*           pResource,
-            UINT                      Subresource,
-            D3D11_RESOURCE_DIMENSION  ResourceType,
-      const D3D11_MAPPED_SUBRESOURCE& MappedResource)
-    : Resource(pResource, Subresource, ResourceType),
-      MapInfo(MappedResource) { }
-
-    D3D11ResourceRef          Resource;
-    D3D11_MAPPED_SUBRESOURCE  MapInfo;
+    uint64_t                  ResourceCookie = 0u;
+    D3D11_MAPPED_SUBRESOURCE  MapInfo = { };
   };
   
   class D3D11DeferredContext : public D3D11CommonContext<D3D11DeferredContext> {
@@ -130,14 +121,11 @@ namespace dxvk {
     void TrackBufferSequenceNumber(
             D3D11Buffer*                  pResource);
 
-    D3D11DeferredContextMapEntry* FindMapEntry(
-            ID3D11Resource*               pResource,
-            UINT                          Subresource);
+    D3D11_MAPPED_SUBRESOURCE FindMapEntry(
+            uint64_t                      Coookie);
 
     void AddMapEntry(
-            ID3D11Resource*               pResource,
-            UINT                          Subresource,
-            D3D11_RESOURCE_DIMENSION      ResourceType,
+            uint64_t                      Cookie,
       const D3D11_MAPPED_SUBRESOURCE&     MapInfo);
 
     static DxvkCsChunkFlags GetCsChunkFlags(

--- a/src/d3d11/d3d11_device.cpp
+++ b/src/d3d11/d3d11_device.cpp
@@ -2435,11 +2435,7 @@ namespace dxvk {
       D3D11_COMMON_TEXTURE_SUBRESOURCE_LAYOUT layout = pTexture->GetSubresourceLayout(aspect, Subresource);
 
       // Compute actual map pointer, accounting for the region offset
-      VkDeviceSize mapOffset = pTexture->ComputeMappedOffset(Subresource, i, offset);
-
-      void* mapPtr = pTexture->GetMapMode() == D3D11_COMMON_TEXTURE_MAP_MODE_BUFFER
-        ? pTexture->GetMappedBuffer(Subresource)->mapPtr(mapOffset)
-        : image->mapPtr(mapOffset);
+      void* mapPtr = pTexture->GetMapPtr(Subresource, pTexture->ComputeMappedOffset(Subresource, i, offset));
 
       if constexpr (std::is_const<Void>::value) {
         // WriteToSubresource

--- a/src/d3d11/d3d11_initializer.cpp
+++ b/src/d3d11/d3d11_initializer.cpp
@@ -177,7 +177,7 @@ namespace dxvk {
           }
 
           if (mapMode != D3D11_COMMON_TEXTURE_MAP_MODE_NONE) {
-            util::packImageData(pTexture->GetMappedBuffer(index)->mapPtr(0),
+            util::packImageData(pTexture->GetMapPtr(index, 0),
               pInitialData[index].pSysMem, pInitialData[index].SysMemPitch, pInitialData[index].SysMemSlicePitch,
               0, 0, pTexture->GetVkImageType(), mipLevelExtent, 1, formatInfo, formatInfo->aspectMask);
           }
@@ -215,8 +215,8 @@ namespace dxvk {
 
       if (mapMode != D3D11_COMMON_TEXTURE_MAP_MODE_NONE) {
         for (uint32_t i = 0; i < pTexture->CountSubresources(); i++) {
-          auto buffer = pTexture->GetMappedBuffer(i);
-          std::memset(buffer->mapPtr(0), 0, buffer->info().size);
+          auto layout = pTexture->GetSubresourceLayout(formatInfo->aspectMask, i);
+          std::memset(pTexture->GetMapPtr(i, layout.Offset), 0, layout.Size);
         }
       }
     }

--- a/src/d3d11/d3d11_options.cpp
+++ b/src/d3d11/d3d11_options.cpp
@@ -36,11 +36,6 @@ namespace dxvk {
     // Clamp LOD bias so that people don't abuse this in unintended ways
     this->samplerLodBias = dxvk::fclamp(this->samplerLodBias, -2.0f, 1.0f);
 
-    int32_t maxDynamicImageBufferSize = config.getOption<int32_t>("d3d11.maxDynamicImageBufferSize", -1);
-    this->maxDynamicImageBufferSize = maxDynamicImageBufferSize >= 0
-      ? VkDeviceSize(maxDynamicImageBufferSize) << 10
-      : VkDeviceSize(~0ull);
-
     auto cachedDynamicResources = config.getOption<std::string>("d3d11.cachedDynamicResources", std::string());
 
     if (IsAPITracingDXGI()) {

--- a/src/d3d11/d3d11_options.h
+++ b/src/d3d11/d3d11_options.h
@@ -18,104 +18,104 @@ namespace dxvk {
     /// This can substantially speed up some games, but may
     /// cause issues if the game submits command lists more
     /// than once.
-    bool dcSingleUseMode;
+    bool dcSingleUseMode = false;
 
     /// Zero-initialize workgroup memory
     ///
     /// Workargound for games that don't initialize
     /// TGSM in compute shaders before reading it.
-    bool zeroInitWorkgroupMemory;
+    bool zeroInitWorkgroupMemory = false;
 
     /// Force thread-group shared memory accesses to be volatile
     ///
     /// Workaround for compute shaders that read and
     /// write from the same shared memory location
     /// without explicit synchronization.
-    bool forceVolatileTgsmAccess;
+    bool forceVolatileTgsmAccess = false;
 
     /// Use relaxed memory barriers
     ///
     /// May improve performance in some games,
     /// but might also cause rendering issues.
-    bool relaxedBarriers;
+    bool relaxedBarriers = false;
 
     /// Ignore graphics barriers
     ///
     /// May improve performance in some games,
     /// but might also cause rendering issues.
-    bool ignoreGraphicsBarriers;
+    bool ignoreGraphicsBarriers = false;
 
     /// Maximum tessellation factor.
     ///
     /// Limits tessellation factors in tessellation
     /// control shaders. Values from 8 to 64 are
     /// supported, other values will be ignored.
-    int32_t maxTessFactor;
+    int32_t maxTessFactor = 0;
 
     /// Anisotropic filter override
     ///
     /// Enforces anisotropic filtering with the
     /// given anisotropy value for all samplers.
-    int32_t samplerAnisotropy;
+    int32_t samplerAnisotropy = -1;
 
     /// Mipmap LOD bias
     ///
     /// Enforces the given LOD bias for all samplers.
-    float samplerLodBias;
+    float samplerLodBias = 0.0f;
 
     /// Clamps negative LOD bias
-    bool clampNegativeLodBias;
+    bool clampNegativeLodBias = false;
 
     /// Declare vertex positions in shaders as invariant
-    bool invariantPosition;
+    bool invariantPosition = true;
 
     /// Enable float control bits
-    bool floatControls;
+    bool floatControls = true;
 
     /// Back buffer count for the Vulkan swap chain.
     /// Overrides DXGI_SWAP_CHAIN_DESC::BufferCount.
-    int32_t numBackBuffers;
+    int32_t numBackBuffers = 0;
 
     /// Override maximum frame latency if the app specifies
     /// a higher value. May help with frame timing issues.
-    int32_t maxFrameLatency;
+    int32_t maxFrameLatency = 0;
 
     /// Defer surface creation until first present call. This
     /// fixes issues with games that create multiple swap chains
     /// for a single window that may interfere with each other.
-    bool deferSurfaceCreation;
+    bool deferSurfaceCreation = false;
 
     /// Enables sample rate shading by interpolating fragment shader
     /// inputs at the sample location rather than pixel center,
     /// unless otherwise specified by the application.
-    bool forceSampleRateShading;
+    bool forceSampleRateShading = false;
 
     /// Forces the sample count of all textures to be 1, and
     /// performs the required shader and resolve fixups.
-    bool disableMsaa;
+    bool disableMsaa = false;
 
     /// Dynamic resources with the given bind flags will be allocated
     /// in cached system memory. Enabled automatically when recording
     /// an api trace.
-    uint32_t cachedDynamicResources;
+    uint32_t cachedDynamicResources = 0;
 
     /// Always lock immediate context on every API call. May be
     /// useful for debugging purposes or when applications have
     /// race conditions.
-    bool enableContextLock;
+    bool enableContextLock = false;
 
     /// Whether to expose the driver command list feature. Enabled by
     /// default and generally beneficial, but some games may assume that
     /// this is not supported when running on an AMD GPU.
-    bool exposeDriverCommandLists;
-
-    /// Shader dump path
-    std::string shaderDumpPath;
+    bool exposeDriverCommandLists = true;
 
     /// Ensure that for the same D3D commands the output VK commands
     /// don't change between runs. Useful for comparative benchmarking,
     /// can negatively affect performance.
-    bool reproducibleCommandStream;
+    bool reproducibleCommandStream = false;
+
+    /// Shader dump path
+    std::string shaderDumpPath;
   };
   
 }

--- a/src/d3d11/d3d11_options.h
+++ b/src/d3d11/d3d11_options.h
@@ -80,9 +80,6 @@ namespace dxvk {
     /// a higher value. May help with frame timing issues.
     int32_t maxFrameLatency;
 
-    /// Limit size of buffer-mapped images
-    VkDeviceSize maxDynamicImageBufferSize;
-
     /// Defer surface creation until first present call. This
     /// fixes issues with games that create multiple swap chains
     /// for a single window that may interfere with each other.

--- a/src/d3d11/d3d11_texture.cpp
+++ b/src/d3d11/d3d11_texture.cpp
@@ -244,6 +244,9 @@ namespace dxvk {
     else
       m_image = m_device->GetDXVKDevice()->importImage(imageInfo, vkImage, memoryProperties);
 
+    if (m_mapMode == D3D11_COMMON_TEXTURE_MAP_MODE_DIRECT)
+      m_mapPtr = m_image->mapPtr(0);
+
     if (imageInfo.sharing.mode == DxvkSharedHandleMode::Export)
       ExportImageInfo();
   }

--- a/src/d3d11/d3d11_texture.cpp
+++ b/src/d3d11/d3d11_texture.cpp
@@ -567,11 +567,12 @@ namespace dxvk {
                                       | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
 
     bool useCached = (m_device->GetOptions()->cachedDynamicResources == ~0u)
-                  || (m_device->GetOptions()->cachedDynamicResources & m_desc.BindFlags);
+                  || (m_device->GetOptions()->cachedDynamicResources & m_desc.BindFlags)
+                  || (m_desc.CPUAccessFlags & D3D11_CPU_ACCESS_READ);
 
     if (m_desc.Usage == D3D11_USAGE_STAGING || useCached)
       memoryFlags |= VK_MEMORY_PROPERTY_HOST_CACHED_BIT;
-    else if (m_desc.Usage == D3D11_USAGE_DEFAULT || m_desc.BindFlags)
+    else if (m_desc.BindFlags)
       memoryFlags |= VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
 
     return memoryFlags;

--- a/src/d3d11/d3d11_texture.cpp
+++ b/src/d3d11/d3d11_texture.cpp
@@ -200,11 +200,14 @@ namespace dxvk {
     }
 
     if (m_mapMode == D3D11_COMMON_TEXTURE_MAP_MODE_BUFFER
-     || m_mapMode == D3D11_COMMON_TEXTURE_MAP_MODE_STAGING) {
+     || m_mapMode == D3D11_COMMON_TEXTURE_MAP_MODE_STAGING
+     || m_mapMode == D3D11_COMMON_TEXTURE_MAP_MODE_DYNAMIC) {
       m_buffers.resize(subresourceCount);
 
-      for (uint32_t i = 0; i < subresourceCount; i++)
-        CreateMappedBuffer(i);
+      if (m_mapMode != D3D11_COMMON_TEXTURE_MAP_MODE_DYNAMIC) {
+        for (uint32_t i = 0; i < subresourceCount; i++)
+          CreateMappedBuffer(i);
+      }
     }
 
     // Skip image creation if possible
@@ -777,6 +780,14 @@ namespace dxvk {
     auto& entry = m_buffers[Subresource];
     entry.buffer = m_device->GetDXVKDevice()->createBuffer(info, memType);
     entry.slice = entry.buffer->storage();
+  }
+
+
+  void D3D11CommonTexture::FreeMappedBuffer(
+          UINT                  Subresource) {
+    auto& entry = m_buffers[Subresource];
+    entry.buffer = nullptr;
+    entry.slice = nullptr;
   }
   
   

--- a/src/d3d11/d3d11_texture.h
+++ b/src/d3d11/d3d11_texture.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "../util/util_small_vector.h"
+
 #include "../dxvk/dxvk_cs.h"
 #include "../dxvk/dxvk_device.h"
 
@@ -546,13 +548,13 @@ namespace dxvk {
     VkFormat                      m_packedFormat;
     
     Rc<DxvkImage>                 m_image;
-    std::vector<MappedBuffer>     m_buffers;
-    std::vector<MappedInfo>       m_mapInfo;
+    small_vector<MappedBuffer, 6> m_buffers;
+    small_vector<MappedInfo, 6>   m_mapInfo;
 
     void*                         m_mapPtr = nullptr;
 
-    MappedBuffer CreateMappedBuffer(
-            UINT                  MipLevel) const;
+    void CreateMappedBuffer(
+            UINT                  Subresource);
     
     BOOL CheckImageSupport(
       const DxvkImageCreateInfo*  pImageInfo,

--- a/src/d3d11/d3d11_texture.h
+++ b/src/d3d11/d3d11_texture.h
@@ -390,7 +390,13 @@ namespace dxvk {
      */
     VkImageSubresource GetSubresourceFromIndex(
             VkImageAspectFlags    Aspect,
-            UINT                  Subresource) const;
+            UINT                  Subresource) const {
+      VkImageSubresource result;
+      result.aspectMask     = Aspect;
+      result.mipLevel       = Subresource % m_desc.MipLevels;
+      result.arrayLayer     = Subresource / m_desc.MipLevels;
+      return result;
+    }
 
     /**
      * \brief Computes subresource layout for the given subresource
@@ -480,8 +486,9 @@ namespace dxvk {
     };
 
     struct MappedInfo {
-      D3D11_MAP             mapType;
-      uint64_t              seq;
+      D3D11_COMMON_TEXTURE_SUBRESOURCE_LAYOUT layout = { };
+      D3D11_MAP                   mapType = D3D11_MAP(~0u);
+      uint64_t                    seq     = 0u;
     };
 
     ID3D11Resource*               m_interface;
@@ -513,8 +520,12 @@ namespace dxvk {
     D3D11_COMMON_TEXTURE_MAP_MODE DetermineMapMode(
       const DxvkImageCreateInfo*  pImageInfo) const;
 
+    D3D11_COMMON_TEXTURE_SUBRESOURCE_LAYOUT DetermineSubresourceLayout(
+      const DxvkImageCreateInfo*  pImageInfo,
+      const VkImageSubresource&   subresource) const;
+
     void ExportImageInfo();
-    
+
     static BOOL IsR32UavCompatibleFormat(
             DXGI_FORMAT           Format);
 

--- a/src/d3d11/d3d11_texture.h
+++ b/src/d3d11/d3d11_texture.h
@@ -562,9 +562,7 @@ namespace dxvk {
             VkFormat              Format,
             VkFormatFeatureFlags2 Features) const;
     
-    VkMemoryPropertyFlags GetMemoryFlags() const;
-    
-    D3D11_COMMON_TEXTURE_MAP_MODE DetermineMapMode(
+    std::pair<D3D11_COMMON_TEXTURE_MAP_MODE, VkMemoryPropertyFlags> DetermineMapMode(
       const DxvkImageCreateInfo*  pImageInfo) const;
 
     D3D11_COMMON_TEXTURE_SUBRESOURCE_LAYOUT DetermineSubresourceLayout(

--- a/src/d3d11/d3d11_texture.h
+++ b/src/d3d11/d3d11_texture.h
@@ -304,6 +304,31 @@ namespace dxvk {
     }
 
     /**
+     * \brief Queries map pointer of the raw image
+     *
+     * If the image is mapped directly, the returned pointer will
+     * point directly to the image, otherwise it will point to a
+     * buffer that contains image data.
+     * \param [in] Subresource Subresource index
+     * \param [in] Offset Offset derived from the subresource layout
+     */
+    void* GetMapPtr(uint32_t Subresource, size_t Offset) const {
+      switch (m_mapMode) {
+        case D3D11_COMMON_TEXTURE_MAP_MODE_DIRECT:
+          return reinterpret_cast<char*>(m_mapPtr) + Offset;
+
+        case D3D11_COMMON_TEXTURE_MAP_MODE_BUFFER:
+        case D3D11_COMMON_TEXTURE_MAP_MODE_STAGING:
+          return reinterpret_cast<char*>(m_buffers[Subresource].slice->mapPtr()) + Offset;
+
+        case D3D11_COMMON_TEXTURE_MAP_MODE_NONE:
+          return nullptr;
+      }
+
+      return nullptr;
+    }
+
+    /**
      * \brief Adds a dirty region
      *
      * This region will be updated on Unmap.
@@ -503,7 +528,9 @@ namespace dxvk {
     Rc<DxvkImage>                 m_image;
     std::vector<MappedBuffer>     m_buffers;
     std::vector<MappedInfo>       m_mapInfo;
-    
+
+    void*                         m_mapPtr = nullptr;
+
     MappedBuffer CreateMappedBuffer(
             UINT                  MipLevel) const;
     

--- a/src/d3d11/d3d11_texture.h
+++ b/src/d3d11/d3d11_texture.h
@@ -304,6 +304,26 @@ namespace dxvk {
     }
 
     /**
+     * \brief Allocates new backing storage
+     * \returns New backing storage for the image
+     */
+    Rc<DxvkResourceAllocation> AllocStorage() {
+      return m_image->allocateStorage();
+    }
+
+    /**
+     * \brief Discards backing storage
+     *
+     * Also updates the mapped pointer if the image is mapped.
+     * \returns New backing storage for the image
+     */
+    Rc<DxvkResourceAllocation> DiscardStorage() {
+      auto storage = m_image->allocateStorage();
+      m_mapPtr = storage->mapPtr();
+      return storage;
+    }
+
+    /**
      * \brief Queries map pointer of the raw image
      *
      * If the image is mapped directly, the returned pointer will

--- a/src/d3d11/d3d11_texture.h
+++ b/src/d3d11/d3d11_texture.h
@@ -310,17 +310,7 @@ namespace dxvk {
      * \returns \c true if tracking is supported for this resource
      */
     bool HasSequenceNumber() const {
-      if (m_mapMode == D3D11_COMMON_TEXTURE_MAP_MODE_NONE)
-        return false;
-
-      // For buffer-mapped images we only need to track copies to
-      // and from that buffer, so we can safely ignore bind flags
-      if (m_mapMode == D3D11_COMMON_TEXTURE_MAP_MODE_BUFFER)
-        return m_desc.Usage != D3D11_USAGE_DEFAULT;
-
-      // Otherwise we can only do accurate tracking if the
-      // image cannot be used in the rendering pipeline.
-      return m_desc.BindFlags == 0;
+      return m_mapMode == D3D11_COMMON_TEXTURE_MAP_MODE_STAGING;
     }
 
     /**

--- a/src/d3d11/d3d11_texture.h
+++ b/src/d3d11/d3d11_texture.h
@@ -173,6 +173,25 @@ namespace dxvk {
     }
 
     /**
+     * \brief Checks whether this texture has an image
+     *
+     * Staging textures will not use an image, only mapped buffers.
+     * \returns \c true for non-staging textures.
+     */
+    bool HasImage() const {
+      return m_mapMode != D3D11_COMMON_TEXTURE_MAP_MODE_STAGING;
+    }
+
+    /**
+     * \brief Checks whether this texture has persistent buffers
+     * \returns \c true for buffer-mapped textures or staging textures.
+     */
+    bool HasPersistentBuffers() const {
+      return m_mapMode == D3D11_COMMON_TEXTURE_MAP_MODE_BUFFER
+          || m_mapMode == D3D11_COMMON_TEXTURE_MAP_MODE_STAGING;
+    }
+
+    /**
      * \brief Map type of a given subresource
      * 
      * \param [in] Subresource Subresource index

--- a/src/dxvk/dxvk_buffer.h
+++ b/src/dxvk/dxvk_buffer.h
@@ -15,26 +15,26 @@ namespace dxvk {
 
   /**
    * \brief Buffer create info
-   * 
+   *
    * The properties of a buffer that are
    * passed to \ref DxvkDevice::createBuffer
    */
   struct DxvkBufferCreateInfo {
-    /// Buffer create flags
-    VkBufferCreateFlags flags = 0;
-
     /// Size of the buffer, in bytes
-    VkDeviceSize size;
-    
+    VkDeviceSize size = 0u;
+
     /// Buffer usage flags
-    VkBufferUsageFlags usage;
-    
+    VkBufferUsageFlags usage = 0u;
+
     /// Pipeline stages that can access
     /// the contents of the buffer.
-    VkPipelineStageFlags stages;
-    
+    VkPipelineStageFlags stages = 0u;
+
     /// Allowed access patterns
-    VkAccessFlags access;
+    VkAccessFlags access = 0u;
+
+    /// Buffer create flags
+    VkBufferCreateFlags flags = 0;
   };
 
 

--- a/src/dxvk/dxvk_device.h
+++ b/src/dxvk/dxvk_device.h
@@ -209,6 +209,19 @@ namespace dxvk {
     }
 
     /**
+     * \brief Queries mapped image subresource layout
+     *
+     * Assumes that the image tiling is linear even
+     * if not explcitly set in the create info.
+     * \param [in] createInfo Image create info
+     * \param [in] subresource Subresource to query
+     * \returns Subresource layout
+     */
+    VkSubresourceLayout queryImageSubresourceLayout(
+      const DxvkImageCreateInfo&        createInfo,
+      const VkImageSubresource&         subresource);
+
+    /**
      * \brief Checks whether this is a UMA system
      *
      * Basically tests whether all heaps are device-local.

--- a/src/dxvk/dxvk_image.cpp
+++ b/src/dxvk/dxvk_image.cpp
@@ -71,17 +71,6 @@ namespace dxvk {
   }
 
 
-  VkSubresourceLayout DxvkImage::querySubresourceLayout(
-    const VkImageSubresource& subresource) const {
-    VkSubresourceLayout result = { };
-
-    m_vkd->vkGetImageSubresourceLayout(m_vkd->device(),
-      m_imageInfo.image, &subresource, &result);
-
-    return result;
-  }
-
-
   HANDLE DxvkImage::sharedHandle() const {
     HANDLE handle = INVALID_HANDLE_VALUE;
 

--- a/src/dxvk/dxvk_image.h
+++ b/src/dxvk/dxvk_image.h
@@ -493,17 +493,6 @@ namespace dxvk {
     bool canRelocate() const;
 
     /**
-     * \brief Queries memory layout of a subresource
-     *
-     * Can be used to retrieve the exact pointer to a
-     * subresource of a mapped image with linear tiling.
-     * \param [in] subresource The image subresource
-     * \returns Memory layout of that subresource
-     */
-    VkSubresourceLayout querySubresourceLayout(
-      const VkImageSubresource& subresource) const;
-
-    /**
      * \brief Create a new shared handle to dedicated memory backing the image
      * \returns The shared handle with the type given by DxvkSharedHandleInfo::type
      */

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -291,10 +291,6 @@ namespace dxvk {
     { R"(\\AoE2DE_s\.exe$)", {{
       { "d3d11.cachedDynamicResources",     "a"    },
     }} },
-    /* Total War: Warhammer III                   */
-    { R"(\\Warhammer3\.exe$)", {{
-      { "d3d11.maxDynamicImageBufferSize",  "4096" },
-    }} },
     /* Assassin's Creed 3 and 4                   */
     { R"(\\ac(3|4bf)[sm]p\.exe$)", {{
       { "d3d11.cachedDynamicResources",     "a"    },


### PR DESCRIPTION
For real now. Main difference to the original PR is that querying linear subresource layouts has a much cleaner solution now and is done in such a way that we can query it *before* creating an image, so we can decide which tiling mode to use based on that.

We also try to use `LINEAR` tiling for more resources now, specifically:
- Images that are essentially linear (i.e. have a height and depth of 1)
- Images that look like a video. We use some dumb heuristic to determine this based on the aspect ratio and format size. We also try to keep these in system memory since they are likely only going to be accessed once per frame anyway.
- Huge images. This both saves memory and makes Warhammer III perform acceptably without an app profile.

This fixes a bunch of bugs, gets rid of another config option that we used in exactly one game (without really regressing said game), but will need extensive testing especially on Nvidia and other non-AMD hardware. The concern that we're hitting poorly code paths both in DXVK *and* inside graphics drivers remains.