### PR TITLE
[util] Enable zeroInitWorkgroupMemory for Far Cry 5 and New Dawn

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -465,6 +465,11 @@ namespace dxvk {
     { R"(\\Varstray_steam(_demo)?\.exe$)", {{
       { "dxgi.maxFrameRate",                "60" },
     }} },
+    /* Far Cry 5 and New Dawn                      *
+     * Invisible terrain on Intel                  */
+    { R"(\\FarCry(5|NewDawn)\.exe$)", {{
+      { "d3d11.zeroInitWorkgroupMemory",    "True" },
+    }} },
 
     /**********************************************/
     /* D3D9 GAMES                                 */


### PR DESCRIPTION
Fixes invisible terrain on Intel (Windows and Linux)