### PR TITLE
[d3d9] Device import API

### DIFF
--- a/src/d3d9/d3d9_interfaces.h
+++ b/src/d3d9/d3d9_interfaces.h
@@ -3,6 +3,27 @@
 #include "d3d9_include.h"
 #include "../vulkan/vulkan_loader.h"
 
+using D3D9VkQueueLockCallback = void(bool);
+
+/**
+ * \brief Device import info
+ */
+struct D3D9VkDeviceImportInfo {
+  VkDevice                          device;
+  D3DDEVTYPE                        deviceType;
+  VkQueue                           graphicsQueue;
+  uint32_t                          graphicsQueueFamily;
+  VkQueue                           transferQueue;
+  uint32_t                          transferQueueFamily;
+  VkQueue                           sparseQueue;
+  uint32_t                          sparseQueueFamily;
+  uint32_t                          extensionCount;
+  const char**                      extensionNames;
+  const VkPhysicalDeviceFeatures2*  features;
+  D3D9VkQueueLockCallback*          queueLockCallback;
+};
+
+
 /**
  * \brief D3D9 interface for Vulkan interop
  *
@@ -28,6 +49,39 @@ ID3D9VkInteropInterface : public IUnknown {
   virtual void STDMETHODCALLTYPE GetPhysicalDeviceHandle(
           UINT                  Adapter,
           VkPhysicalDevice*     pPhysicalDevice) = 0;
+
+  /**
+   * \brief Gets the VkDeviceCreateInfo for a D3D9 adapter
+   *
+   * \param [in] Adapter Adapter ordinal
+   * \param [out] pCreateInfo The Vulkan device create info
+   */
+  virtual HRESULT STDMETHODCALLTYPE GetDeviceCreateInfo(
+          UINT                   Adapter,
+          VkDeviceCreateInfo*    pCreateInfo) = 0;
+
+  /**
+   * \brief Create a D3D9 device for an existing Vulkan device
+   * 
+   * It is suggested to create the device with the
+   * VkDeviceCreateInfo returned by GetDeviceCreateInfo,
+   * which will specify everything the device needs for
+   * DXVK to function.
+   * 
+   * \param [in] Adapter Adapter ordinal
+   * \param [in] ... Arguments to IDirect3D9Ex::CreateDeviceEx
+   * \param [in] pInfo Info about the created device
+   * \param [out] ppReturnedDevice The D3D9 device
+   */
+  virtual HRESULT STDMETHODCALLTYPE ImportDevice(
+          UINT                        Adapter,
+          D3DDEVTYPE                  DeviceType,
+          HWND                        hFocusWindow,
+          DWORD                       BehaviorFlags,
+          D3DPRESENT_PARAMETERS*      pPresentationParameters,
+          D3DDISPLAYMODEEX*           pFullscreenDisplayMode,
+          D3D9VkDeviceImportInfo*     pInfo,
+          IDirect3DDevice9Ex**        ppReturnedDevice) = 0;
 };
 
 /**

--- a/src/d3d9/d3d9_interfaces.h
+++ b/src/d3d9/d3d9_interfaces.h
@@ -6,6 +6,15 @@
 using D3D9VkQueueLockCallback = void(bool);
 
 /**
+ * \brief Device queue info
+ */
+struct D3D9VkQueueFamilies {
+  uint32_t graphics;
+  uint32_t transfer;
+  uint32_t sparse;
+};
+
+/**
  * \brief Device import info
  */
 struct D3D9VkDeviceImportInfo {
@@ -55,10 +64,12 @@ ID3D9VkInteropInterface : public IUnknown {
    *
    * \param [in] Adapter Adapter ordinal
    * \param [out] pCreateInfo The Vulkan device create info
+   * \param [out] pQueueFamilies The required queue families
    */
   virtual HRESULT STDMETHODCALLTYPE GetDeviceCreateInfo(
           UINT                   Adapter,
-          VkDeviceCreateInfo*    pCreateInfo) = 0;
+          VkDeviceCreateInfo*    pCreateInfo,
+          D3D9VkQueueFamilies*   pQueueFamilies) = 0;
 
   /**
    * \brief Create a D3D9 device for an existing Vulkan device

--- a/src/d3d9/d3d9_interfaces.h
+++ b/src/d3d9/d3d9_interfaces.h
@@ -6,12 +6,14 @@
 using D3D9VkQueueLockCallback = void(bool);
 
 /**
- * \brief Device queue info
+ * \brief Device create info
  */
-struct D3D9VkQueueFamilies {
-  uint32_t graphics;
-  uint32_t transfer;
-  uint32_t sparse;
+struct D3D9VkDeviceCreateInfo {
+  VkDeviceCreateInfo*         info;
+  VkPhysicalDeviceFeatures2*  features;
+  uint32_t                    graphics;
+  uint32_t                    transfer;
+  uint32_t                    sparse;
 };
 
 /**
@@ -62,14 +64,15 @@ ID3D9VkInteropInterface : public IUnknown {
   /**
    * \brief Gets the VkDeviceCreateInfo for a D3D9 adapter
    *
+   * Pointers returned are guaranteed to be valid until
+   * the next call to GetDeviceCreateInfo or Release.
+   * 
    * \param [in] Adapter Adapter ordinal
    * \param [out] pCreateInfo The Vulkan device create info
-   * \param [out] pQueueFamilies The required queue families
    */
   virtual HRESULT STDMETHODCALLTYPE GetDeviceCreateInfo(
-          UINT                   Adapter,
-          VkDeviceCreateInfo*    pCreateInfo,
-          D3D9VkQueueFamilies*   pQueueFamilies) = 0;
+          UINT                        Adapter,
+          D3D9VkDeviceCreateInfo*     pCreateInfo) = 0;
 
   /**
    * \brief Create a D3D9 device for an existing Vulkan device

--- a/src/d3d9/d3d9_interop.cpp
+++ b/src/d3d9/d3d9_interop.cpp
@@ -53,8 +53,9 @@ namespace dxvk {
 
   HRESULT STDMETHODCALLTYPE D3D9VkInteropInterface::GetDeviceCreateInfo(
         UINT                   Adapter,
-        VkDeviceCreateInfo*    pCreateInfo) {
-    if (unlikely(pCreateInfo == nullptr))
+        VkDeviceCreateInfo*    pCreateInfo,
+        D3D9VkQueueFamilies*   pQueueFamilies) {
+    if (unlikely(pCreateInfo == nullptr && pQueueFamilies == nullptr))
       return D3DERR_INVALIDCALL;
 
     auto* adapter = m_interface->GetAdapter(Adapter);
@@ -68,7 +69,14 @@ namespace dxvk {
     if (!dxvkAdapter->getDeviceCreateInfo(m_interface->GetInstance(), D3D9DeviceEx::GetDeviceFeatures(dxvkAdapter), false, createInfo))
       return D3DERR_INVALIDCALL;
 
-    *pCreateInfo = createInfo.info;
+    if (pCreateInfo != nullptr)
+      *pCreateInfo = createInfo.info;
+
+    if (pQueueFamilies != nullptr) {
+      pQueueFamilies->graphics = createInfo.queueFamilies.graphics;
+      pQueueFamilies->transfer = createInfo.queueFamilies.transfer;
+      pQueueFamilies->sparse   = createInfo.queueFamilies.sparse;
+    }
 
     return D3D_OK;
   }

--- a/src/d3d9/d3d9_interop.cpp
+++ b/src/d3d9/d3d9_interop.cpp
@@ -52,10 +52,9 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D9VkInteropInterface::GetDeviceCreateInfo(
-        UINT                   Adapter,
-        VkDeviceCreateInfo*    pCreateInfo,
-        D3D9VkQueueFamilies*   pQueueFamilies) {
-    if (unlikely(pCreateInfo == nullptr && pQueueFamilies == nullptr))
+        UINT                        Adapter,
+        D3D9VkDeviceCreateInfo*     pCreateInfo) {
+    if (unlikely(pCreateInfo == nullptr))
       return D3DERR_INVALIDCALL;
 
     auto* adapter = m_interface->GetAdapter(Adapter);
@@ -65,18 +64,18 @@ namespace dxvk {
 
     auto dxvkAdapter = adapter->GetDXVKAdapter();
 
-    DxvkDeviceCreateInfo createInfo;
+    DxvkDeviceCreateInfo& createInfo = m_deviceCreateInfos[Adapter];
     if (!dxvkAdapter->getDeviceCreateInfo(m_interface->GetInstance(), D3D9DeviceEx::GetDeviceFeatures(dxvkAdapter), false, createInfo))
       return D3DERR_INVALIDCALL;
 
-    if (pCreateInfo != nullptr)
-      *pCreateInfo = createInfo.info;
+    createInfo.info.enabledLayerCount   = 0;
+    createInfo.info.ppEnabledLayerNames = nullptr;
 
-    if (pQueueFamilies != nullptr) {
-      pQueueFamilies->graphics = createInfo.queueFamilies.graphics;
-      pQueueFamilies->transfer = createInfo.queueFamilies.transfer;
-      pQueueFamilies->sparse   = createInfo.queueFamilies.sparse;
-    }
+    pCreateInfo->info     = &createInfo.info;
+    pCreateInfo->features = &createInfo.features.core;
+    pCreateInfo->graphics = createInfo.queueFamilies.graphics;
+    pCreateInfo->transfer = createInfo.queueFamilies.transfer;
+    pCreateInfo->sparse   = createInfo.queueFamilies.sparse;
 
     return D3D_OK;
   }

--- a/src/d3d9/d3d9_interop.h
+++ b/src/d3d9/d3d9_interop.h
@@ -2,6 +2,7 @@
 
 #include "d3d9_interfaces.h"
 #include "d3d9_multithread.h"
+#include "../dxvk/dxvk_adapter.h"
 
 namespace dxvk {
 
@@ -35,9 +36,8 @@ namespace dxvk {
             VkPhysicalDevice*     pPhysicalDevice);
 
     HRESULT STDMETHODCALLTYPE GetDeviceCreateInfo(
-            UINT                   Adapter,
-            VkDeviceCreateInfo*    pCreateInfo,
-            D3D9VkQueueFamilies*   pQueueFamilies);
+            UINT                        Adapter,
+            D3D9VkDeviceCreateInfo*     pCreateInfo);
 
     HRESULT STDMETHODCALLTYPE ImportDevice(
             UINT                        Adapter,
@@ -52,6 +52,7 @@ namespace dxvk {
   private:
 
     D3D9InterfaceEx* m_interface;
+    std::unordered_map<UINT, DxvkDeviceCreateInfo> m_deviceCreateInfos;
 
   };
 

--- a/src/d3d9/d3d9_interop.h
+++ b/src/d3d9/d3d9_interop.h
@@ -34,6 +34,20 @@ namespace dxvk {
             UINT                  Adapter,
             VkPhysicalDevice*     pPhysicalDevice);
 
+    HRESULT STDMETHODCALLTYPE GetDeviceCreateInfo(
+            UINT                   Adapter,
+            VkDeviceCreateInfo*    pCreateInfo);
+
+    HRESULT STDMETHODCALLTYPE ImportDevice(
+            UINT                        Adapter,
+            D3DDEVTYPE                  DeviceType,
+            HWND                        hFocusWindow,
+            DWORD                       BehaviorFlags,
+            D3DPRESENT_PARAMETERS*      pPresentationParameters,
+            D3DDISPLAYMODEEX*           pFullscreenDisplayMode,
+            D3D9VkDeviceImportInfo*     pInfo,
+            IDirect3DDevice9Ex**        ppReturnedDevice);
+
   private:
 
     D3D9InterfaceEx* m_interface;

--- a/src/d3d9/d3d9_interop.h
+++ b/src/d3d9/d3d9_interop.h
@@ -36,7 +36,8 @@ namespace dxvk {
 
     HRESULT STDMETHODCALLTYPE GetDeviceCreateInfo(
             UINT                   Adapter,
-            VkDeviceCreateInfo*    pCreateInfo);
+            VkDeviceCreateInfo*    pCreateInfo,
+            D3D9VkQueueFamilies*   pQueueFamilies);
 
     HRESULT STDMETHODCALLTYPE ImportDevice(
             UINT                        Adapter,

--- a/src/dxvk/dxvk_adapter.cpp
+++ b/src/dxvk/dxvk_adapter.cpp
@@ -678,10 +678,16 @@ namespace dxvk {
     // Create device loader
     Rc<vk::DeviceFn> vkd = new vk::DeviceFn(m_vki, false, args.device);
 
-    // We only support one queue when importing devices, and no sparse.
+    // By default, we only use one queue when importing devices, and no sparse.
     DxvkDeviceQueueSet queues = { };
     queues.graphics = { args.queue, args.queueFamily };
     queues.transfer = queues.graphics;
+
+    if (args.transferQueue != VK_NULL_HANDLE && args.transferQueueFamily != VK_QUEUE_FAMILY_IGNORED)
+      queues.transfer = { args.transferQueue, args.transferQueueFamily };
+
+    if (args.sparseQueue != VK_NULL_HANDLE && args.sparseQueueFamily != VK_QUEUE_FAMILY_IGNORED)
+      queues.sparse = { args.sparseQueue, args.sparseQueueFamily };
 
     return new DxvkDevice(instance, this, vkd, enabledFeatures, queues, args.queueCallback);
   }

--- a/src/dxvk/dxvk_adapter.h
+++ b/src/dxvk/dxvk_adapter.h
@@ -69,6 +69,16 @@ namespace dxvk {
     std::atomic<uint64_t> used = { 0u };
   };
 
+  /**
+   * \brief Device create info
+   */
+  struct DxvkDeviceCreateInfo {
+    VkDeviceCreateInfo      info;
+    DxvkAdapterQueueIndices queueFamilies;
+    DxvkNameSet             extensionsEnabled;
+    DxvkDeviceExtensions    devExtensions;
+    bool                    enableCudaInterop;
+  };
 
   /**
    * \brief Device import info
@@ -213,6 +223,21 @@ namespace dxvk {
       const DxvkNameSet&        extensions);
     
     /**
+     * \brief Gets device create info
+     *
+     * \param [in] instance Parent instance
+     * \param [in] enabledFeatures Device features
+     * \param [in] logDeviceInfo If true, prints device info
+     * \param [out] info Device create info
+     * \returns true if succeeded
+     */
+    bool getDeviceCreateInfo(
+      const Rc<DxvkInstance>&       instance,
+            DxvkDeviceFeatures      enabledFeatures,
+            bool                    logDeviceInfo,
+            DxvkDeviceCreateInfo&   createInfo) const;
+
+    /**
      * \brief Creates a DXVK device
      * 
      * Creates a logical device for this adapter.
@@ -343,7 +368,7 @@ namespace dxvk {
             VkQueueFlags          flags) const;
     
     std::vector<DxvkExt*> getExtensionList(
-            DxvkDeviceExtensions&   devExtensions);
+            DxvkDeviceExtensions&   devExtensions) const;
 
     static void initFeatureChain(
             DxvkDeviceFeatures&   enabledFeatures,

--- a/src/dxvk/dxvk_adapter.h
+++ b/src/dxvk/dxvk_adapter.h
@@ -73,11 +73,14 @@ namespace dxvk {
    * \brief Device create info
    */
   struct DxvkDeviceCreateInfo {
-    VkDeviceCreateInfo      info;
-    DxvkAdapterQueueIndices queueFamilies;
-    DxvkNameSet             extensionsEnabled;
-    DxvkDeviceExtensions    devExtensions;
-    bool                    enableCudaInterop;
+    VkDeviceCreateInfo                    info;
+    DxvkAdapterQueueIndices               queueFamilies;
+    DxvkNameSet                           extensionsEnabled;
+    DxvkNameList                          extensionNameList;
+    DxvkDeviceExtensions                  devExtensions;
+    bool                                  enableCudaInterop;
+    std::vector<VkDeviceQueueCreateInfo>  queueInfos;
+    DxvkDeviceFeatures                    features;
   };
 
   /**

--- a/src/dxvk/dxvk_adapter.h
+++ b/src/dxvk/dxvk_adapter.h
@@ -84,13 +84,19 @@ namespace dxvk {
    * \brief Device import info
    */
   struct DxvkDeviceImportInfo {
-    VkDevice device;
-    VkQueue queue;
-    uint32_t queueFamily;
-    uint32_t extensionCount;
-    const char** extensionNames;
-    const VkPhysicalDeviceFeatures2* features;
-    DxvkQueueCallback queueCallback;
+    VkDevice                          device;
+    VkQueue                           queue;
+    uint32_t                          queueFamily;
+    uint32_t                          extensionCount;
+    const char**                      extensionNames;
+    const VkPhysicalDeviceFeatures2*  features;
+    DxvkQueueCallback                 queueCallback;
+
+    // Optional additional queues
+    VkQueue                           transferQueue       = VK_NULL_HANDLE;
+    uint32_t                          transferQueueFamily = VK_QUEUE_FAMILY_IGNORED;
+    VkQueue                           sparseQueue         = VK_NULL_HANDLE;
+    uint32_t                          sparseQueueFamily   = VK_QUEUE_FAMILY_IGNORED;
   };
 
   /**


### PR DESCRIPTION
**EDIT**: See below. Instead of creating an async compute queue we instead allow the interop client to provide their own device

<s>Currently, the DXVK interop app I'm working on needs to use the async compute queue. However, DXVK creates the device without any queues from the compute family. This PR simply adds an extra compute queue to the `VkDeviceCreateInfo`.

If there's some reason that we'd want to avoid doing this unless the interop client asks for it, for example if it might cause unexpected performance or behavior changes, then I can add another commit to this PR to make it conditional, but I wouldn't expect this to have any side effects at all since DXVK never uses async compute.</s>