### PR TITLE
[d3d9] Fix invalid strings returned by GetInstanceExtensions

### DIFF
--- a/src/dxvk/dxvk_instance.cpp
+++ b/src/dxvk/dxvk_instance.cpp
@@ -115,18 +115,18 @@ namespace dxvk {
 
   void DxvkInstance::createInstanceLoader(const DxvkInstanceImportInfo& args, DxvkInstanceFlags flags) {
     DxvkNameList layerList;
-    DxvkNameSet extensionSet;
+    m_extensionSet = DxvkNameSet();
 
     bool enablePerfEvents = false;
     bool enableValidation = false;
 
     if (args.instance) {
       m_extensionNames = DxvkNameList(args.extensionCount, args.extensionNames);
-      extensionSet = getExtensionSet(m_extensionNames);
+      m_extensionSet = getExtensionSet(m_extensionNames);
 
       auto extensionInfos = getExtensionList(m_extensions, true);
 
-      if (!extensionSet.enableExtensions(extensionInfos.size(), extensionInfos.data(), nullptr))
+      if (!m_extensionSet.enableExtensions(extensionInfos.size(), extensionInfos.data(), nullptr))
         throw DxvkError("DxvkInstance: Required instance extensions not enabled");
     } else {
       // Hide VK_EXT_debug_utils behind an environment variable.
@@ -160,14 +160,14 @@ namespace dxvk {
       auto extensionInfos = getExtensionList(m_extensions, enableDebug);
       DxvkNameSet extensionsAvailable = DxvkNameSet::enumInstanceExtensions(m_vkl);
 
-      if (!extensionsAvailable.enableExtensions(extensionInfos.size(), extensionInfos.data(), &extensionSet))
+      if (!extensionsAvailable.enableExtensions(extensionInfos.size(), extensionInfos.data(), &m_extensionSet))
         throw DxvkError("DxvkInstance: Required instance extensions not supported");
 
       for (const auto& provider : m_extProviders)
-        extensionSet.merge(provider->getInstanceExtensions());
+        m_extensionSet.merge(provider->getInstanceExtensions());
 
       // Generate list of extensions to enable
-      m_extensionNames = extensionSet.toNameList();
+      m_extensionNames = m_extensionSet.toNameList();
     }
 
     Logger::info("Enabled instance extensions:");

--- a/src/dxvk/dxvk_instance.h
+++ b/src/dxvk/dxvk_instance.h
@@ -165,6 +165,7 @@ namespace dxvk {
     Rc<vk::LibraryFn>       m_vkl;
     Rc<vk::InstanceFn>      m_vki;
     DxvkInstanceExtensions  m_extensions;
+    DxvkNameSet             m_extensionSet;
     DxvkNameList            m_extensionNames;
 
     VkDebugUtilsMessengerEXT m_messenger = VK_NULL_HANDLE;


### PR DESCRIPTION
There was a major bug in #4505 where the instance extension name set is freed from scope which invalidates the strings in `m_extensionNames`. This is trivially fixed by storing the extension set in `DxvkInstance`. Not sure how I didn't notice this, I think when I tested it the custom memory allocator my project uses left the freed string data untouched on the heap or something. Anyway, this PR fixes it.