### PR TITLE
[d3d8] Use unsigned values to identify remapped sampler states

### DIFF
--- a/src/d3d8/d3d8_d3d9_util.h
+++ b/src/d3d8/d3d8_d3d9_util.h
@@ -158,7 +158,7 @@ namespace dxvk {
   }
 
   // If this D3DTEXTURESTAGESTATETYPE has been remapped to a d3d9::D3DSAMPLERSTATETYPE
-  // it will be returned, otherwise returns -1
+  // it will be returned, otherwise returns -1u
   inline d3d9::D3DSAMPLERSTATETYPE GetSamplerStateType9(const D3DTEXTURESTAGESTATETYPE StageType) {
     switch (StageType) {
       // 13-21:
@@ -169,11 +169,11 @@ namespace dxvk {
       case D3DTSS_MINFILTER:      return d3d9::D3DSAMP_MINFILTER;
       case D3DTSS_MIPFILTER:      return d3d9::D3DSAMP_MIPFILTER;
       case D3DTSS_MIPMAPLODBIAS:  return d3d9::D3DSAMP_MIPMAPLODBIAS;
-      case D3DTSS_MAXMIPLEVEL:    return d3d9::D3DSAMP_MIPFILTER;
+      case D3DTSS_MAXMIPLEVEL:    return d3d9::D3DSAMP_MAXMIPLEVEL;
       case D3DTSS_MAXANISOTROPY:  return d3d9::D3DSAMP_MAXANISOTROPY;
       // 25:
       case D3DTSS_ADDRESSW:       return d3d9::D3DSAMP_ADDRESSW;
-      default:                    return d3d9::D3DSAMPLERSTATETYPE(-1);
+      default:                    return d3d9::D3DSAMPLERSTATETYPE(-1u);
     }
   }
 }

--- a/src/d3d8/d3d8_device.cpp
+++ b/src/d3d8/d3d8_device.cpp
@@ -1282,7 +1282,7 @@ namespace dxvk {
           DWORD*                   pValue) {
     d3d9::D3DSAMPLERSTATETYPE stateType = GetSamplerStateType9(Type);
 
-    if (stateType != -1) {
+    if (stateType != -1u) {
       // if the type has been remapped to a sampler state type:
       return GetD3D9()->GetSamplerState(Stage, stateType, pValue);
     }
@@ -1298,7 +1298,7 @@ namespace dxvk {
     d3d9::D3DSAMPLERSTATETYPE stateType = GetSamplerStateType9(Type);
 
     StateChange();
-    if (stateType != -1) {
+    if (stateType != -1u) {
       // if the type has been remapped to a sampler state type:
       return GetD3D9()->SetSamplerState(Stage, stateType, Value);
     } else {


### PR DESCRIPTION
Two rather derpy derps. Should now work as intended, and the `-1u` part should also silence a clang warning.