### PR TITLE
[d3d8] Wine device tests fixes (Part 4)

### DIFF
--- a/src/d3d8/d3d8_device.cpp
+++ b/src/d3d8/d3d8_device.cpp
@@ -1696,6 +1696,17 @@ namespace dxvk {
     if (unlikely(pDeclaration == nullptr || pHandle == nullptr))
       return D3DERR_INVALIDCALL;
 
+    // Validate VS version for non-FF shaders
+    if (pFunction != nullptr) {
+      uint32_t majorVersion = (pFunction[0] >> 8) & 0xff;
+      uint32_t minorVersion = pFunction[0] & 0xff;
+
+      if (unlikely(majorVersion != 1 || minorVersion > 1)) {
+        Logger::err(str::format("D3D8Device::CreateVertexShader: Unsupported VS version ", majorVersion, ".", minorVersion));
+        return D3DERR_INVALIDCALL;
+      }
+    }
+
     D3D8VertexShaderInfo& info = m_vertexShaders.emplace_back();
 
     // Store D3D8 bytecodes in the shader info
@@ -1925,6 +1936,14 @@ namespace dxvk {
 
     if (unlikely(pFunction == nullptr || pHandle == nullptr))
       return D3DERR_INVALIDCALL;
+
+    uint32_t majorVersion = (pFunction[0] >> 8) & 0xff;
+    uint32_t minorVersion = pFunction[0] & 0xff;
+
+    if (unlikely(majorVersion != 1 || minorVersion > 4)) {
+      Logger::err(str::format("D3D8Device::CreatePixelShader: Unsupported PS version ", majorVersion, ".", minorVersion));
+      return D3DERR_INVALIDCALL;
+    }
 
     d3d9::IDirect3DPixelShader9* pPixelShader;
     

--- a/src/d3d8/d3d8_device.cpp
+++ b/src/d3d8/d3d8_device.cpp
@@ -1683,13 +1683,15 @@ namespace dxvk {
     D3D8VertexShaderInfo& info = m_vertexShaders.emplace_back();
 
     // Store D3D8 bytecodes in the shader info
-    if (pDeclaration != nullptr)
-      for (UINT i = 0; pDeclaration[i+1] != D3DVSD_END(); i++)
-        info.declaration.push_back(pDeclaration[i]);
+    for (UINT i = 0; pDeclaration[i] != D3DVSD_END(); i++)
+      info.declaration.push_back(pDeclaration[i]);
+    info.declaration.push_back(D3DVSD_END());
 
-    if (pFunction != nullptr)
-      for (UINT i = 0; pFunction[i+1] != D3DVS_END(); i++)
+    if (pFunction != nullptr) {
+      for (UINT i = 0; pFunction[i] != D3DVS_END(); i++)
         info.function.push_back(pFunction[i]);
+      info.function.push_back(D3DVS_END());
+    }
     
     D3D9VertexShaderCode result = TranslateVertexShader8(pDeclaration, pFunction, m_d3d8Options);
 
@@ -1829,6 +1831,9 @@ namespace dxvk {
 
       info->declaration.clear();
       info->function.clear();
+
+      if (m_currentVertexShader == Handle)
+        m_currentVertexShader = 0;
     }
 
     return D3D_OK;
@@ -1854,8 +1859,10 @@ namespace dxvk {
 
     // D3D8-specific behavior
     if (SizeOfData < ActualSize) {
-      *pSizeOfData = ActualSize;
-      return D3DERR_MOREDATA;
+      // D3DERR_MOREDATA should be returned according to the D3D8 documentation,
+      // along with a correction to the ActualSize, however tests have shown that
+      // D3DERR_INVALIDCALL is returned and no size correction is performed.
+      return D3DERR_INVALIDCALL;
     }
 
     memcpy(pData, pInfo->declaration.data(), ActualSize);
@@ -1882,8 +1889,10 @@ namespace dxvk {
 
     // D3D8-specific behavior
     if (SizeOfData < ActualSize) {
-      *pSizeOfData = ActualSize;
-      return D3DERR_MOREDATA;
+      // D3DERR_MOREDATA should be returned according to the D3D8 documentation,
+      // along with a correction to the ActualSize, however tests have shown that
+      // D3DERR_INVALIDCALL is returned and no size correction is performed.
+      return D3DERR_INVALIDCALL;
     }
 
     memcpy(pData, pInfo->function.data(), ActualSize);
@@ -1986,6 +1995,9 @@ namespace dxvk {
 
     m_pixelShaders[getShaderIndex(Handle)] = nullptr;
 
+    if (m_currentPixelShader == Handle)
+      m_currentPixelShader = 0;
+
     return D3D_OK;
   }
 
@@ -2010,8 +2022,10 @@ namespace dxvk {
 
     // D3D8-specific behavior
     if (SizeOfData < ActualSize) {
-      *pSizeOfData = ActualSize;
-      return D3DERR_MOREDATA;
+      // D3DERR_MOREDATA should be returned according to the D3D8 documentation,
+      // along with a correction to the ActualSize, however tests have shown that
+      // D3DERR_INVALIDCALL is returned and no size correction is performed.
+      return D3DERR_INVALIDCALL;
     }
 
     return pPixelShader->GetFunction(pData, &SizeOfData);

--- a/src/d3d8/d3d8_main.cpp
+++ b/src/d3d8/d3d8_main.cpp
@@ -19,14 +19,38 @@ extern "C" {
       const D3DCAPS8*  pCaps,
       BOOL             errorReturn,
       char**           pErrorString) {
-    dxvk::Logger::warn("D3D8: ValidatePixelShader: Stub");
+    std::string errorMessage = "";
 
-    if (unlikely(pPixelShader == nullptr))
+    if (unlikely(pPixelShader == nullptr)) {
+      errorMessage = "D3D8: ValidatePixelShader: Null pPixelShader";
+    } else {
+      uint32_t majorVersion = (pPixelShader[0] >> 8) & 0xff;
+      uint32_t minorVersion = pPixelShader[0] & 0xff;
+
+      if (unlikely(majorVersion != 1 || minorVersion > 4)) {
+        errorMessage = dxvk::str::format("D3D8: ValidatePixelShader: Unsupported PS version ",
+                                          majorVersion, ".", minorVersion);
+      } else if (unlikely(pCaps && pPixelShader[0] > pCaps->PixelShaderVersion)) {
+        errorMessage = dxvk::str::format("D3D8: ValidatePixelShader: Caps: Unsupported PS version ",
+                                          majorVersion, ".", minorVersion);
+      }
+    }
+
+    const size_t errorMessageSize = errorMessage.size() + 1;
+
+#ifdef _WIN32
+    if (pErrorString != nullptr && errorReturn) {
+      // Wine tests call HeapFree() on the returned error string,
+      // so the expectation is for it to be allocated on the heap.
+      *pErrorString = (char*) HeapAlloc(GetProcessHeap(), 0, errorMessageSize);
+      if (*pErrorString)
+        memcpy(*pErrorString, errorMessage.c_str(), errorMessageSize);
+    }
+#endif
+
+    if (errorMessageSize > 1) {
+      dxvk::Logger::warn(errorMessage);
       return E_FAIL;
-
-    if (errorReturn && pErrorString != nullptr) {
-      const char* errorMessage = "";
-      *pErrorString = (char *) errorMessage;
     }
 
     return S_OK;
@@ -38,22 +62,44 @@ extern "C" {
       const D3DCAPS8*  pCaps,
       BOOL             errorReturn,
       char**           pErrorString) {
-    dxvk::Logger::warn("D3D8: ValidateVertexShader: Stub");
+    std::string errorMessage = "";
 
-    if (unlikely(pVertexShader == nullptr))
+    if (unlikely(pVertexShader == nullptr)) {
+      errorMessage = "D3D8: ValidateVertexShader: Null pVertexShader";
+    } else {
+      uint32_t majorVersion = (pVertexShader[0] >> 8) & 0xff;
+      uint32_t minorVersion = pVertexShader[0] & 0xff;
+
+      if (unlikely(majorVersion != 1 || minorVersion > 1)) {
+        errorMessage = dxvk::str::format("D3D8: ValidateVertexShader: Unsupported VS version ",
+                                          majorVersion, ".", minorVersion);
+      } else if (unlikely(pCaps && pVertexShader[0] > pCaps->VertexShaderVersion)) {
+        errorMessage = dxvk::str::format("D3D8: ValidateVertexShader: Caps: Unsupported VS version ",
+                                          majorVersion, ".", minorVersion);
+      }
+    }
+
+    const size_t errorMessageSize = errorMessage.size() + 1;
+
+#ifdef _WIN32
+    if (pErrorString != nullptr && errorReturn) {
+      // Wine tests call HeapFree() on the returned error string,
+      // so the expectation is for it to be allocated on the heap.
+      *pErrorString = (char*) HeapAlloc(GetProcessHeap(), 0, errorMessageSize);
+      if (*pErrorString)
+        memcpy(*pErrorString, errorMessage.c_str(), errorMessageSize);
+    }
+#endif
+
+    if (errorMessageSize > 1) {
+      dxvk::Logger::warn(errorMessage);
       return E_FAIL;
-
-    if (errorReturn && pErrorString != nullptr) {
-      const char* errorMessage = "";
-      *pErrorString = (char *) errorMessage;
     }
 
     return S_OK;
   }
 
-  DLLEXPORT void __stdcall DebugSetMute() {
-    dxvk::Logger::debug("D3D8: DebugSetMute: Stub");
-  }
+  DLLEXPORT void __stdcall DebugSetMute() {}
 
   DLLEXPORT IDirect3D8* __stdcall Direct3DCreate8(UINT nSDKVersion) {
     IDirect3D8* pDirect3D = nullptr;

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -476,10 +476,15 @@ namespace dxvk {
     Logger::info("Device reset");
     m_deviceLostState = D3D9DeviceLostState::Ok;
 
-    HRESULT hr = m_parent->ValidatePresentationParameters(pPresentationParameters);
+    HRESULT hr;
+    // Black Desert creates a D3DDEVTYPE_NULLREF device and
+    // expects reset to work despite passing invalid parameters.
+    if (likely(m_deviceType != D3DDEVTYPE_NULLREF)) {
+      hr = m_parent->ValidatePresentationParameters(pPresentationParameters);
 
-    if (unlikely(FAILED(hr)))
-      return hr;
+      if (unlikely(FAILED(hr)))
+        return hr;
+    }
 
     if (!IsExtended()) {
       // The internal references are always cleared, regardless of whether the Reset call succeeds.
@@ -8304,12 +8309,12 @@ namespace dxvk {
       "    - Windowed:           ", pPresentationParameters->Windowed ? "true" : "false", "\n",
       "    - Swap effect:        ", pPresentationParameters->SwapEffect, "\n"));
 
-    // Black Desert creates a device with a NULL hDeviceWindow and
-    // seemingly expects this validation to not prevent a swapchain reset.
-    if (pPresentationParameters->hDeviceWindow != nullptr &&
-       !pPresentationParameters->Windowed &&
-       (pPresentationParameters->BackBufferWidth  == 0
-     || pPresentationParameters->BackBufferHeight == 0)) {
+    // Black Desert creates a D3DDEVTYPE_NULLREF device and
+    // expects this validation to not prevent a swapchain reset.
+    if (likely(m_deviceType != D3DDEVTYPE_NULLREF) &&
+        unlikely(!pPresentationParameters->Windowed &&
+                 (pPresentationParameters->BackBufferWidth  == 0
+               || pPresentationParameters->BackBufferHeight == 0))) {
       return D3DERR_INVALIDCALL;
     }
 

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -4070,7 +4070,7 @@ namespace dxvk {
     desc.IsAttachmentOnly   = TRUE;
     desc.IsLockable         = Lockable;
 
-    if (FAILED(D3D9CommonTexture::NormalizeTextureProperties(this, D3DRTYPE_TEXTURE, &desc)))
+    if (FAILED(D3D9CommonTexture::NormalizeTextureProperties(this, D3DRTYPE_SURFACE, &desc)))
       return D3DERR_INVALIDCALL;
 
     try {
@@ -4118,7 +4118,7 @@ namespace dxvk {
     // Docs: Off-screen plain surfaces are always lockable, regardless of their pool types.
     desc.IsLockable         = TRUE;
 
-    if (FAILED(D3D9CommonTexture::NormalizeTextureProperties(this, D3DRTYPE_TEXTURE, &desc)))
+    if (FAILED(D3D9CommonTexture::NormalizeTextureProperties(this, D3DRTYPE_SURFACE, &desc)))
       return D3DERR_INVALIDCALL;
 
     if (pSharedHandle != nullptr && Pool != D3DPOOL_DEFAULT)
@@ -4172,7 +4172,7 @@ namespace dxvk {
     desc.IsAttachmentOnly   = TRUE;
     desc.IsLockable         = IsLockableDepthStencilFormat(desc.Format);
 
-    if (FAILED(D3D9CommonTexture::NormalizeTextureProperties(this, D3DRTYPE_TEXTURE, &desc)))
+    if (FAILED(D3D9CommonTexture::NormalizeTextureProperties(this, D3DRTYPE_SURFACE, &desc)))
       return D3DERR_INVALIDCALL;
 
     try {
@@ -8362,7 +8362,7 @@ namespace dxvk {
       desc.IsAttachmentOnly   = TRUE;
       desc.IsLockable         = IsLockableDepthStencilFormat(desc.Format);
 
-      if (FAILED(D3D9CommonTexture::NormalizeTextureProperties(this, D3DRTYPE_TEXTURE, &desc)))
+      if (FAILED(D3D9CommonTexture::NormalizeTextureProperties(this, D3DRTYPE_SURFACE, &desc)))
         return D3DERR_NOTAVAILABLE;
 
       m_autoDepthStencil = new D3D9Surface(this, &desc, nullptr, nullptr);

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -1592,7 +1592,12 @@ namespace dxvk {
           IDirect3DSurface9* pRenderTarget) {
     D3D9DeviceLock lock = LockDevice();
 
-    if (unlikely((pRenderTarget == nullptr && RenderTargetIndex == 0)))
+    if (unlikely(pRenderTarget == nullptr && RenderTargetIndex == 0))
+      return D3DERR_INVALIDCALL;
+
+    // We need to make sure the render target was created using this device.
+    D3D9Surface* rt = static_cast<D3D9Surface*>(pRenderTarget);
+    if (unlikely(rt != nullptr && rt->GetDevice() != this))
       return D3DERR_INVALIDCALL;
 
     return SetRenderTargetInternal(RenderTargetIndex, pRenderTarget);

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -4980,9 +4980,13 @@ namespace dxvk {
 
     UINT Subresource = pResource->CalcSubresource(Face, MipLevel);
 
-    // We weren't locked anyway!
-    if (unlikely(!pResource->GetLocked(Subresource)))
-      return D3D_OK;
+    // Don't allow multiple unlockings, except for D3DRTYPE_TEXTURE
+    if (unlikely(!pResource->GetLocked(Subresource))) {
+      if (pResource->GetType() == D3DRTYPE_TEXTURE)
+        return D3D_OK;
+      else
+        return D3DERR_INVALIDCALL;
+    }
 
     MapTexture(pResource, Subresource); // Add it to the list of mapped resources
     pResource->SetLocked(Subresource, false);

--- a/src/d3d9/d3d9_interface.cpp
+++ b/src/d3d9/d3d9_interface.cpp
@@ -360,10 +360,15 @@ namespace dxvk {
                !(BehaviorFlags & D3DCREATE_HARDWARE_VERTEXPROCESSING)))
       return D3DERR_INVALIDCALL;
 
-    HRESULT hr = ValidatePresentationParameters(pPresentationParameters);
+    HRESULT hr;
+    // Black Desert creates a D3DDEVTYPE_NULLREF device and
+    // expects it be created despite passing invalid parameters.
+    if (likely(DeviceType != D3DDEVTYPE_NULLREF)) {
+      hr = ValidatePresentationParameters(pPresentationParameters);
 
-    if (unlikely(FAILED(hr)))
-      return hr;
+      if (unlikely(FAILED(hr)))
+        return hr;
+    }
 
     auto* adapter = GetAdapter(Adapter);
 
@@ -421,10 +426,7 @@ namespace dxvk {
     }
 
     // The swap effect value can not be 0.
-    // Black Desert sets this to 0 with a NULL hDeviceWindow
-    // and expects device creation to succeed.
-    if (unlikely(pPresentationParameters->hDeviceWindow != nullptr
-              && !pPresentationParameters->SwapEffect))
+    if (unlikely(!pPresentationParameters->SwapEffect))
       return D3DERR_INVALIDCALL;
 
     // D3DSWAPEFFECT_COPY can not be used with more than one back buffer.


### PR DESCRIPTION
I'm aiming to fix a few more d3d8/d3d9 Wine devices tests. 

So far:
- readdressed a relaxation of validations done to prevent crashing in Black Desert in a way that now passes the affected Wine device tests
- fixed invalid storage of VS/PS functions and declarations as well as other d3d8 VS/PS behavior
- added DS dimensions validation on SetRenderTarget (d3d8 specific)
- added PS/VS version validation on shader creation (d3d8)
- partially implemented ValidateVertexShader/ValidatePixelShader, with version validations (d3d8)
- fixed d3d9 multiple image unlock behavior
- validated RT parent device during SetRenderTarget
- added various NormalizeTextureProperties validations