### PR TITLE
[util] Unify Borderlands games fixes

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -469,17 +469,12 @@ namespace dxvk {
     { R"(\\anarchyonline\.exe$)", {{
       { "d3d9.memoryTrackTest",             "True" },
     }} },
-    /* Borderlands 2 and The Pre Sequel!          * 
-     * Missing lava in Vault of the Warrior       *
-     * without Strict floats                      */
-    { R"(\\Borderlands(2|PreSequel)\.exe$)", {{
+    /* Borderlands, Borderlands 2 and Borderlands: The Pre-Sequel   *
+     * Missing lava in Vault of the Warrior without Strict floats   */
+    { R"(\\(Borderlands(2|PreSequel)?)\.exe$)", {{
       { "d3d9.lenientClear",                "True" },
       { "d3d9.supportDFFormats",            "False" },
       { "d3d9.floatEmulation",              "Strict" },
-    }} },
-    /* Borderlands                                */
-    { R"(\\Borderlands\.exe$)", {{
-      { "d3d9.lenientClear",                "True" },
     }} },
     /* Gothic 3                                   */
     { R"(\\Gothic(3|3Final| III Forsaken Gods)\.exe$)", {{


### PR DESCRIPTION
This PR unifies utility fixes for Borderlands, Borderlands 2 and Borderlands: The Pre-Sequel.

Motives:
- BO2 and Pre-Sequel currently share the same fixes.
- BO has one of the fixes that BO2 and Pre-Sequel have.
- The three games were made by a common developer: "Gearbox Software".
- The three games were published by the same publisher: "2K Games".
- The three games use Unreal Engine 3.
- The release dates are, respectively: 2009-10-26, 2012-09-18 and 2014-10-14 (not too much time difference between releases).

**These changes were not tested.** However, I think they won't cause problems (if there are any).

*Thanks to fuzzyquils and pixelcluster for helping me to craft the necessary RegEx on Discord.*