### PR TITLE
D3D11: Support debug names for resources

### DIFF
--- a/src/d3d11/d3d11_annotation.cpp
+++ b/src/d3d11/d3d11_annotation.cpp
@@ -38,7 +38,7 @@ namespace dxvk {
           ContextType*          container,
     const Rc<DxvkDevice>&       dxvkDevice)
   : m_container(container), m_eventDepth(0),
-    m_annotationsEnabled(dxvkDevice->instance()->extensions().extDebugUtils) {
+    m_annotationsEnabled(dxvkDevice->isDebugEnabled()) {
     if (!IsDeferred && m_annotationsEnabled)
       RegisterUserDefinedAnnotation<true>(this);
   }

--- a/src/d3d11/d3d11_annotation.cpp
+++ b/src/d3d11/d3d11_annotation.cpp
@@ -87,7 +87,7 @@ namespace dxvk {
       label.pLabelName = labelName.c_str();
       DecodeD3DCOLOR(color, label.color);
 
-      ctx->beginDebugLabel(&label);
+      ctx->beginDebugLabel(label);
     });
 
     return m_eventDepth++;
@@ -125,7 +125,7 @@ namespace dxvk {
       label.pLabelName = labelName.c_str();
       DecodeD3DCOLOR(color, label.color);
 
-      ctx->insertDebugLabel(&label);
+      ctx->insertDebugLabel(label);
     });
   }
 

--- a/src/d3d11/d3d11_buffer.cpp
+++ b/src/d3d11/d3d11_buffer.cpp
@@ -370,6 +370,8 @@ namespace dxvk {
                 | VK_ACCESS_INDIRECT_COMMAND_READ_BIT
                 | VK_ACCESS_TRANSFORM_FEEDBACK_COUNTER_READ_BIT_EXT
                 | VK_ACCESS_TRANSFORM_FEEDBACK_COUNTER_WRITE_BIT_EXT;
+    info.debugName = "SO counter";
+
     return device->createBuffer(info, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
   }
 

--- a/src/d3d11/d3d11_buffer.cpp
+++ b/src/d3d11/d3d11_buffer.cpp
@@ -1,5 +1,6 @@
 #include "d3d11_buffer.h"
 #include "d3d11_context.h"
+#include "d3d11_context_imm.h"
 #include "d3d11_device.h"
 
 namespace dxvk {
@@ -208,6 +209,18 @@ namespace dxvk {
     VkFormatFeatureFlags2 features = GetBufferFormatFeatures(BindFlags);
 
     return CheckFormatFeatureSupport(viewFormat.Format, features);
+  }
+
+
+  void D3D11Buffer::SetDebugName(const char* pName) {
+    if (m_buffer) {
+      m_parent->GetContext()->InjectCs([
+        cBuffer = m_buffer,
+        cName   = std::string(pName ? pName : "")
+      ] (DxvkContext* ctx) {
+        ctx->setDebugName(cBuffer, cName.c_str());
+      });
+    }
   }
 
 

--- a/src/d3d11/d3d11_buffer.h
+++ b/src/d3d11/d3d11_buffer.h
@@ -61,6 +61,8 @@ namespace dxvk {
     void STDMETHODCALLTYPE GetDesc(
             D3D11_BUFFER_DESC *pDesc) final;
     
+    void STDMETHODCALLTYPE SetDebugName(const char* pName) final;
+
     bool CheckViewCompatibility(
             UINT                BindFlags,
             DXGI_FORMAT         Format) const;

--- a/src/d3d11/d3d11_device_child.h
+++ b/src/d3d11/d3d11_device_child.h
@@ -19,24 +19,28 @@ namespace dxvk {
     }
     
     HRESULT STDMETHODCALLTYPE GetPrivateData(
-            REFGUID guid,
-            UINT    *pDataSize,
-            void    *pData) final {
+            REFGUID               guid,
+            UINT*                 pDataSize,
+            void*                 pData) final {
       return m_privateData.getData(
         guid, pDataSize, pData);
     }
     
     HRESULT STDMETHODCALLTYPE SetPrivateData(
-            REFGUID guid,
-            UINT    DataSize,
-      const void    *pData) final {
+            REFGUID               guid,
+            UINT                  DataSize,
+      const void*                 pData) final {
+      // WKPDID_D3DDebugObjectName, can't use directly due to MSVC link errors
+      if (guid == GUID{0x429b8c22,0x9188,0x4b0c,0x87,0x42,0xac,0xb0,0xbf,0x85,0xc2,0x00})
+        SetDebugName(static_cast<const char*>(pData));
+
       return m_privateData.setData(
         guid, DataSize, pData);
     }
     
     HRESULT STDMETHODCALLTYPE SetPrivateDataInterface(
-            REFGUID  guid,
-      const IUnknown *pUnknown) final {
+            REFGUID               guid,
+      const IUnknown*             pUnknown) final {
       return m_privateData.setInterface(
         guid, pUnknown);
     }
@@ -44,6 +48,10 @@ namespace dxvk {
     void STDMETHODCALLTYPE GetDevice(
             ID3D11Device**        ppDevice) final {
       *ppDevice = ref(GetParentInterface());
+    }
+
+    virtual void STDMETHODCALLTYPE SetDebugName(const char* pName) {
+      // No-op by default
     }
 
   protected:

--- a/src/d3d11/d3d11_shader.cpp
+++ b/src/d3d11/d3d11_shader.cpp
@@ -67,6 +67,7 @@ namespace dxvk {
       info.usage  = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
       info.stages = util::pipelineStages(shaderInfo.stage);
       info.access = VK_ACCESS_UNIFORM_READ_BIT;
+      info.debugName = "Icb";
       
       VkMemoryPropertyFlags memFlags
         = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT

--- a/src/d3d11/d3d11_swapchain.cpp
+++ b/src/d3d11/d3d11_swapchain.cpp
@@ -571,6 +571,7 @@ namespace dxvk {
     imageInfo.tiling      = VK_IMAGE_TILING_OPTIMAL;
     imageInfo.layout      = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
     imageInfo.shared      = VK_TRUE;
+    imageInfo.debugName   = "Swap image";
 
     DxvkImageViewKey viewInfo;
     viewInfo.viewType     = VK_IMAGE_VIEW_TYPE_2D;
@@ -652,6 +653,8 @@ namespace dxvk {
       cImages = std::move(images)
     ] (DxvkContext* ctx) {
       for (size_t i = 0; i < cImages.size(); i++) {
+        ctx->setDebugName(cImages[i], str::format("Back buffer ", i).c_str());
+
         ctx->initImage(cImages[i],
           cImages[i]->getAvailableSubresources(),
           VK_IMAGE_LAYOUT_UNDEFINED);

--- a/src/d3d11/d3d11_texture.cpp
+++ b/src/d3d11/d3d11_texture.cpp
@@ -1,4 +1,5 @@
 #include "d3d11_device.h"
+#include "d3d11_context_imm.h"
 #include "d3d11_gdi.h"
 #include "d3d11_texture.h"
 
@@ -372,8 +373,31 @@ namespace dxvk {
       return viewFormat.Format == baseFormat.Format && planeCount == 1;
     }
   }
-  
-  
+
+
+  void D3D11CommonTexture::SetDebugName(const char* pName) {
+    if (m_image) {
+      m_device->GetContext()->InjectCs([
+        cImage  = m_image,
+        cName   = std::string(pName ? pName : "")
+      ] (DxvkContext* ctx) {
+        ctx->setDebugName(cImage, cName.c_str());
+      });
+    }
+
+    if (m_mapMode == D3D11_COMMON_TEXTURE_MAP_MODE_STAGING) {
+      for (uint32_t i = 0; i < m_buffers.size(); i++) {
+        m_device->GetContext()->InjectCs([
+          cBuffer = m_buffers[i].buffer,
+          cName   = std::string(pName ? pName : "")
+        ] (DxvkContext* ctx) {
+          ctx->setDebugName(cBuffer, cName.c_str());
+        });
+      }
+    }
+  }
+
+
   HRESULT D3D11CommonTexture::NormalizeTextureProperties(D3D11_COMMON_TEXTURE_DESC* pDesc) {
     if (pDesc->Width == 0 || pDesc->Height == 0 || pDesc->Depth == 0 || pDesc->ArraySize == 0)
       return E_INVALIDARG;
@@ -1194,8 +1218,13 @@ namespace dxvk {
     pDesc->CPUAccessFlags = m_texture.Desc()->CPUAccessFlags;
     pDesc->MiscFlags      = m_texture.Desc()->MiscFlags;
   }
-  
-  
+
+
+  void STDMETHODCALLTYPE D3D11Texture1D::SetDebugName(const char* pName) {
+    m_texture.SetDebugName(pName);
+  }
+
+
   ///////////////////////////////////////////
   //      D 3 D 1 1 T E X T U R E 2 D
   D3D11Texture2D::D3D11Texture2D(
@@ -1377,6 +1406,11 @@ namespace dxvk {
   }
   
   
+  void STDMETHODCALLTYPE D3D11Texture2D::SetDebugName(const char* pName) {
+    m_texture.SetDebugName(pName);
+  }
+
+
   ///////////////////////////////////////////
   //      D 3 D 1 1 T E X T U R E 3 D
   D3D11Texture3D::D3D11Texture3D(
@@ -1488,6 +1522,11 @@ namespace dxvk {
   }
   
   
+  void STDMETHODCALLTYPE D3D11Texture3D::SetDebugName(const char* pName) {
+    m_texture.SetDebugName(pName);
+  }
+
+
   D3D11CommonTexture* GetCommonTexture(ID3D11Resource* pResource) {
     D3D11_RESOURCE_DIMENSION dimension = D3D11_RESOURCE_DIMENSION_UNKNOWN;
     pResource->GetType(&dimension);

--- a/src/d3d11/d3d11_texture.cpp
+++ b/src/d3d11/d3d11_texture.cpp
@@ -754,6 +754,7 @@ namespace dxvk {
                 | VK_ACCESS_TRANSFER_WRITE_BIT
                 | VK_ACCESS_SHADER_READ_BIT
                 | VK_ACCESS_SHADER_WRITE_BIT;
+    info.debugName = "Image buffer";
 
     // We may read mapped buffers even if it is
     // marked as CPU write-only on the D3D11 side.

--- a/src/d3d11/d3d11_texture.h
+++ b/src/d3d11/d3d11_texture.h
@@ -526,6 +526,14 @@ namespace dxvk {
     }
 
     /**
+     * \brief Sets debug name for texture
+     *
+     * Passes the given name to the backing image or buffer.
+     * \param [in] name Debug name
+     */
+    void SetDebugName(const char* pName);
+
+    /**
      * \brief Normalizes and validates texture description
      * 
      * Fills in undefined values and validates the texture
@@ -759,6 +767,8 @@ namespace dxvk {
     void STDMETHODCALLTYPE GetDesc(
             D3D11_TEXTURE1D_DESC *pDesc) final;
     
+    void STDMETHODCALLTYPE SetDebugName(const char* pName) final;
+
     D3D11CommonTexture* GetCommonTexture() {
       return &m_texture;
     }
@@ -825,6 +835,8 @@ namespace dxvk {
     void STDMETHODCALLTYPE GetDesc1(
             D3D11_TEXTURE2D_DESC1* pDesc) final;
     
+    void STDMETHODCALLTYPE SetDebugName(const char* pName) final;
+
     D3D11CommonTexture* GetCommonTexture() {
       return &m_texture;
     }
@@ -875,6 +887,8 @@ namespace dxvk {
     void STDMETHODCALLTYPE GetDesc1(
             D3D11_TEXTURE3D_DESC1* pDesc) final;
     
+    void STDMETHODCALLTYPE SetDebugName(const char* pName) final;
+
     D3D11CommonTexture* GetCommonTexture() {
       return &m_texture;
     }

--- a/src/d3d11/d3d11_video.cpp
+++ b/src/d3d11/d3d11_video.cpp
@@ -1323,6 +1323,8 @@ namespace dxvk {
     bufferInfo.usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
     bufferInfo.stages = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
     bufferInfo.access = VK_ACCESS_UNIFORM_READ_BIT;
+    bufferInfo.debugName = "Video blit parameters";
+
     m_ubo = m_device->createBuffer(bufferInfo, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
   }
 

--- a/src/d3d11/d3d11_view_uav.cpp
+++ b/src/d3d11/d3d11_view_uav.cpp
@@ -450,6 +450,7 @@ namespace dxvk {
                 | VK_ACCESS_TRANSFER_READ_BIT
                 | VK_ACCESS_SHADER_WRITE_BIT
                 | VK_ACCESS_SHADER_READ_BIT;
+    info.debugName = "UAV counter";
 
     Rc<DxvkBuffer> buffer = device->createBuffer(info, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
 

--- a/src/d3d9/d3d9_annotation.cpp
+++ b/src/d3d9/d3d9_annotation.cpp
@@ -135,7 +135,7 @@ namespace dxvk {
       label.pLabelName = labelName.c_str();
       DecodeD3DCOLOR(color, label.color);
 
-      ctx->beginDebugLabel(&label);
+      ctx->beginDebugLabel(label);
     });
 
     // Handled by the global list.
@@ -165,7 +165,7 @@ namespace dxvk {
       label.pLabelName = labelName.c_str();
       DecodeD3DCOLOR(color, label.color);
 
-      ctx->insertDebugLabel(&label);
+      ctx->insertDebugLabel(label);
     });
   }
 

--- a/src/d3d9/d3d9_constant_buffer.cpp
+++ b/src/d3d9/d3d9_constant_buffer.cpp
@@ -101,6 +101,7 @@ namespace dxvk {
     bufferInfo.usage  = m_usage;
     bufferInfo.access = 0;
     bufferInfo.stages = util::pipelineStages(m_stages);
+    bufferInfo.debugName = "Constant buffer";
 
     if (m_usage & VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT)
       bufferInfo.access |= VK_ACCESS_UNIFORM_READ_BIT;

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -4576,6 +4576,7 @@ namespace dxvk {
       info.access = VK_ACCESS_VERTEX_ATTRIBUTE_READ_BIT
                   | VK_ACCESS_INDEX_READ_BIT;
       info.stages = VK_PIPELINE_STAGE_VERTEX_INPUT_BIT;
+      info.debugName = "UP buffer";
 
       Rc<DxvkBuffer> buffer = m_dxvkDevice->createBuffer(info, memoryFlags);
       void* mapPtr = buffer->mapPtr(0);

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -70,7 +70,7 @@ namespace dxvk {
     if (canSWVP)
       Logger::info("D3D9DeviceEx: Using extended constant set for software vertex processing.");
 
-    if (m_dxvkDevice->instance()->extensions().extDebugUtils)
+    if (m_dxvkDevice->isDebugEnabled())
       m_annotation = new D3D9UserDefinedAnnotation(this);
 
     m_initializer      = new D3D9Initializer(this);

--- a/src/dxvk/dxvk_buffer.h
+++ b/src/dxvk/dxvk_buffer.h
@@ -35,6 +35,9 @@ namespace dxvk {
 
     /// Buffer create flags
     VkBufferCreateFlags flags = 0;
+
+    /// Debug name.
+    const char* debugName = nullptr;
   };
 
 
@@ -341,6 +344,9 @@ namespace dxvk {
       m_storage = std::move(slice);
       m_bufferInfo = m_storage->getBufferInfo();
 
+      if (unlikely(m_info.debugName))
+        updateDebugName();
+
       // Implicitly invalidate views
       m_version += 1u;
       return result;
@@ -406,6 +412,12 @@ namespace dxvk {
     Rc<DxvkResourceAllocation> relocateStorage(
             DxvkAllocationModes         mode);
 
+    /**
+     * \brief Sets debug name for the backing resource
+     * \param [in] name New debug name
+     */
+    void setDebugName(const char* name);
+
   private:
 
     Rc<vk::DeviceFn>            m_vkd;
@@ -428,6 +440,12 @@ namespace dxvk {
     dxvk::mutex                 m_viewMutex;
     std::unordered_map<DxvkBufferViewKey,
       DxvkBufferView, DxvkHash, DxvkEq> m_views;
+
+    std::string                 m_debugName;
+
+    void updateDebugName();
+
+    std::string createDebugName(const char* name) const;
 
   };
 

--- a/src/dxvk/dxvk_cmdlist.cpp
+++ b/src/dxvk/dxvk_cmdlist.cpp
@@ -115,7 +115,7 @@ namespace dxvk {
   }
 
 
-  VkCommandBuffer DxvkCommandPool::getCommandBuffer() {
+  VkCommandBuffer DxvkCommandPool::getCommandBuffer(DxvkCmdBuffer type) {
     auto vk = m_device->vkd();
 
     if (m_next == m_commandBuffers.size()) {
@@ -143,6 +143,24 @@ namespace dxvk {
     if (vk->vkBeginCommandBuffer(commandBuffer, &info))
       throw DxvkError("DxvkCommandPool: Failed to begin command buffer");
 
+    if (m_device->isDebugEnabled()) {
+      auto vki = m_device->vki();
+
+      VkDebugUtilsLabelEXT label = { };
+
+      switch (type) {
+        case DxvkCmdBuffer::ExecBuffer: label = vk::makeLabel(0xdcc0a2, "Graphics commands"); break;
+        case DxvkCmdBuffer::InitBuffer: label = vk::makeLabel(0xc0dca2, "Init commands"); break;
+        case DxvkCmdBuffer::InitBarriers: label = vk::makeLabel(0xd0e6b8, "Init barriers"); break;
+        case DxvkCmdBuffer::SdmaBuffer: label = vk::makeLabel(0xc0a2dc, "Upload commands"); break;
+        case DxvkCmdBuffer::SdmaBarriers: label = vk::makeLabel(0xd0b8e6, "Upload barriers"); break;
+        default: ;
+      }
+
+      if (label.pLabelName)
+        vki->vkCmdBeginDebugUtilsLabelEXT(commandBuffer, &label);
+    }
+
     return commandBuffer;
   }
 
@@ -162,7 +180,7 @@ namespace dxvk {
   DxvkCommandList::DxvkCommandList(DxvkDevice* device)
   : m_device        (device),
     m_vkd           (device->vkd()),
-    m_vki           (device->instance()->vki()) {
+    m_vki           (device->vki()) {
     const auto& graphicsQueue = m_device->queues().graphics;
     const auto& transferQueue = m_device->queues().transfer;
 
@@ -409,6 +427,9 @@ namespace dxvk {
   void DxvkCommandList::endCommandBuffer(VkCommandBuffer cmdBuffer) {
     auto vk = m_device->vkd();
 
+    if (m_device->isDebugEnabled())
+      m_vki->vkCmdEndDebugUtilsLabelEXT(cmdBuffer);
+
     if (vk->vkEndCommandBuffer(cmdBuffer))
       throw DxvkError("DxvkCommandList: Failed to end command buffer");
   }
@@ -416,8 +437,8 @@ namespace dxvk {
 
   VkCommandBuffer DxvkCommandList::allocateCommandBuffer(DxvkCmdBuffer type) {
     return type == DxvkCmdBuffer::SdmaBuffer || type == DxvkCmdBuffer::SdmaBarriers
-      ? m_transferPool->getCommandBuffer()
-      : m_graphicsPool->getCommandBuffer();
+      ? m_transferPool->getCommandBuffer(type)
+      : m_graphicsPool->getCommandBuffer(type);
   }
 
 }

--- a/src/dxvk/dxvk_cmdlist.h
+++ b/src/dxvk/dxvk_cmdlist.h
@@ -1048,25 +1048,28 @@ namespace dxvk {
     
 
     void cmdBeginDebugUtilsLabel(
-            VkDebugUtilsLabelEXT*   pLabelInfo) {
+            DxvkCmdBuffer           cmdBuffer,
+      const VkDebugUtilsLabelEXT&   labelInfo) {
       m_cmd.execCommands = true;
 
-      m_vki->vkCmdBeginDebugUtilsLabelEXT(getCmdBuffer(), pLabelInfo);
+      m_vki->vkCmdBeginDebugUtilsLabelEXT(getCmdBuffer(cmdBuffer), &labelInfo);
     }
 
 
-    void cmdEndDebugUtilsLabel() {
+    void cmdEndDebugUtilsLabel(
+            DxvkCmdBuffer           cmdBuffer) {
       m_cmd.execCommands = true;
 
-      m_vki->vkCmdEndDebugUtilsLabelEXT(getCmdBuffer());
+      m_vki->vkCmdEndDebugUtilsLabelEXT(getCmdBuffer(cmdBuffer));
     }
 
 
     void cmdInsertDebugUtilsLabel(
-            VkDebugUtilsLabelEXT*   pLabelInfo) {
+            DxvkCmdBuffer           cmdBuffer,
+      const VkDebugUtilsLabelEXT&   labelInfo) {
       m_cmd.execCommands = true;
 
-      m_vki->vkCmdInsertDebugUtilsLabelEXT(getCmdBuffer(), pLabelInfo);
+      m_vki->vkCmdInsertDebugUtilsLabelEXT(getCmdBuffer(cmdBuffer), &labelInfo);
     }
 
 

--- a/src/dxvk/dxvk_cmdlist.h
+++ b/src/dxvk/dxvk_cmdlist.h
@@ -172,9 +172,11 @@ namespace dxvk {
 
     /**
      * \brief Retrieves or allocates a command buffer
+     *
+     * \param [in] type Command buffer type
      * \returns New command buffer in begun state
      */
-    VkCommandBuffer getCommandBuffer();
+    VkCommandBuffer getCommandBuffer(DxvkCmdBuffer type);
 
     /**
      * \brief Resets command pool and all command buffers

--- a/src/dxvk/dxvk_compute.cpp
+++ b/src/dxvk/dxvk_compute.cpp
@@ -24,7 +24,8 @@ namespace dxvk {
     m_library       (library),
     m_libraryHandle (VK_NULL_HANDLE),
     m_shaders       (std::move(shaders)),
-    m_bindings      (layout) {
+    m_bindings      (layout),
+    m_debugName     (createDebugName()) {
 
   }
   
@@ -155,6 +156,14 @@ namespace dxvk {
     }
 
     Logger::log(level, sstr.str());
+  }
+
+
+  std::string DxvkComputePipeline::createDebugName() const {
+    std::string shaderName = m_shaders.cs->debugName();
+    size_t len = std::min(shaderName.size(), size_t(10));
+
+    return str::format("[", shaderName.substr(0, len), "]");
   }
 
 }

--- a/src/dxvk/dxvk_compute.h
+++ b/src/dxvk/dxvk_compute.h
@@ -119,7 +119,17 @@ namespace dxvk {
      */
     void compilePipeline(
       const DxvkComputePipelineStateInfo& state);
-    
+
+    /**
+     * \brief Debug name
+     *
+     * Consists of the compute shader's debug name.
+     * \returns Debug name
+     */
+    const char* debugName() const {
+      return m_debugName.c_str();
+    }
+
   private:
     
     DxvkDevice*                 m_device;    
@@ -132,6 +142,8 @@ namespace dxvk {
     DxvkComputePipelineShaders  m_shaders;
     DxvkBindingLayoutObjects*   m_bindings;
     
+    std::string                 m_debugName;
+
     alignas(CACHE_LINE_SIZE)
     dxvk::mutex                             m_mutex;
     sync::List<DxvkComputePipelineInstance> m_pipelines;
@@ -151,6 +163,8 @@ namespace dxvk {
     void logPipelineState(
             LogLevel                      level,
       const DxvkComputePipelineStateInfo& state) const;
+
+    std::string createDebugName() const;
 
   };
   

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -2477,25 +2477,21 @@ namespace dxvk {
   }
 
 
-  void DxvkContext::beginDebugLabel(VkDebugUtilsLabelEXT *label) {
-    if (!m_device->instance()->extensions().extDebugUtils)
-      return;
-
-    m_cmd->cmdBeginDebugUtilsLabel(label);
+  void DxvkContext::beginDebugLabel(VkDebugUtilsLabelEXT* label) {
+    if (m_device->isDebugEnabled())
+      m_cmd->cmdBeginDebugUtilsLabel(DxvkCmdBuffer::ExecBuffer, *label);
   }
+
 
   void DxvkContext::endDebugLabel() {
-    if (!m_device->instance()->extensions().extDebugUtils)
-      return;
-
-    m_cmd->cmdEndDebugUtilsLabel();
+    if (m_device->isDebugEnabled())
+      m_cmd->cmdEndDebugUtilsLabel(DxvkCmdBuffer::ExecBuffer);
   }
 
-  void DxvkContext::insertDebugLabel(VkDebugUtilsLabelEXT *label) {
-    if (!m_device->instance()->extensions().extDebugUtils)
-      return;
 
-    m_cmd->cmdInsertDebugUtilsLabel(label);
+  void DxvkContext::insertDebugLabel(VkDebugUtilsLabelEXT* label) {
+    if (m_device->isDebugEnabled())
+      m_cmd->cmdInsertDebugUtilsLabel(DxvkCmdBuffer::ExecBuffer, *label);
   }
   
   

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -63,6 +63,10 @@ namespace dxvk {
     // Maintenance5 introduced a bounded BindIndexBuffer function
     if (m_device->features().khrMaintenance5.maintenance5)
       m_features.set(DxvkContextFeature::IndexBufferRobustness);
+
+    // Add a fast path to query debug utils support
+    if (m_device->isDebugEnabled())
+      m_features.set(DxvkContextFeature::DebugUtils);
   }
   
   
@@ -101,6 +105,8 @@ namespace dxvk {
       m_cmd->trackDescriptorPool(m_descriptorPool, m_descriptorManager);
       m_descriptorPool = m_descriptorManager->getDescriptorPool();
     }
+
+    m_renderPassIndex = 0u;
   }
 
 
@@ -2481,29 +2487,27 @@ namespace dxvk {
   }
 
 
-  void DxvkContext::beginDebugLabel(VkDebugUtilsLabelEXT* label) {
-    if (m_device->isDebugEnabled())
+  void DxvkContext::beginDebugLabel(VkDebugUtilsLabelEXT *label) {
+    if (m_features.test(DxvkContextFeature::DebugUtils))
       m_cmd->cmdBeginDebugUtilsLabel(DxvkCmdBuffer::ExecBuffer, *label);
   }
 
 
   void DxvkContext::endDebugLabel() {
-    if (m_device->isDebugEnabled())
+    if (m_features.test(DxvkContextFeature::DebugUtils))
       m_cmd->cmdEndDebugUtilsLabel(DxvkCmdBuffer::ExecBuffer);
   }
 
 
-  void DxvkContext::insertDebugLabel(VkDebugUtilsLabelEXT* label) {
-    if (m_device->isDebugEnabled())
+  void DxvkContext::insertDebugLabel(VkDebugUtilsLabelEXT *label) {
+    if (m_features.test(DxvkContextFeature::DebugUtils))
       m_cmd->cmdInsertDebugUtilsLabel(DxvkCmdBuffer::ExecBuffer, *label);
   }
 
 
   void DxvkContext::setDebugName(const Rc<DxvkPagedResource>& resource, const char* name) {
-    if (!m_device->isDebugEnabled())
-      return;
-
-    resource->setDebugName(name);
+    if (m_features.test(DxvkContextFeature::DebugUtils))
+      resource->setDebugName(name);
   }
   
   

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -4940,6 +4940,11 @@ namespace dxvk {
     if (newPipeline->getBindings()->layout().getPushConstantRange(true).size)
       m_flags.set(DxvkContextFlag::DirtyPushConstants);
 
+    if (unlikely(m_features.test(DxvkContextFeature::DebugUtils))) {
+      m_cmd->cmdInsertDebugUtilsLabel(DxvkCmdBuffer::ExecBuffer,
+        vk::makeLabel(0xf0dca2, newPipeline->debugName()));
+    }
+
     m_flags.clr(DxvkContextFlag::CpDirtyPipelineState);
     return true;
   }
@@ -5106,6 +5111,11 @@ namespace dxvk {
       accessMemory(DxvkCmdBuffer::ExecBuffer,
         srcBarrier.stages, srcBarrier.access,
         dstBarrier.stages, dstBarrier.access);
+    }
+
+    if (unlikely(m_features.test(DxvkContextFeature::DebugUtils))) {
+      m_cmd->cmdInsertDebugUtilsLabel(DxvkCmdBuffer::ExecBuffer,
+        vk::makeLabel(0xa2dcf0, m_state.gp.pipeline->debugName()));
     }
 
     m_flags.clr(DxvkContextFlag::GpDirtyPipelineState);

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -1234,6 +1234,13 @@ namespace dxvk {
 
     flushPendingAccesses(*imageView->image(), imageView->imageSubresources(), DxvkAccess::Write);
 
+    if (unlikely(m_features.test(DxvkContextFeature::DebugUtils))) {
+      const char* dstName = imageView->image()->info().debugName;
+
+      m_cmd->cmdBeginDebugUtilsLabel(DxvkCmdBuffer::ExecBuffer, vk::makeLabel(0xe6dcf0,
+        str::format("Mip gen (", dstName ? dstName : "unknown", ")").c_str()));
+    }
+
     // Create image views, etc.
     DxvkMetaMipGenViews mipGenerator(imageView);
     
@@ -1366,6 +1373,9 @@ namespace dxvk {
         VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT,
         VK_ACCESS_2_COLOR_ATTACHMENT_WRITE_BIT);
     }
+
+    if (unlikely(m_features.test(DxvkContextFeature::DebugUtils)))
+      m_cmd->cmdEndDebugUtilsLabel(DxvkCmdBuffer::ExecBuffer);
 
     m_cmd->track(imageView->image(), DxvkAccess::Write);
     m_cmd->track(std::move(sampler));

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -1798,6 +1798,12 @@ namespace dxvk {
 
       flushPendingAccesses(*imageView, DxvkAccess::Write);
 
+      if (unlikely(m_features.test(DxvkContextFeature::DebugUtils))) {
+        const char* imageName = imageView->image()->info().debugName;
+        m_cmd->cmdBeginDebugUtilsLabel(DxvkCmdBuffer::ExecBuffer,
+          vk::makeLabel(0xe6f0dc, str::format("Clear render target (", imageName ? imageName : "unknown", ")").c_str()));
+      }
+
       // Set up a temporary render pass to execute the clear
       VkImageLayout imageLayout = ((clearAspects | discardAspects) & VK_IMAGE_ASPECT_COLOR_BIT)
         ? imageView->pickLayout(VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL)
@@ -1882,6 +1888,9 @@ namespace dxvk {
         imageLayout, clearStages, clearAccess, storeLayout,
         imageView->image()->info().stages,
         imageView->image()->info().access);
+
+      if (unlikely(m_features.test(DxvkContextFeature::DebugUtils)))
+        m_cmd->cmdEndDebugUtilsLabel(DxvkCmdBuffer::ExecBuffer);
 
       m_cmd->track(imageView->image(), DxvkAccess::Write);
     } else {

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -6612,6 +6612,11 @@ namespace dxvk {
     if (resourceList.empty())
       return;
 
+    if (unlikely(m_features.test(DxvkContextFeature::DebugUtils))) {
+      m_cmd->cmdBeginDebugUtilsLabel(DxvkCmdBuffer::ExecBuffer,
+        vk::makeLabel(0xc0a2f0, "Memory defrag"));
+    }
+
     std::vector<DxvkRelocateBufferInfo> bufferInfos;
     std::vector<DxvkRelocateImageInfo> imageInfos;
 
@@ -6649,6 +6654,9 @@ namespace dxvk {
       imageInfos.size(), imageInfos.data());
 
     m_cmd->setSubmissionBarrier();
+
+    if (unlikely(m_features.test(DxvkContextFeature::DebugUtils)))
+      m_cmd->cmdEndDebugUtilsLabel(DxvkCmdBuffer::ExecBuffer);
   }
 
 

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -2493,6 +2493,14 @@ namespace dxvk {
     if (m_device->isDebugEnabled())
       m_cmd->cmdInsertDebugUtilsLabel(DxvkCmdBuffer::ExecBuffer, *label);
   }
+
+
+  void DxvkContext::setDebugName(const Rc<DxvkPagedResource>& resource, const char* name) {
+    if (!m_device->isDebugEnabled())
+      return;
+
+    resource->setDebugName(name);
+  }
   
   
   void DxvkContext::blitImageFb(

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -456,6 +456,7 @@ namespace dxvk {
       bufInfo.stages  = VK_PIPELINE_STAGE_TRANSFER_BIT;
       bufInfo.access  = VK_ACCESS_TRANSFER_WRITE_BIT
                       | VK_ACCESS_TRANSFER_READ_BIT;
+      bufInfo.debugName = "Temp buffer";
 
       auto tmpBuffer = m_device->createBuffer(
         bufInfo, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
@@ -567,6 +568,7 @@ namespace dxvk {
                             | VK_ACCESS_TRANSFER_READ_BIT;
       imgInfo.tiling        = dstImage->info().tiling;
       imgInfo.layout        = VK_IMAGE_LAYOUT_GENERAL;
+      imgInfo.debugName     = "Temp image";
 
       auto tmpImage = m_device->createImage(
         imgInfo, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
@@ -679,6 +681,8 @@ namespace dxvk {
                         | VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT;
       bufferInfo.access = VK_ACCESS_TRANSFER_WRITE_BIT
                         | VK_ACCESS_SHADER_READ_BIT;
+      bufferInfo.debugName = "Temp buffer";
+
       Rc<DxvkBuffer> tmpBuffer = m_device->createBuffer(bufferInfo, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
 
       auto tmpBufferSlice = tmpBuffer->getSliceHandle();
@@ -6615,6 +6619,7 @@ namespace dxvk {
     bufInfo.stages  = VK_PIPELINE_STAGE_TRANSFER_BIT;
     bufInfo.access  = VK_ACCESS_TRANSFER_WRITE_BIT
                     | VK_ACCESS_TRANSFER_READ_BIT;
+    bufInfo.debugName = "Zero buffer";
 
     m_zeroBuffer = m_device->createBuffer(bufInfo,
       VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);

--- a/src/dxvk/dxvk_context.h
+++ b/src/dxvk/dxvk_context.h
@@ -1328,12 +1328,12 @@ namespace dxvk {
 
     /**
      * \brief Begins a debug label region
-     * \param [in] label The debug label
      *
      * Marks the start of a debug label region. Used by debugging/profiling
      * tools to mark different workloads within a frame.
+     * \param [in] label The debug label
      */
-    void beginDebugLabel(VkDebugUtilsLabelEXT *label);
+    void beginDebugLabel(const VkDebugUtilsLabelEXT& label);
 
     /**
      * \brief Ends a debug label region
@@ -1345,12 +1345,12 @@ namespace dxvk {
 
     /**
      * \brief Inserts a debug label
-     * \param [in] label The debug label
      *
      * Inserts an instantaneous debug label. Used by debugging/profiling
      * tools to mark different workloads within a frame.
+     * \param [in] label The debug label
      */
-    void insertDebugLabel(VkDebugUtilsLabelEXT *label);
+    void insertDebugLabel(const VkDebugUtilsLabelEXT& label);
 
     /**
      * \brief Increments a given stat counter
@@ -1417,6 +1417,9 @@ namespace dxvk {
     std::array<DxvkComputePipeline*,   256> m_cpLookupCache = { };
 
     std::vector<VkImageMemoryBarrier2> m_imageLayoutTransitions;
+
+    std::vector<util::DxvkDebugLabel> m_debugLabelStack;
+    bool                              m_debugLabelInternalActive = false;
 
     void blitImageFb(
             Rc<DxvkImageView>     dstView,
@@ -1934,6 +1937,15 @@ namespace dxvk {
       // Check whether there are any pending reads.
       return pred(DxvkAccess::Read);
     }
+
+    void beginInternalDebugRegion(
+      const VkDebugUtilsLabelEXT&       label);
+
+    void endInternalDebugRegion();
+
+    void beginActiveDebugRegions();
+
+    void endActiveDebugRegions();
 
     static bool formatsAreCopyCompatible(
             VkFormat                  imageFormat,

--- a/src/dxvk/dxvk_context.h
+++ b/src/dxvk/dxvk_context.h
@@ -1379,6 +1379,7 @@ namespace dxvk {
     DxvkObjects*            m_common;
 
     uint64_t                m_trackingId = 0u;
+    uint32_t                m_renderPassIndex = 0u;
     
     Rc<DxvkCommandList>     m_cmd;
     Rc<DxvkBuffer>          m_zeroBuffer;

--- a/src/dxvk/dxvk_context.h
+++ b/src/dxvk/dxvk_context.h
@@ -1365,6 +1365,14 @@ namespace dxvk {
         m_cmd->addStatCtr(counter, value);
     }
 
+    /**
+     * \brief Sets new debug name for a resource
+     *
+     * \param [in] buffer Buffer object
+     * \param [in] name New debug name, or \c nullptr
+     */
+    void setDebugName(const Rc<DxvkPagedResource>& resource, const char* name);
+
   private:
     
     Rc<DxvkDevice>          m_device;

--- a/src/dxvk/dxvk_context.h
+++ b/src/dxvk/dxvk_context.h
@@ -1938,6 +1938,8 @@ namespace dxvk {
       return pred(DxvkAccess::Read);
     }
 
+    void beginRenderPassDebugRegion();
+
     void beginInternalDebugRegion(
       const VkDebugUtilsLabelEXT&       label);
 

--- a/src/dxvk/dxvk_context_state.h
+++ b/src/dxvk/dxvk_context_state.h
@@ -66,6 +66,7 @@ namespace dxvk {
     TrackGraphicsPipeline,
     VariableMultisampleRate,
     IndexBufferRobustness,
+    DebugUtils,
     FeatureCount
   };
 

--- a/src/dxvk/dxvk_device.h
+++ b/src/dxvk/dxvk_device.h
@@ -93,11 +93,27 @@ namespace dxvk {
     }
     
     /**
+     * \brief Vulkan instance functions
+     * \returns Vulkan instance functions
+     */
+    Rc<vk::InstanceFn> vki() const {
+      return m_instance->vki();
+    }
+    
+    /**
      * \brief Logical device handle
      * \returns The device handle
      */
     VkDevice handle() const {
       return m_vkd->device();
+    }
+
+    /**
+     * \brief Checks whether debug functionality is enabled
+     * \returns \c true if debug utils are enabled
+     */
+    bool isDebugEnabled() const {
+      return bool(m_instance->extensions().extDebugUtils);
     }
 
     /**

--- a/src/dxvk/dxvk_graphics.cpp
+++ b/src/dxvk/dxvk_graphics.cpp
@@ -945,7 +945,8 @@ namespace dxvk {
     m_bindings      (layout),
     m_barrier       (layout->getGlobalBarrier()),
     m_vsLibrary     (vsLibrary),
-    m_fsLibrary     (fsLibrary) {
+    m_fsLibrary     (fsLibrary),
+    m_debugName     (createDebugName()) {
     m_vsIn  = m_shaders.vs != nullptr ? m_shaders.vs->info().inputMask  : 0;
     m_fsOut = m_shaders.fs != nullptr ? m_shaders.fs->info().outputMask : 0;
     m_specConstantMask = this->computeSpecConstantMask();
@@ -1672,6 +1673,29 @@ namespace dxvk {
     }
 
     Logger::log(level, sstr.str());
+  }
+
+
+  std::string DxvkGraphicsPipeline::createDebugName() const {
+    std::stringstream name;
+
+    std::array<Rc<DxvkShader>, 5> shaders = {{
+      m_shaders.vs,
+      m_shaders.tcs,
+      m_shaders.tes,
+      m_shaders.gs,
+      m_shaders.fs,
+    }};
+
+    for (const auto& shader : shaders) {
+      if (shader) {
+        std::string shaderName = shader->debugName();
+        size_t len = std::min(shaderName.size(), size_t(10));
+        name << "[" << shaderName.substr(0, len) << "] ";
+      }
+    }
+
+    return name.str();
   }
   
 }

--- a/src/dxvk/dxvk_graphics.h
+++ b/src/dxvk/dxvk_graphics.h
@@ -561,6 +561,17 @@ namespace dxvk {
      */
     void releasePipeline();
 
+    /**
+     * \brief Queries debug name for the pipeline
+     *
+     * The pipeline debug name contains the debug name of
+     * each shader included in the pipeline.
+     * \returns Pipeline debug name
+     */
+    const char* debugName() const {
+      return m_debugName.c_str();
+    }
+
   private:
 
     DxvkDevice*                 m_device;    
@@ -582,6 +593,8 @@ namespace dxvk {
 
     uint32_t m_specConstantMask = 0;
 
+    std::string m_debugName;
+
     alignas(CACHE_LINE_SIZE)
     dxvk::mutex                                   m_mutex;
     sync::List<DxvkGraphicsPipelineInstance>      m_pipelines;
@@ -596,7 +609,7 @@ namespace dxvk {
     std::unordered_map<
       DxvkGraphicsPipelineFastInstanceKey,
       VkPipeline, DxvkHash, DxvkEq>               m_fastPipelines;
-    
+
     DxvkGraphicsPipelineInstance* createInstance(
       const DxvkGraphicsPipelineStateInfo& state,
             bool                           doCreateBasePipeline);
@@ -642,6 +655,8 @@ namespace dxvk {
     void logPipelineState(
             LogLevel                       level,
       const DxvkGraphicsPipelineStateInfo& state) const;
+
+    std::string createDebugName() const;
 
   };
   

--- a/src/dxvk/dxvk_image.h
+++ b/src/dxvk/dxvk_image.h
@@ -66,6 +66,9 @@ namespace dxvk {
 
     // Shared handle info
     DxvkSharedHandleInfo sharing = { };
+
+    // Debug name
+    const char* debugName = nullptr;
   };
   
   
@@ -601,6 +604,12 @@ namespace dxvk {
     bool isInitialized(
       const VkImageSubresourceRange& subresources) const;
 
+    /**
+     * \brief Sets debug name for the backing resource
+     * \param [in] name New debug name
+     */
+    void setDebugName(const char* name);
+
   private:
 
     Rc<vk::DeviceFn>            m_vkd;
@@ -625,6 +634,12 @@ namespace dxvk {
     dxvk::mutex                 m_viewMutex;
     std::unordered_map<DxvkImageViewKey,
       DxvkImageView, DxvkHash, DxvkEq> m_views;
+
+    std::string                 m_debugName;
+
+    void updateDebugName();
+
+    std::string createDebugName(const char* name) const;
 
     VkImageCreateInfo getImageCreateInfo(
       const DxvkImageUsageInfo&         usageInfo) const;

--- a/src/dxvk/dxvk_memory.cpp
+++ b/src/dxvk/dxvk_memory.cpp
@@ -752,6 +752,8 @@ namespace dxvk {
         memoryRequirements.memoryTypeBits = findGlobalBufferMemoryTypeMask(createInfo.usage);
 
       if (likely(memoryRequirements.memoryTypeBits)) {
+        bool allowSuballocation = true;
+
         // If the given allocation cache supports the memory types and usage
         // flags that we need, try to use it to service this allocation.
         // Only use the allocation cache for mappable allocations since those
@@ -769,44 +771,50 @@ namespace dxvk {
           // for any relevant memory pools as necessary.
           if (refillAllocationCache(allocationCache, memoryRequirements, allocationInfo.properties))
             return allocationCache->allocateFromCache(createInfo.size);
+        } else {
+          // Do not suballocate buffers if debug mode is enabled in order
+          // to allow the application to set meaningful debug names.
+          allowSuballocation = !m_device->isDebugEnabled();
         }
 
         // If there is at least one memory type that supports the required
         // buffer usage flags and requested memory properties, suballocate
         // from a global buffer.
-        allocation = allocateMemory(memoryRequirements, allocationInfo);
-
-        if (likely(allocation && allocation->m_buffer))
-          return allocation;
-
-        if (!allocation && (allocationInfo.properties & VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT)
-         && !allocationInfo.mode.test(DxvkAllocationMode::NoFallback)) {
-          DxvkAllocationInfo fallbackInfo = allocationInfo;
-          fallbackInfo.properties &= ~VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
-
-          allocation = allocateMemory(memoryRequirements, fallbackInfo);
+        if (likely(allowSuballocation)) {
+          allocation = allocateMemory(memoryRequirements, allocationInfo);
 
           if (likely(allocation && allocation->m_buffer))
             return allocation;
-        }
 
-        // If we can't get an allocation for a global buffer, there's no
-        // real point in retrying with a dedicated buffer since the result
-        // will most likely be the same.
-        if (!allocation) {
-          if (allocationInfo.mode.isClear()) {
-            logMemoryError(memoryRequirements);
-            logMemoryStats();
+          if (!allocation && (allocationInfo.properties & VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT)
+          && !allocationInfo.mode.test(DxvkAllocationMode::NoFallback)) {
+            DxvkAllocationInfo fallbackInfo = allocationInfo;
+            fallbackInfo.properties &= ~VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
+
+            allocation = allocateMemory(memoryRequirements, fallbackInfo);
+
+            if (likely(allocation && allocation->m_buffer))
+              return allocation;
           }
 
-          return nullptr;
-        }
+          // If we can't get an allocation for a global buffer, there's no
+          // real point in retrying with a dedicated buffer since the result
+          // will most likely be the same.
+          if (!allocation) {
+            if (allocationInfo.mode.isClear()) {
+              logMemoryError(memoryRequirements);
+              logMemoryStats();
+            }
 
-        // If we end up here with an allocation but no buffer, something
-        // is weird, but we can keep the allocation around for now.
-        if (!allocation->m_buffer) {
-          Logger::err(str::format("Got allocation from memory type ",
-            allocation->m_type->index, " without global buffer"));
+            return nullptr;
+          }
+
+          // If we end up here with an allocation but no buffer, something
+          // is weird, but we can keep the allocation around for now.
+          if (!allocation->m_buffer) {
+            Logger::err(str::format("Got allocation from memory type ",
+              allocation->m_type->index, " without global buffer"));
+          }
         }
       }
     }

--- a/src/dxvk/dxvk_memory.h
+++ b/src/dxvk/dxvk_memory.h
@@ -67,6 +67,7 @@ namespace dxvk {
     VkDeviceSize          size    = 0u;
     void*                 mapPtr  = nullptr;
     VkDeviceAddress       gpuVa   = 0u;
+    uint64_t              cookie  = 0u;
   };
 
 
@@ -83,8 +84,6 @@ namespace dxvk {
     high_resolution_clock::time_point unusedTime = { };
     /// Unordered list of resources suballocated from this chunk.
     DxvkResourceAllocation* allocationList = nullptr;
-    /// Chunk cookie
-    uint32_t chunkCookie = 0u;
     /// Whether defragmentation can be performed on this chunk.
     /// Only relevant for chunks in non-mappable device memory.
     VkBool32 canMove = true;
@@ -115,8 +114,6 @@ namespace dxvk {
     VkDeviceSize nextChunkSize = MinChunkSize;
     /// Maximum chunk size for the memory pool. Hard limit.
     VkDeviceSize maxChunkSize = MaxChunkSize;
-    /// Next chunk cookie, used to order chunks in statistics
-    uint32_t nextChunkCookie = 0u;
     /// Next chunk to relocate for defragmentation
     uint32_t nextDefragChunk = ~0u;
 
@@ -1322,6 +1319,8 @@ namespace dxvk {
 
     DxvkResourceAllocationPool  m_allocationPool;
 
+    uint64_t            m_nextCookie = 0u;
+
     alignas(CACHE_LINE_SIZE)
     high_resolution_clock::time_point m_taskDeadline = { };
     std::array<DxvkMemoryStats, VK_MAX_MEMORY_HEAPS> m_adapterHeapStats = { };
@@ -1337,6 +1336,10 @@ namespace dxvk {
             DxvkMemoryType&       type,
             VkDeviceSize          size,
       const void*                 next);
+
+    void assignMemoryDebugName(
+      const DxvkDeviceMemory&     memory,
+      const DxvkMemoryType&       type);
 
     bool allocateChunkInPool(
             DxvkMemoryType&       type,

--- a/src/dxvk/dxvk_sparse.h
+++ b/src/dxvk/dxvk_sparse.h
@@ -604,6 +604,18 @@ namespace dxvk {
     virtual Rc<DxvkResourceAllocation> relocateStorage(
             DxvkAllocationModes         mode) = 0;
 
+    /**
+     * \brief Sets debug name for the backing resource
+     *
+     * The caller \e must ensure that the backing resource
+     * is not being swapped out at the same time. This may
+     * also be ignored for certain types of resources for
+     * performance reasons, and has no effect if the device
+     * does not have debug layers enabled.
+     * \param [in] name New debug name
+     */
+    virtual void setDebugName(const char* name) = 0;
+
   private:
 
     std::atomic<uint64_t> m_useCount = { 0u };

--- a/src/dxvk/dxvk_staging.cpp
+++ b/src/dxvk/dxvk_staging.cpp
@@ -27,6 +27,7 @@ namespace dxvk {
                 | VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
     info.access = VK_ACCESS_TRANSFER_READ_BIT
                 | VK_ACCESS_SHADER_READ_BIT;
+    info.debugName = "Staging buffer";
 
     VkDeviceSize alignedSize = dxvk::align(size, 256u);
     m_allocationCounter += alignedSize;

--- a/src/dxvk/dxvk_swapchain_blitter.cpp
+++ b/src/dxvk/dxvk_swapchain_blitter.cpp
@@ -212,6 +212,7 @@ namespace dxvk {
                        | VK_ACCESS_SHADER_READ_BIT;
       imageInfo.tiling = VK_IMAGE_TILING_OPTIMAL;
       imageInfo.layout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+      imageInfo.debugName = "Swapchain cursor";
 
       m_cursorImage = m_device->createImage(imageInfo, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
 
@@ -367,6 +368,7 @@ namespace dxvk {
       imageInfo.tiling = VK_IMAGE_TILING_OPTIMAL;
       imageInfo.layout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
       imageInfo.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+      imageInfo.debugName = "Swapchain gamma ramp";
 
       m_gammaImage = m_device->createImage(imageInfo,
         VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);

--- a/src/dxvk/dxvk_swapchain_blitter.cpp
+++ b/src/dxvk/dxvk_swapchain_blitter.cpp
@@ -252,6 +252,11 @@ namespace dxvk {
           VkColorSpaceKHR     srcColorSpace,
           VkRect2D            srcRect,
           VkBool32            enableBlending) {
+    if (unlikely(m_device->isDebugEnabled())) {
+      ctx.cmd->cmdInsertDebugUtilsLabel(DxvkCmdBuffer::ExecBuffer,
+        vk::makeLabel(0xdcc0f0, "Swapchain blit"));
+    }
+
     VkExtent3D dstExtent = dstView->mipLevelExtent(0);
 
     VkOffset2D coordA = dstRect.offset;

--- a/src/dxvk/dxvk_unbound.cpp
+++ b/src/dxvk/dxvk_unbound.cpp
@@ -83,6 +83,7 @@ namespace dxvk {
     info.access     = VK_ACCESS_UNIFORM_READ_BIT
                     | VK_ACCESS_SHADER_READ_BIT
                     | VK_ACCESS_SHADER_WRITE_BIT;
+    info.debugName  = "Null buffer";
     
     Rc<DxvkBuffer> buffer = m_device->createBuffer(info,
       VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT |

--- a/src/dxvk/dxvk_util.h
+++ b/src/dxvk/dxvk_util.h
@@ -3,7 +3,41 @@
 #include "dxvk_include.h"
 
 namespace dxvk::util {
-  
+
+  /**
+   * \brief Debug label wrapper
+   *
+   * Wrapper around a Vulkan debug label that
+   * persistently stores the string in question.
+   */
+  class DxvkDebugLabel {
+
+  public:
+
+    DxvkDebugLabel() = default;
+
+    DxvkDebugLabel(const VkDebugUtilsLabelEXT& label)
+    : m_text(label.pLabelName ? label.pLabelName : "") {
+      for (uint32_t i = 0; i < m_color.size(); i++)
+        m_color[i] = label.color[i];
+    }
+
+    VkDebugUtilsLabelEXT get() const {
+      VkDebugUtilsLabelEXT label = { VK_STRUCTURE_TYPE_DEBUG_UTILS_LABEL_EXT };
+      label.pLabelName = m_text.c_str();
+      for (uint32_t i = 0; i < m_color.size(); i++)
+        label.color[i] = m_color[i];
+      return label;
+    }
+
+  private:
+
+    std::string           m_text;
+    std::array<float, 4>  m_color = { };
+
+  };
+
+
   /**
    * \brief Gets pipeline stage flags for shader stages
    * 

--- a/src/dxvk/hud/dxvk_hud_item.cpp
+++ b/src/dxvk/hud/dxvk_hud_item.cpp
@@ -277,6 +277,11 @@ namespace dxvk::hud {
           uint32_t            dataPoint,
           HudPos              minPos,
           HudPos              maxPos) {
+    if (unlikely(m_device->isDebugEnabled())) {
+      ctx.cmd->cmdBeginDebugUtilsLabel(DxvkCmdBuffer::InitBuffer,
+        vk::makeLabel(0xf0c0dc, "HUD frame time processing"));
+    }
+
     // Write current time stamp to the buffer
     DxvkBufferSliceHandle sliceHandle = m_gpuBuffer->getSliceHandle();
     std::pair<VkQueryPool, uint32_t> query = m_query->getQuery();
@@ -371,6 +376,9 @@ namespace dxvk::hud {
 
     renderer.drawTextIndirect(ctx, key, drawParamBuffer,
       drawInfoBuffer, textBufferView, 2u);
+
+    if (unlikely(m_device->isDebugEnabled()))
+      ctx.cmd->cmdEndDebugUtilsLabel(DxvkCmdBuffer::InitBuffer);
 
     // Make sure GPU resources are being kept alive as necessary
     ctx.cmd->track(m_gpuBuffer, DxvkAccess::Write);

--- a/src/dxvk/hud/dxvk_hud_item.cpp
+++ b/src/dxvk/hud/dxvk_hud_item.cpp
@@ -445,6 +445,7 @@ namespace dxvk::hud {
                       | VK_ACCESS_INDIRECT_COMMAND_READ_BIT
                       | VK_ACCESS_SHADER_READ_BIT
                       | VK_ACCESS_SHADER_WRITE_BIT;
+    bufferInfo.debugName = "HUD frame time data";
 
     m_gpuBuffer = m_device->createBuffer(bufferInfo, VK_MEMORY_HEAP_DEVICE_LOCAL_BIT);
 
@@ -1203,6 +1204,7 @@ namespace dxvk::hud {
       bufferInfo.usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
       bufferInfo.access = VK_ACCESS_SHADER_READ_BIT;
       bufferInfo.stages = VK_PIPELINE_STAGE_VERTEX_SHADER_BIT | VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
+      bufferInfo.debugName = "HUD memory data";
 
       m_dataBuffer = m_device->createBuffer(bufferInfo,
         VK_MEMORY_HEAP_DEVICE_LOCAL_BIT |

--- a/src/dxvk/hud/dxvk_hud_renderer.cpp
+++ b/src/dxvk/hud/dxvk_hud_renderer.cpp
@@ -140,6 +140,7 @@ namespace dxvk::hud {
                             | VK_PIPELINE_STAGE_VERTEX_SHADER_BIT;
       textBufferInfo.access = VK_ACCESS_SHADER_READ_BIT
                             | VK_ACCESS_INDIRECT_COMMAND_READ_BIT;
+      textBufferInfo.debugName = "HUD text buffer";
 
       m_textBuffer = m_device->createBuffer(textBufferInfo,
         VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT |
@@ -327,6 +328,7 @@ namespace dxvk::hud {
     fontBufferInfo.access = VK_ACCESS_TRANSFER_WRITE_BIT
                           | VK_ACCESS_TRANSFER_READ_BIT
                           | VK_ACCESS_SHADER_READ_BIT;
+    fontBufferInfo.debugName = "HUD font metadata";
 
     m_fontBuffer = m_device->createBuffer(fontBufferInfo, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
 
@@ -348,6 +350,7 @@ namespace dxvk::hud {
     fontTextureInfo.tiling = VK_IMAGE_TILING_OPTIMAL;
     fontTextureInfo.layout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
     fontTextureInfo.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    fontTextureInfo.debugName = "HUD font texture";
 
     m_fontTexture = m_device->createImage(fontTextureInfo, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
 

--- a/src/dxvk/hud/dxvk_hud_renderer.cpp
+++ b/src/dxvk/hud/dxvk_hud_renderer.cpp
@@ -59,6 +59,11 @@ namespace dxvk::hud {
     const Rc<DxvkImageView>&  dstView,
           VkColorSpaceKHR     dstColorSpace,
     const HudOptions&         options) {
+    if (unlikely(m_device->isDebugEnabled())) {
+      ctx.cmd->cmdInsertDebugUtilsLabel(DxvkCmdBuffer::ExecBuffer,
+        vk::makeLabel(0xf0c0dc, "HUD"));
+    }
+
     if (!m_fontTextureView) {
       createFontResources();
       uploadFontResources(ctx);

--- a/src/vulkan/vulkan_util.h
+++ b/src/vulkan/vulkan_util.h
@@ -211,6 +211,22 @@ namespace dxvk::vk {
     }
   }
 
+
+  inline uint64_t getObjectHandle(uint64_t handle) {
+    return handle;
+  }
+
+
+  template<typename T>
+  uint64_t getObjectHandle(T* object) {
+    return reinterpret_cast<uintptr_t>(object);
+  }
+
+
+  inline bool isValidDebugName(const char* name) {
+    return name && name[0];
+  }
+
 }
 
 

--- a/src/vulkan/vulkan_util.h
+++ b/src/vulkan/vulkan_util.h
@@ -227,6 +227,23 @@ namespace dxvk::vk {
     return name && name[0];
   }
 
+
+  /**
+   * \brief Makes debug label
+   *
+   * \param [in] color Color, as BGR with implied opaque alpha
+   * \param [in] text Label text
+   */
+  inline VkDebugUtilsLabelEXT makeLabel(uint32_t color, const char* text) {
+    VkDebugUtilsLabelEXT label = { VK_STRUCTURE_TYPE_DEBUG_UTILS_LABEL_EXT };
+    label.color[0] = ((color >> 16u) & 0xffu) / 255.0f;
+    label.color[1] = ((color >> 8u)  & 0xffu) / 255.0f;
+    label.color[2] = ((color >> 0u)  & 0xffu) / 255.0f;
+    label.color[3] = 1.0f;
+    label.pLabelName = text;
+    return label;
+  }
+
 }
 
 


### PR DESCRIPTION
Supersedes #4589. Requires setting `DXVK_DEBUG=markers` to do anything.

I've tested this with some Unity Engine stuff, generally appears to work.

We can't meaningfully support resource views and samplers since the backend deduplicates them. Shaders would be nice to have support for, but those are very tricky too since we don't know the debug name at compile time.

In case of buffers, enabling debug names **does** alter overall DXVK behaviour in that we now have to create dedicated `VkBuffer`s for each D3D11 buffer. We ignore small buffers that are serviced by the allocation cache here since otherwise we'd end up creating and destroying thousands of `VkBuffer` objects *per frame*.

There's a couple other things I'd like to do, mostly annotating our various different command buffers since it can be a bit difficult to figure out what's going on in a capture these days. **Edit:** Done.

CC @aleiby