### PR TITLE
[d3d9] Spec-constant out writes to clip distances when disabled

### DIFF
--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -5933,17 +5933,21 @@ namespace dxvk {
     auto mapPtr = m_vsClipPlanes.AllocSlice();
     auto dst = reinterpret_cast<D3D9ClipPlane*>(mapPtr);
 
-    uint32_t clipPlaneMask = 0u;
+    uint32_t clipPlaneCount = 0u;
     for (uint32_t i = 0; i < caps::MaxClipPlanes; i++) {
-      dst[i] = (m_state.renderStates[D3DRS_CLIPPLANEENABLE] & (1 << i))
+      D3D9ClipPlane clipPlane = (m_state.renderStates[D3DRS_CLIPPLANEENABLE] & (1 << i))
         ? m_state.clipPlanes[i]
         : D3D9ClipPlane();
 
-      if (dst[i] != D3D9ClipPlane())
-        clipPlaneMask |= 1u << i;
+      if (clipPlane != D3D9ClipPlane())
+        dst[clipPlaneCount++] = clipPlane;
     }
 
-    if (m_specInfo.set<SpecClipPlaneMask>(clipPlaneMask))
+    // Write the rest to 0 for GPL.
+    for (uint32_t i = clipPlaneCount; i < caps::MaxClipPlanes; i++)
+      dst[i] = D3D9ClipPlane();
+
+    if (m_specInfo.set<SpecClipPlaneCount>(clipPlaneCount))
       m_flags.set(D3D9DeviceFlag::DirtySpecializationEntries);
   }
 

--- a/src/d3d9/d3d9_fixed_function.cpp
+++ b/src/d3d9/d3d9_fixed_function.cpp
@@ -2407,6 +2407,9 @@ namespace dxvk {
 
     m_module.decorateBuiltIn(clipDistArray, spv::BuiltInClipDistance);
 
+    // Always consider clip planes enabled when doing GPL by forcing 6 for the quick value.
+    uint32_t clipPlaneCount = m_spec.get(m_module, m_specUbo, SpecClipPlaneCount, 0, 32, m_module.constu32(caps::MaxClipPlanes));
+
     // Compute clip distances
     for (uint32_t i = 0; i < caps::MaxClipPlanes; i++) {
       std::array<uint32_t, 2> blockMembers = {{
@@ -2421,9 +2424,7 @@ namespace dxvk {
       
       uint32_t distId = m_module.opDot(floatType, worldPos, planeId);
 
-      // Always consider clip planes enabled when doing GPL by forcing a mask of 0xffffffff for the quick value.
-      uint32_t clipPlaneEnabledBit = m_spec.get(m_module, m_specUbo, SpecClipPlaneMask, i, 1, m_module.constu32(0xffffffff));
-      uint32_t clipPlaneEnabled = m_module.opINotEqual(boolType, clipPlaneEnabledBit, m_module.constu32(0));
+      uint32_t clipPlaneEnabled = m_module.opULessThan(boolType, m_module.constu32(i), clipPlaneCount);
 
       uint32_t value = m_module.opSelect(floatType, clipPlaneEnabled, distId, m_module.constf32(0.0f));
       

--- a/src/d3d9/d3d9_fixed_function.cpp
+++ b/src/d3d9/d3d9_fixed_function.cpp
@@ -2366,6 +2366,7 @@ namespace dxvk {
     
     uint32_t floatType = m_module.defFloatType(32);
     uint32_t vec4Type  = m_module.defVectorType(floatType, 4);
+    uint32_t boolType  = m_module.defBoolType();
     
     // Declare uniform buffer containing clip planes
     uint32_t clipPlaneArray  = m_module.defArrayTypeUnique(vec4Type, clipPlaneCountId);
@@ -2419,12 +2420,16 @@ namespace dxvk {
           clipPlaneBlock, blockMembers.size(), blockMembers.data()));
       
       uint32_t distId = m_module.opDot(floatType, worldPos, planeId);
+
+      // Always consider clip planes enabled when doing GPL by forcing a mask of 0xffffffff for the quick value.
+      uint32_t clipPlaneEnabledBit = m_spec.get(m_module, m_specUbo, SpecClipPlaneMask, i, 1, m_module.constu32(0xffffffff));
+      uint32_t clipPlaneEnabled = m_module.opINotEqual(boolType, clipPlaneEnabledBit, m_module.constu32(0));
+
+      uint32_t value = m_module.opSelect(floatType, clipPlaneEnabled, distId, m_module.constf32(0.0f));
       
-      m_module.opStore(
-        m_module.opAccessChain(
-          m_module.defPointerType(floatType, spv::StorageClassOutput),
-          clipDistArray, 1, &blockMembers[1]),
-        distId);
+      m_module.opStore(m_module.opAccessChain(
+        m_module.defPointerType(floatType, spv::StorageClassOutput),
+        clipDistArray, 1, &blockMembers[1]), value);
     }
   }
 

--- a/src/d3d9/d3d9_spec_constants.h
+++ b/src/d3d9/d3d9_spec_constants.h
@@ -30,7 +30,7 @@ namespace dxvk {
     SpecDrefClamp,          // 1 bit for 16 PS samplers       | Bits: 16
     SpecFetch4,             // 1 bit for 16 PS samplers       | Bits: 16
 
-    SpecClipPlaneMask,      // 6 bits for 6 clip planes       | Bits : 6
+    SpecClipPlaneCount,     // 3 bits for 6 clip planes       | Bits : 3
 
     SpecConstantCount,
   };
@@ -71,7 +71,7 @@ namespace dxvk {
       { 4, 0,  16 }, // DrefClamp
       { 4, 16, 16 }, // Fetch4
 
-      { 5, 0, 6 },   // ClipPlaneEnabled
+      { 5, 0, 3 },   // ClipPlaneCount
     }};
 
     template <D3D9SpecConstantId Id, typename T>

--- a/src/d3d9/d3d9_spec_constants.h
+++ b/src/d3d9/d3d9_spec_constants.h
@@ -30,6 +30,8 @@ namespace dxvk {
     SpecDrefClamp,          // 1 bit for 16 PS samplers       | Bits: 16
     SpecFetch4,             // 1 bit for 16 PS samplers       | Bits: 16
 
+    SpecClipPlaneMask,      // 6 bits for 6 clip planes       | Bits : 6
+
     SpecConstantCount,
   };
 
@@ -44,7 +46,10 @@ namespace dxvk {
   };
 
   struct D3D9SpecializationInfo {
-    static constexpr uint32_t MaxSpecDwords = 5;
+    static constexpr uint32_t MaxSpecDwords = 6;
+
+    static constexpr uint32_t MaxUBODwords  = 5;
+    static constexpr size_t UBOSize = MaxUBODwords * sizeof(uint32_t);
 
     static constexpr std::array<BitfieldPosition, SpecConstantCount> Layout{{
       { 0, 0, 32 },  // SamplerType
@@ -65,6 +70,8 @@ namespace dxvk {
 
       { 4, 0,  16 }, // DrefClamp
       { 4, 16, 16 }, // Fetch4
+
+      { 5, 0, 6 },   // ClipPlaneEnabled
     }};
 
     template <D3D9SpecConstantId Id, typename T>
@@ -97,13 +104,13 @@ namespace dxvk {
       return get(module, specUbo, id, 0, 32);
     }
 
-    uint32_t get(SpirvModule &module, uint32_t specUbo, D3D9SpecConstantId id, uint32_t bitOffset, uint32_t bitCount) {
+    uint32_t get(SpirvModule &module, uint32_t specUbo, D3D9SpecConstantId id, uint32_t bitOffset, uint32_t bitCount, uint32_t uboOverride = 0) {
       const auto &layout = D3D9SpecializationInfo::Layout[id];
 
       uint32_t uintType = module.defIntType(32, 0);
       uint32_t optimized = getOptimizedBool(module);
 
-      uint32_t quickValue     = getSpecUBODword(module, specUbo, layout.dwordOffset);
+      uint32_t quickValue     = uboOverride ? uboOverride : getSpecUBODword(module, specUbo, layout.dwordOffset);
       uint32_t optimizedValue = getSpecConstDword(module, layout.dwordOffset);
 
       uint32_t val = module.opSelect(uintType, optimized, optimizedValue, quickValue);

--- a/src/d3d9/d3d9_state.h
+++ b/src/d3d9/d3d9_state.h
@@ -28,6 +28,14 @@ namespace dxvk {
   
   struct D3D9ClipPlane {
     float coeff[4] = {};
+
+    bool operator == (const D3D9ClipPlane& other) {
+      return std::memcmp(this, &other, sizeof(D3D9ClipPlane)) == 0;
+    }
+
+    bool operator != (const D3D9ClipPlane& other) {
+      return !this->operator == (other);
+    }
   };
 
   struct D3D9RenderStateInfo {

--- a/src/dxso/dxso_compiler.cpp
+++ b/src/dxso/dxso_compiler.cpp
@@ -3537,6 +3537,9 @@ void DxsoCompiler::emitControlFlowGenericLoop(
     DxsoRegisterValue position;
     position.type = { DxsoScalarType::Float32, 4 };
     position.id = m_module.opLoad(vec4Type, positionPtr);
+
+    // Always consider clip planes enabled when doing GPL by forcing 6 for the quick value.
+    uint32_t clipPlaneCount = m_spec.get(m_module, m_specUbo, SpecClipPlaneCount, 0, 32, m_module.constu32(caps::MaxClipPlanes));
     
     for (uint32_t i = 0; i < caps::MaxClipPlanes; i++) {
       std::array<uint32_t, 2> blockMembers = {{
@@ -3552,9 +3555,7 @@ void DxsoCompiler::emitControlFlowGenericLoop(
 
       DxsoRegisterValue dist = emitDot(position, plane);
 
-      // Always consider clip planes enabled when doing GPL by forcing a mask of 0xffffffff for the quick value.
-      uint32_t clipPlaneEnabledBit = m_spec.get(m_module, m_specUbo, SpecClipPlaneMask, i, 1, m_module.constu32(0xffffffff));
-      uint32_t clipPlaneEnabled = m_module.opINotEqual(boolType, clipPlaneEnabledBit, m_module.constu32(0));
+      uint32_t clipPlaneEnabled = m_module.opULessThan(boolType, m_module.constu32(i), clipPlaneCount);
 
       uint32_t value = m_module.opSelect(floatType, clipPlaneEnabled, dist.id, m_module.constf32(0.0f));
 


### PR DESCRIPTION
Add a new spec constant with a mask of the enabled clip planes such that they can be optimized out to improve performance.

For GPL shaders, override what we return here so it's always true and don't bother putting the mask in the UBO.