### PR TITLE
[d3d9] Allow interop to query enabled instance extensions

### DIFF
--- a/src/d3d9/d3d9_interfaces.h
+++ b/src/d3d9/d3d9_interfaces.h
@@ -28,6 +28,17 @@ ID3D9VkInteropInterface : public IUnknown {
   virtual void STDMETHODCALLTYPE GetPhysicalDeviceHandle(
           UINT                  Adapter,
           VkPhysicalDevice*     pPhysicalDevice) = 0;
+
+  /**
+   * \brief Gets a list of enabled instance extensions
+   * 
+   * \param [out] pExtensionCount Number of extensions
+   * \param [out] ppExtensions List of extension names
+   * \returns D3DERR_MOREDATA if the list was truncated
+   */
+  virtual HRESULT STDMETHODCALLTYPE GetInstanceExtensions(
+          UINT*                       pExtensionCount,
+    const char**                      ppExtensions) = 0;
 };
 
 /**

--- a/src/d3d9/d3d9_interop.cpp
+++ b/src/d3d9/d3d9_interop.cpp
@@ -51,6 +51,41 @@ namespace dxvk {
     }
   }
 
+  HRESULT STDMETHODCALLTYPE D3D9VkInteropInterface::GetInstanceExtensions(
+          UINT* pExtensionCount,
+    const char** ppExtensions) {
+    if (pExtensionCount == nullptr)
+      return D3DERR_INVALIDCALL;
+
+    auto extensions = m_interface->GetInstance()->extensions().getExtensionList();
+    if (ppExtensions == nullptr) {
+      // Count extensions
+      UINT count = 0;
+      for (const DxvkExt* ext : extensions) {
+        if (ext && *ext)
+          count++;
+      }
+
+      *pExtensionCount = count;
+      return D3D_OK;
+    } else {
+      // Write extensions
+      UINT count = 0;
+      UINT maxCount = *pExtensionCount;
+      for (const DxvkExt* ext : extensions) {
+        if (ext && *ext) {
+          if (count < maxCount)
+            ppExtensions[count++] = ext->name();
+          else
+            break;
+        }
+      }
+
+      *pExtensionCount = count;
+      return (count < maxCount) ? D3DERR_MOREDATA : D3D_OK;
+    }
+  }
+
   ////////////////////////////////
   // Texture Interop
   ///////////////////////////////

--- a/src/d3d9/d3d9_interop.h
+++ b/src/d3d9/d3d9_interop.h
@@ -34,6 +34,10 @@ namespace dxvk {
             UINT                  Adapter,
             VkPhysicalDevice*     pPhysicalDevice);
 
+    HRESULT STDMETHODCALLTYPE GetInstanceExtensions(
+            UINT*                 pExtensionCount,
+      const char**                ppExtensions);
+
   private:
 
     D3D9InterfaceEx* m_interface;

--- a/src/dxvk/dxvk_extensions.h
+++ b/src/dxvk/dxvk_extensions.h
@@ -343,6 +343,14 @@ namespace dxvk {
     DxvkExt extSurfaceMaintenance1          = { VK_EXT_SURFACE_MAINTENANCE_1_EXTENSION_NAME,            DxvkExtMode::Optional };
     DxvkExt khrGetSurfaceCapabilities2      = { VK_KHR_GET_SURFACE_CAPABILITIES_2_EXTENSION_NAME,       DxvkExtMode::Optional };
     DxvkExt khrSurface                      = { VK_KHR_SURFACE_EXTENSION_NAME,                          DxvkExtMode::Required };
+
+    /**
+     * \brief Get list of supported extensions
+     * \returns List of supported extensions
+     */
+    std::initializer_list<const DxvkExt*> getExtensionList() const {
+      return { &extDebugUtils, &extSurfaceMaintenance1, &khrGetSurfaceCapabilities2, &khrSurface };
+    }
   };
   
 }


### PR DESCRIPTION
Just adds a simple function to get a list of enabled instance extensions. This allows the interop user to, for example, check if debug utils are enabled.