### PR TITLE
[util] Set textureMemory to 0 for Dark Sector

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -1010,6 +1010,10 @@ namespace dxvk {
     { R"(\\APGame\.exe$)", {{
       { "d3d9.forceSamplerTypeSpecConstants", "True" },
     }} },
+    /* Dark Sector - Crashes in places             */
+    { R"(\\DS\.exe$)", {{
+      { "d3d9.textureMemory",                "0" },
+    }} },
 
     /**********************************************/
     /* D3D8 GAMES                                 */


### PR DESCRIPTION
See #4519 
Does not close the issue as it isn't a proper fix