### PR TITLE
[util] Set Borderlands 2 floatEmulation to Strict

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -469,10 +469,13 @@ namespace dxvk {
     { R"(\\anarchyonline\.exe$)", {{
       { "d3d9.memoryTrackTest",             "True" },
     }} },
-    /* Borderlands 2 and The Pre Sequel!           */
+    /* Borderlands 2 and The Pre Sequel!          * 
+     * Missing lava in Vault of the Warrior       *
+     * without Strict floats                      */
     { R"(\\Borderlands(2|PreSequel)\.exe$)", {{
       { "d3d9.lenientClear",                "True" },
       { "d3d9.supportDFFormats",            "False" },
+      { "d3d9.floatEmulation",              "Strict" },
     }} },
     /* Borderlands                                */
     { R"(\\Borderlands\.exe$)", {{


### PR DESCRIPTION
Indirect bug report on the Borderlands 2 PCGamingWiki page