### PR TITLE
Rework swapchain management

### DIFF
--- a/dxvk.conf
+++ b/dxvk.conf
@@ -140,15 +140,6 @@
 # dxgi.maxSharedMemory = 0
 
 
-# Override back buffer count for the Vulkan swap chain.
-# Setting this to 0 or less will have no effect.
-#
-# Supported values: Any number greater than or equal to 2.
-
-# dxgi.numBackBuffers = 0
-# d3d9.numBackBuffers = 0
-
-
 # Overrides synchronization interval (Vsync) for presentation.
 # Setting this to 0 disables vertical synchronization entirely.
 # A positive value 'n' will enable Vsync and repeat the same
@@ -160,10 +151,10 @@
 # d3d9.presentInterval = -1
 
 
+# Controls tearing behaviour with regards to in-game Vsync settings.
+#
 # True enables the mailbox present mode in case regular Vsync is disabled.
-# This should avoid tearing, but may be unsupported on some systems
-# or require setting dxgi.numBackBuffers to a higher value in order
-# to work properly. 
+# This eliminates tearing, but may be unsupported on some systems.
 #
 # False enables the relaxed fifo present mode in case regular Vsync is enabled.
 # This should result in tearing but reduce stutter if FPS are too low,

--- a/src/d3d11/d3d11_options.cpp
+++ b/src/d3d11/d3d11_options.cpp
@@ -28,7 +28,6 @@ namespace dxvk {
     this->disableMsaa           = config.getOption<bool>("d3d11.disableMsaa", false);
     this->enableContextLock     = config.getOption<bool>("d3d11.enableContextLock", false);
     this->deferSurfaceCreation  = config.getOption<bool>("dxgi.deferSurfaceCreation", false);
-    this->numBackBuffers        = config.getOption<int32_t>("dxgi.numBackBuffers", 0);
     this->maxFrameLatency       = config.getOption<int32_t>("dxgi.maxFrameLatency", 0);
     this->exposeDriverCommandLists = config.getOption<bool>("d3d11.exposeDriverCommandLists", true);
     this->reproducibleCommandStream = config.getOption<bool>("d3d11.reproducibleCommandStream", false);

--- a/src/d3d11/d3d11_options.h
+++ b/src/d3d11/d3d11_options.h
@@ -72,10 +72,6 @@ namespace dxvk {
     /// Enable float control bits
     bool floatControls = true;
 
-    /// Back buffer count for the Vulkan swap chain.
-    /// Overrides DXGI_SWAP_CHAIN_DESC::BufferCount.
-    int32_t numBackBuffers = 0;
-
     /// Override maximum frame latency if the app specifies
     /// a higher value. May help with frame timing issues.
     int32_t maxFrameLatency = 0;

--- a/src/d3d11/d3d11_swapchain.cpp
+++ b/src/d3d11/d3d11_swapchain.cpp
@@ -69,9 +69,6 @@ namespace dxvk {
     CreateBackBuffers();
     CreateBlitter();
     CreateHud();
-
-    if (!pDevice->GetOptions()->deferSurfaceCreation)
-      RecreateSwapChain();
   }
 
 
@@ -531,6 +528,7 @@ namespace dxvk {
     presenterDesc.imageExtent     = { m_desc.Width, m_desc.Height };
     presenterDesc.imageCount      = PickImageCount(m_desc.BufferCount + 1);
     presenterDesc.numFormats      = PickFormats(m_desc.Format, presenterDesc.formats);
+    presenterDesc.deferSurfaceCreation = m_parent->GetOptions()->deferSurfaceCreation;
 
     m_presenter = new Presenter(m_device, m_frameLatencySignal, presenterDesc, [
       cAdapter  = m_device->adapter(),

--- a/src/d3d11/d3d11_swapchain.cpp
+++ b/src/d3d11/d3d11_swapchain.cpp
@@ -421,6 +421,14 @@ namespace dxvk {
       cColorSpace     = m_colorSpace,
       cFrameId        = m_frameId
     ] (DxvkContext* ctx) {
+      // Update back buffer color space as necessary
+      if (cSwapImage->image()->info().colorSpace != cColorSpace) {
+        DxvkImageUsageInfo usage = { };
+        usage.colorSpace = cColorSpace;
+
+        ctx->ensureImageCompatibility(cSwapImage->image(), usage);
+      }
+
       // Blit the D3D back buffer onto the actual Vulkan
       // swap chain and render the HUD if we have one.
       auto contextObjects = ctx->beginExternalRendering();

--- a/src/d3d11/d3d11_swapchain.cpp
+++ b/src/d3d11/d3d11_swapchain.cpp
@@ -434,15 +434,15 @@ namespace dxvk {
       auto contextObjects = ctx->beginExternalRendering();
 
       cBlitter->beginPresent(contextObjects,
-        cBackBuffer, cColorSpace, VkRect2D(),
-        cSwapImage, cColorSpace, VkRect2D());
+        cBackBuffer, VkRect2D(),
+        cSwapImage, VkRect2D());
 
       if (cHud != nullptr) {
         cHud->update();
-        cHud->render(contextObjects, cBackBuffer, cColorSpace);
+        cHud->render(contextObjects, cBackBuffer);
       }
 
-      cBlitter->endPresent(contextObjects, cBackBuffer, cColorSpace);
+      cBlitter->endPresent(contextObjects, cBackBuffer);
 
       // Submit current command list and present
       ctx->synchronizeWsi(cSync);

--- a/src/d3d11/d3d11_swapchain.cpp
+++ b/src/d3d11/d3d11_swapchain.cpp
@@ -322,10 +322,8 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE D3D11SwapChain::SetHDRMetaData(
     const DXGI_VK_HDR_METADATA*     pMetaData) {
     // For some reason this call always seems to succeed on Windows
-    if (pMetaData->Type == DXGI_HDR_METADATA_TYPE_HDR10) {
-      m_hdrMetadata = ConvertHDRMetadata(pMetaData->HDR10);
-      m_dirtyHdrMetadata = true;
-    }
+    if (pMetaData->Type == DXGI_HDR_METADATA_TYPE_HDR10)
+      m_presenter->setHdrMetadata(ConvertHDRMetadata(pMetaData->HDR10));
 
     return S_OK;
   }
@@ -400,11 +398,6 @@ namespace dxvk {
 
       if (status == VK_SUBOPTIMAL_KHR)
         break;
-    }
-
-    if (m_hdrMetadata && m_dirtyHdrMetadata) {
-      m_presenter->setHdrMetadata(*m_hdrMetadata);
-      m_dirtyHdrMetadata = false;
     }
 
     m_frameId += 1;
@@ -501,7 +494,6 @@ namespace dxvk {
     m_device->waitForIdle();
 
     m_presentStatus.result = VK_SUCCESS;
-    m_dirtyHdrMetadata = true;
 
     PresenterDesc presenterDesc;
     presenterDesc.imageExtent     = { m_desc.Width, m_desc.Height };

--- a/src/d3d11/d3d11_swapchain.h
+++ b/src/d3d11/d3d11_swapchain.h
@@ -147,8 +147,6 @@ namespace dxvk {
 
     void CreatePresenter();
 
-    VkResult CreateSurface(VkSurfaceKHR* pSurface);
-
     void CreateRenderTargetViews();
 
     void CreateBackBuffers();

--- a/src/d3d11/d3d11_swapchain.h
+++ b/src/d3d11/d3d11_swapchain.h
@@ -108,8 +108,6 @@ namespace dxvk {
 
     Rc<DxvkSwapchainBlitter>  m_blitter;
 
-    Rc<hud::Hud>              m_hud;
-
     small_vector<Com<D3D11Texture2D, false>, 4> m_backBuffers;
     DxvkSubmitStatus          m_presentStatus;
 
@@ -141,8 +139,6 @@ namespace dxvk {
     void CreateBackBuffers();
 
     void CreateBlitter();
-
-    void CreateHud();
 
     void DestroyFrameLatencyEvent();
 

--- a/src/d3d11/d3d11_swapchain.h
+++ b/src/d3d11/d3d11_swapchain.h
@@ -119,9 +119,7 @@ namespace dxvk {
     HANDLE                    m_frameLatencyEvent = nullptr;
     Rc<sync::CallbackFence>   m_frameLatencySignal;
 
-    bool                      m_dirty = true;
-
-    VkColorSpaceKHR           m_colorspace = VK_COLOR_SPACE_SRGB_NONLINEAR_KHR;
+    VkColorSpaceKHR           m_colorSpace = VK_COLOR_SPACE_SRGB_NONLINEAR_KHR;
 
     double                    m_targetFrameRate = 0.0;
 
@@ -135,8 +133,6 @@ namespace dxvk {
     void RotateBackBuffers(D3D11ImmediateContext* ctx);
 
     void SynchronizePresent();
-
-    void RecreateSwapChain();
 
     void CreateFrameLatencyEvent();
 
@@ -154,12 +150,7 @@ namespace dxvk {
 
     uint32_t GetActualFrameLatency();
     
-    uint32_t PickFormats(
-            DXGI_FORMAT               Format,
-            VkSurfaceFormatKHR*       pDstFormats);
-    
-    uint32_t PickImageCount(
-            UINT                      Preferred);
+    VkSurfaceFormatKHR GetSurfaceFormat(DXGI_FORMAT Format);
     
     std::string GetApiName() const;
 

--- a/src/d3d11/d3d11_swapchain.h
+++ b/src/d3d11/d3d11_swapchain.h
@@ -109,7 +109,6 @@ namespace dxvk {
     Rc<DxvkSwapchainBlitter>  m_blitter;
 
     small_vector<Com<D3D11Texture2D, false>, 4> m_backBuffers;
-    DxvkSubmitStatus          m_presentStatus;
 
     uint64_t                  m_frameId      = DXGI_MAX_SWAP_CHAIN_BUFFERS;
     uint32_t                  m_frameLatency = DefaultFrameLatency;
@@ -129,8 +128,6 @@ namespace dxvk {
     HRESULT PresentImage(UINT SyncInterval);
 
     void RotateBackBuffers(D3D11ImmediateContext* ctx);
-
-    void SynchronizePresent();
 
     void CreateFrameLatencyEvent();
 

--- a/src/d3d11/d3d11_swapchain.h
+++ b/src/d3d11/d3d11_swapchain.h
@@ -123,9 +123,6 @@ namespace dxvk {
 
     VkColorSpaceKHR           m_colorspace = VK_COLOR_SPACE_SRGB_NONLINEAR_KHR;
 
-    std::optional<VkHdrMetadataEXT> m_hdrMetadata;
-    bool                      m_dirtyHdrMetadata = true;
-
     double                    m_targetFrameRate = 0.0;
 
     dxvk::mutex               m_frameStatisticsLock;

--- a/src/d3d11/d3d11_swapchain.h
+++ b/src/d3d11/d3d11_swapchain.h
@@ -113,8 +113,6 @@ namespace dxvk {
     small_vector<Com<D3D11Texture2D, false>, 4> m_backBuffers;
     DxvkSubmitStatus          m_presentStatus;
 
-    std::vector<Rc<DxvkImageView>> m_imageViews;
-
     uint64_t                  m_frameId      = DXGI_MAX_SWAP_CHAIN_BUFFERS;
     uint32_t                  m_frameLatency = DefaultFrameLatency;
     uint32_t                  m_frameLatencyCap = 0;
@@ -146,8 +144,6 @@ namespace dxvk {
     void CreateFrameLatencyEvent();
 
     void CreatePresenter();
-
-    void CreateRenderTargetViews();
 
     void CreateBackBuffers();
 

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -539,7 +539,7 @@ namespace dxvk {
     SynchronizeCsThread(DxvkCsThread::SynchronizeAll);
 
     if (m_d3d9Options.deferSurfaceCreation)
-      m_deviceHasBeenReset = true;
+      m_resetCtr++;
 
     return D3D_OK;
   }

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -1143,12 +1143,12 @@ namespace dxvk {
     }
 
     /**
-     * \brief Returns whether the device has been reset and marks it as true.
+     * \brief Queries current reset counter
      * Used for the deferred surface creation workaround.
      * (Device Reset detection for D3D9SwapChainEx::Present)
      */
-    bool IsDeviceReset() {
-      return std::exchange(m_deviceHasBeenReset, false);
+    uint32_t GetResetCounter() {
+      return m_resetCtr;
     }
 
     template <bool Synchronize9On12>
@@ -1513,7 +1513,7 @@ namespace dxvk {
     VkImageLayout                   m_hazardLayout = VK_IMAGE_LAYOUT_GENERAL;
 
     bool                            m_usingGraphicsPipelines = false;
-    bool                            m_deviceHasBeenReset = false;
+    uint32_t                        m_resetCtr = 0u;
 
     DxvkDepthBiasRepresentation     m_depthBiasRepresentation = { VK_DEPTH_BIAS_REPRESENTATION_LEAST_REPRESENTABLE_VALUE_FORMAT_EXT, false };
     float                           m_depthBiasScale  = 0.0f;

--- a/src/d3d9/d3d9_options.cpp
+++ b/src/d3d9/d3d9_options.cpp
@@ -49,7 +49,6 @@ namespace dxvk {
     this->strictConstantCopies          = config.getOption<bool>        ("d3d9.strictConstantCopies",          false);
     this->strictPow                     = config.getOption<bool>        ("d3d9.strictPow",                     true);
     this->lenientClear                  = config.getOption<bool>        ("d3d9.lenientClear",                  false);
-    this->numBackBuffers                = config.getOption<int32_t>     ("d3d9.numBackBuffers",                0);
     this->deferSurfaceCreation          = config.getOption<bool>        ("d3d9.deferSurfaceCreation",          false);
     this->samplerAnisotropy             = config.getOption<int32_t>     ("d3d9.samplerAnisotropy",             -1);
     this->maxAvailableMemory            = config.getOption<int32_t>     ("d3d9.maxAvailableMemory",            4096);

--- a/src/d3d9/d3d9_options.h
+++ b/src/d3d9/d3d9_options.h
@@ -50,10 +50,6 @@ namespace dxvk {
     /// Whether or not to do a fast path clear if we're close enough to the whole render target.
     bool lenientClear;
 
-    /// Back buffer count for the Vulkan swap chain.
-    /// Overrides buffer count in present parameters.
-    int32_t numBackBuffers;
-
     /// Defer surface creation
     bool deferSurfaceCreation;
 

--- a/src/d3d9/d3d9_swapchain.cpp
+++ b/src/d3d9/d3d9_swapchain.cpp
@@ -878,17 +878,16 @@ namespace dxvk {
         auto contextObjects = ctx->beginExternalRendering();
 
         cBlitter->beginPresent(contextObjects,
-          cDstView, cColorSpace, cDstRect,
-          cSrcView, cColorSpace, cSrcRect);
+          cDstView, cDstRect, cSrcView, cSrcRect);
 
         if (cHud) {
           if (!cRepeat)
             cHud->update();
 
-          cHud->render(contextObjects, cDstView, cColorSpace);
+          cHud->render(contextObjects, cDstView);
         }
 
-        cBlitter->endPresent(contextObjects, cDstView, cColorSpace);
+        cBlitter->endPresent(contextObjects, cDstView);
 
         // Submit command list and present
         ctx->synchronizeWsi(cSync);

--- a/src/d3d9/d3d9_swapchain.cpp
+++ b/src/d3d9/d3d9_swapchain.cpp
@@ -866,6 +866,14 @@ namespace dxvk {
         cHud            = m_hud,
         cFrameId        = m_wctx->frameId
       ] (DxvkContext* ctx) {
+        // Update back buffer color space as necessary
+        if (cSrcView->image()->info().colorSpace != cColorSpace) {
+          DxvkImageUsageInfo usage = { };
+          usage.colorSpace = cColorSpace;
+
+          ctx->ensureImageCompatibility(cSrcView->image(), usage);
+        }
+
         // Blit back buffer onto Vulkan swap chain
         auto contextObjects = ctx->beginExternalRendering();
 

--- a/src/d3d9/d3d9_swapchain.cpp
+++ b/src/d3d9/d3d9_swapchain.cpp
@@ -151,7 +151,7 @@ namespace dxvk {
     if (!UpdateWindowCtx())
       return D3D_OK;
 
-    if (options->deferSurfaceCreation && m_parent->IsDeviceReset())
+    if (options->deferSurfaceCreation && IsDeviceReset(m_wctx))
       m_wctx->presenter->invalidateSurface();
 
     m_wctx->presenter->setSyncInterval(presentInterval);
@@ -1271,6 +1271,18 @@ namespace dxvk {
   std::string D3D9SwapChainEx::GetApiName() {
     return this->GetParent()->IsExtended() ? "D3D9Ex" : "D3D9";
   }
+
+
+  bool D3D9SwapChainEx::IsDeviceReset(D3D9WindowContext* wctx) {
+    uint32_t counter = m_parent->GetResetCounter();
+
+    if (counter == wctx->deviceResetCounter)
+      return false;
+
+    wctx->deviceResetCounter = counter;
+    return true;
+  }
+
 
   D3D9VkExtSwapchain::D3D9VkExtSwapchain(D3D9SwapChainEx *pSwapChain)
     : m_swapchain(pSwapChain) {

--- a/src/d3d9/d3d9_swapchain.cpp
+++ b/src/d3d9/d3d9_swapchain.cpp
@@ -36,12 +36,8 @@ namespace dxvk {
 
     UpdatePresentRegion(nullptr, nullptr);
 
-    if (m_window) {
+    if (m_window)
       CreatePresenter();
-
-      if (!pDevice->GetOptions()->deferSurfaceCreation)
-        RecreateSwapChain();
-    }
 
     if (FAILED(CreateBackBuffers(m_presentParams.BackBufferCount, m_presentParams.Flags)))
       throw DxvkError("D3D9: Failed to create swapchain backbuffers");
@@ -972,6 +968,7 @@ namespace dxvk {
     presenterDesc.imageExtent     = GetPresentExtent();
     presenterDesc.imageCount      = PickImageCount(m_presentParams.BackBufferCount + 1);
     presenterDesc.numFormats      = PickFormats(EnumerateFormat(m_presentParams.BackBufferFormat), presenterDesc.formats);
+    presenterDesc.deferSurfaceCreation = m_parent->GetOptions()->deferSurfaceCreation;
 
     m_wctx->presenter = new Presenter(m_device,
       m_wctx->frameLatencySignal, presenterDesc, [

--- a/src/d3d9/d3d9_swapchain.h
+++ b/src/d3d9/d3d9_swapchain.h
@@ -156,8 +156,6 @@ namespace dxvk {
 
     D3D9WindowContext*        m_wctx = nullptr;
 
-    Rc<hud::Hud>              m_hud;
-
     std::vector<Com<D3D9Surface, false>> m_backBuffers;
     
     RECT                      m_srcRect;
@@ -176,11 +174,11 @@ namespace dxvk {
 
     double                    m_displayRefreshRate = 0.0;
 
-    const char*               m_apiName  = nullptr;
-
     bool                      m_warnedAboutGDIFallback = false;
 
     VkColorSpaceKHR           m_colorspace = VK_COLOR_SPACE_SRGB_NONLINEAR_KHR;
+
+    Rc<hud::HudClientApiItem> m_apiHud;
 
     std::optional<VkHdrMetadataEXT> m_hdrMetadata;
     bool m_unlockAdditionalFormats = false;
@@ -200,8 +198,6 @@ namespace dxvk {
             DWORD               Flags);
 
     void CreateBlitter();
-
-    void CreateHud();
 
     void InitRamp();
 

--- a/src/d3d9/d3d9_swapchain.h
+++ b/src/d3d9/d3d9_swapchain.h
@@ -55,6 +55,8 @@ namespace dxvk {
 
     uint64_t                       frameId = D3D9DeviceEx::MaxFrameLatency;
     Rc<sync::Fence>                frameLatencySignal;
+
+    uint32_t                       deviceResetCounter = 0u;
   };
 
   using D3D9SwapChainExBase = D3D9DeviceChild<IDirect3DSwapChain9Ex>;
@@ -227,6 +229,8 @@ namespace dxvk {
     VkExtent2D GetPresentExtent();
 
     std::string GetApiName();
+
+    bool IsDeviceReset(D3D9WindowContext* wctx);
 
     const Com<D3D9Surface, false>& GetFrontBuffer() const {
       return m_backBuffers.back();

--- a/src/d3d9/d3d9_swapchain.h
+++ b/src/d3d9/d3d9_swapchain.h
@@ -199,8 +199,6 @@ namespace dxvk {
 
     void CreatePresenter();
 
-    VkResult CreateSurface(VkSurfaceKHR* pSurface);
-
     void CreateRenderTargetViews();
 
     HRESULT CreateBackBuffers(

--- a/src/d3d9/d3d9_swapchain.h
+++ b/src/d3d9/d3d9_swapchain.h
@@ -163,8 +163,6 @@ namespace dxvk {
     VkExtent2D                m_swapchainExtent = { 0u, 0u };
     bool                      m_partialCopy = false;
 
-    DxvkSubmitStatus          m_presentStatus;
-
     uint32_t                  m_frameLatencyCap = 0;
 
     HWND                      m_window   = nullptr;
@@ -186,8 +184,6 @@ namespace dxvk {
     D3D9VkExtSwapchain m_swapchainExt;
 
     void PresentImage(UINT PresentInterval);
-
-    void SynchronizePresent();
 
     Rc<Presenter> CreatePresenter(
             HWND                Window,

--- a/src/d3d9/d3d9_swapchain.h
+++ b/src/d3d9/d3d9_swapchain.h
@@ -169,8 +169,6 @@ namespace dxvk {
 
     uint32_t                  m_frameLatencyCap = 0;
 
-    bool                      m_dirty    = true;
-
     HWND                      m_window   = nullptr;
     HMONITOR                  m_monitor  = nullptr;
 
@@ -185,7 +183,6 @@ namespace dxvk {
     VkColorSpaceKHR           m_colorspace = VK_COLOR_SPACE_SRGB_NONLINEAR_KHR;
 
     std::optional<VkHdrMetadataEXT> m_hdrMetadata;
-    bool m_dirtyHdrMetadata = true;
     bool m_unlockAdditionalFormats = false;
 
     D3D9VkExtSwapchain m_swapchainExt;
@@ -194,7 +191,7 @@ namespace dxvk {
 
     void SynchronizePresent();
 
-    void RecreateSwapChain();
+    void RecreateSurface();
 
     void CreatePresenter();
 
@@ -212,13 +209,8 @@ namespace dxvk {
 
     uint32_t GetActualFrameLatency();
 
-    uint32_t PickFormats(
-            D3D9Format                Format,
-            VkSurfaceFormatKHR*       pDstFormats);
+    VkSurfaceFormatKHR GetSurfaceFormat();
     
-    uint32_t PickImageCount(
-            UINT                      Preferred);
-
     void NormalizePresentParameters(D3DPRESENT_PARAMETERS* pPresentParams);
 
     void NotifyDisplayRefreshRate(
@@ -236,7 +228,9 @@ namespace dxvk {
     
     HRESULT RestoreDisplayMode(HMONITOR hMonitor);
 
-    bool    UpdatePresentRegion(const RECT* pSourceRect, const RECT* pDestRect);
+    void UpdatePresentRegion(const RECT* pSourceRect, const RECT* pDestRect);
+
+    void UpdatePresentParameters();
 
     VkExtent2D GetPresentExtent();
 

--- a/src/d3d9/d3d9_swapchain.h
+++ b/src/d3d9/d3d9_swapchain.h
@@ -52,7 +52,6 @@ namespace dxvk {
 
   struct D3D9WindowContext {
     Rc<Presenter>                  presenter;
-    std::vector<Rc<DxvkImageView>> imageViews;
 
     uint64_t                       frameId = D3D9DeviceEx::MaxFrameLatency;
     Rc<sync::Fence>                frameLatencySignal;
@@ -198,8 +197,6 @@ namespace dxvk {
     void RecreateSwapChain();
 
     void CreatePresenter();
-
-    void CreateRenderTargetViews();
 
     HRESULT CreateBackBuffers(
             uint32_t            NumBackBuffers,

--- a/src/d3d9/d3d9_swapchain.h
+++ b/src/d3d9/d3d9_swapchain.h
@@ -135,7 +135,7 @@ namespace dxvk {
 
     void SetApiName(const char* name);
 
-    void UpdateWindowCtx();
+    bool UpdateWindowCtx();
 
   private:
 
@@ -189,9 +189,9 @@ namespace dxvk {
 
     void SynchronizePresent();
 
-    void RecreateSurface();
-
-    void CreatePresenter();
+    Rc<Presenter> CreatePresenter(
+            HWND                Window,
+            Rc<sync::Signal>    Signal);
 
     HRESULT CreateBackBuffers(
             uint32_t            NumBackBuffers,

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -1517,7 +1517,12 @@ namespace dxvk {
     // If everything matches already, no need to do anything. Only ensure
     // that the stable adress bit is respected if set for the first time.
     if (isUsageAndFormatCompatible && isAccessAndLayoutCompatible) {
-      if (usageInfo.stableGpuAddress && image->canRelocate()) {
+      bool needsUpdate = (usageInfo.stableGpuAddress && image->canRelocate());
+
+      if (usageInfo.colorSpace != VK_COLOR_SPACE_MAX_ENUM_KHR)
+        needsUpdate |= (usageInfo.colorSpace != image->info().colorSpace);
+
+      if (needsUpdate) {
         image->assignStorageWithUsage(image->storage(), usageInfo);
         m_common->memoryManager().lockResourceGpuAddress(image->storage());
       }

--- a/src/dxvk/dxvk_device.cpp
+++ b/src/dxvk/dxvk_device.cpp
@@ -307,14 +307,12 @@ namespace dxvk {
 
   void DxvkDevice::presentImage(
     const Rc<Presenter>&            presenter,
-          VkPresentModeKHR          presentMode,
           uint64_t                  frameId,
           DxvkSubmitStatus*         status) {
     status->result = VK_NOT_READY;
 
     DxvkPresentInfo presentInfo = { };
     presentInfo.presenter = presenter;
-    presentInfo.presentMode = presentMode;
     presentInfo.frameId = frameId;
     m_submissionQueue.present(presentInfo, status);
     

--- a/src/dxvk/dxvk_device.cpp
+++ b/src/dxvk/dxvk_device.cpp
@@ -309,8 +309,6 @@ namespace dxvk {
     const Rc<Presenter>&            presenter,
           uint64_t                  frameId,
           DxvkSubmitStatus*         status) {
-    status->result = VK_NOT_READY;
-
     DxvkPresentInfo presentInfo = { };
     presentInfo.presenter = presenter;
     presentInfo.frameId = frameId;

--- a/src/dxvk/dxvk_device.h
+++ b/src/dxvk/dxvk_device.h
@@ -485,13 +485,11 @@ namespace dxvk {
      * the submission thread. The status of this operation
      * can be retrieved with \ref waitForSubmission.
      * \param [in] presenter The presenter
-     * \param [in] presenteMode Present mode
      * \param [in] frameId Optional frame ID
      * \param [out] status Present status
      */
     void presentImage(
       const Rc<Presenter>&            presenter,
-            VkPresentModeKHR          presentMode,
             uint64_t                  frameId,
             DxvkSubmitStatus*         status);
     

--- a/src/dxvk/dxvk_image.cpp
+++ b/src/dxvk/dxvk_image.cpp
@@ -226,6 +226,9 @@ namespace dxvk {
     if (usageInfo.layout != VK_IMAGE_LAYOUT_UNDEFINED)
       m_info.layout = usageInfo.layout;
 
+    if (usageInfo.colorSpace != VK_COLOR_SPACE_MAX_ENUM_KHR)
+      m_info.colorSpace = usageInfo.colorSpace;
+
     for (uint32_t i = 0; i < usageInfo.viewFormatCount; i++) {
       if (!isViewCompatible(usageInfo.viewFormats[i]))
         m_viewFormats.push_back(usageInfo.viewFormats[i]);

--- a/src/dxvk/dxvk_image.cpp
+++ b/src/dxvk/dxvk_image.cpp
@@ -216,6 +216,9 @@ namespace dxvk {
     if (m_storage != old) {
       m_imageInfo = m_storage->getImageInfo();
       m_version += 1u;
+
+      if (unlikely(m_info.debugName))
+        updateDebugName();
     }
 
     m_info.flags |= usageInfo.flags;
@@ -238,9 +241,6 @@ namespace dxvk {
       m_info.viewFormatCount = m_viewFormats.size();
       m_info.viewFormats = m_viewFormats.data();
     }
-
-    if (unlikely(m_info.debugName))
-      updateDebugName();
 
     m_stableAddress |= usageInfo.stableGpuAddress;
     return old;

--- a/src/dxvk/dxvk_image.h
+++ b/src/dxvk/dxvk_image.h
@@ -55,6 +55,10 @@ namespace dxvk {
     // Initial image layout
     VkImageLayout initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
 
+    // Color space to interpret image data with. This
+    // is only meaningful for swap chain back buffers.
+    VkColorSpaceKHR colorSpace = VK_COLOR_SPACE_MAX_ENUM_KHR;
+
     // Image is used by multiple contexts so it needs
     // to be in its default layout after each submission
     VkBool32 shared = VK_FALSE;
@@ -89,6 +93,8 @@ namespace dxvk {
     // New image layout. If undefined, the
     // default layout will not be changed.
     VkImageLayout layout = VK_IMAGE_LAYOUT_UNDEFINED;
+    // Color space to interpret the image in
+    VkColorSpaceKHR colorSpace = VK_COLOR_SPACE_MAX_ENUM_KHR;
     // Number of new view formats to add
     uint32_t viewFormatCount = 0u;
     // View formats to add to the compatibility list

--- a/src/dxvk/dxvk_presenter.cpp
+++ b/src/dxvk/dxvk_presenter.cpp
@@ -27,6 +27,12 @@ namespace dxvk {
     // with present operations and periodically signals the event
     if (m_device->features().khrPresentWait.presentWait && m_signal != nullptr)
       m_frameThread = dxvk::thread([this] { runFrameThread(); });
+
+    // Create Vulkan surface immediately if possible, but ignore
+    // failures since the app window may still be in use in some
+    // way at this point, e.g. by a different device.
+    if (!desc.deferSurfaceCreation)
+      createSurface();
   }
 
   

--- a/src/dxvk/dxvk_presenter.cpp
+++ b/src/dxvk/dxvk_presenter.cpp
@@ -508,6 +508,7 @@ namespace dxvk {
       imageInfo.usage       = swapInfo.imageUsage;
       imageInfo.tiling      = VK_IMAGE_TILING_OPTIMAL;
       imageInfo.layout      = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
+      imageInfo.colorSpace  = swapInfo.imageColorSpace;
       imageInfo.shared      = VK_TRUE;
       imageInfo.debugName   = debugName.c_str();
 

--- a/src/dxvk/dxvk_presenter.h
+++ b/src/dxvk/dxvk_presenter.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <functional>
+#include <optional>
 #include <queue>
 #include <vector>
 
@@ -190,16 +191,17 @@ namespace dxvk {
     }
 
     /**
-     * \brief Checks if a presenter supports the colorspace
+     * \brief Checks support for a Vulkan color space
      *
-     * \param [in] colorspace The colorspace to test
-     * * \returns \c true if the presenter supports the colorspace
+     * \param [in] colorspace The color space to test
+     * \returns \c true if the Vulkan surface supports the colorspace
      */
     bool supportsColorSpace(VkColorSpaceKHR colorspace);
 
     /**
      * \brief Sets HDR metadata
      *
+     * Updated HDR metadata will be applied on the next \c acquire.
      * \param [in] hdrMetadata HDR Metadata
      */
     void setHdrMetadata(const VkHdrMetadataEXT& hdrMetadata);
@@ -229,6 +231,9 @@ namespace dxvk {
     uint32_t                    m_frameIndex = 0;
 
     VkResult                    m_acquireStatus = VK_NOT_READY;
+
+    std::optional<VkHdrMetadataEXT> m_hdrMetadata;
+    bool                        m_hdrMetadataDirty = false;
 
     alignas(CACHE_LINE_SIZE)
     dxvk::mutex                 m_frameMutex;

--- a/src/dxvk/dxvk_presenter.h
+++ b/src/dxvk/dxvk_presenter.h
@@ -304,6 +304,9 @@ namespace dxvk {
 
     void runFrameThread();
 
+    static VkResult softError(
+            VkResult                  vr);
+
   };
 
 }

--- a/src/dxvk/dxvk_presenter.h
+++ b/src/dxvk/dxvk_presenter.h
@@ -200,6 +200,17 @@ namespace dxvk {
      */
     void invalidateSurface();
 
+    /**
+     * \brief Destroys resources immediately
+     *
+     * Blocks calling thread until pending swapchain operations
+     * have completed, and guarantees that the Vulkan swapchain
+     * and surface get destroyed before the function returns.
+     * This is useful to ensure that the application window can
+     * be reused, even if the presenter object is kept alive.
+     */
+    void destroyResources();
+
   private:
 
     Rc<DxvkDevice>              m_device;
@@ -208,8 +219,10 @@ namespace dxvk {
     Rc<vk::InstanceFn>          m_vki;
     Rc<vk::DeviceFn>            m_vkd;
 
-    dxvk::mutex                 m_surfaceMutex;
     PresenterSurfaceProc        m_surfaceProc;
+
+    dxvk::mutex                 m_surfaceMutex;
+    dxvk::condition_variable    m_surfaceCond;
 
     VkSurfaceKHR                m_surface     = VK_NULL_HANDLE;
     VkSwapchainKHR              m_swapchain   = VK_NULL_HANDLE;
@@ -234,6 +247,7 @@ namespace dxvk {
     uint32_t                    m_frameIndex = 0;
 
     VkResult                    m_acquireStatus = VK_NOT_READY;
+    bool                        m_presentPending = false;
 
     std::optional<VkHdrMetadataEXT> m_hdrMetadata;
     bool                        m_hdrMetadataDirty = false;

--- a/src/dxvk/dxvk_presenter.h
+++ b/src/dxvk/dxvk_presenter.h
@@ -32,10 +32,11 @@ namespace dxvk {
    * an input during swap chain creation.
    */
   struct PresenterDesc {
-    VkExtent2D          imageExtent;
-    uint32_t            imageCount;
-    uint32_t            numFormats;
-    VkSurfaceFormatKHR  formats[4];
+    VkExtent2D          imageExtent = { };
+    uint32_t            imageCount = 0u;
+    uint32_t            numFormats = 0u;
+    VkSurfaceFormatKHR  formats[4] = { };
+    bool                deferSurfaceCreation = false;
   };
 
   /**

--- a/src/dxvk/dxvk_presenter.h
+++ b/src/dxvk/dxvk_presenter.h
@@ -249,6 +249,8 @@ namespace dxvk {
     alignas(CACHE_LINE_SIZE)
     FpsLimiter                  m_fpsLimiter;
 
+    static const std::array<std::pair<VkColorSpaceKHR, VkColorSpaceKHR>, 2> s_colorSpaceFallbacks;
+
     void updateSwapChain();
 
     VkResult recreateSwapChain();

--- a/src/dxvk/dxvk_queue.cpp
+++ b/src/dxvk/dxvk_queue.cpp
@@ -145,7 +145,7 @@ namespace dxvk {
           entry.result = entry.submit.cmdList->submit(m_semaphores, m_timelines);
           entry.timelines = m_timelines;
         } else if (entry.present.presenter != nullptr) {
-          entry.result = entry.present.presenter->presentImage(entry.present.presentMode, entry.present.frameId);
+          entry.result = entry.present.presenter->presentImage(entry.present.frameId);
         }
 
         if (m_callback)
@@ -235,8 +235,7 @@ namespace dxvk {
         // Signal the frame and then immediately destroy the reference.
         // This is necessary since the front-end may want to explicitly
         // destroy the presenter object. 
-        entry.present.presenter->signalFrame(entry.result,
-          entry.present.presentMode, entry.present.frameId);
+        entry.present.presenter->signalFrame(entry.result, entry.present.frameId);
         entry.present.presenter = nullptr;
       }
 

--- a/src/dxvk/dxvk_queue.h
+++ b/src/dxvk/dxvk_queue.h
@@ -43,7 +43,6 @@ namespace dxvk {
    */
   struct DxvkPresentInfo {
     Rc<Presenter>       presenter;
-    VkPresentModeKHR    presentMode;
     uint64_t            frameId;
   };
 

--- a/src/dxvk/dxvk_swapchain_blitter.h
+++ b/src/dxvk/dxvk_swapchain_blitter.h
@@ -47,6 +47,10 @@ namespace dxvk {
     VkBool32 needsGamma = VK_FALSE;
     /// Bit indicating whether alpha blending is required
     VkBool32 needsBlending = VK_FALSE;
+    /// Bit indicating whether the HUD needs to be composited
+    VkBool32 compositeHud = VK_FALSE;
+    /// Bit indicating whether the software cursor needs to be composited
+    VkBool32 compositeCursor = VK_FALSE;
 
     size_t hash() const {
       DxvkHashState hash;
@@ -58,6 +62,8 @@ namespace dxvk {
       hash.add(uint32_t(needsBlit));
       hash.add(uint32_t(needsGamma));
       hash.add(uint32_t(needsBlending));
+      hash.add(uint32_t(compositeHud));
+      hash.add(uint32_t(compositeCursor));
       return hash;
     }
 
@@ -69,7 +75,9 @@ namespace dxvk {
           && dstFormat == other.dstFormat
           && needsBlit == other.needsBlit
           && needsGamma == other.needsGamma
-          && needsBlending == other.needsBlending;
+          && needsBlending == other.needsBlending
+          && compositeHud == other.compositeHud
+          && compositeCursor == other.compositeCursor;
     }
   };
 
@@ -155,12 +163,16 @@ namespace dxvk {
       VkBool32 srcIsSrgb;
       VkColorSpaceKHR dstSpace;
       VkBool32 dstIsSrgb;
+      VkBool32 compositeHud;
+      VkBool32 compositeCursor;
     };
 
     struct PushConstants {
       VkOffset2D srcOffset;
       VkExtent2D srcExtent;
       VkOffset2D dstOffset;
+      VkOffset2D cursorOffset;
+      VkExtent2D cursorExtent;
     };
 
     struct ShaderModule {
@@ -190,6 +202,11 @@ namespace dxvk {
 
     Rc<DxvkSampler>     m_samplerPresent;
     Rc<DxvkSampler>     m_samplerGamma;
+    Rc<DxvkSampler>     m_samplerCursorLinear;
+    Rc<DxvkSampler>     m_samplerCursorNearest;
+
+    Rc<DxvkImage>       m_hudImage;
+    Rc<DxvkImageView>   m_hudView;
 
     VkDescriptorSetLayout m_setLayout = VK_NULL_HANDLE;
     VkPipelineLayout    m_pipelineLayout = VK_NULL_HANDLE;

--- a/src/dxvk/dxvk_swapchain_blitter.h
+++ b/src/dxvk/dxvk_swapchain_blitter.h
@@ -93,7 +93,6 @@ namespace dxvk {
      * The swap chain image will remain bound for rendering.
      * \param [in] ctx Context objects
      * \param [in] dstView Swap chain image view
-     * \param [in] dstColorSpace Swap chain color space
      * \param [in] dstRect Destination rectangle
      * \param [in] srcView Image to present
      * \param [in] srcColorSpace Image color space
@@ -102,10 +101,8 @@ namespace dxvk {
     void beginPresent(
       const DxvkContextObjects& ctx,
       const Rc<DxvkImageView>&  dstView,
-            VkColorSpaceKHR     dstColorSpace,
             VkRect2D            dstRect,
       const Rc<DxvkImageView>&  srcView,
-            VkColorSpaceKHR     srcColorSpace,
             VkRect2D            srcRect);
 
     /**
@@ -114,12 +111,10 @@ namespace dxvk {
      * Finishes rendering and prepares the image for presentation.
      * \param [in] ctx Context objects
      * \param [in] dstView Swap chain image view
-     * \param [in] dstColorSpace Swap chain color space
      */
     void endPresent(
       const DxvkContextObjects& ctx,
-      const Rc<DxvkImageView>&  dstView,
-            VkColorSpaceKHR     dstColorSpace);
+      const Rc<DxvkImageView>&  dstView);
 
     /**
      * \brief Sets gamma ramp
@@ -211,10 +206,8 @@ namespace dxvk {
     void performDraw(
       const DxvkContextObjects&         ctx,
       const Rc<DxvkImageView>&          dstView,
-            VkColorSpaceKHR             dstColorSpace,
             VkRect2D                    dstRect,
       const Rc<DxvkImageView>&          srcView,
-            VkColorSpaceKHR             srcColorSpace,
             VkRect2D                    srcRect,
             VkBool32                    enableBlending);
 

--- a/src/dxvk/dxvk_swapchain_blitter.h
+++ b/src/dxvk/dxvk_swapchain_blitter.h
@@ -4,6 +4,8 @@
 #include <thread>
 #include <unordered_map>
 
+#include "./hud/dxvk_hud.h"
+
 #include "../util/thread.h"
 
 #include "../dxvk/dxvk_device.h"
@@ -82,7 +84,9 @@ namespace dxvk {
     
   public:
 
-    DxvkSwapchainBlitter(const Rc<DxvkDevice>& device);
+    DxvkSwapchainBlitter(
+      const Rc<DxvkDevice>& device,
+      const Rc<hud::Hud>&   hud);
     ~DxvkSwapchainBlitter();
 
     /**
@@ -98,23 +102,12 @@ namespace dxvk {
      * \param [in] srcColorSpace Image color space
      * \param [in] srcRect Source rectangle to present
      */
-    void beginPresent(
+    void present(
       const DxvkContextObjects& ctx,
       const Rc<DxvkImageView>&  dstView,
             VkRect2D            dstRect,
       const Rc<DxvkImageView>&  srcView,
             VkRect2D            srcRect);
-
-    /**
-     * \brief Finalizes presentation commands
-     *
-     * Finishes rendering and prepares the image for presentation.
-     * \param [in] ctx Context objects
-     * \param [in] dstView Swap chain image view
-     */
-    void endPresent(
-      const DxvkContextObjects& ctx,
-      const Rc<DxvkImageView>&  dstView);
 
     /**
      * \brief Sets gamma ramp
@@ -176,6 +169,7 @@ namespace dxvk {
     };
 
     Rc<DxvkDevice>      m_device;
+    Rc<hud::Hud>        m_hud;
 
     ShaderModule        m_shaderVsBlit;
     ShaderModule        m_shaderFsCopy;

--- a/src/dxvk/hud/dxvk_hud.cpp
+++ b/src/dxvk/hud/dxvk_hud.cpp
@@ -42,11 +42,15 @@ namespace dxvk::hud {
   void Hud::render(
     const DxvkContextObjects& ctx,
     const Rc<DxvkImageView>&  dstView) {
+    if (empty())
+      return;
+
     auto key = m_renderer.getPipelineKey(dstView);
 
     m_renderer.beginFrame(ctx, dstView, m_options);
     m_hudItems.render(ctx, key, m_options, m_renderer);
     m_renderer.flushDraws(ctx, dstView, m_options);
+    m_renderer.endFrame(ctx);
   }
 
 

--- a/src/dxvk/hud/dxvk_hud.cpp
+++ b/src/dxvk/hud/dxvk_hud.cpp
@@ -41,13 +41,12 @@ namespace dxvk::hud {
 
   void Hud::render(
     const DxvkContextObjects& ctx,
-    const Rc<DxvkImageView>&  dstView,
-          VkColorSpaceKHR     dstColorSpace) {
-    auto key = m_renderer.getPipelineKey(dstView, dstColorSpace);
+    const Rc<DxvkImageView>&  dstView) {
+    auto key = m_renderer.getPipelineKey(dstView);
 
-    m_renderer.beginFrame(ctx, dstView, dstColorSpace, m_options);
+    m_renderer.beginFrame(ctx, dstView, m_options);
     m_hudItems.render(ctx, key, m_options, m_renderer);
-    m_renderer.flushDraws(ctx, dstView, dstColorSpace, m_options);
+    m_renderer.flushDraws(ctx, dstView, m_options);
   }
 
 

--- a/src/dxvk/hud/dxvk_hud.h
+++ b/src/dxvk/hud/dxvk_hud.h
@@ -35,12 +35,10 @@ namespace dxvk::hud {
      * Renders the HUD to the given context.
      * \param [in] ctx Context objects for rendering
      * \param [in] dstView Swap chain image view
-     * \param [in] dstColorSpace Color space
      */
     void render(
       const DxvkContextObjects& ctx,
-      const Rc<DxvkImageView>&  dstView,
-            VkColorSpaceKHR     dstColorSpace);
+      const Rc<DxvkImageView>&  dstView);
 
     /**
      * \brief Adds a HUD item if enabled

--- a/src/dxvk/hud/dxvk_hud.h
+++ b/src/dxvk/hud/dxvk_hud.h
@@ -20,7 +20,7 @@ namespace dxvk::hud {
     Hud(const Rc<DxvkDevice>& device);
     
     ~Hud();
-    
+
     /**
      * \brief Update HUD
      * 
@@ -39,6 +39,14 @@ namespace dxvk::hud {
     void render(
       const DxvkContextObjects& ctx,
       const Rc<DxvkImageView>&  dstView);
+
+    /**
+     * \brief Checks whether the HUD is empty
+     * \returns \c true if the HUD is empty
+     */
+    bool empty() const {
+      return m_hudItems.empty();
+    }
 
     /**
      * \brief Adds a HUD item if enabled

--- a/src/dxvk/hud/dxvk_hud.h
+++ b/src/dxvk/hud/dxvk_hud.h
@@ -48,8 +48,8 @@ namespace dxvk::hud {
      * \param [in] args Constructor arguments
      */
     template<typename T, typename... Args>
-    void addItem(const char* name, int32_t at, Args... args) {
-      m_hudItems.add<T>(name, at, std::forward<Args>(args)...);
+    Rc<T> addItem(const char* name, int32_t at, Args... args) {
+      return m_hudItems.add<T>(name, at, std::forward<Args>(args)...);
     }
     
     /**

--- a/src/dxvk/hud/dxvk_hud_item.cpp
+++ b/src/dxvk/hud/dxvk_hud_item.cpp
@@ -112,7 +112,7 @@ namespace dxvk::hud {
 
 
   HudClientApiItem::HudClientApiItem(std::string api)
-  : m_api(api) {
+  : m_api(std::move(api)) {
 
   }
 
@@ -122,12 +122,20 @@ namespace dxvk::hud {
   }
 
 
+  void HudClientApiItem::setApiName(std::string api) {
+    std::lock_guard lock(m_mutex);
+    m_api = std::move(api);
+  }
+
+
   HudPos HudClientApiItem::render(
     const DxvkContextObjects& ctx,
     const HudPipelineKey&     key,
     const HudOptions&         options,
           HudRenderer&        renderer,
           HudPos              position) {
+    std::lock_guard lock(m_mutex);
+
     position.y += 16;
     renderer.drawText(16, position, 0xffffffffu, m_api);
 

--- a/src/dxvk/hud/dxvk_hud_item.h
+++ b/src/dxvk/hud/dxvk_hud_item.h
@@ -163,6 +163,8 @@ namespace dxvk::hud {
 
     ~HudClientApiItem();
 
+    void setApiName(std::string api);
+
     HudPos render(
       const DxvkContextObjects& ctx,
       const HudPipelineKey&     key,
@@ -172,7 +174,8 @@ namespace dxvk::hud {
 
   private:
 
-    std::string m_api;
+    sync::Spinlock  m_mutex;
+    std::string     m_api;
 
   };
 

--- a/src/dxvk/hud/dxvk_hud_item.h
+++ b/src/dxvk/hud/dxvk_hud_item.h
@@ -91,7 +91,7 @@ namespace dxvk::hud {
      * \param [in] args Constructor arguments
      */
     template<typename T, typename... Args>
-    void add(const char* name, int32_t at, Args... args) {
+    Rc<T> add(const char* name, int32_t at, Args... args) {
       bool enable = m_enableFull;
 
       if (!enable) {
@@ -102,10 +102,14 @@ namespace dxvk::hud {
       if (at < 0 || at > int32_t(m_items.size()))
         at = m_items.size();
 
+      Rc<T> item;
+
       if (enable) {
-        m_items.insert(m_items.begin() + at,
-          new T(std::forward<Args>(args)...));
+        item = new T(std::forward<Args>(args)...);
+        m_items.insert(m_items.begin() + at, item);
       }
+
+      return item;
     }
 
     template<typename T>

--- a/src/dxvk/hud/dxvk_hud_item.h
+++ b/src/dxvk/hud/dxvk_hud_item.h
@@ -83,6 +83,14 @@ namespace dxvk::hud {
             HudRenderer&        renderer);
 
     /**
+     * \brief Checks whether the item set is empty
+     * \returns \c true if there are no items
+     */
+    bool empty() const {
+      return m_items.empty();
+    }
+
+    /**
      * \brief Creates a HUD item if enabled
      *
      * \tparam T The HUD item type

--- a/src/dxvk/hud/dxvk_hud_renderer.cpp
+++ b/src/dxvk/hud/dxvk_hud_renderer.cpp
@@ -57,7 +57,6 @@ namespace dxvk::hud {
   void HudRenderer::beginFrame(
     const DxvkContextObjects& ctx,
     const Rc<DxvkImageView>&  dstView,
-          VkColorSpaceKHR     dstColorSpace,
     const HudOptions&         options) {
     if (unlikely(m_device->isDebugEnabled())) {
       ctx.cmd->cmdInsertDebugUtilsLabel(DxvkCmdBuffer::ExecBuffer,
@@ -116,7 +115,6 @@ namespace dxvk::hud {
   void HudRenderer::flushDraws(
     const DxvkContextObjects& ctx,
     const Rc<DxvkImageView>&  dstView,
-          VkColorSpaceKHR     dstColorSpace,
     const HudOptions&         options) {
     if (m_textDraws.empty())
       return;
@@ -192,7 +190,7 @@ namespace dxvk::hud {
     VkDescriptorBufferInfo textBufferDescriptor = m_textBuffer->getDescriptor(textSizeAligned, drawInfoSize).buffer;
     VkDescriptorBufferInfo drawBufferDescriptor = m_textBuffer->getDescriptor(drawArgOffset, drawArgWriteSize).buffer;
 
-    drawTextIndirect(ctx, getPipelineKey(dstView, dstColorSpace),
+    drawTextIndirect(ctx, getPipelineKey(dstView),
       drawBufferDescriptor, textBufferDescriptor,
       m_textBufferView->handle(), m_textDraws.size());
 
@@ -261,11 +259,10 @@ namespace dxvk::hud {
 
 
   HudPipelineKey HudRenderer::getPipelineKey(
-    const Rc<DxvkImageView>&  dstView,
-          VkColorSpaceKHR     dstColorSpace) const {
+    const Rc<DxvkImageView>&  dstView) const {
     HudPipelineKey key;
     key.format = dstView->info().format;
-    key.colorSpace = dstColorSpace;
+    key.colorSpace = dstView->image()->info().colorSpace;
     return key;
   }
 

--- a/src/dxvk/hud/dxvk_hud_renderer.cpp
+++ b/src/dxvk/hud/dxvk_hud_renderer.cpp
@@ -59,7 +59,7 @@ namespace dxvk::hud {
     const Rc<DxvkImageView>&  dstView,
     const HudOptions&         options) {
     if (unlikely(m_device->isDebugEnabled())) {
-      ctx.cmd->cmdInsertDebugUtilsLabel(DxvkCmdBuffer::ExecBuffer,
+      ctx.cmd->cmdBeginDebugUtilsLabel(DxvkCmdBuffer::ExecBuffer,
         vk::makeLabel(0xf0c0dc, "HUD"));
     }
 
@@ -91,6 +91,13 @@ namespace dxvk::hud {
   }
   
   
+  void HudRenderer::endFrame(
+    const DxvkContextObjects& ctx) {
+    if (unlikely(m_device->isDebugEnabled()))
+      ctx.cmd->cmdEndDebugUtilsLabel(DxvkCmdBuffer::ExecBuffer);
+  }
+
+
   void HudRenderer::drawText(
           uint32_t            size,
           HudPos              pos,

--- a/src/dxvk/hud/dxvk_hud_renderer.h
+++ b/src/dxvk/hud/dxvk_hud_renderer.h
@@ -105,6 +105,9 @@ namespace dxvk::hud {
       const Rc<DxvkImageView>&  dstView,
       const HudOptions&         options);
 
+    void endFrame(
+      const DxvkContextObjects& ctx);
+
     void drawText(
             uint32_t            size,
             HudPos              pos,

--- a/src/dxvk/hud/dxvk_hud_renderer.h
+++ b/src/dxvk/hud/dxvk_hud_renderer.h
@@ -103,7 +103,6 @@ namespace dxvk::hud {
     void beginFrame(
       const DxvkContextObjects& ctx,
       const Rc<DxvkImageView>&  dstView,
-            VkColorSpaceKHR     dstColorSpace,
       const HudOptions&         options);
 
     void drawText(
@@ -123,12 +122,10 @@ namespace dxvk::hud {
     void flushDraws(
       const DxvkContextObjects& ctx,
       const Rc<DxvkImageView>&  dstView,
-            VkColorSpaceKHR     dstColorSpace,
       const HudOptions&         options);
 
     HudPipelineKey getPipelineKey(
-      const Rc<DxvkImageView>&  dstView,
-            VkColorSpaceKHR     dstColorSpace) const;
+      const Rc<DxvkImageView>&  dstView) const;
 
     HudSpecConstants getSpecConstants(
       const HudPipelineKey&     key) const;

--- a/src/dxvk/meson.build
+++ b/src/dxvk/meson.build
@@ -28,6 +28,9 @@ dxvk_shaders = files([
   'shaders/dxvk_copy_depth_stencil_2d.frag',
   'shaders/dxvk_copy_depth_stencil_ms.frag',
 
+  'shaders/dxvk_cursor_vert.vert',
+  'shaders/dxvk_cursor_frag.frag',
+
   'shaders/dxvk_dummy_frag.frag',
 
   'shaders/dxvk_fullscreen_geom.geom',

--- a/src/dxvk/shaders/dxvk_cursor_frag.frag
+++ b/src/dxvk/shaders/dxvk_cursor_frag.frag
@@ -1,0 +1,43 @@
+#version 460
+
+#extension GL_GOOGLE_include_directive : require
+
+#include "dxvk_color_space.glsl"
+
+layout(constant_id = 0) const uint s_color_space = VK_COLOR_SPACE_SRGB_NONLINEAR_KHR;
+layout(constant_id = 1) const bool s_srgb = false;
+
+layout(set = 0, binding = 0) uniform sampler2D s_texture;
+
+layout(location = 0) in vec2 i_texcoord;
+layout(location = 0) out vec4 o_color;
+
+
+vec4 linear_to_output(vec4 color) {
+  switch (s_color_space) {
+    case VK_COLOR_SPACE_SRGB_NONLINEAR_KHR: {
+      if (!s_srgb)
+        color.rgb = linear_to_srgb(color.rgb);
+
+      return color;
+    }
+
+    case VK_COLOR_SPACE_EXTENDED_SRGB_LINEAR_EXT:
+      color.rgb = nits_to_sc_rgb(color.rgb * SDR_NITS);
+      return color;
+
+    case VK_COLOR_SPACE_HDR10_ST2084_EXT:
+      color.rgb = rec709_to_rec2020 * color.rgb;
+      color.rgb = nits_to_pq(color.rgb * SDR_NITS);
+      return color;
+
+    default: /* pass through */
+      return color;
+  }
+}
+
+
+void main() {
+  o_color = linear_to_output(texture(s_texture, i_texcoord));
+  o_color.rgb *= o_color.a;
+}

--- a/src/dxvk/shaders/dxvk_cursor_vert.vert
+++ b/src/dxvk/shaders/dxvk_cursor_vert.vert
@@ -1,0 +1,23 @@
+#version 460
+
+layout(push_constant)
+uniform present_info_t {
+  ivec2 dst_extent;
+  ivec2 cursor_offset;
+  ivec2 cursor_extent;
+};
+
+layout(location = 0) out vec2 o_texcoord;
+
+void main() {
+  vec2 coord = vec2(
+    float((gl_VertexIndex >> 1) & 1),
+    float(gl_VertexIndex & 1));
+
+  o_texcoord = coord;
+
+  coord *= vec2(cursor_extent) / vec2(dst_extent);
+  coord += vec2(cursor_offset) / vec2(dst_extent);
+
+  gl_Position = vec4(-1.0f + 2.0f * coord, 0.0f, 1.0f);
+}

--- a/src/dxvk/shaders/dxvk_present_common.glsl
+++ b/src/dxvk/shaders/dxvk_present_common.glsl
@@ -1,5 +1,7 @@
 #include "dxvk_color_space.glsl"
 
+#extension GL_EXT_samplerless_texture_functions : require
+
 layout(constant_id = 0) const uint c_samples = 0u;
 layout(constant_id = 1) const bool c_gamma = false;
 
@@ -7,17 +9,52 @@ layout(constant_id = 2) const uint c_src_color_space = VK_COLOR_SPACE_SRGB_NONLI
 layout(constant_id = 3) const bool c_src_is_srgb = true;
 layout(constant_id = 4) const uint c_dst_color_space = VK_COLOR_SPACE_SRGB_NONLINEAR_KHR;
 layout(constant_id = 5) const bool c_dst_is_srgb = true;
+layout(constant_id = 6) const bool c_composite_hud = false;
+layout(constant_id = 7) const bool c_composite_cursor = false;
 
 layout(set = 0, binding = 0) uniform sampler2D s_image;
 layout(set = 0, binding = 0) uniform sampler2DMS s_image_ms;
 layout(set = 0, binding = 1) uniform sampler1D s_gamma;
+layout(set = 0, binding = 2) uniform texture2D s_hud;
+layout(set = 0, binding = 3) uniform sampler2D s_cursor;
 
 layout(push_constant)
 uniform present_info_t {
   ivec2 src_offset;
   ivec2 src_extent;
   ivec2 dst_offset;
+  ivec2 cursor_offset;
+  ivec2 cursor_extent;
 };
+
+
+vec4 blend_sc_rgb(vec4 dst, vec4 src) {
+  return mix(dst, vec4(src.rgb, 1.0f), src.aaaa);
+}
+
+
+vec4 blend_linear_sdr(vec4 dst, vec4 src) {
+  src.rgb = nits_to_sc_rgb(src.rgb * SDR_NITS);
+  return blend_sc_rgb(dst, src);
+}
+
+
+vec4 composite_image(vec4 color) {
+  ivec2 coord = ivec2(gl_FragCoord.xy);
+
+  if (c_composite_hud)
+    color = blend_linear_sdr(color, texelFetch(s_hud, coord, 0));
+
+  if (c_composite_cursor) {
+    ivec2 rel_ofs = coord - cursor_offset;
+
+    if (max(rel_ofs.x, rel_ofs.y) >= 0 && all(lessThan(rel_ofs, cursor_extent)))
+      color = blend_linear_sdr(color, texture(s_cursor, vec2(rel_ofs) / vec2(cursor_extent)));
+  }
+
+  return color;
+}
+
 
 vec4 input_to_sc_rgb(vec4 color) {
   switch (c_src_color_space) {

--- a/src/dxvk/shaders/dxvk_present_frag.frag
+++ b/src/dxvk/shaders/dxvk_present_frag.frag
@@ -10,5 +10,6 @@ void main() {
   ivec2 coord = ivec2(gl_FragCoord.xy) + src_offset - dst_offset;
 
   o_color = input_to_sc_rgb(texelFetch(s_image, coord, 0));
+  o_color = composite_image(o_color);
   o_color = sc_rgb_to_output(o_color);
 }

--- a/src/dxvk/shaders/dxvk_present_frag_blit.frag
+++ b/src/dxvk/shaders/dxvk_present_frag_blit.frag
@@ -10,5 +10,6 @@ layout(location = 0) out vec4 o_color;
 void main() {
   vec2 coord = vec2(src_offset) + vec2(src_extent) * i_coord;
   o_color = input_to_sc_rgb(textureLod(s_image, coord, 0.0f));
+  o_color = composite_image(o_color);
   o_color = sc_rgb_to_output(o_color);
 }

--- a/src/dxvk/shaders/dxvk_present_frag_ms.frag
+++ b/src/dxvk/shaders/dxvk_present_frag_ms.frag
@@ -13,5 +13,6 @@ void main() {
   for (uint i = 1; i < c_samples; i++)
     o_color += input_to_sc_rgb(texelFetch(s_image_ms, coord, int(i)));
 
-  o_color = sc_rgb_to_output(o_color / float(c_samples));
+  o_color = composite_image(o_color / float(c_samples));
+  o_color = sc_rgb_to_output(o_color);
 }

--- a/src/dxvk/shaders/dxvk_present_frag_ms_amd.frag
+++ b/src/dxvk/shaders/dxvk_present_frag_ms_amd.frag
@@ -31,5 +31,6 @@ void main() {
     fragCount = bitfieldInsert(fragCount, 0, fragShift, 4);
   }
 
-  o_color = sc_rgb_to_output(o_color / float(c_samples));
+  o_color = composite_image(o_color / float(c_samples));
+  o_color = sc_rgb_to_output(o_color);
 }

--- a/src/dxvk/shaders/dxvk_present_frag_ms_blit.frag
+++ b/src/dxvk/shaders/dxvk_present_frag_ms_blit.frag
@@ -61,5 +61,6 @@ void main() {
     o_color += input_to_sc_rgb(texelFetch(s_image_ms, cint + coffset, int(i)));
   }
 
-  o_color = sc_rgb_to_output(o_color / float(c_samples));
+  o_color = composite_image(o_color / float(c_samples));
+  o_color = sc_rgb_to_output(o_color);
 }


### PR DESCRIPTION
Big refactor that moves a lot of responsibility to the backend, where it should have been in the first place.

Key changes:
- Vulkan surface and swapchain creation now happens *entirely* in the backend. Instead of this clusterfuck where the front-end needs to manually synchronize everything through four different threads and then pray that it actually works, we now just set swapchain properties via a bunch of functions that can then get applied during the next `acquireNextImage` call.
- Enabled automatic conversion between HDR10 and scRGB color spaces if the system only supports one of those and the game uses the other. This is definitely not well tested with actual HDR content though.
- Fixed broken blending with the HUD and software cursor in non-linear color spaces (sRGB if the image format is non-sRGB; HDR10)

Needs **lots** of testing, especially in D3D9 apps since there are so many weird edge cases wrt swapchain usage.