### PR TITLE
[util] Hide iGPU for WoW and WC3 Reforged

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -38,6 +38,11 @@ namespace dxvk {
     { R"(\\P3R\.exe$)", {{
       { "dxgi.syncInterval",                "1" },
     }} },
+    /* World of Warcraft                           *
+     * Bugs out on some multi-gpu systems.         */
+    { R"(\\Wow(Classic)?\.exe$)", {{
+      { "dxvk.hideIntegratedGraphics",      "True"  },
+    }} },
 
     /**********************************************/
     /* D3D11 GAMES                                */
@@ -444,6 +449,11 @@ namespace dxvk {
      * Static ags crash with HDR support          */
     { R"(\\(LibertyCity|ViceCity|SanAndreas)\.exe$)", {{
       { "dxgi.enableUe4Workarounds",        "True" },
+    }} },
+    /* Warcraft 3 Reforged                         *
+     * Bugs out on some multi-gpu systems.         */
+    { R"(\\Warcraft III\.exe$)", {{
+      { "dxvk.hideIntegratedGraphics",      "True"  },
     }} },
 
     /**********************************************/


### PR DESCRIPTION
Currently with Proton/Wine these games will prefer to use the iGPU. On systems using the Nvidia proprietary driver this can make them bug out so they don't start or show a gray screen.

It has to be figured and fixed why they even want to use the iGPU, but in the meantime we might as well work around the issue.