### PR TITLE
D3D9: Fix various ColorFill cases

### DIFF
--- a/src/d3d9/d3d9_common_texture.cpp
+++ b/src/d3d9/d3d9_common_texture.cpp
@@ -499,8 +499,6 @@ namespace dxvk {
 
 
   VkImageLayout D3D9CommonTexture::OptimizeLayout(VkImageUsageFlags Usage) const {
-    const VkImageUsageFlags usageFlags = Usage;
-    
     // Filter out unnecessary flags. Transfer operations
     // are handled by the backend in a transparent manner.
     // Feedback loops are handled by hazard tracking.
@@ -524,8 +522,12 @@ namespace dxvk {
     if (Usage == VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT)
       return VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
 
+    // Fall back to GENERAL if the image is not shader-readable
+    if (!(Usage & VK_IMAGE_USAGE_SAMPLED_BIT))
+      return VK_IMAGE_LAYOUT_GENERAL;
+
     // Otherwise, pick a layout that can be used for reading.
-    return usageFlags & VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT
+    return Usage & VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT
       ? VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL
       : VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
   }

--- a/src/d3d9/d3d9_common_texture.h
+++ b/src/d3d9/d3d9_common_texture.h
@@ -75,6 +75,8 @@ namespace dxvk {
 
   public:
 
+    static constexpr UINT AllLayers = UINT32_MAX;
+
     D3D9CommonTexture(
             D3D9DeviceEx*             pDevice,
             IUnknown*                 pInterface,
@@ -554,8 +556,6 @@ namespace dxvk {
     static VkImageViewType GetImageViewTypeFromResourceType(
             D3DRESOURCETYPE  Dimension,
             UINT             Layer);
-
-    static constexpr UINT AllLayers = UINT32_MAX;
 
   };
 

--- a/src/d3d9/d3d9_format_helpers.cpp
+++ b/src/d3d9/d3d9_format_helpers.cpp
@@ -23,6 +23,9 @@ namespace dxvk {
 
     for (auto& p : m_pipelines)
       vk->vkDestroyPipeline(vk->device(), p, nullptr);
+
+    vk->vkDestroyDescriptorSetLayout(vk->device(), m_setLayout, nullptr);
+    vk->vkDestroyPipelineLayout(vk->device(), m_pipelineLayout, nullptr);
   }
 
 

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -6397,10 +6397,10 @@ namespace dxvk {
       copy.regionCount = 1;
       copy.pRegions = &region;
 
+      invalidateBuffer(info.buffer, Rc<DxvkResourceAllocation>(info.storage));
+
       m_cmd->cmdCopyBuffer(DxvkCmdBuffer::ExecBuffer, &copy);
       m_cmd->track(info.buffer, DxvkAccess::Write);
-
-      invalidateBuffer(info.buffer, Rc<DxvkResourceAllocation>(info.storage));
 
       memoryBarrier.dstStageMask |= info.buffer->info().stages;
       memoryBarrier.dstAccessMask |= info.buffer->info().access;
@@ -6493,10 +6493,10 @@ namespace dxvk {
       copy.regionCount = imageRegions.size();
       copy.pRegions = imageRegions.data();
 
+      invalidateImageWithUsage(info.image, Rc<DxvkResourceAllocation>(info.storage), info.usageInfo);
+
       m_cmd->cmdCopyImage(DxvkCmdBuffer::ExecBuffer, &copy);
       m_cmd->track(info.image, DxvkAccess::Write);
-
-      invalidateImageWithUsage(info.image, Rc<DxvkResourceAllocation>(info.storage), info.usageInfo);
     }
 
     if (!imageBarriers.empty()) {


### PR DESCRIPTION
Adds support for clearing compressed formats and errors out on depth formats, which fixes a wine test. Also ensures that we can actually render to the image in question, there were a **lot** of related validation errors.

This fixes `color_fill_test` crashing inside the CS thread.