### PR TITLE
[d3d9] Fix race condition in PIX events

### DIFF
--- a/src/d3d9/d3d9_annotation.cpp
+++ b/src/d3d9/d3d9_annotation.cpp
@@ -127,6 +127,7 @@ namespace dxvk {
   INT STDMETHODCALLTYPE D3D9UserDefinedAnnotation::BeginEvent(
           D3DCOLOR                Color,
           LPCWSTR                 Name) {
+    D3D9DeviceLock lock = m_container->LockDevice();
     m_container->EmitCs([color = Color, labelName = dxvk::str::fromws(Name)](DxvkContext *ctx) {
       VkDebugUtilsLabelEXT label;
       label.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_LABEL_EXT;
@@ -143,6 +144,7 @@ namespace dxvk {
 
 
   INT STDMETHODCALLTYPE D3D9UserDefinedAnnotation::EndEvent() {
+    D3D9DeviceLock lock = m_container->LockDevice();
     m_container->EmitCs([](DxvkContext *ctx) {
       ctx->endDebugLabel();
     });
@@ -155,6 +157,7 @@ namespace dxvk {
   void STDMETHODCALLTYPE D3D9UserDefinedAnnotation::SetMarker(
           D3DCOLOR                Color,
           LPCWSTR                 Name) {
+    D3D9DeviceLock lock = m_container->LockDevice();
     m_container->EmitCs([color = Color, labelName = dxvk::str::fromws(Name)](DxvkContext *ctx) {
       VkDebugUtilsLabelEXT label;
       label.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_LABEL_EXT;


### PR DESCRIPTION
The `D3DPERF_` PIX event functions can crash the app due to a race condition. Typically this means that the calls to `EmitCs` trigger an access violation because `m_csChunk` is null. This PR fixes it by simply locking the device before calling `EmitCs` for these functions. The issue is worse in complex pipelines with a lot of markers.