### PR TITLE
[d3d9] Early return D3D_OK on present with a NULL m_window

### DIFF
--- a/src/d3d9/d3d9_swapchain.cpp
+++ b/src/d3d9/d3d9_swapchain.cpp
@@ -153,6 +153,9 @@ namespace dxvk {
     if (hDestWindowOverride != nullptr)
       m_window = hDestWindowOverride;
 
+    if (m_window == nullptr)
+      return D3D_OK;
+
     UpdateWindowCtx();
 
     bool recreate = false;
@@ -170,9 +173,6 @@ namespace dxvk {
     m_dirty    |= recreate;
 
     m_lastDialog = m_dialog;
-
-    if (m_window == nullptr)
-      return D3D_OK;
 
 #ifdef _WIN32
     const bool useGDIFallback = m_partialCopy && !HasFrontBuffer();


### PR DESCRIPTION
Tenatively fixes #3894.

Creating a device with NULL hFocusWindow and hDeviceWindow already works, so does getting the backbuffers. However, Present crashes because  `m_wctx` is uninitialized when m_window is nullptr.

Moving the return a bit earlier makes it work just fine however. Haven't checked if this messes with anything else, but I doubt any of the `m_wctx` stuff is relevant for this use case.

I have yet to check if rendering to the backbuffer works in this situation, but I think it will. Drafting until I actually check on that bit.