### PR TITLE
[spirv] Emit the grad and const offset image ops in the correct order

### DIFF
--- a/src/spirv/spirv_module.cpp
+++ b/src/spirv/spirv_module.cpp
@@ -3892,15 +3892,15 @@ namespace dxvk {
       
       if (op.flags & spv::ImageOperandsLodMask)
         m_code.putWord(op.sLod);
-      
-      if (op.flags & spv::ImageOperandsConstOffsetMask)
-        m_code.putWord(op.sConstOffset);
-      
+
       if (op.flags & spv::ImageOperandsGradMask) {
         m_code.putWord(op.sGradX);
         m_code.putWord(op.sGradY);
       }
-      
+
+      if (op.flags & spv::ImageOperandsConstOffsetMask)
+        m_code.putWord(op.sConstOffset);
+
       if (op.flags & spv::ImageOperandsOffsetMask)
         m_code.putWord(op.gOffset);
       


### PR DESCRIPTION
Currently the grad and const offset image operand ids are emitted in the incorrect order. This causes incorrect code gen if both the grad and const offset image operands are used.

https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#Image_Operands

This fixes the compilation error found when running TopSpin 2k25 through DXVK using the NVIDIA proprietary Vulkan driver.

https://github.com/ValveSoftware/Proton/issues/7684