### PR TITLE
[util] Add a config option for shader register index validations and enable it for The Void

### DIFF
--- a/src/d3d9/d3d9_interface.cpp
+++ b/src/d3d9/d3d9_interface.cpp
@@ -4,6 +4,7 @@
 #include "d3d9_caps.h"
 #include "d3d9_device.h"
 #include "d3d9_bridge.h"
+#include "d3d9_shader_validator.h"
 
 #include "../util/util_singleton.h"
 
@@ -67,6 +68,8 @@ namespace dxvk {
       SetProcessDPIAware();
     }
 #endif
+
+    D3D9ShaderValidator::SetValidateInputRegisterIndex(m_d3d9Options.validateInputRegisterIndex);
   }
 
 

--- a/src/d3d9/d3d9_options.cpp
+++ b/src/d3d9/d3d9_options.cpp
@@ -76,6 +76,7 @@ namespace dxvk {
     this->clampNegativeLodBias          = config.getOption<bool>        ("d3d9.clampNegativeLodBias",          false);
     this->countLosableResources         = config.getOption<bool>        ("d3d9.countLosableResources",         true);
     this->reproducibleCommandStream     = config.getOption<bool>        ("d3d9.reproducibleCommandStream",     false);
+    this->validateInputRegisterIndex    = config.getOption<bool>        ("d3d9.validateInputRegisterIndex",    false);
 
     // D3D8 options
     this->drefScaling                   = config.getOption<int32_t>     ("d3d8.scaleDref",                     0);

--- a/src/d3d9/d3d9_options.h
+++ b/src/d3d9/d3d9_options.h
@@ -153,6 +153,9 @@ namespace dxvk {
     /// can negatively affect performance.
     bool reproducibleCommandStream;
 
+    // Validate input register index for PS 3.0 in D3D9ShaderValidator
+    bool validateInputRegisterIndex;
+
     /// Enable depth texcoord Z (Dref) scaling (D3D8 quirk)
     int32_t drefScaling;
   };

--- a/src/d3d9/d3d9_shader_validator.cpp
+++ b/src/d3d9/d3d9_shader_validator.cpp
@@ -77,7 +77,7 @@ namespace dxvk {
     }*/
 
     // a maximum of 10 inputs are supported with PS 3.0 (validation required by The Void)
-    if (m_isPixelShader && m_majorVersion == 3) {
+    if (s_validateInputRegisterIndex && m_isPixelShader && m_majorVersion == 3) {
       switch (instContext.instruction.opcode) {
         case DxsoOpcode::Comment:
         case DxsoOpcode::Def:
@@ -193,13 +193,16 @@ namespace dxvk {
     if (m_callback)
         m_callback(pFile, Line, Unknown, MessageID, Message.c_str(), m_userData);
 
-    // TODO: Consider switching this to debug, once we're
-    // confident the implementation doesn't cause any issues
     Logger::warn(Message);
 
     m_state = D3D9ShaderValidatorState::Error;
 
     return E_FAIL;
   }
+
+
+  // s_validateInputRegisterIndex will be parsed and set appropriately based
+  // on config options whenever a D3D9InterfaceEx type object is created
+  bool D3D9ShaderValidator::s_validateInputRegisterIndex = false;
 
 }

--- a/src/d3d9/d3d9_shader_validator.h
+++ b/src/d3d9/d3d9_shader_validator.h
@@ -76,6 +76,10 @@ namespace dxvk {
 
     HRESULT STDMETHODCALLTYPE End();
 
+    static void SetValidateInputRegisterIndex (bool value) {
+      s_validateInputRegisterIndex = value;
+    }
+
   private:
 
     HRESULT ValidateHeader(const char* pFile, UINT Line, const DWORD* pdwInst, DWORD cdw);
@@ -88,6 +92,8 @@ namespace dxvk {
               DWORD                      Unknown,
               D3D9ShaderValidatorMessage MessageID,
         const std::string&               Message);
+
+    static bool                 s_validateInputRegisterIndex;
 
     bool                        m_isPixelShader = false;
     uint32_t                    m_majorVersion  = 0;

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -1021,6 +1021,11 @@ namespace dxvk {
     { R"(\\(AH3LM|AALib)\.exe$)", {{
       { "d3d9.maxFrameRate",                "60" },
     }} },
+    /* The Void - Crashes in several locations     *
+     * without input register index validations    */
+    { R"(\\The Void\\bin\\win32\\Game\.exe$)", {{
+      { "d3d9.validateInputRegisterIndex",  "True" },
+    }} },
 
     /**********************************************/
     /* D3D8 GAMES                                 */


### PR DESCRIPTION
Fixes #4537 by restricting the shader register index validations to The Void. TBD if it's the preferred approach to handle the issue.