### PR TITLE
[d3d9] Change correctness factor to 0.5f

### DIFF
--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -6571,12 +6571,7 @@ namespace dxvk {
     const D3DVIEWPORT9& vp = m_state.viewport;
 
     // Correctness Factor for 1/2 texel offset
-    // We need to bias this slightly to make
-    // imprecision in games happy.
-    // Originally we did this only for powers of two
-    // resolutions but since NEAREST filtering fixed to
-    // truncate, we need to do this all the time now.
-    constexpr float cf = 0.5f - (1.0f / 128.0f);
+    constexpr float cf = 0.5f;
 
     // How much to bias MinZ by to avoid a depth
     // degenerate viewport.


### PR DESCRIPTION
Been doing a lot of testing of this issue to figure out what is up and down.

The [original issue the current code fixed](https://github.com/doitsujin/dxvk/issues/1854) is actually a game bug that also happens with the version of the FF13Fix addon used back then (1.4.6). On Windows with native d3d9 amd drivers this issue can be observed when running the game with a 2560 x 1440 resolution. 
This was then later fixed in the addon and so if you download the latest version of FF13Fix it will look correct both with the native driver and dxvk with a 0.5f correctness factor. https://github.com/rebtd7/FF13Fix/releases
> Fixed misaligned screen effects (proper fix for the 1440p resolution)

Fixing the game bug back then in dxvk sadly introduced issues in other games like https://github.com/doitsujin/dxvk/issues/3708, https://github.com/doitsujin/dxvk/issues/3818 and https://github.com/doitsujin/dxvk/issues/4425.

I have tested on radv, amdvlk open , amd pro, nvk and Nvidia prop that a correctness factor of specifically 0.5f fixes those issues. FFXIV will behave like on Windows and the addon can still be used to fix the 1440p bug.
(amdvlk and amd pro didn't want to work with gamescope when faking 1440p)

![image](https://github.com/user-attachments/assets/619f1e94-31a3-42ab-ad5b-a230e70471e3)

Fixes #3708
Fixes #3818
Fixes #4425
Closes #4461 