### PR TITLE
[util] Enable Strict floatEmulation for Max Payne 3

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -1031,6 +1031,11 @@ namespace dxvk {
     { R"(\\(AH3LM|AALib)\.exe$)", {{
       { "d3d9.maxFrameRate",                "60" },
     }} },
+    /* May Payne 3 - Visual issues on some drivers *
+     * such as ANV (and amdvlk when set to True)   */
+    { R"(\\MaxPayne3\.exe$)", {{
+      { "d3d9.floatEmulation",              "Strict" },
+    }} },
 
     /**********************************************/
     /* D3D8 GAMES                                 */


### PR DESCRIPTION
First time i have seen a driver dependent floatEmulation issue. Have reproduced ANV and amdvlk, but not on radv with `True`.

<details>
  <summary>Screenshots</summary>
  
![image](https://github.com/user-attachments/assets/09454f54-759b-4079-9802-71127e283313)
![image](https://github.com/user-attachments/assets/03bc4192-3de7-4f08-8792-ccc691ad606a)
</details>

Fixes https://gitlab.freedesktop.org/mesa/mesa/-/issues/12114