### PR TITLE
[d3d8/9] Clear pLockedRect/Box contents universally on lock

### DIFF
--- a/src/d3d9/d3d9_surface.cpp
+++ b/src/d3d9/d3d9_surface.cpp
@@ -124,17 +124,19 @@ namespace dxvk {
       return D3DERR_INVALIDCALL;
 
     D3DBOX box;
+    auto& desc = *(m_texture->Desc());
     D3DRESOURCETYPE type = m_texture->GetType();
 
-    if (m_texture->Device()->IsD3D8Compatible() && type != D3DRTYPE_TEXTURE) {
-      // D3D8 LockRect clears any existing content present in
-      // pLockedRect for anything beside D3DRTYPE_TEXTURE surfaces
+    // LockRect clears any existing content present in pLockedRect,
+    // for surfaces in D3DPOOL_DEFAULT. D3D8 additionally clears the content
+    // for non-D3DPOOL_DEFAULT surfaces if their type is not D3DRTYPE_TEXTURE.
+    if (desc.Pool == D3DPOOL_DEFAULT
+     || (m_texture->Device()->IsD3D8Compatible() && type != D3DRTYPE_TEXTURE)) {
       pLockedRect->pBits = nullptr;
       pLockedRect->Pitch = 0;
     }
 
     if (unlikely(pRect != nullptr)) {
-      auto& desc = *(m_texture->Desc());
       D3D9_FORMAT_BLOCK_SIZE blockSize = GetFormatAlignedBlockSize(desc.Format);
 
       bool isBlockAlignedFormat = blockSize.Width > 0 && blockSize.Height > 0;

--- a/src/d3d9/d3d9_volume.cpp
+++ b/src/d3d9/d3d9_volume.cpp
@@ -102,12 +102,10 @@ namespace dxvk {
     if (unlikely(pLockedBox == nullptr))
       return D3DERR_INVALIDCALL;
 
-    if (m_texture->Device()->IsD3D8Compatible()) {
-      // D3D8 LockBox clears any existing content present in pLockedBox
-      pLockedBox->pBits = nullptr;
-      pLockedBox->RowPitch = 0;
-      pLockedBox->SlicePitch = 0;
-    }
+    // LockBox clears any existing content present in pLockedBox
+    pLockedBox->pBits = nullptr;
+    pLockedBox->RowPitch = 0;
+    pLockedBox->SlicePitch = 0;
 
     if (unlikely(pBox != nullptr)) {
       auto& desc = *(m_texture->Desc());


### PR DESCRIPTION
Based on a test that I wrote and ran on Windows XP it looks like:
- d3d9 behaves similarly to d3d8 during LockRect/Box
- ~LockRect doesn't discriminate based on RTYPE and textures also get their pLockedRect contents cleared~

So the Wine tests were partially incorrect for d3d8 and incomplete for d3d9 (the Wine test in question was d3d8 specific, in all fairness).

I'm waiting for @Blisto91 to confirm modern native behavior, and in the meantime I will do some general testing. Not that I expect anything to blow up due to this minor nit, but you never know.

Edit: All the above is confirmed on modern AMD and Intel Windows drivers.