### PR TITLE
[CI] Add fetch-depth: 0 to Windows CI

### DIFF
--- a/.github/workflows/test-build-windows.yml
+++ b/.github/workflows/test-build-windows.yml
@@ -12,6 +12,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: recursive
+        fetch-depth: 0
 
     - name: Setup glslangValidator
       shell: pwsh


### PR DESCRIPTION
Fixes the msvc CI builds not including the git commit in the dxvk version because 'git describe --dirty=+'  called though meson fails.