### PR TITLE
[d3d9] Add device import interop API

### DIFF
--- a/src/d3d9/d3d9_interfaces.h
+++ b/src/d3d9/d3d9_interfaces.h
@@ -4,6 +4,30 @@
 #include "../vulkan/vulkan_loader.h"
 
 /**
+ * \brief Queue family and handle
+ */
+struct D3D9VkDeviceQueue {
+  uint32_t family = VK_QUEUE_FAMILY_IGNORED;
+  VkQueue  queue  = VK_NULL_HANDLE;
+};
+
+/**
+ * \brief D3D9 VkDevice import info
+ */
+struct D3D9VkDeviceImportInfo {
+    VkDevice                          device          = VK_NULL_HANDLE;
+    D3D9VkDeviceQueue                 graphicsQueue   = {};
+    uint32_t                          extensionCount  = 0u;
+    const char**                      extensionNames  = nullptr;
+    const VkPhysicalDeviceFeatures2*  features        = nullptr;
+    D3DDEVTYPE                        deviceType      = D3DDEVTYPE_HAL;
+    HWND                              focusWindow     = NULL;
+    DWORD                             behaviorFlags   = 0u;
+    D3DPRESENT_PARAMETERS*            presentParams   = nullptr;
+    D3DDISPLAYMODEEX*                 fullscreenMode  = nullptr;
+};
+
+/**
  * \brief D3D9 interface for Vulkan interop
  *
  * Provides access to the instance and physical device
@@ -115,6 +139,23 @@ ID3D9VkInteropInterface1 : public ID3D9VkInteropInterface {
           UINT                        Adapter,
           size_t*                     Size,
           void*                       Data) = 0;
+
+  /**
+   * \brief Create a D3D9 device for an existing Vulkan device.
+   * 
+   * The device must have been created with the following rules:
+   * - All extensions returned by \c QueryDeviceExtensions \e must be enabled
+   * - The \c graphicsQueue \e must support both graphics and compute operations
+   * - All features returned by \c QueryDeviceFeatures \e must be enabled
+   * 
+   * \param [in] Adapter Adapter ordinal
+   * \param [in] pInfo Info about the created device
+   * \param [out] ppReturnedDevice The D3D9 device
+   */
+  virtual HRESULT STDMETHODCALLTYPE ImportDevice(
+          UINT                     Adapter,
+          D3D9VkDeviceImportInfo*  pInfo,
+          IDirect3DDevice9Ex**     ppReturnedDevice) = 0;
 };
 
 /**

--- a/src/d3d9/d3d9_interfaces.h
+++ b/src/d3d9/d3d9_interfaces.h
@@ -17,6 +17,8 @@ struct D3D9VkDeviceQueue {
 struct D3D9VkDeviceImportInfo {
     VkDevice                          device          = VK_NULL_HANDLE;
     D3D9VkDeviceQueue                 graphicsQueue   = {};
+    D3D9VkDeviceQueue                 transferQueue   = {};
+    D3D9VkDeviceQueue                 sparseQueue     = {};
     uint32_t                          extensionCount  = 0u;
     const char**                      extensionNames  = nullptr;
     const VkPhysicalDeviceFeatures2*  features        = nullptr;
@@ -146,6 +148,10 @@ ID3D9VkInteropInterface1 : public ID3D9VkInteropInterface {
    * The device must have been created with the following rules:
    * - All extensions returned by \c QueryDeviceExtensions \e must be enabled
    * - The \c graphicsQueue \e must support both graphics and compute operations
+   * - The \c transferQueue is optional if the \c graphicsQueue has \c VK_QUEUE_TRANSFER_BIT,
+   *   but you may still wish to supply a separate transfer queue for concurrency.
+   * - The \c sparseQueue is optional if the \c graphicsQueue has \c VK_QUEUE_SPARSE_BINDING_BIT,
+   *   in which case it is preferred to use the graphics queue for sparse binding.
    * - All features returned by \c QueryDeviceFeatures \e must be enabled
    * 
    * \param [in] Adapter Adapter ordinal

--- a/src/d3d9/d3d9_interfaces.h
+++ b/src/d3d9/d3d9_interfaces.h
@@ -48,6 +48,73 @@ ID3D9VkInteropInterface1 : public ID3D9VkInteropInterface {
   virtual HRESULT STDMETHODCALLTYPE GetInstanceExtensions(
           UINT*                       pExtensionCount,
     const char**                      ppExtensions) = 0;
+
+  /**
+   * \brief Queries required extensions
+   *
+   * All returned extensions \e must be enabled when
+   * using an external Vulkan device for DXVK.
+   * 
+   * \param [in] Adapter Adapter ordinal
+   * \param [in,out] Count Number of extensions
+   * \param [out] Extensions Extension properties, optional
+   * \returns \c D3D_OK on success, or if Extensions is \c nullptr
+   * \returns \c D3DERR_INVALIDCALL if the adapter cannot be found
+   * \returns \c D3DERR_INVALIDCALL if \c Count is nullptr
+   * \returns \c D3DERR_MOREDATA if the extension array is too small
+   */
+  virtual HRESULT STDMETHODCALLTYPE QueryDeviceExtensions(
+          UINT                        Adapter,
+          uint32_t*                   Count,
+          VkExtensionProperties*      Extensions) = 0;
+
+  /**
+   * \brief Queries device queue create infos
+   *
+   * Writes an array of queues that can be used to create a Vulkan device
+   * compatible with DXVK. Applications are free to add or remove queues
+   * as they wish, however disabling queues may reduce performance, and at
+   * least one queue \e must support both graphics and, compute operations.
+   * For each written member of \c queues, if \c pQueuePriorities is non-null,
+   * it must point to an array of \c queueCount floats that can be \e written.
+   * As a result, this function needs to be called up to three times to query
+   * queue properties.
+   * 
+   * \param [in] Adapter Adapter ordinal
+   * \param [in,out] Count Number of queues to enable
+   * \param [out] Queues Queue properties
+   * \returns \c D3D_OK on success, or if Queues is \c nullptr
+   * \returns \c D3DERR_INVALIDCALL if the adapter cannot be found
+   * \returns \c D3DERR_INVALIDCALL if \c Count is nullptr
+   * \returns \c D3DERR_MOREDATA if if the queue array is too small
+   */
+  virtual HRESULT STDMETHODCALLTYPE QueryDeviceQueues(
+          UINT                        Adapter,
+          uint32_t*                   Count,
+          VkDeviceQueueCreateInfo*    Queues) = 0;
+
+  /**
+   * \brief Queries required device features
+   *
+   * Returns a blob of memory containing feature structs, led by a single
+   * \c VkPhysicalDeviceFeatures2 structure at the start. The \c pNext
+   * chain includes all feature structs that are both known to DXVK and
+   * supported by the device. Applications can enable additional features
+   * by scanning feature structs by their \c sType, and change the \c pNext
+   * chain to insert feature structs that DXVK is not aware of.
+   * 
+   * \param [in] Adapter Adapter ordinal
+   * \param [in,out] Size Memory data size, in bytes
+   * \param [out] Data Pointer to meory blob of \c Size bytes
+   * \returns \c D3D_OK on success, or if Data is \c nullptr
+   * \returns \c D3DERR_INVALIDCALL if the adapter cannot be found
+   * \returns \c D3DERR_INVALIDCALL if \c Size is nullptr
+   * \returns \c D3DERR_MOREDATA if the blob at \c Data is too small
+   */
+  virtual HRESULT STDMETHODCALLTYPE QueryDeviceFeatures(
+          UINT                        Adapter,
+          size_t*                     Size,
+          void*                       Data) = 0;
 };
 
 /**

--- a/src/d3d9/d3d9_interop.cpp
+++ b/src/d3d9/d3d9_interop.cpp
@@ -73,6 +73,60 @@ namespace dxvk {
     return (count < maxCount) ? D3DERR_MOREDATA : D3D_OK;
   }
 
+  HRESULT STDMETHODCALLTYPE D3D9VkInteropInterface::QueryDeviceExtensions(
+         UINT                      Adapter,
+         uint32_t*                 Count,
+         VkExtensionProperties*    Extensions) {
+    if (unlikely(Count == nullptr))
+      return D3DERR_INVALIDCALL;
+
+    auto* adapter = m_interface->GetAdapter(Adapter);
+    if (unlikely(adapter == nullptr))
+      return D3DERR_INVALIDCALL;
+
+    auto dxvkAdapter = adapter->GetDXVKAdapter();
+    if (!dxvkAdapter->capabilities().queryDeviceExtensions(Count, Extensions))
+      return D3DERR_MOREDATA;
+
+    return D3D_OK;
+  }
+
+  HRESULT STDMETHODCALLTYPE D3D9VkInteropInterface::QueryDeviceQueues(
+        UINT                      Adapter,
+        uint32_t*                 Count,
+        VkDeviceQueueCreateInfo*  Queues) {
+    if (unlikely(Count == nullptr))
+      return D3DERR_INVALIDCALL;
+
+    auto* adapter = m_interface->GetAdapter(Adapter);
+    if (unlikely(adapter == nullptr))
+      return D3DERR_INVALIDCALL;
+
+    auto dxvkAdapter = adapter->GetDXVKAdapter();
+    if (!dxvkAdapter->capabilities().queryDeviceQueues(Count, Queues))
+      return D3DERR_MOREDATA;
+
+    return D3D_OK;
+  }
+
+  HRESULT STDMETHODCALLTYPE D3D9VkInteropInterface::QueryDeviceFeatures(
+        UINT                      Adapter,
+        size_t*                   Size,
+        void*                     Data) {
+    if (unlikely(Size == nullptr))
+      return D3DERR_INVALIDCALL;
+
+    auto* adapter = m_interface->GetAdapter(Adapter);
+    if (unlikely(adapter == nullptr))
+      return D3DERR_INVALIDCALL;
+
+    auto dxvkAdapter = adapter->GetDXVKAdapter();
+    if (!dxvkAdapter->capabilities().queryDeviceFeatures(Size, Data))
+      return D3DERR_MOREDATA;
+
+    return D3D_OK;
+  }
+
   ////////////////////////////////
   // Texture Interop
   ///////////////////////////////

--- a/src/d3d9/d3d9_interop.cpp
+++ b/src/d3d9/d3d9_interop.cpp
@@ -149,13 +149,17 @@ namespace dxvk {
     auto dxvkAdapter = adapter->GetDXVKAdapter();
 
     DxvkDeviceImportInfo info;
-    info.device         = pInfo->device;
-    info.queue          = pInfo->graphicsQueue.queue;
-    info.queueFamily    = pInfo->graphicsQueue.family;
-    info.extensionCount = pInfo->extensionCount;
-    info.extensionNames = pInfo->extensionNames;
-    info.features       = pInfo->features;
-    info.queueCallback  = nullptr;
+    info.device               = pInfo->device;
+    info.queue                = pInfo->graphicsQueue.queue;
+    info.queueFamily          = pInfo->graphicsQueue.family;
+    info.transferQueue        = pInfo->transferQueue.queue;
+    info.transferQueueFamily  = pInfo->transferQueue.family;
+    info.sparseQueue          = pInfo->sparseQueue.queue;
+    info.sparseQueueFamily    = pInfo->sparseQueue.family;
+    info.extensionCount       = pInfo->extensionCount;
+    info.extensionNames       = pInfo->extensionNames;
+    info.features             = pInfo->features;
+    info.queueCallback        = nullptr;
 
     try {
       auto dxvkDevice = dxvkAdapter->importDevice(info);

--- a/src/d3d9/d3d9_interop.h
+++ b/src/d3d9/d3d9_interop.h
@@ -40,6 +40,21 @@ namespace dxvk {
             UINT*                 pExtensionCount,
       const char**                ppExtensions);
 
+    HRESULT STDMETHODCALLTYPE QueryDeviceExtensions(
+            UINT                      Adapter,
+            uint32_t*                 Count,
+            VkExtensionProperties*    Extensions);
+
+    HRESULT STDMETHODCALLTYPE QueryDeviceQueues(
+            UINT                      Adapter,
+            uint32_t*                 Count,
+            VkDeviceQueueCreateInfo*  Queues);
+
+    HRESULT STDMETHODCALLTYPE QueryDeviceFeatures(
+            UINT                      Adapter,
+            size_t*                   Size,
+            void*                     Data);
+
   private:
 
     D3D9InterfaceEx* m_interface;

--- a/src/d3d9/d3d9_interop.h
+++ b/src/d3d9/d3d9_interop.h
@@ -55,6 +55,11 @@ namespace dxvk {
             size_t*                   Size,
             void*                     Data);
 
+    HRESULT STDMETHODCALLTYPE ImportDevice(
+          UINT                        Adapter,
+          D3D9VkDeviceImportInfo*     pInfo,
+          IDirect3DDevice9Ex**        ppReturnedDevice);
+
   private:
 
     D3D9InterfaceEx* m_interface;

--- a/src/dxvk/dxvk_adapter.cpp
+++ b/src/dxvk/dxvk_adapter.cpp
@@ -242,17 +242,36 @@ namespace dxvk {
     const DxvkDeviceImportInfo& args) {
     const float queuePriority = 1.0f;
 
-    VkDeviceQueueCreateInfo queueInfo = { VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO };
-    queueInfo.queueFamilyIndex = args.queueFamily;
-    queueInfo.queueCount = 1u;
-    queueInfo.pQueuePriorities = &queuePriority;
+    std::vector<VkDeviceQueueCreateInfo> queueInfos;
+
+    VkDeviceQueueCreateInfo graphicsQueueInfo = { VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO };
+    graphicsQueueInfo.queueFamilyIndex = args.queueFamily;
+    graphicsQueueInfo.queueCount = 1u;
+    graphicsQueueInfo.pQueuePriorities = &queuePriority;
+    queueInfos.push_back(graphicsQueueInfo);
+
+    if (args.transferQueue != VK_NULL_HANDLE && args.transferQueue != args.queue && args.transferQueueFamily != VK_QUEUE_FAMILY_IGNORED) {
+      VkDeviceQueueCreateInfo transferQueueInfo = { VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO };
+      transferQueueInfo.queueFamilyIndex = args.transferQueueFamily;
+      transferQueueInfo.queueCount = 1u;
+      transferQueueInfo.pQueuePriorities = &queuePriority;
+      queueInfos.push_back(transferQueueInfo);
+    }
+
+    if (args.sparseQueue != VK_NULL_HANDLE && args.sparseQueue != args.queue && args.sparseQueueFamily != VK_QUEUE_FAMILY_IGNORED) {
+      VkDeviceQueueCreateInfo sparseQueueInfo = { VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO };
+      sparseQueueInfo.queueFamilyIndex = args.sparseQueueFamily;
+      sparseQueueInfo.queueCount = 1u;
+      sparseQueueInfo.pQueuePriorities = &queuePriority;
+      queueInfos.push_back(sparseQueueInfo);
+    }
 
     VkDeviceCreateInfo deviceInfo = { VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO };
     deviceInfo.pNext = args.features;
     deviceInfo.enabledExtensionCount = args.extensionCount;
     deviceInfo.ppEnabledExtensionNames = args.extensionNames;
-    deviceInfo.queueCreateInfoCount = 1u;
-    deviceInfo.pQueueCreateInfos = &queueInfo;
+    deviceInfo.queueCreateInfoCount = queueInfos.size();
+    deviceInfo.pQueueCreateInfos = queueInfos.data();
 
     DxvkDeviceCapabilities importCaps(*m_instance, m_handle, &deviceInfo);
 

--- a/src/dxvk/dxvk_adapter.h
+++ b/src/dxvk/dxvk_adapter.h
@@ -74,13 +74,17 @@ namespace dxvk {
    * \brief Device import info
    */
   struct DxvkDeviceImportInfo {
-    VkDevice          device          = VK_NULL_HANDLE;
-    VkQueue           queue           = VK_NULL_HANDLE;
-    uint32_t          queueFamily     = VK_QUEUE_FAMILY_IGNORED;
-    uint32_t          extensionCount  = 0u;
-    const char**      extensionNames  = nullptr;
-    const VkPhysicalDeviceFeatures2* features = nullptr;
-    DxvkQueueCallback queueCallback   = { };
+    VkDevice                          device                  = VK_NULL_HANDLE;
+    VkQueue                           queue                   = VK_NULL_HANDLE;
+    uint32_t                          queueFamily             = VK_QUEUE_FAMILY_IGNORED;
+    VkQueue                           transferQueue           = VK_NULL_HANDLE;
+    uint32_t                          transferQueueFamily     = VK_QUEUE_FAMILY_IGNORED;
+    VkQueue                           sparseQueue             = VK_NULL_HANDLE;
+    uint32_t                          sparseQueueFamily       = VK_QUEUE_FAMILY_IGNORED;
+    uint32_t                          extensionCount          = 0u;
+    const char**                      extensionNames          = nullptr;
+    const VkPhysicalDeviceFeatures2*  features                = nullptr;
+    DxvkQueueCallback                 queueCallback           = { };
   };
 
   /**

--- a/src/dxvk/dxvk_adapter.h
+++ b/src/dxvk/dxvk_adapter.h
@@ -112,6 +112,14 @@ namespace dxvk {
     VkPhysicalDevice handle() const {
       return m_handle;
     }
+
+    /**
+     * \brief Device capability info
+     * \returns The device capabilities object
+     */
+    const DxvkDeviceCapabilities& capabilities() const {
+      return m_capabilities;
+    }
     
     /**
      * \brief Physical device properties


### PR DESCRIPTION
As requested by @doitsujin in #4497, I have added an API to import existing Vulkan devices. Here is an [example](https://gist.github.com/AlpyneDreams/210dc9156f1a63c278c1fc6a92bebe10) of how it could be used to add an async compute queue when creating the device. First, all device creation info is queried with `GetDeviceCreateInfo`, then the device is created in userspace and passed to `ImportDevice`. I have tested this extensively in a project under active development and can confirm that it works. Feedback or nits are welcomed!

I have personally tested it on AMD and NVIDIA on Linux and NVIDIA on Windows (both MSVC and Mingw).

EDIT: The new API in of July 2025 has three separate calls to get device info: `QueryDeviceExtensions`, `QueryDeviceQueues`, and `QueryDeviceFeatures`. These correspond to calls in `DxvkDeviceCapabilities`. The only changes to the backend are to support importing separate transfer and sparse queues. A separate transfer queue may be preferable for concurrency. A separate sparse queue may be necessary for compatibility with devices that do not support sparse binding on the main graphics queue.

<!--
I am including screenshots of clustered lighting, GTAO, and froxel volumetric fog running atop our DX9 renderer for fun and to show the power of DXVK interop. All of this has been possible on vanilla DXVK with just this one PR.
<img src="https://github.com/user-attachments/assets/ffeffb83-728e-4d7b-be5a-d0e486be2f0d" alt="deferred_sponza_20250703_171920" width="480">
<img alt="deferred_sponza_20250703_212249" src="https://github.com/user-attachments/assets/6e478757-b710-40dc-b42f-2acf8dcd3c18" width="480">
<img alt="deferred_sponza_20250712_022004" src="https://github.com/user-attachments/assets/e5344480-63f4-4460-987a-cfc0db26b353" width="480">
-->