### PR TITLE
[util] Enable deferSurfaceCreation for the Codename Panzer series

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -822,7 +822,8 @@ namespace dxvk {
      * Main menu won't render after intros     *
      * and CPU bound performance               */
     { R"(\\(PANZERS|PANZERS_Phase_2)\.exe$)", {{
-      { "d3d9.cachedDynamicBuffers",        "True"   },
+      { "d3d9.deferSurfaceCreation",        "True" },
+      { "d3d9.cachedDynamicBuffers",        "True" },
     }} },
     /* DC Universe Online                      *
      * Freezes after alt tabbing               */


### PR DESCRIPTION
Intros are played back using ddraw, and main menu isn't rendered otherwise.