### PR TITLE
[d3d8] Add missing include to d3d8_state_block.h

### DIFF
--- a/src/d3d8/d3d8_state_block.h
+++ b/src/d3d8/d3d8_state_block.h
@@ -5,6 +5,8 @@
 #include "d3d8_device.h"
 #include "d3d8_device_child.h"
 
+#include "../util/util_bit.h"
+
 #include <array>
 
 namespace dxvk {


### PR DESCRIPTION
Minor nit, mostly for my future sanity. We sort of lucked out so far, because that header is *somehow* included through other imports, but we should also add it explicitly here.