### PR TITLE
[build] Use the static version of the run-time library for MSVC builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ git clone --recursive https://github.com/doitsujin/dxvk.git
 
 ### Requirements:
 - [wine 7.1](https://www.winehq.org/) or newer
-- [Meson](https://mesonbuild.com/) build system (at least version 0.49)
+- [Meson](https://mesonbuild.com/) build system (at least version 0.58)
 - [Mingw-w64](https://www.mingw-w64.org) compiler and headers (at least version 10.0)
 - [glslang](https://github.com/KhronosGroup/glslang) compiler
 

--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,4 @@
-project('dxvk', ['c', 'cpp'], version : 'v2.4.1', meson_version : '>= 0.58', default_options : [ 'cpp_std=c++17', 'warning_level=2' ])
+project('dxvk', ['c', 'cpp'], version : 'v2.4.1', meson_version : '>= 0.58', default_options : [ 'cpp_std=c++17', 'b_vscrt=static_from_buildtype', 'warning_level=2' ])
 
 pkg = import('pkgconfig')
 cpu_family = target_machine.cpu_family()
@@ -90,8 +90,8 @@ if platform == 'windows'
     # setup file alignment + enable PDB output for MSVC builds
     # PDBs are useful for Windows consumers of DXVK 
     compiler_args += [
-	  '/Z7'
-	]
+      '/Z7'
+    ]
     link_args += [
       '/FILEALIGN:4096',
       '/DEBUG:FULL'


### PR DESCRIPTION
Statically linking the run-time library in MSVC is controlled via [b_vscrt in Meson](https://mesonbuild.com/Builtin-options.html#base-options). I've switched the default to `static_from_buildtype`, to get the statically linked equivalent of default behavior.

Needs some sanity testing at least to confirm it builds something functional.