### PR TITLE
[util] Re-enable direct buffer mapping for Rayman 3

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -1150,7 +1150,7 @@ namespace dxvk {
      * Missing geometry and textures without      *
      * legacy DISCARD behavior                    */
     { R"(\\Rayman3\.exe$)", {{
-      { "d3d9.allowDirectBufferMapping",   "False" },
+      { "d3d9.maxFrameRate",                  "60" },
       { "d3d8.forceLegacyDiscard",          "True" },
     }} },
   }};


### PR DESCRIPTION
Fixes #4422. While disabling direct buffer mapping got rid of some queue syncs caused by buffer locks, which improved the game's quirky frame-rate heuristics, it seems to break some in-game effects. Guess it is what it is.

The games's SWVP mode (hackable through the game's ini) seems to rely on disabling direct buffer mapping to render properly, but since it's not recommended or exposed by the game and HWVP now works properly, that's not that big of a problem.