### PR TITLE
[build] Remove old d3dcompiler_47 dependency

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -103,12 +103,6 @@ if platform == 'windows'
   lib_dxgi    = cpp.find_library('dxgi')
 
   if dxvk_is_msvc
-    lib_d3dcompiler_47 = cpp.find_library('d3dcompiler')
-  else
-    lib_d3dcompiler_47 = cpp.find_library('d3dcompiler_47')
-  endif
-
-  if dxvk_is_msvc
     res_ext = '.res'
     wrc = find_program('rc')
     wrc_generator = generator(wrc,


### PR DESCRIPTION
Leftover from when tests were in the main repository