### PR TITLE
[d3d9] Use cdw to iterate over register tokens in D3D9ShaderValidator

### DIFF
--- a/src/d3d9/d3d9_shader_validator.cpp
+++ b/src/d3d9/d3d9_shader_validator.cpp
@@ -87,7 +87,7 @@ namespace dxvk {
 
         default:
           // Iterate over register tokens. Bit 31 of register tokens is always 1.
-          for (uint32_t instNum = 1; pdwInst[instNum] & 0x80000000; instNum++) {
+          for (uint32_t instNum = 1; instNum < cdw && (pdwInst[instNum] >> 31); instNum++) {
             DWORD regType  = ((pdwInst[instNum] & D3DSP_REGTYPE_MASK)  >> D3DSP_REGTYPE_SHIFT)
                             | ((pdwInst[instNum] & D3DSP_REGTYPE_MASK2) >> D3DSP_REGTYPE_SHIFT2);
             DWORD regIndex = pdwInst[instNum] & D3DSP_REGNUM_MASK;


### PR DESCRIPTION
Tentatively fixes #4537, by making sure we don't read tokens out of bounds. The Void still works fine with the change (ergo the validation still fails, as it's supposed to).