### PR TITLE
[CI] Make MSCV artifacts output match the regular artifact CI

### DIFF
--- a/.github/workflows/test-build-windows.yml
+++ b/.github/workflows/test-build-windows.yml
@@ -54,14 +54,6 @@ jobs:
         meson --buildtype release --backend vs2022 build-msvc-x86
         msbuild -m build-msvc-x86/dxvk.sln
 
-    - name: Upload artifacts (x86)
-      uses: actions/upload-artifact@v4
-      with:
-        name: dxvk-${{ env.VERSION_NAME }}-msvc-x86-output
-        path: |
-          build-msvc-x86\**\*.pdb
-          build-msvc-x86\**\*.dll
-
     - name: Build MSVC x64
       shell: pwsh
       run: |
@@ -71,10 +63,18 @@ jobs:
         meson --buildtype release --backend vs2022 build-msvc-x64
         msbuild -m build-msvc-x64/dxvk.sln
 
-    - name: Upload artifacts (x64)
+    - name: Prepare artifacts
+      shell: pwsh
+      run: |
+        mkdir artifacts\x32
+        ls -Path build-msvc-x86\src -Include *.dll,*.pdb -Recurse
+          | cp -Destination (Join-Path -Path (pwd) -ChildPath artifacts\x32)
+        mkdir artifacts\x64
+        ls -Path build-msvc-x64\src -Include *.dll,*.pdb -Recurse
+          | cp -Destination (Join-Path -Path (pwd) -ChildPath artifacts\x64)
+
+    - name: Upload artifacts
       uses: actions/upload-artifact@v4
       with:
-        name: dxvk-${{ env.VERSION_NAME }}-msvc-amd64-output
-        path: |
-          build-msvc-x64\**\*.pdb
-          build-msvc-x64\**\*.dll
+        name: dxvk-${{ env.VERSION_NAME }}-msvc-output
+        path: artifacts\*


### PR DESCRIPTION
Merges the two separate archives in to one and puts the dll and pdb files in a x32 and x64 folder. Currently the two archives package the output in a folder called src and the files in subfolders of the respective names. E.g. `src/d3d9/d3d9.dll` etc.

This makes the MSCV artifacts archive match the regular artifacts CI output.