### PR TITLE
Disable memory defragmentation on ANV

### DIFF
--- a/dxvk.conf
+++ b/dxvk.conf
@@ -390,9 +390,10 @@
 #
 # Supported values:
 # - True: Enable defragmentation
+# - Auto: Enable defragmentation, except on blocked drivers
 # - False: Disable defragmentation
 
-# dxvk.enableMemoryDefrag = True
+# dxvk.enableMemoryDefrag = Auto
 
 
 # Sets enabled HUD elements

--- a/src/dxvk/dxvk_memory.cpp
+++ b/src/dxvk/dxvk_memory.cpp
@@ -2316,7 +2316,13 @@ namespace dxvk {
         m_memTypes[i].sharedCache->cleanupUnusedFromLockedAllocator(currentTime);
     }
 
-    if (m_device->config().enableMemoryDefrag) {
+    // For unknown reasons, defragmentation seems to break Genshin Impact and
+    // possibly other games on ANV while working fine on other drivers even in
+    // a stress-test scenario, see https://github.com/doitsujin/dxvk/issues/4395.
+    bool enableDefrag = !m_device->adapter()->matchesDriver(VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA);
+    applyTristate(enableDefrag, m_device->config().enableMemoryDefrag);
+
+    if (enableDefrag) {
       // Periodically defragment device-local memory types. We cannot
       // do anything about mapped allocations since we rely on pointer
       // stability there.

--- a/src/dxvk/dxvk_options.cpp
+++ b/src/dxvk/dxvk_options.cpp
@@ -5,7 +5,7 @@ namespace dxvk {
   DxvkOptions::DxvkOptions(const Config& config) {
     enableDebugUtils      = config.getOption<bool>    ("dxvk.enableDebugUtils",       false);
     enableStateCache      = config.getOption<bool>    ("dxvk.enableStateCache",       true);
-    enableMemoryDefrag    = config.getOption<bool>    ("dxvk.enableMemoryDefrag",     true);
+    enableMemoryDefrag    = config.getOption<Tristate>("dxvk.enableMemoryDefrag",     Tristate::Auto);
     numCompilerThreads    = config.getOption<int32_t> ("dxvk.numCompilerThreads",     0);
     enableGraphicsPipelineLibrary = config.getOption<Tristate>("dxvk.enableGraphicsPipelineLibrary", Tristate::Auto);
     trackPipelineLifetime = config.getOption<Tristate>("dxvk.trackPipelineLifetime",  Tristate::Auto);

--- a/src/dxvk/dxvk_options.h
+++ b/src/dxvk/dxvk_options.h
@@ -15,7 +15,7 @@ namespace dxvk {
     bool enableStateCache = true;
 
     /// Enable memory defragmentation
-    bool enableMemoryDefrag = true;
+    Tristate enableMemoryDefrag = Tristate::Auto;
 
     /// Number of compiler threads
     /// when using the state cache


### PR DESCRIPTION
We still don't understand what the problem is or to which extent it affects other games, so unless a solution magically pops up by next week, we should disable defragmentation on this driver for now to reduce breakage for users.

See: #4395, https://gitlab.freedesktop.org/mesa/mesa/-/issues/12084