### PR TITLE
[CI] Use latest action runner images

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -4,7 +4,7 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   artifacts-mingw-w64:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
     - name: Checkout code
@@ -35,7 +35,7 @@ jobs:
         if-no-files-found: error
 
   artifacts-steamrt-sniper:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     container: registry.gitlab.steamos.cloud/steamrt/sniper/sdk:beta
 
     steps:
@@ -66,7 +66,7 @@ jobs:
         if-no-files-found: error
 
   merge-artifacts:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs: [artifacts-mingw-w64, artifacts-steamrt-sniper]
     steps:
       - name: Get version

--- a/.github/workflows/test-build-windows.yml
+++ b/.github/workflows/test-build-windows.yml
@@ -4,7 +4,7 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build-set-windows:
-    runs-on: windows-2022
+    runs-on: windows-latest
 
     steps:
     - name: Checkout code


### PR DESCRIPTION
Now future-proof with free auto-upgrades! Also, bigger number better (we get newer kernels in the linux runners, which might help speed things up a little), otherwise rather inconsequential since actual builds are containerized. windows-2022 is currently latest anyway, so no actual change there.

P.S.: ubuntu-20.04 is set to be deprecated by the end of the year anyway.