### PR TITLE
Set private data debug object name

### DIFF
--- a/src/d3d11/d3d11_buffer.h
+++ b/src/d3d11/d3d11_buffer.h
@@ -181,7 +181,12 @@ namespace dxvk {
             D3D11_BUFFER_DESC*      pBufferDesc);
 
   private:
-    
+
+    virtual void SetD3DDebugObjectName(const char* name) {
+      if (m_buffer)
+        m_buffer->setDebugName(name);
+    }
+
     D3D11_BUFFER_DESC             m_desc;
     D3D11_ON_12_RESOURCE_INFO     m_11on12;
     D3D11_COMMON_BUFFER_MAP_MODE  m_mapMode;

--- a/src/d3d11/d3d11_device_child.h
+++ b/src/d3d11/d3d11_device_child.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <initguid.h>
 #include "d3d11_include.h"
 
 #include "../util/com/com_private_data.h"
@@ -30,6 +31,8 @@ namespace dxvk {
             REFGUID guid,
             UINT    DataSize,
       const void    *pData) final {
+      if (guid == WKPDID_D3DDebugObjectName)
+          SetD3DDebugObjectName((const char*)pData);
       return m_privateData.setData(
         guid, DataSize, pData);
     }
@@ -55,6 +58,8 @@ namespace dxvk {
     }
 
     D3D11Device* const m_parent;
+
+    virtual void SetD3DDebugObjectName(const char* name) {}
     
   private:
     

--- a/src/d3d11/d3d11_fence.h
+++ b/src/d3d11/d3d11_fence.h
@@ -40,7 +40,12 @@ namespace dxvk {
     }
     
   private:
-    
+
+    virtual void SetD3DDebugObjectName(const char* name) {
+      if (m_fence)
+        m_fence->setDebugName(name);
+    }
+
     Rc<DxvkFence> m_fence;
     D3D11_FENCE_FLAG m_flags;
 

--- a/src/d3d11/d3d11_texture.h
+++ b/src/d3d11/d3d11_texture.h
@@ -769,6 +769,11 @@ namespace dxvk {
     
   private:
     
+    virtual void SetD3DDebugObjectName(const char* name) {
+      if (m_texture.GetImage())
+        m_texture.GetImage()->setDebugName(name);
+    }
+
     D3D11CommonTexture    m_texture;
     D3D11VkInteropSurface m_interop;
     D3D11DXGISurface      m_surface;
@@ -834,6 +839,11 @@ namespace dxvk {
     }
 
   private:
+
+    virtual void SetD3DDebugObjectName(const char* name) {
+      if (m_texture.GetImage())
+        m_texture.GetImage()->setDebugName(name);
+    }
     
     D3D11CommonTexture    m_texture;
     D3D11VkInteropSurface m_interop;
@@ -884,6 +894,11 @@ namespace dxvk {
     }
 
   private:
+
+    virtual void SetD3DDebugObjectName(const char* name) {
+      if (m_texture.GetImage())
+        m_texture.GetImage()->setDebugName(name);
+    }
     
     D3D11CommonTexture    m_texture;
     D3D11VkInteropSurface m_interop;

--- a/src/d3d11/d3d11_view_dsv.h
+++ b/src/d3d11/d3d11_view_dsv.h
@@ -91,6 +91,11 @@ namespace dxvk {
     
   private:
     
+    virtual void SetD3DDebugObjectName(const char* name) {
+      if (m_view)
+        m_view->setDebugName(name);
+    }
+
     ID3D11Resource*                   m_resource;
     D3D11_DEPTH_STENCIL_VIEW_DESC     m_desc;
     D3D11_VK_VIEW_INFO                m_info;

--- a/src/d3d11/d3d11_view_rtv.h
+++ b/src/d3d11/d3d11_view_rtv.h
@@ -80,6 +80,11 @@ namespace dxvk {
 
   private:
     
+    virtual void SetD3DDebugObjectName(const char* name) {
+      if (m_view)
+        m_view->setDebugName(name);
+    }
+
     ID3D11Resource*                   m_resource;
     D3D11_RENDER_TARGET_VIEW_DESC1    m_desc;
     D3D11_VK_VIEW_INFO                m_info;

--- a/src/d3d11/d3d11_view_srv.h
+++ b/src/d3d11/d3d11_view_srv.h
@@ -82,6 +82,13 @@ namespace dxvk {
 
   private:
     
+    virtual void SetD3DDebugObjectName(const char* name) {
+      if (m_bufferView)
+        m_bufferView->setDebugName(name);
+      if (m_imageView)
+        m_imageView->setDebugName(name);
+    }
+
     ID3D11Resource*                   m_resource;
     D3D11_SHADER_RESOURCE_VIEW_DESC1  m_desc;
     D3D11_VK_VIEW_INFO                m_info;

--- a/src/d3d11/d3d11_view_uav.h
+++ b/src/d3d11/d3d11_view_uav.h
@@ -78,6 +78,15 @@ namespace dxvk {
 
   private:
     
+    virtual void SetD3DDebugObjectName(const char* name) {
+      if (m_bufferView)
+        m_bufferView->setDebugName(name);
+      if (m_imageView)
+        m_imageView->setDebugName(name);
+      if (m_counterView)
+        m_counterView->setDebugName(name);
+    }
+
     ID3D11Resource*                   m_resource;
     D3D11_UNORDERED_ACCESS_VIEW_DESC1 m_desc;
     D3D11_VK_VIEW_INFO                m_info;

--- a/src/dxvk/dxvk_buffer.cpp
+++ b/src/dxvk/dxvk_buffer.cpp
@@ -99,5 +99,37 @@ namespace dxvk {
 
     return m_allocator->createBufferResource(info, allocationInfo, nullptr);
   }
-  
+
+
+  void DxvkBuffer::setDebugName(
+      const char* name) {
+      if (!m_vkd->vkSetDebugUtilsObjectNameEXT)
+          return;
+
+      VkDebugUtilsObjectNameInfoEXT nameInfo{};
+      nameInfo.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT;
+      nameInfo.pNext = nullptr;
+      nameInfo.objectType = VK_OBJECT_TYPE_BUFFER;
+      nameInfo.objectHandle = (uint64_t)storage()->getBufferInfo().buffer;
+      nameInfo.pObjectName = name;
+
+      m_vkd->vkSetDebugUtilsObjectNameEXT(m_vkd->device(), &nameInfo);
+  }
+
+
+  void DxvkBufferView::setDebugName(
+      const char* name) {
+      if (!m_buffer->m_vkd->vkSetDebugUtilsObjectNameEXT)
+          return;
+
+      VkDebugUtilsObjectNameInfoEXT nameInfo{};
+      nameInfo.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT;
+      nameInfo.pNext = nullptr;
+      nameInfo.objectType = VK_OBJECT_TYPE_BUFFER_VIEW;
+      nameInfo.objectHandle = (uint64_t)handle();
+      nameInfo.pObjectName = name;
+
+      m_buffer->m_vkd->vkSetDebugUtilsObjectNameEXT(m_buffer->m_vkd->device(), &nameInfo);
+  }
+
 }

--- a/src/dxvk/dxvk_buffer.h
+++ b/src/dxvk/dxvk_buffer.h
@@ -132,6 +132,13 @@ namespace dxvk {
       return lookupFormatInfo(m_key.format);
     }
 
+    /**
+     * \brief Sets debug name for this resources when markers are enabled
+     *
+     * \params[in] name Name of the resource to set
+     */
+    void setDebugName(const char* name);
+
   private:
 
     DxvkBuffer*       m_buffer  = nullptr;
@@ -405,6 +412,13 @@ namespace dxvk {
      */
     Rc<DxvkResourceAllocation> relocateStorage(
             DxvkAllocationModes         mode);
+
+    /**
+     * \brief Sets debug name for this resources when markers are enabled
+     *
+     * \params[in] name Name of the resource to set
+     */
+    void setDebugName(const char* name);
 
   private:
 

--- a/src/dxvk/dxvk_fence.cpp
+++ b/src/dxvk/dxvk_fence.cpp
@@ -181,4 +181,20 @@ namespace dxvk {
 
     return sharedHandle;
   }
+
+  void DxvkFence::setDebugName(
+      const char* name) {
+      if (!m_vkd->vkSetDebugUtilsObjectNameEXT)
+          return;
+
+      VkDebugUtilsObjectNameInfoEXT nameInfo{};
+      nameInfo.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT;
+      nameInfo.pNext = nullptr;
+      nameInfo.objectType = VK_OBJECT_TYPE_FENCE;
+      nameInfo.objectHandle = (uint64_t)m_semaphore;
+      nameInfo.pObjectName = name;
+
+      m_vkd->vkSetDebugUtilsObjectNameEXT(m_vkd->device(), &nameInfo);
+  }
+
 }

--- a/src/dxvk/dxvk_fence.h
+++ b/src/dxvk/dxvk_fence.h
@@ -97,6 +97,13 @@ namespace dxvk {
     */
     void wait(uint64_t value);
 
+    /**
+     * \brief Sets debug name for this resources when markers are enabled
+     *
+     * \params[in] name Name of the resource to set
+     */
+    void setDebugName(const char* name);
+
   private:
 
     struct QueueItem {

--- a/src/dxvk/dxvk_image.cpp
+++ b/src/dxvk/dxvk_image.cpp
@@ -283,6 +283,22 @@ namespace dxvk {
   }
 
 
+  void DxvkImage::setDebugName(
+    const char* name) {
+    if (!m_vkd->vkSetDebugUtilsObjectNameEXT)
+        return;
+
+    VkDebugUtilsObjectNameInfoEXT nameInfo{};
+    nameInfo.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT;
+    nameInfo.pNext = nullptr;
+    nameInfo.objectType = VK_OBJECT_TYPE_IMAGE;
+    nameInfo.objectHandle = (uint64_t)storage()->getImageInfo().image;
+    nameInfo.pObjectName = name;
+
+    m_vkd->vkSetDebugUtilsObjectNameEXT(m_vkd->device(), &nameInfo);
+  }
+
+
   VkImageCreateInfo DxvkImage::getImageCreateInfo(
     const DxvkImageUsageInfo&         usageInfo) const {
     VkImageCreateInfo info = { VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO };
@@ -452,5 +468,20 @@ namespace dxvk {
 
     m_version = m_image->m_version;
   }
-  
+
+  void DxvkImageView::setDebugName(
+      const char* name) {
+      if (!m_image->m_vkd->vkSetDebugUtilsObjectNameEXT)
+          return;
+
+      VkDebugUtilsObjectNameInfoEXT nameInfo{};
+      nameInfo.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT;
+      nameInfo.pNext = nullptr;
+      nameInfo.objectType = VK_OBJECT_TYPE_IMAGE_VIEW;
+      nameInfo.objectHandle = (uint64_t)handle();
+      nameInfo.pObjectName = name;
+
+      m_image->m_vkd->vkSetDebugUtilsObjectNameEXT(m_image->m_vkd->device(), &nameInfo);
+  }
+
 }

--- a/src/dxvk/dxvk_image.h
+++ b/src/dxvk/dxvk_image.h
@@ -263,6 +263,13 @@ namespace dxvk {
         view->imageSubresources());
     }
 
+    /**
+     * \brief Sets debug name for this resources when markers are enabled
+     *
+     * \params[in] name Name of the resource to set
+     */
+    void setDebugName(const char* name);
+
   private:
 
     DxvkImage*              m_image     = nullptr;
@@ -600,6 +607,13 @@ namespace dxvk {
      */
     bool isInitialized(
       const VkImageSubresourceRange& subresources) const;
+
+    /**
+     * \brief Sets debug name for this resources when markers are enabled
+     *
+     * \params[in] name Name of the resource to set
+     */
+    void setDebugName(const char* name);
 
   private:
 

--- a/src/dxvk/dxvk_instance.cpp
+++ b/src/dxvk/dxvk_instance.cpp
@@ -31,6 +31,19 @@ namespace dxvk {
 
     m_options = DxvkOptions(m_config);
 
+    std::string vkLoaderLayersDisableEnv = env::getEnvVar("VK_LOADER_LAYERS_DISABLE");
+    if (!vkLoaderLayersDisableEnv.empty())
+        Logger::info(str::format("VK_LOADER_LAYERS_DISABLE: ", vkLoaderLayersDisableEnv));
+
+    // Optionally override VK_LOADER_LAYERS_DISABLE with specified DXVK_LOADER_LAYERS_DISABLE
+    // Or set DXVK_OVERRIDE_VK_LOADER_LAYERS_DISABLE=1 alone, to clear VK_LOADER_LAYERS_DISABLE
+    std::string dxvkLoaderLayersDisableEnv = env::getEnvVar("DXVK_LOADER_LAYERS_DISABLE");
+    if (!dxvkLoaderLayersDisableEnv.empty() || env::getEnvVar("DXVK_OVERRIDE_VK_LOADER_LAYERS_DISABLE") == "1")
+    {
+        Logger::info(str::format("DXVK_LOADER_LAYERS_DISABLE: ", dxvkLoaderLayersDisableEnv));
+        env::setEnvVar("VK_LOADER_LAYERS_DISABLE", dxvkLoaderLayersDisableEnv.c_str());
+    }
+
     // Load Vulkan library
     createLibraryLoader(args);
 

--- a/src/util/util_env.cpp
+++ b/src/util/util_env.cpp
@@ -35,6 +35,13 @@ namespace dxvk::env {
 #endif
   }
 
+  void setEnvVar(const char* name, const char* value) {
+#ifdef _WIN32
+      ::SetEnvironmentVariableA(name, value);
+#else
+      std::setenv(name, value);
+#endif
+  }
 
   size_t matchFileExtension(const std::string& name, const char* ext) {
     auto pos = name.find_last_of('.');

--- a/src/util/util_env.h
+++ b/src/util/util_env.h
@@ -27,6 +27,13 @@ namespace dxvk::env {
    * \returns Value of the variable
    */
   std::string getEnvVar(const char* name);
+
+  /**
+   * \brief Sets environment variable
+   * \param [in] name Name of the variable
+   * \param [in] value New value to set
+   */
+  void setEnvVar(const char* name, const char* value);
   
   /**
    * \brief Checks whether a file name has a given extension


### PR DESCRIPTION
Set debug names for buffers, fences, textures, and views to match the app's DX11 set values.