### PR TITLE
[util] Don't include original WC3 in Reforged config

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -452,7 +452,7 @@ namespace dxvk {
     }} },
     /* Warcraft 3 Reforged                         *
      * Bugs out on some multi-gpu systems.         */
-    { R"(\\Warcraft III\.exe$)", {{
+    { R"(\\x86_64\\Warcraft III\.exe$)", {{
       { "dxvk.hideIntegratedGraphics",      "True"  },
     }} },
 


### PR DESCRIPTION
My brain didn't catch on that this would also affect the original Warcraft 3 as it isn't a dxgi config. Thanks @WinterSnowfall 
Reforged sits in a folder called x86_64 which should filter out the original Warcraft 3