### PR TITLE
Add more logging to D3D9 shader validation

### DIFF
--- a/src/d3d9/d3d9_shader_validator.cpp
+++ b/src/d3d9/d3d9_shader_validator.cpp
@@ -93,12 +93,11 @@ namespace dxvk {
             DWORD regIndex = pdwInst[instNum] & D3DSP_REGNUM_MASK;
 
             if (unlikely(regType == static_cast<DWORD>(DxsoRegisterType::Input) && regIndex >= 10)) {
-              Logger::debug(str::format("IDirect3DShaderValidator9::Instruction: Found register index ", regIndex));
               return ErrorCallback(pFile, Line, 0x2, pdwInst, cdw,
                 instContext.instruction.opcode == DxsoOpcode::Dcl ?
                   D3D9ShaderValidatorMessage::BadInputRegisterDeclaration :
                   D3D9ShaderValidatorMessage::BadInputRegister,
-                "IDirect3DShaderValidator9::Instruction: Invalid number of PS input registers specified. Aborting validation.");
+                str::format("IDirect3DShaderValidator9::Instruction: PS input registers index #", regIndex, " not valid for operand ", instNum, "."));
             }
           }
       }

--- a/src/d3d9/d3d9_shader_validator.h
+++ b/src/d3d9/d3d9_shader_validator.h
@@ -86,8 +86,10 @@ namespace dxvk {
         const char*                      pFile,
               UINT                       Line,
               DWORD                      Unknown,
+        const DWORD*                     pInstr,
+              DWORD                      InstrLength,
               D3D9ShaderValidatorMessage MessageID,
-        const std::string&               Message);
+              std::string                Message);
 
     bool                        m_isPixelShader = false;
     uint32_t                    m_majorVersion  = 0;


### PR DESCRIPTION
If something fails, print the entire instruction as dwords.