### PR TITLE
Only force late clears on older Nvidia drivers

### DIFF
--- a/src/dxvk/dxvk_device.cpp
+++ b/src/dxvk/dxvk_device.cpp
@@ -346,6 +346,10 @@ namespace dxvk {
     hints.preferFbResolve = m_features.amdShaderFragmentMask
       && (m_adapter->matchesDriver(VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR)
        || m_adapter->matchesDriver(VK_DRIVER_ID_AMD_PROPRIETARY_KHR));
+    // Older Nvidia drivers sometimes use the wrong format
+    // to interpret the clear color in render pass clears.
+    hints.renderPassClearFormatBug = m_adapter->matchesDriver(
+      VK_DRIVER_ID_NVIDIA_PROPRIETARY, Version(), Version(560, 28, 3));
     return hints;
   }
 

--- a/src/dxvk/dxvk_device.h
+++ b/src/dxvk/dxvk_device.h
@@ -36,6 +36,7 @@ namespace dxvk {
   struct DxvkDevicePerfHints {
     VkBool32 preferFbDepthStencilCopy : 1;
     VkBool32 preferFbResolve          : 1;
+    VkBool32 renderPassClearFormatBug : 1;
   };
   
   /**


### PR DESCRIPTION
Disables the workaround introduced in 00872e9e4fdd87d92f2dd662791b8de6a7edf10c on drivers that were not affected by the bug.