### PR TITLE
[util] Enable hideIntegratedGraphics for Bright memory

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -43,6 +43,11 @@ namespace dxvk {
     { R"(\\Wow(Classic)?\.exe$)", {{
       { "dxvk.hideIntegratedGraphics",      "True"  },
     }} },
+    /* Bright Memory - Will choose other vendors   *
+     * over Intel even if Intel is the only dGPU   */
+    { R"(\\BrightMemory_EP1-Win64-Shipping\.exe$)", {{
+      { "dxvk.hideIntegratedGraphics",      "True"  },
+    }} },
 
     /**********************************************/
     /* D3D11 GAMES                                */


### PR DESCRIPTION
The game will prefer other vendors over Intel even if the latter is the dGPU in the system. It likely assumes that Intel is always a iGPU. This also happens with the native game on Windows and so isn't a Linux exclusive. Both in d3d11 and d3d12 mode.

Bright Memory: Infinite which is a newer game does not seem to suffer from this.