### PR TITLE
Always disable exclusive full-screen on Windows

### DIFF
--- a/dxvk.conf
+++ b/dxvk.conf
@@ -500,16 +500,6 @@
 # d3d9.floatEmulation = Auto
 
 
-# Enable dialog box mode
-#
-# Changes the default state of dialog box mode.
-# *Disables* exclusive fullscreen when enabled.
-#
-# Supported values:
-# - True, False: Always enable / disable
-
-# d3d9.enableDialogMode = False
-
 # Overrides the application's MSAA level on the swapchain
 # 
 # Supported values: -1 (application) and 0 to 16 (user override)

--- a/src/d3d11/d3d11_swapchain.cpp
+++ b/src/d3d11/d3d11_swapchain.cpp
@@ -502,7 +502,6 @@ namespace dxvk {
     presenterDesc.imageExtent     = { m_desc.Width, m_desc.Height };
     presenterDesc.imageCount      = PickImageCount(m_desc.BufferCount + 1);
     presenterDesc.numFormats      = PickFormats(m_desc.Format, presenterDesc.formats);
-    presenterDesc.fullScreenExclusive = PickFullscreenMode();
 
     VkResult vr = m_presenter->recreateSwapChain(presenterDesc);
 
@@ -537,7 +536,6 @@ namespace dxvk {
     presenterDesc.imageExtent     = { m_desc.Width, m_desc.Height };
     presenterDesc.imageCount      = PickImageCount(m_desc.BufferCount + 1);
     presenterDesc.numFormats      = PickFormats(m_desc.Format, presenterDesc.formats);
-    presenterDesc.fullScreenExclusive = PickFullscreenMode();
 
     m_presenter = new Presenter(m_device, m_frameLatencySignal, presenterDesc);
     m_presenter->setFrameRateLimit(m_targetFrameRate, GetActualFrameLatency());
@@ -755,13 +753,6 @@ namespace dxvk {
           UINT                      Preferred) {
     int32_t option = m_parent->GetOptions()->numBackBuffers;
     return option > 0 ? uint32_t(option) : uint32_t(Preferred);
-  }
-
-
-  VkFullScreenExclusiveEXT D3D11SwapChain::PickFullscreenMode() {
-    return m_desc.Flags & DXGI_SWAP_CHAIN_FLAG_ALLOW_MODE_SWITCH
-      ? VK_FULL_SCREEN_EXCLUSIVE_ALLOWED_EXT
-      : VK_FULL_SCREEN_EXCLUSIVE_DISALLOWED_EXT;
   }
 
 

--- a/src/d3d11/d3d11_swapchain.h
+++ b/src/d3d11/d3d11_swapchain.h
@@ -170,8 +170,6 @@ namespace dxvk {
     uint32_t PickImageCount(
             UINT                      Preferred);
     
-    VkFullScreenExclusiveEXT PickFullscreenMode();
-
     std::string GetApiName() const;
 
   };

--- a/src/d3d9/d3d9_options.cpp
+++ b/src/d3d9/d3d9_options.cpp
@@ -61,7 +61,6 @@ namespace dxvk {
     this->invariantPosition             = config.getOption<bool>        ("d3d9.invariantPosition",             true);
     this->memoryTrackTest               = config.getOption<bool>        ("d3d9.memoryTrackTest",               false);
     this->supportVCache                 = config.getOption<bool>        ("d3d9.supportVCache",                 vendorId == uint32_t(DxvkGpuVendor::Nvidia));
-    this->enableDialogMode              = config.getOption<bool>        ("d3d9.enableDialogMode",              false);
     this->forceSamplerTypeSpecConstants = config.getOption<bool>        ("d3d9.forceSamplerTypeSpecConstants", false);
     this->forceSwapchainMSAA            = config.getOption<int32_t>     ("d3d9.forceSwapchainMSAA",            -1);
     this->forceSampleRateShading        = config.getOption<bool>        ("d3d9.forceSampleRateShading",        false);

--- a/src/d3d9/d3d9_options.h
+++ b/src/d3d9/d3d9_options.h
@@ -103,9 +103,6 @@ namespace dxvk {
     /// Forced aspect ratio, disable other modes
     std::string forceAspectRatio;
 
-    /// Enable dialog mode (ie. no exclusive fullscreen)
-    bool enableDialogMode;
-
     /// Always use a spec constant to determine sampler type (instead of just in PS 1.x)
     /// Works around a game bug in Halo CE where it gives cube textures to 2d/volume samplers
     bool forceSamplerTypeSpecConstants;

--- a/src/d3d9/d3d9_swapchain.cpp
+++ b/src/d3d9/d3d9_swapchain.cpp
@@ -27,7 +27,6 @@ namespace dxvk {
     : D3D9SwapChainExBase(pDevice)
     , m_device           (pDevice->GetDXVKDevice())
     , m_frameLatencyCap  (pDevice->GetOptions()->maxFrameLatency)
-    , m_dialog           (pDevice->GetOptions()->enableDialogMode)
     , m_swapchainExt     (this) {
     this->NormalizePresentParameters(pPresentParams);
     m_presentParams = *pPresentParams;
@@ -160,7 +159,6 @@ namespace dxvk {
 
     bool recreate = false;
     recreate   |= m_wctx->presenter == nullptr;
-    recreate   |= m_dialog != m_lastDialog;
     if (options->deferSurfaceCreation)
       recreate |= m_parent->IsDeviceReset();
 
@@ -171,8 +169,6 @@ namespace dxvk {
 
     m_dirty    |= UpdatePresentRegion(pSourceRect, pDestRect);
     m_dirty    |= recreate;
-
-    m_lastDialog = m_dialog;
 
 #ifdef _WIN32
     const bool useGDIFallback = m_partialCopy && !HasFrontBuffer();
@@ -775,15 +771,10 @@ namespace dxvk {
 
 
   HRESULT D3D9SwapChainEx::SetDialogBoxMode(bool bEnableDialogs) {
-    D3D9DeviceLock lock = m_parent->LockDevice();
-
     // https://docs.microsoft.com/en-us/windows/win32/api/d3d9/nf-d3d9-idirect3ddevice9-setdialogboxmode
     // The MSDN documentation says this will error out under many weird conditions.
     // However it doesn't appear to error at all in any of my tests of these
     // cases described in the documentation.
-
-    m_dialog = bEnableDialogs;
-
     return D3D_OK;
   }
 

--- a/src/d3d9/d3d9_swapchain.cpp
+++ b/src/d3d9/d3d9_swapchain.cpp
@@ -952,7 +952,6 @@ namespace dxvk {
     presenterDesc.imageExtent     = GetPresentExtent();
     presenterDesc.imageCount      = PickImageCount(m_presentParams.BackBufferCount + 1);
     presenterDesc.numFormats      = PickFormats(EnumerateFormat(m_presentParams.BackBufferFormat), presenterDesc.formats);
-    presenterDesc.fullScreenExclusive = PickFullscreenMode();
 
     VkResult vr = m_wctx->presenter->recreateSwapChain(presenterDesc);
 
@@ -985,7 +984,6 @@ namespace dxvk {
     presenterDesc.imageExtent     = GetPresentExtent();
     presenterDesc.imageCount      = PickImageCount(m_presentParams.BackBufferCount + 1);
     presenterDesc.numFormats      = PickFormats(EnumerateFormat(m_presentParams.BackBufferFormat), presenterDesc.formats);
-    presenterDesc.fullScreenExclusive = PickFullscreenMode();
 
     m_wctx->presenter = new Presenter(m_device, m_wctx->frameLatencySignal, presenterDesc);
   }
@@ -1403,13 +1401,6 @@ namespace dxvk {
 
   VkExtent2D D3D9SwapChainEx::GetPresentExtent() {
     return m_swapchainExtent;
-  }
-
-
-  VkFullScreenExclusiveEXT D3D9SwapChainEx::PickFullscreenMode() {
-    return m_dialog
-      ? VK_FULL_SCREEN_EXCLUSIVE_DISALLOWED_EXT
-      : VK_FULL_SCREEN_EXCLUSIVE_DEFAULT_EXT;
   }
 
 

--- a/src/d3d9/d3d9_swapchain.h
+++ b/src/d3d9/d3d9_swapchain.h
@@ -171,8 +171,6 @@ namespace dxvk {
     uint32_t                  m_frameLatencyCap = 0;
 
     bool                      m_dirty    = true;
-    bool                      m_dialog   = false;
-    bool                      m_lastDialog = false;
 
     HWND                      m_window   = nullptr;
     HMONITOR                  m_monitor  = nullptr;

--- a/src/d3d9/d3d9_swapchain.h
+++ b/src/d3d9/d3d9_swapchain.h
@@ -247,8 +247,6 @@ namespace dxvk {
 
     VkExtent2D GetPresentExtent();
 
-    VkFullScreenExclusiveEXT PickFullscreenMode();
-
     std::string GetApiName();
 
     const Com<D3D9Surface, false>& GetFrontBuffer() const {

--- a/src/dxvk/dxvk_presenter.cpp
+++ b/src/dxvk/dxvk_presenter.cpp
@@ -171,7 +171,7 @@ namespace dxvk {
       return VK_ERROR_SURFACE_LOST_KHR;
 
     VkSurfaceFullScreenExclusiveInfoEXT fullScreenExclusiveInfo = { VK_STRUCTURE_TYPE_SURFACE_FULL_SCREEN_EXCLUSIVE_INFO_EXT };
-    fullScreenExclusiveInfo.fullScreenExclusive = desc.fullScreenExclusive;
+    fullScreenExclusiveInfo.fullScreenExclusive = VK_FULL_SCREEN_EXCLUSIVE_DISALLOWED_EXT;
 
     VkPhysicalDeviceSurfaceInfo2KHR surfaceInfo = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SURFACE_INFO_2_KHR };
     surfaceInfo.surface = m_surface;
@@ -211,13 +211,13 @@ namespace dxvk {
     }
 
     // Select format based on swap chain properties
-    if ((status = getSupportedFormats(formats, desc.fullScreenExclusive)))
+    if ((status = getSupportedFormats(formats)))
       return status;
 
     m_info.format = pickFormat(formats.size(), formats.data(), desc.numFormats, desc.formats);
 
     // Select a present mode for the current sync interval
-    if ((status = getSupportedPresentModes(modes, desc.fullScreenExclusive)))
+    if ((status = getSupportedPresentModes(modes)))
       return status;
 
     m_info.presentMode = pickPresentMode(modes.size(), modes.data(), m_info.syncInterval);
@@ -300,7 +300,7 @@ namespace dxvk {
     m_info.imageCount = pickImageCount(minImageCount, maxImageCount, desc.imageCount);
 
     VkSurfaceFullScreenExclusiveInfoEXT fullScreenInfo = { VK_STRUCTURE_TYPE_SURFACE_FULL_SCREEN_EXCLUSIVE_INFO_EXT };
-    fullScreenInfo.fullScreenExclusive = desc.fullScreenExclusive;
+    fullScreenInfo.fullScreenExclusive = VK_FULL_SCREEN_EXCLUSIVE_DISALLOWED_EXT;
 
     VkSwapchainPresentModesCreateInfoEXT modeInfo = { VK_STRUCTURE_TYPE_SWAPCHAIN_PRESENT_MODES_CREATE_INFO_EXT };
     modeInfo.presentModeCount       = compatibleModes.size();
@@ -333,8 +333,7 @@ namespace dxvk {
       "\n  Color space:  ", m_info.format.colorSpace,
       "\n  Present mode: ", m_info.presentMode, " (dynamic: ", (dynamicModes.empty() ? "no)" : "yes)"),
       "\n  Buffer size:  ", m_info.imageExtent.width, "x", m_info.imageExtent.height,
-      "\n  Image count:  ", m_info.imageCount,
-      "\n  Exclusive FS: ", desc.fullScreenExclusive));
+      "\n  Image count:  ", m_info.imageCount));
     
     if ((status = m_vkd->vkCreateSwapchainKHR(m_vkd->device(),
         &swapInfo, nullptr, &m_swapchain)))
@@ -414,7 +413,7 @@ namespace dxvk {
       return false;
 
     std::vector<VkSurfaceFormatKHR> surfaceFormats;
-    getSupportedFormats(surfaceFormats, VK_FULL_SCREEN_EXCLUSIVE_DEFAULT_EXT);
+    getSupportedFormats(surfaceFormats);
 
     for (const auto& surfaceFormat : surfaceFormats) {
       if (surfaceFormat.colorSpace == colorspace)
@@ -454,11 +453,11 @@ namespace dxvk {
   }
 
 
-  VkResult Presenter::getSupportedFormats(std::vector<VkSurfaceFormatKHR>& formats, VkFullScreenExclusiveEXT fullScreenExclusive) const {
+  VkResult Presenter::getSupportedFormats(std::vector<VkSurfaceFormatKHR>& formats) const {
     uint32_t numFormats = 0;
 
     VkSurfaceFullScreenExclusiveInfoEXT fullScreenInfo = { VK_STRUCTURE_TYPE_SURFACE_FULL_SCREEN_EXCLUSIVE_INFO_EXT };
-    fullScreenInfo.fullScreenExclusive = fullScreenExclusive;
+    fullScreenInfo.fullScreenExclusive = VK_FULL_SCREEN_EXCLUSIVE_DISALLOWED_EXT;
 
     VkPhysicalDeviceSurfaceInfo2KHR surfaceInfo = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SURFACE_INFO_2_KHR, &fullScreenInfo };
     surfaceInfo.surface = m_surface;
@@ -496,11 +495,11 @@ namespace dxvk {
   }
 
   
-  VkResult Presenter::getSupportedPresentModes(std::vector<VkPresentModeKHR>& modes, VkFullScreenExclusiveEXT fullScreenExclusive) const {
+  VkResult Presenter::getSupportedPresentModes(std::vector<VkPresentModeKHR>& modes) const {
     uint32_t numModes = 0;
 
     VkSurfaceFullScreenExclusiveInfoEXT fullScreenInfo = { VK_STRUCTURE_TYPE_SURFACE_FULL_SCREEN_EXCLUSIVE_INFO_EXT };
-    fullScreenInfo.fullScreenExclusive = fullScreenExclusive;
+    fullScreenInfo.fullScreenExclusive = VK_FULL_SCREEN_EXCLUSIVE_DISALLOWED_EXT;
 
     VkPhysicalDeviceSurfaceInfo2KHR surfaceInfo = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SURFACE_INFO_2_KHR, &fullScreenInfo };
     surfaceInfo.surface = m_surface;

--- a/src/dxvk/dxvk_presenter.h
+++ b/src/dxvk/dxvk_presenter.h
@@ -32,7 +32,6 @@ namespace dxvk {
     uint32_t            imageCount;
     uint32_t            numFormats;
     VkSurfaceFormatKHR  formats[4];
-    VkFullScreenExclusiveEXT fullScreenExclusive;
   };
 
   /**
@@ -262,12 +261,10 @@ namespace dxvk {
       const PresenterDesc&  desc);
 
     VkResult getSupportedFormats(
-            std::vector<VkSurfaceFormatKHR>& formats,
-            VkFullScreenExclusiveEXT         fullScreenExclusive) const;
+            std::vector<VkSurfaceFormatKHR>& formats) const;
     
     VkResult getSupportedPresentModes(
-            std::vector<VkPresentModeKHR>& modes,
-            VkFullScreenExclusiveEXT       fullScreenExclusive) const;
+            std::vector<VkPresentModeKHR>& modes) const;
     
     VkResult getSwapImages(
             std::vector<VkImage>&     images);

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -819,7 +819,6 @@ namespace dxvk {
      * Main menu won't render after intros     *
      * and CPU bound performance               */
     { R"(\\(PANZERS|PANZERS_Phase_2)\.exe$)", {{
-      { "d3d9.enableDialogMode",            "True"   },
       { "d3d9.cachedDynamicBuffers",        "True"   },
     }} },
     /* DC Universe Online                      *
@@ -1011,11 +1010,6 @@ namespace dxvk {
     { R"(\\DukeForever\.exe$)", {{
       { "d3d9.maxFrameRate",                "60"   },
     }} },
-    /* Indiana Jones and the Emperor's Tomb      *
-     * Fixes intro window being stuck on screen  */
-    { R"(\\indy\.exe$)", {{
-      { "d3d9.enableDialogMode",            "True" },
-    }} },
     /* Anito: Defend a Land Enraged              */
     { R"(\\Anito\.exe$)", {{
       { "d3d9.memoryTrackTest",             "True" },
@@ -1052,7 +1046,6 @@ namespace dxvk {
     /* Need for Speed III: Hot Pursuit           *
        (with the "Modern Patch")                 */
     { R"(\\nfs3\.exe$)", {{
-      { "d3d9.enableDialogMode",            "True" },
       { "d3d9.cachedDynamicBuffers",        "True" },
       { "d3d8.batching",                    "True" },
     }} },
@@ -1061,7 +1054,6 @@ namespace dxvk {
        Won't actually render anything in game     *
        without a memory limit in place            */
     { R"(\\nfs4\.exe$)", {{
-      { "d3d9.enableDialogMode",            "True" },
       { "d3d9.cachedDynamicBuffers",        "True" },
       { "d3d9.memoryTrackTest",             "True" },
       { "d3d9.maxAvailableMemory",           "256" },


### PR DESCRIPTION
So far we're always letting the driver decide whatever it wants to, but since Windows doesn't seem to give drivers any sort of low-level access to anything more modern than D3D9-level presentation APIs we just end up in a situation that sucks for everyone anyway, so migth as well disable it and at least have a slim chance of things like alt+tab actually working.

Should also fix #4465 and related issues, I can't be arsed to add hundreds of app profiles for this garbage.