### PR TITLE
[d3d11] Avoid UB declaring the UnmappedSubresource constant

### DIFF
--- a/src/d3d11/d3d11_texture.h
+++ b/src/d3d11/d3d11_texture.h
@@ -85,7 +85,7 @@ namespace dxvk {
     
   public:
 
-    static constexpr D3D11_MAP UnmappedSubresource = D3D11_MAP(-1u);
+    static const D3D11_MAP UnmappedSubresource = D3D11_MAP(-1u);
 
     D3D11CommonTexture(
             ID3D11Resource*             pInterface,


### PR DESCRIPTION
See https://github.com/llvm/llvm-project/issues/59036