### PR TITLE
D3D9: Handle binding mismatching texture types

### DIFF
--- a/src/d3d9/d3d9_common_texture.h
+++ b/src/d3d9/d3d9_common_texture.h
@@ -319,7 +319,7 @@ namespace dxvk {
       return std::exchange(m_transitionedToHazardLayout, true);
     }
 
-    D3DRESOURCETYPE GetType() {
+    D3DRESOURCETYPE GetType() const {
       return m_type;
     }
 
@@ -441,6 +441,10 @@ namespace dxvk {
     static VkImageType GetImageTypeFromResourceType(
             D3DRESOURCETYPE  Dimension);
 
+    static VkImageViewType GetImageViewTypeFromResourceType(
+            D3DRESOURCETYPE  Dimension,
+            UINT             Layer);
+
      /**
      * \brief Tracks sequence number for a given subresource
      *
@@ -552,10 +556,6 @@ namespace dxvk {
             VkImageUsageFlags         Usage) const;
 
     void ExportImageInfo();
-
-    static VkImageViewType GetImageViewTypeFromResourceType(
-            D3DRESOURCETYPE  Dimension,
-            UINT             Layer);
 
   };
 

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -817,6 +817,10 @@ namespace dxvk {
 
     void UpdateActiveFetch4(uint32_t stateSampler);
 
+    void UpdateTextureTypeMismatchesForShader(const D3D9CommonShader* shader, uint32_t shaderSamplerMask, uint32_t shaderSamplerOffset);
+
+    void UpdateTextureTypeMismatchesForTexture(uint32_t stateSampler);
+
     void UploadManagedTexture(D3D9CommonTexture* pResource);
 
     void UploadManagedTextures(uint32_t mask);
@@ -1461,6 +1465,7 @@ namespace dxvk {
     uint32_t                        m_drefClamp = 0;
     uint32_t                        m_cubeTextures = 0;
     uint32_t                        m_textureTypes = 0;
+    uint32_t                        m_mismatchingTextureTypes = 0;
     uint32_t                        m_projectionBitfield  = 0;
 
     uint32_t                        m_dirtySamplerStates = 0;

--- a/src/d3d9/d3d9_shader.cpp
+++ b/src/d3d9/d3d9_shader.cpp
@@ -57,6 +57,7 @@ namespace dxvk {
     m_shader       = pModule->compile(*pDxsoModuleInfo, name, AnalysisInfo, constantLayout);
     m_isgn         = pModule->isgn();
     m_usedSamplers = pModule->usedSamplers();
+    m_textureTypes = pModule->textureTypes();
 
     // Shift up these sampler bits so we can just
     // do an or per-draw in the device.

--- a/src/d3d9/d3d9_shader.h
+++ b/src/d3d9/d3d9_shader.h
@@ -54,11 +54,18 @@ namespace dxvk {
 
     uint32_t GetMaxDefinedConstant() const { return m_maxDefinedConst; }
 
+    VkImageViewType GetImageViewType(uint32_t samplerSlot) const {
+      const uint32_t offset = samplerSlot * 2;
+      const uint32_t mask = 0b11;
+      return static_cast<VkImageViewType>((m_textureTypes >> offset) & mask);
+    }
+
   private:
 
     DxsoIsgn              m_isgn;
     uint32_t              m_usedSamplers;
     uint32_t              m_usedRTs;
+    uint32_t              m_textureTypes;
 
     DxsoProgramInfo       m_info;
     DxsoShaderMetaInfo    m_meta;

--- a/src/dxso/dxso_compiler.cpp
+++ b/src/dxso/dxso_compiler.cpp
@@ -41,6 +41,7 @@ namespace dxvk {
 
     m_usedSamplers = 0;
     m_usedRTs      = 0;
+    m_textureTypes = 0;
     m_rRegs.reserve(DxsoMaxTempRegs);
 
     for (uint32_t i = 0; i < m_rRegs.size(); i++)
@@ -762,6 +763,10 @@ namespace dxvk {
         // We could also be depth compared!
         DclSampler(idx, binding, samplerType, true, implicit);
       }
+
+      const uint32_t offset = idx * 2;
+      uint32_t textureBits = uint32_t(viewType);
+      m_textureTypes |= textureBits << offset;
     }
     else {
       // Could be any of these!

--- a/src/dxso/dxso_compiler.h
+++ b/src/dxso/dxso_compiler.h
@@ -248,6 +248,7 @@ namespace dxvk {
     uint32_t usedSamplers() const { return m_usedSamplers; }
     uint32_t usedRTs() const { return m_usedRTs; }
     uint32_t maxDefinedConstant() const { return m_maxDefinedConstant; }
+    uint32_t textureTypes() const { return m_textureTypes; }
 
   private:
 
@@ -357,6 +358,8 @@ namespace dxvk {
     // and render targets for hazard tracking
     uint32_t m_usedSamplers;
     uint32_t m_usedRTs;
+
+    uint32_t m_textureTypes;
 
     uint32_t m_specUbo = 0;
 

--- a/src/dxso/dxso_module.cpp
+++ b/src/dxso/dxso_module.cpp
@@ -38,6 +38,7 @@ namespace dxvk {
     m_constants       = compiler->constants();
     m_maxDefinedConst = compiler->maxDefinedConstant();
     m_usedSamplers    = compiler->usedSamplers();
+    m_textureTypes    = compiler->textureTypes();
 
     compiler->finalize();
 

--- a/src/dxso/dxso_module.h
+++ b/src/dxso/dxso_module.h
@@ -61,6 +61,8 @@ namespace dxvk {
 
     uint32_t maxDefinedConstant() { return m_maxDefinedConst; }
 
+    uint32_t textureTypes() { return m_textureTypes; }
+
   private:
 
     void runCompiler(
@@ -77,6 +79,7 @@ namespace dxvk {
     DxsoIsgn        m_isgn;
     uint32_t        m_usedSamplers;
     uint32_t        m_usedRTs;
+    uint32_t        m_textureTypes;
 
     DxsoShaderMetaInfo   m_meta;
     uint32_t             m_maxDefinedConst;

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -1007,10 +1007,6 @@ namespace dxvk {
       { "d3d9.customVendorId",              "10de" },
       { "d3d9.cachedDynamicBuffers",        "True" },
     }} },
-    /* Alpha Protocol - Rids unwanted reflections  */
-    { R"(\\APGame\.exe$)", {{
-      { "d3d9.forceSamplerTypeSpecConstants", "True" },
-    }} },
     /* Dark Sector - Crashes in places             */
     { R"(\\DS\.exe$)", {{
       { "d3d9.textureMemory",                "0" },


### PR DESCRIPTION
Fixes #4387

Alpha Protocol binds a cube texture to a slot which is declared as a 2d texture in the shader. Binding a mismatching texture type leads yields (0,0,0,0) (yes, alpha 0, unlike binding NULL) on native D3D9. See the table inside the issue.

I also checked that this is checked at draw time, not at the time of the SetTexture call. So binding a shader with a correct texture type afterwards results in correct rendering and the other way around as well. 

Because if there's one thing the D3D9 frontend needed, it is more bit field tracking... :)