### PR TITLE
[d3d9] Several Wine device test fixes

### DIFF
--- a/src/d3d8/d3d8_d3d9_util.h
+++ b/src/d3d8/d3d8_d3d9_util.h
@@ -49,13 +49,9 @@ namespace dxvk {
                                    & ~D3DPRASTERCAPS_DEPTHBIAS
                                    & ~D3DPRASTERCAPS_MULTISAMPLE_TOGGLE;
 
-    pCaps8->SrcBlendCaps          &= ~D3DPBLENDCAPS_BLENDFACTOR
-                                   & ~D3DPBLENDCAPS_INVSRCCOLOR2
-                                   & ~D3DPBLENDCAPS_SRCCOLOR2;
+    pCaps8->SrcBlendCaps          &= ~D3DPBLENDCAPS_BLENDFACTOR;
 
-    pCaps8->DestBlendCaps         &= ~D3DPBLENDCAPS_BLENDFACTOR
-                                   & ~D3DPBLENDCAPS_INVSRCCOLOR2
-                                   & ~D3DPBLENDCAPS_SRCCOLOR2;
+    pCaps8->DestBlendCaps         &= ~D3DPBLENDCAPS_BLENDFACTOR;
 
     pCaps8->LineCaps              &= ~D3DLINECAPS_ANTIALIAS;
 

--- a/src/d3d9/d3d9_adapter.cpp
+++ b/src/d3d9/d3d9_adapter.cpp
@@ -412,9 +412,13 @@ namespace dxvk {
                                     | D3DPBLENDCAPS_SRCALPHASAT
                                     | D3DPBLENDCAPS_BOTHSRCALPHA
                                     | D3DPBLENDCAPS_BOTHINVSRCALPHA
-                                    | D3DPBLENDCAPS_BLENDFACTOR
-                                    | D3DPBLENDCAPS_INVSRCCOLOR2
-                                    | D3DPBLENDCAPS_SRCCOLOR2;
+                                    | D3DPBLENDCAPS_BLENDFACTOR;
+
+    // Only 9Ex devices advertise D3DPBLENDCAPS_SRCCOLOR2 and D3DPBLENDCAPS_INVSRCCOLOR2
+    if (m_parent->IsExtended())
+      pCaps->SrcBlendCaps          |= D3DPBLENDCAPS_SRCCOLOR2
+                                    | D3DPBLENDCAPS_INVSRCCOLOR2;
+
     // Destination Blend Caps
     pCaps->DestBlendCaps            = pCaps->SrcBlendCaps;
     // Alpha Comparison Caps

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -2025,10 +2025,6 @@ namespace dxvk {
 
     const uint32_t idx = GetTransformIndex(TransformState);
 
-    // D3D8 state blocks ignore capturing calls to MultiplyTransform().
-    if (unlikely(!m_isD3D8Compatible && ShouldRecord()))
-      return m_recorder->MultiplyStateTransform(idx, pMatrix);
-
     m_state.transforms[idx] = m_state.transforms[idx] * ConvertMatrix(pMatrix);
 
     m_flags.set(D3D9DeviceFlag::DirtyFFVertexData);

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -514,7 +514,8 @@ namespace dxvk {
     if (unlikely(m_losableResourceCounter.load() != 0 && !IsExtended() && m_d3d9Options.countLosableResources)) {
       Logger::warn(str::format("Device reset failed because device still has alive losable resources: Device not reset. Remaining resources: ", m_losableResourceCounter.load()));
       m_deviceLostState = D3D9DeviceLostState::NotReset;
-      return D3DERR_DEVICELOST;
+      // D3D8 returns D3DERR_DEVICELOST here, whereas D3D9 returns D3DERR_INVALIDCALL.
+      return m_isD3D8Compatible ? D3DERR_DEVICELOST : D3DERR_INVALIDCALL;
     }
 
     hr = ResetSwapChain(pPresentationParameters, nullptr);

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -2187,8 +2187,12 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE D3D9DeviceEx::SetClipPlane(DWORD Index, const float* pPlane) {
     D3D9DeviceLock lock = LockDevice();
 
-    if (unlikely(Index >= caps::MaxClipPlanes || !pPlane))
+    if (unlikely(!pPlane))
       return D3DERR_INVALIDCALL;
+
+    // Higher indexes will be capped to the last valid index
+    if (unlikely(Index >= caps::MaxClipPlanes))
+      Index = caps::MaxClipPlanes - 1;
 
     if (unlikely(ShouldRecord()))
       return m_recorder->SetClipPlane(Index, pPlane);
@@ -2213,8 +2217,12 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE D3D9DeviceEx::GetClipPlane(DWORD Index, float* pPlane) {
     D3D9DeviceLock lock = LockDevice();
 
-    if (unlikely(Index >= caps::MaxClipPlanes || !pPlane))
+    if (unlikely(!pPlane))
       return D3DERR_INVALIDCALL;
+
+    // Higher indexes will be capped to the last valid index
+    if (unlikely(Index >= caps::MaxClipPlanes))
+      Index = caps::MaxClipPlanes - 1;
 
     for (uint32_t i = 0; i < 4; i++)
       pPlane[i] = m_state.clipPlanes[Index].coeff[i];

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -1020,6 +1020,13 @@ namespace dxvk {
      */
     void RemoveMappedTexture(D3D9CommonTexture* pTexture);
 
+    /**
+     * \brief Returns whether the device is currently recording a StateBlock
+     */
+    bool ShouldRecord() const {
+      return m_recorder != nullptr;
+    }
+
     bool IsD3D8Compatible() const {
       return m_isD3D8Compatible;
     }
@@ -1159,11 +1166,6 @@ namespace dxvk {
      * \brief Waits until the amount of used staging memory is below a certain threshold.
      */
     void WaitStagingBuffer();
-
-    /**
-     * \brief Returns whether the device is currently recording a StateBlock
-     */
-    inline bool ShouldRecord();
 
     HRESULT               CreateShaderModule(
             D3D9CommonShader*     pShaderModule,

--- a/src/d3d9/d3d9_format.h
+++ b/src/d3d9/d3d9_format.h
@@ -255,4 +255,16 @@ namespace dxvk {
         || format == D3D9Format::DXT5;
   }
 
+  // D3D9 documentation says: IDirect3DSurface9::GetDC is valid on the following formats only:
+  // D3DFMT_R5G6B5, D3DFMT_X1R5G5B5, D3DFMT_R8G8B8, and D3DFMT_X8R8G8B8. However,
+  // the equivalent formats of D3DFMT_A1R5G5B5 and D3DFMT_A8R8G8B8 are also supported.
+  inline bool IsSurfaceGetDCCompatibleFormat(D3D9Format format) {
+    return format == D3D9Format::R5G6B5
+        || format == D3D9Format::X1R5G5B5
+        || format == D3D9Format::A1R5G5B5
+        || format == D3D9Format::R8G8B8
+        || format == D3D9Format::X8R8G8B8
+        || format == D3D9Format::A8R8G8B8;
+  }
+
 }

--- a/src/d3d9/d3d9_stateblock.cpp
+++ b/src/d3d9/d3d9_stateblock.cpp
@@ -243,15 +243,6 @@ namespace dxvk {
   }
 
 
-  HRESULT D3D9StateBlock::MultiplyStateTransform(uint32_t idx, const D3DMATRIX* pMatrix) {
-    m_state.transforms[idx] = m_state.transforms[idx] * ConvertMatrix(pMatrix);
-
-    m_captures.flags.set(D3D9CapturedStateFlag::Transforms);
-    m_captures.transforms.set(idx, true);
-    return D3D_OK;
-  }
-
-
   HRESULT D3D9StateBlock::SetViewport(const D3DVIEWPORT9* pViewport) {
     m_state.viewport = *pViewport;
 

--- a/src/d3d9/d3d9_stateblock.h
+++ b/src/d3d9/d3d9_stateblock.h
@@ -141,8 +141,6 @@ namespace dxvk {
             D3D9TextureStageStateTypes Type,
             DWORD                      Value);
 
-    HRESULT MultiplyStateTransform(uint32_t idx, const D3DMATRIX* pMatrix);
-
     HRESULT SetViewport(const D3DVIEWPORT9* pViewport);
 
     HRESULT SetScissorRect(const RECT* pRect);

--- a/src/d3d9/d3d9_stateblock.h
+++ b/src/d3d9/d3d9_stateblock.h
@@ -388,10 +388,6 @@ namespace dxvk {
     HRESULT SetVertexBoolBitfield(uint32_t idx, uint32_t mask, uint32_t bits);
     HRESULT SetPixelBoolBitfield (uint32_t idx, uint32_t mask, uint32_t bits);
 
-    inline bool IsApplying() {
-      return m_applying;
-    }
-
   private:
 
     void CapturePixelRenderStates();
@@ -407,9 +403,7 @@ namespace dxvk {
     D3D9CapturableState  m_state;
     D3D9StateCaptures    m_captures;
 
-    D3D9DeviceState* m_deviceState;
-
-    bool                 m_applying = false;
+    D3D9DeviceState*     m_deviceState;
 
   };
 

--- a/src/d3d9/d3d9_surface.cpp
+++ b/src/d3d9/d3d9_surface.cpp
@@ -71,7 +71,7 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D9Surface::QueryInterface(REFIID riid, void** ppvObject) {
-    if (ppvObject == nullptr)
+    if (unlikely(ppvObject == nullptr))
       return E_POINTER;
 
     *ppvObject = nullptr;
@@ -101,7 +101,7 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D9Surface::GetDesc(D3DSURFACE_DESC *pDesc) {
-    if (pDesc == nullptr)
+    if (unlikely(pDesc == nullptr))
       return D3DERR_INVALIDCALL;
 
     auto& desc = *(m_texture->Desc());
@@ -190,10 +190,13 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D9Surface::GetDC(HDC *phDC) {
-    if (phDC == nullptr)
+    if (unlikely(phDC == nullptr))
       return D3DERR_INVALIDCALL;
 
     const D3D9_COMMON_TEXTURE_DESC& desc = *m_texture->Desc();
+
+    if (unlikely(!IsSurfaceGetDCCompatibleFormat(desc.Format)))
+      return D3DERR_INVALIDCALL;
 
     D3DLOCKED_RECT lockedRect;
     HRESULT hr = LockRect(&lockedRect, nullptr, 0);
@@ -228,7 +231,7 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D9Surface::ReleaseDC(HDC hDC) {
-    if (m_dcDesc.hDC == nullptr || m_dcDesc.hDC != hDC)
+    if (unlikely(m_dcDesc.hDC == nullptr || m_dcDesc.hDC != hDC))
       return D3DERR_INVALIDCALL;
 
     D3DKMTDestroyDCFromMemory(&m_dcDesc);


### PR DESCRIPTION
~WIP to fix several low hanging d3d9-specific Wine device tests.~ Done.

So far:
- fixed SRCCOLOR2 & INVSCRCCOLOR2 caps being exposed with non-9Ex devices/interfaces (allegedly only WARP does this)
- fixed the `test_refcount` Wine test by preventing device child refcount underruns (we were already doing this in d3d8, thanks to Motor City Online)
- apply MultiplyTransform state block behavior universally (it is not d3d8 specific)
- operations on clip planes with an out of bounds index will reflect on the highest valid clip plane
- add surface format validations to `D3D9Surface::GetDC()` (note that valid formats still don't seem to work properly here, which might be something we'd want to revisit at some point)
- fixed a d3d8/d3d9 difference of expected error codes on failed device reset (due to losable resurces)
- fixed d3d9 state block clearing and recording behavior (the validations work similarly to the system we have in d3d8, but have to be implemented differently due to d3d9 state block implementation differences).