### PR TITLE
Added ability to override VK_LOADER_LAYERS_DISABLE env var.

### DIFF
--- a/src/dxvk/dxvk_instance.cpp
+++ b/src/dxvk/dxvk_instance.cpp
@@ -31,6 +31,19 @@ namespace dxvk {
 
     m_options = DxvkOptions(m_config);
 
+    std::string vkLoaderLayersDisableEnv = env::getEnvVar("VK_LOADER_LAYERS_DISABLE");
+    if (!vkLoaderLayersDisableEnv.empty())
+        Logger::info(str::format("VK_LOADER_LAYERS_DISABLE: ", vkLoaderLayersDisableEnv));
+
+    // Optionally override VK_LOADER_LAYERS_DISABLE with specified DXVK_LOADER_LAYERS_DISABLE
+    // Or set DXVK_OVERRIDE_VK_LOADER_LAYERS_DISABLE=1 alone, to clear VK_LOADER_LAYERS_DISABLE
+    std::string dxvkLoaderLayersDisableEnv = env::getEnvVar("DXVK_LOADER_LAYERS_DISABLE");
+    if (!dxvkLoaderLayersDisableEnv.empty() || env::getEnvVar("DXVK_OVERRIDE_VK_LOADER_LAYERS_DISABLE") == "1")
+    {
+        Logger::info(str::format("DXVK_LOADER_LAYERS_DISABLE: ", dxvkLoaderLayersDisableEnv));
+        env::setEnvVar("VK_LOADER_LAYERS_DISABLE", dxvkLoaderLayersDisableEnv.c_str());
+    }
+
     // Load Vulkan library
     createLibraryLoader(args);
 

--- a/src/util/util_env.cpp
+++ b/src/util/util_env.cpp
@@ -35,6 +35,13 @@ namespace dxvk::env {
 #endif
   }
 
+  void setEnvVar(const char* name, const char* value) {
+#ifdef _WIN32
+      ::SetEnvironmentVariableA(name, value);
+#else
+      std::setenv(name, value);
+#endif
+  }
 
   size_t matchFileExtension(const std::string& name, const char* ext) {
     auto pos = name.find_last_of('.');

--- a/src/util/util_env.h
+++ b/src/util/util_env.h
@@ -27,6 +27,13 @@ namespace dxvk::env {
    * \returns Value of the variable
    */
   std::string getEnvVar(const char* name);
+
+  /**
+   * \brief Sets environment variable
+   * \param [in] name Name of the variable
+   * \param [in] value New value to set
+   */
+  void setEnvVar(const char* name, const char* value);
   
   /**
    * \brief Checks whether a file name has a given extension


### PR DESCRIPTION
When testing against an old Unity app on Windows, I discovered someone was setting VK_LOADER_LAYERS_DISABLE=~implicit~ which was preventing me from using RenderDoc to compare DX11 vs Vulkan output.  Since dxvk is right in the middle of all of this, it provides an opportune place to fix that.