### PR TITLE
Latency tracker

### DIFF
--- a/dxvk.conf
+++ b/dxvk.conf
@@ -106,6 +106,15 @@
 # dxvk.latencyTolerance = 1000
 
 
+# Disables the use of VK_NV_low_latency2. This will make Reflex unavailable
+# in games, and if dxvk.latencySleep is set to True, a custom algorithm will
+# be used for latency control.
+#
+# Supported values: True, False
+
+# dxvk.disableNvLowLatency2 = False
+
+
 # Override PCI vendor and device IDs reported to the application. Can
 # cause the app to adjust behaviour depending on the selected values.
 #

--- a/dxvk.conf
+++ b/dxvk.conf
@@ -76,6 +76,36 @@
 # d3d9.maxFrameRate = 0
 
 
+# Controls latency sleep and Nvidia Reflex support.
+#
+# Supported values:
+# - Auto: By default, DXVK only supports latency sleep in D3D11 games that
+#         use Reflex if the graphics driver supports VK_NV_low_latency2,
+#         and if dxvk-nvapi is enabled in Proton.
+# - True: Enables built-in latency reduction based on internal timings.
+#         This assumes that input sampling for any given frame happens after
+#         the D3D9 or DXGI Present call returns; games that render and present
+#         asynchronously will not behave as intended.
+#         Similarly, this will not have any effect in games with built-in frame
+#         rate limiters, or if an external limiter (such as MangoHud) is used.
+#         In some games, enabling this may reduce performance or lead to less
+#         consistent frame pacing.
+#         The implementation will either use VK_NV_low_latency2 if supported
+#         by the driver, or a custom algorithm.
+# - False: Disable Reflex support as well as built-in latency reduction.
+  
+# dxvk.latencySleep = Auto
+
+
+# Tolerance for the latency sleep heuristic, in microseconds. Higher values
+# increase latency, but may lead to better frame pacing in some cases. Does
+# not have any effect if NV_low_latency2 is used.
+#
+# Supported values: Any non-negative number
+
+# dxvk.latencyTolerance = 1000
+
+
 # Override PCI vendor and device IDs reported to the application. Can
 # cause the app to adjust behaviour depending on the selected values.
 #

--- a/src/d3d11/d3d11_context_imm.cpp
+++ b/src/d3d11/d3d11_context_imm.cpp
@@ -861,11 +861,15 @@ namespace dxvk {
   }
   
   
-  void D3D11ImmediateContext::EndFrame() {
+  void D3D11ImmediateContext::EndFrame(
+          Rc<DxvkLatencyTracker>      LatencyTracker) {
     D3D10DeviceLock lock = LockContext();
 
-    EmitCs<false>([] (DxvkContext* ctx) {
+    EmitCs<false>([
+      cTracker = std::move(LatencyTracker)
+    ] (DxvkContext* ctx) {
       ctx->endFrame();
+      ctx->endLatencyTracking(cTracker);
     });
   }
 

--- a/src/d3d11/d3d11_context_imm.h
+++ b/src/d3d11/d3d11_context_imm.h
@@ -169,7 +169,8 @@ namespace dxvk {
 
     void SynchronizeDevice();
 
-    void EndFrame();
+    void EndFrame(
+            Rc<DxvkLatencyTracker>      LatencyTracker);
     
     bool WaitForResource(
       const DxvkPagedResource&          Resource,

--- a/src/d3d11/d3d11_swapchain.cpp
+++ b/src/d3d11/d3d11_swapchain.cpp
@@ -425,7 +425,7 @@ namespace dxvk {
       ctx->synchronizeWsi(cSync);
       ctx->flushCommandList(nullptr);
 
-      cDevice->presentImage(cPresenter, cFrameId, nullptr);
+      cDevice->presentImage(cPresenter, nullptr, cFrameId, nullptr);
     });
 
     if (m_backBuffers.size() > 1u)

--- a/src/d3d11/d3d11_swapchain.h
+++ b/src/d3d11/d3d11_swapchain.h
@@ -4,6 +4,7 @@
 
 #include "../dxvk/hud/dxvk_hud.h"
 
+#include "../dxvk/dxvk_latency.h"
 #include "../dxvk/dxvk_swapchain_blitter.h"
 
 #include "../util/sync/sync_signal.h"
@@ -107,6 +108,7 @@ namespace dxvk {
     Rc<Presenter>             m_presenter;
 
     Rc<DxvkSwapchainBlitter>  m_blitter;
+    Rc<DxvkLatencyTracker>    m_latency;
 
     small_vector<Com<D3D11Texture2D, false>, 4> m_backBuffers;
 
@@ -123,6 +125,8 @@ namespace dxvk {
     dxvk::mutex               m_frameStatisticsLock;
     DXGI_VK_FRAME_STATISTICS  m_frameStatistics = { };
 
+    Rc<hud::HudLatencyItem>   m_latencyHud;
+
     Rc<DxvkImageView> GetBackBufferView();
 
     HRESULT PresentImage(UINT SyncInterval);
@@ -138,6 +142,8 @@ namespace dxvk {
     void CreateBlitter();
 
     void DestroyFrameLatencyEvent();
+
+    void DestroyLatencyTracker();
 
     void SyncFrameLatency();
 

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -800,7 +800,8 @@ namespace dxvk {
     void Flush();
     void FlushAndSync9On12();
 
-    void EndFrame();
+    void BeginFrame(Rc<DxvkLatencyTracker> LatencyTracker, uint64_t FrameId);
+    void EndFrame(Rc<DxvkLatencyTracker> LatencyTracker);
 
     void UpdateActiveRTs(uint32_t index);
 

--- a/src/d3d9/d3d9_swapchain.cpp
+++ b/src/d3d9/d3d9_swapchain.cpp
@@ -23,10 +23,12 @@ namespace dxvk {
   D3D9SwapChainEx::D3D9SwapChainEx(
           D3D9DeviceEx*          pDevice,
           D3DPRESENT_PARAMETERS* pPresentParams,
-    const D3DDISPLAYMODEEX*      pFullscreenDisplayMode)
+    const D3DDISPLAYMODEEX*      pFullscreenDisplayMode,
+          bool                   EnableLatencyTracking)
     : D3D9SwapChainExBase(pDevice)
     , m_device           (pDevice->GetDXVKDevice())
     , m_frameLatencyCap  (pDevice->GetOptions()->maxFrameLatency)
+    , m_latencyTracking  (EnableLatencyTracking)
     , m_swapchainExt     (this) {
     this->NormalizePresentParameters(pPresentParams);
     m_presentParams = *pPresentParams;
@@ -186,7 +188,7 @@ namespace dxvk {
   #define DCX_USESTYLE 0x00010000
 
   HRESULT D3D9SwapChainEx::PresentImageGDI(HWND Window) {
-    m_parent->EndFrame();
+    m_parent->EndFrame(nullptr);
     m_parent->Flush();
 
     if (!std::exchange(m_warnedAboutGDIFallback, true))
@@ -717,6 +719,9 @@ namespace dxvk {
       if (entry->second.presenter) {
         entry->second.presenter->destroyResources();
         entry->second.presenter = nullptr;
+
+        if (m_presentParams.hDeviceWindow == hWindow)
+          DestroyLatencyTracker();
       }
 
       if (m_wctx == &entry->second)
@@ -802,10 +807,15 @@ namespace dxvk {
 
 
   void D3D9SwapChainEx::PresentImage(UINT SyncInterval) {
-    m_parent->EndFrame();
+    m_parent->EndFrame(m_latencyTracker);
     m_parent->Flush();
 
+    if (m_latencyTracker)
+      m_latencyTracker->notifyCpuPresentBegin(m_wctx->frameId + 1u);
+
     // Retrieve the image and image view to present
+    VkResult status = VK_SUCCESS;
+
     Rc<DxvkImage> swapImage = m_backBuffers[0]->GetCommonTexture()->GetImage();
     Rc<DxvkImageView> swapImageView = m_backBuffers[0]->GetImageView(false);
 
@@ -814,10 +824,12 @@ namespace dxvk {
       PresenterSync sync = { };
       Rc<DxvkImage> backBuffer;
 
-      VkResult status = m_wctx->presenter->acquireNextImage(sync, backBuffer);
+      status = m_wctx->presenter->acquireNextImage(sync, backBuffer);
 
-      if (status < 0 || status == VK_NOT_READY)
+      if (status < 0 || status == VK_NOT_READY) {
+        status = i ? VK_SUCCESS : status;
         break;
+      }
 
       VkRect2D srcRect = {
         {  int32_t(m_srcRect.left),                    int32_t(m_srcRect.top)                    },
@@ -854,7 +866,8 @@ namespace dxvk {
         cDstRect        = dstRect,
         cRepeat         = i,
         cSync           = sync,
-        cFrameId        = m_wctx->frameId
+        cFrameId        = m_wctx->frameId,
+        cLatency        = m_latencyTracker
       ] (DxvkContext* ctx) {
         // Update back buffer color space as necessary
         if (cSrcView->image()->info().colorSpace != cColorSpace) {
@@ -876,13 +889,32 @@ namespace dxvk {
 
         uint64_t frameId = cRepeat ? 0 : cFrameId;
 
-        cDevice->presentImage(cPresenter, nullptr, frameId, nullptr);
+        cDevice->presentImage(cPresenter, cLatency, frameId, nullptr);
       });
 
       m_parent->FlushCsChunk();
     }
 
+    if (m_latencyTracker) {
+      if (status == VK_SUCCESS)
+        m_latencyTracker->notifyCpuPresentEnd(m_wctx->frameId);
+      else
+        m_latencyTracker->discardTimings();
+    }
+
     SyncFrameLatency();
+
+    DxvkLatencyStats latencyStats = { };
+
+    if (m_latencyTracker && status == VK_SUCCESS) {
+      latencyStats = m_latencyTracker->getStatistics(m_wctx->frameId);
+      m_latencyTracker->sleepAndBeginFrame(m_wctx->frameId + 1, std::abs(m_targetFrameRate));
+
+      m_parent->BeginFrame(m_latencyTracker, m_wctx->frameId + 1u);
+    }
+
+    if (m_latencyHud)
+      m_latencyHud->accumulateStats(latencyStats);
 
     // Rotate swap chain buffers so that the back
     // buffer at index 0 becomes the front buffer.
@@ -941,6 +973,9 @@ namespace dxvk {
 
       entry->second.frameLatencySignal = new sync::Fence(entry->second.frameId);
       entry->second.presenter = CreatePresenter(m_window, entry->second.frameLatencySignal);
+
+      if (m_presentParams.hDeviceWindow == m_window && m_latencyTracking)
+        m_latencyTracker = m_device->createLatencyTracker(entry->second.presenter);
     }
 
     m_wctx = &entry->second;
@@ -1017,6 +1052,10 @@ namespace dxvk {
 
     if (hud) {
       m_apiHud = hud->addItem<hud::HudClientApiItem>("api", 1, GetApiName());
+
+      if (m_latencyTracking)
+        m_latencyHud = hud->addItem<hud::HudLatencyItem>("latency", 4);
+
       hud->addItem<hud::HudSamplerCount>("samplers", -1, m_parent);
       hud->addItem<hud::HudFixedFunctionShaders>("ffshaders", -1, m_parent);
       hud->addItem<hud::HudSWVPState>("swvp", -1, m_parent);
@@ -1041,6 +1080,18 @@ namespace dxvk {
   }
 
 
+  void D3D9SwapChainEx::DestroyLatencyTracker() {
+    if (!m_latencyTracker)
+      return;
+
+    m_parent->InjectCs([
+      cTracker = std::move(m_latencyTracker)
+    ] (DxvkContext* ctx) {
+      ctx->endLatencyTracking(cTracker);
+    });
+  }
+
+
   void D3D9SwapChainEx::UpdateTargetFrameRate(uint32_t SyncInterval) {
     double frameRateOption = double(m_parent->GetOptions()->maxFrameRate);
     double frameRate = std::max(frameRateOption, 0.0);
@@ -1049,6 +1100,7 @@ namespace dxvk {
       frameRate = -m_displayRefreshRate / double(SyncInterval);
 
     m_wctx->presenter->setFrameRateLimit(frameRate, GetActualFrameLatency());
+    m_targetFrameRate = frameRate;
   }
 
 

--- a/src/d3d9/d3d9_swapchain.cpp
+++ b/src/d3d9/d3d9_swapchain.cpp
@@ -876,7 +876,7 @@ namespace dxvk {
 
         uint64_t frameId = cRepeat ? 0 : cFrameId;
 
-        cDevice->presentImage(cPresenter, frameId, nullptr);
+        cDevice->presentImage(cPresenter, nullptr, frameId, nullptr);
       });
 
       m_parent->FlushCsChunk();

--- a/src/d3d9/d3d9_swapchain.h
+++ b/src/d3d9/d3d9_swapchain.h
@@ -69,7 +69,8 @@ namespace dxvk {
     D3D9SwapChainEx(
             D3D9DeviceEx*          pDevice,
             D3DPRESENT_PARAMETERS* pPresentParams,
-      const D3DDISPLAYMODEEX*      pFullscreenDisplayMode);
+      const D3DDISPLAYMODEEX*      pFullscreenDisplayMode,
+            bool                   EnableLatencyTracking);
 
     ~D3D9SwapChainEx();
 
@@ -173,12 +174,17 @@ namespace dxvk {
     wsi::DxvkWindowState      m_windowState;
 
     double                    m_displayRefreshRate = 0.0;
+    double                    m_targetFrameRate = 0.0;
 
     bool                      m_warnedAboutGDIFallback = false;
 
     VkColorSpaceKHR           m_colorspace = VK_COLOR_SPACE_SRGB_NONLINEAR_KHR;
 
+    bool                      m_latencyTracking = false;
+    Rc<DxvkLatencyTracker>    m_latencyTracker = nullptr;
+
     Rc<hud::HudClientApiItem> m_apiHud;
+    Rc<hud::HudLatencyItem>   m_latencyHud;
 
     std::optional<VkHdrMetadataEXT> m_hdrMetadata;
     bool m_unlockAdditionalFormats = false;
@@ -196,6 +202,8 @@ namespace dxvk {
             DWORD               Flags);
 
     void CreateBlitter();
+
+    void DestroyLatencyTracker();
 
     void InitRamp();
 

--- a/src/d3d9/d3d9_swapchain.h
+++ b/src/d3d9/d3d9_swapchain.h
@@ -173,8 +173,10 @@ namespace dxvk {
 
     wsi::DxvkWindowState      m_windowState;
 
-    double                    m_displayRefreshRate = 0.0;
     double                    m_targetFrameRate = 0.0;
+
+    double                    m_displayRefreshRate = 0.0;
+    bool                      m_displayRefreshRateDirty = true;
 
     bool                      m_warnedAboutGDIFallback = false;
 
@@ -215,8 +217,7 @@ namespace dxvk {
     
     void NormalizePresentParameters(D3DPRESENT_PARAMETERS* pPresentParams);
 
-    void NotifyDisplayRefreshRate(
-            double                  RefreshRate);
+    void UpdateWindowedRefreshRate();
 
     HRESULT EnterFullscreenMode(
             D3DPRESENT_PARAMETERS*  pPresentParams,

--- a/src/dxgi/dxgi_swapchain.cpp
+++ b/src/dxgi/dxgi_swapchain.cpp
@@ -43,6 +43,14 @@ namespace dxvk {
 
     // Ensure that RGBA16 swap chains are scRGB if supported
     UpdateColorSpace(m_desc.Format, m_colorSpace);
+
+    // Somewhat hacky way to determine whether to forward the
+    // display refresh rate in windowed mode even with a sync
+    // interval of 1.
+    if (!m_is_d3d12) {
+      auto instance = pFactory->GetDXVKInstance();
+      m_hasLatencyControl = instance->options().latencySleep == Tristate::True;
+    }
   }
   
   
@@ -1000,10 +1008,12 @@ namespace dxvk {
     // Engage the frame limiter with large sync intervals even in windowed
     // mode since we want to avoid double-presenting to the swap chain.
     if (SyncInterval != m_frameRateSyncInterval && m_descFs.Windowed) {
+      bool engageLimiter = (SyncInterval > 1u) || (SyncInterval && m_hasLatencyControl);
+
       m_frameRateSyncInterval = SyncInterval;
       m_frameRateRefresh = 0.0f;
 
-      if (SyncInterval > 1 && wsi::isWindow(m_window)) {
+      if (engageLimiter && wsi::isWindow(m_window)) {
         wsi::WsiMode mode = { };
 
         if (wsi::getCurrentDisplayMode(wsi::getWindowMonitor(m_window), &mode)) {

--- a/src/dxgi/dxgi_swapchain.h
+++ b/src/dxgi/dxgi_swapchain.h
@@ -205,6 +205,7 @@ namespace dxvk {
     DXGI_COLOR_SPACE_TYPE           m_colorSpace = DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P709;
 
     uint32_t                        m_globalHDRStateSerial = 0;
+    bool                            m_hasLatencyControl = false;
     
     HRESULT EnterFullscreenMode(
             IDXGIOutput1            *pTarget);

--- a/src/dxvk/dxvk_adapter.cpp
+++ b/src/dxvk/dxvk_adapter.cpp
@@ -293,6 +293,10 @@ namespace dxvk {
       enabledFeatures.vk12.bufferDeviceAddress = VK_TRUE;
     }
 
+    // Disable NV_low_latency2 if allowed via config
+    if (instance->options().disableNvLowLatency2)
+      devExtensions.nvLowLatency2.setMode(DxvkExtMode::Disabled);
+
     // If we don't have pageable device memory support, at least use
     // the legacy AMD extension to ensure we can oversubscribe VRAM
     if (!m_deviceExtensions.supports(devExtensions.extPageableDeviceLocalMemory.name()))

--- a/src/dxvk/dxvk_adapter.cpp
+++ b/src/dxvk/dxvk_adapter.cpp
@@ -1027,6 +1027,7 @@ namespace dxvk {
       &devExtensions.khrSwapchain,
       &devExtensions.khrWin32KeyedMutex,
       &devExtensions.nvDescriptorPoolOverallocation,
+      &devExtensions.nvLowLatency2,
       &devExtensions.nvRawAccessChains,
       &devExtensions.nvxBinaryImport,
       &devExtensions.nvxImageViewHandle,
@@ -1176,6 +1177,9 @@ namespace dxvk {
       enabledFeatures.nvDescriptorPoolOverallocation.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_POOL_OVERALLOCATION_FEATURES_NV;
       enabledFeatures.nvDescriptorPoolOverallocation.pNext = std::exchange(enabledFeatures.core.pNext, &enabledFeatures.nvDescriptorPoolOverallocation);
     }
+
+    if (devExtensions.nvLowLatency2.revision() >= 2)
+      enabledFeatures.nvLowLatency2 = VK_TRUE;
 
     if (devExtensions.nvRawAccessChains) {
       enabledFeatures.nvRawAccessChains.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAW_ACCESS_CHAINS_FEATURES_NV;
@@ -1332,6 +1336,8 @@ namespace dxvk {
       "\n  presentWait                            : ", features.khrPresentWait.presentWait ? "1" : "0",
       "\n", VK_NV_DESCRIPTOR_POOL_OVERALLOCATION_EXTENSION_NAME,
       "\n  descriptorPoolOverallocation           : ", features.nvDescriptorPoolOverallocation.descriptorPoolOverallocation ? "1" : "0",
+      "\n", VK_NV_LOW_LATENCY_2_EXTENSION_NAME,
+      "\n  extension supported                    : ", features.nvLowLatency2 ? "1" : "0",
       "\n", VK_NV_RAW_ACCESS_CHAINS_EXTENSION_NAME,
       "\n  shaderRawAccessChains                  : ", features.nvRawAccessChains.shaderRawAccessChains ? "1" : "0",
       "\n", VK_NVX_BINARY_IMPORT_EXTENSION_NAME,

--- a/src/dxvk/dxvk_cmdlist.cpp
+++ b/src/dxvk/dxvk_cmdlist.cpp
@@ -50,8 +50,12 @@ namespace dxvk {
 
   VkResult DxvkCommandSubmission::submit(
           DxvkDevice*           device,
-          VkQueue               queue) {
+          VkQueue               queue,
+          uint64_t              trackedId) {
     auto vk = device->vkd();
+
+    VkLatencySubmissionPresentIdNV latencyInfo = { VK_STRUCTURE_TYPE_LATENCY_SUBMISSION_PRESENT_ID_NV };
+    latencyInfo.presentID = trackedId;
 
     VkSubmitInfo2 submitInfo = { VK_STRUCTURE_TYPE_SUBMIT_INFO_2 };
 
@@ -69,6 +73,9 @@ namespace dxvk {
       submitInfo.signalSemaphoreInfoCount = m_semaphoreSignals.size();
       submitInfo.pSignalSemaphoreInfos = m_semaphoreSignals.data();
     }
+
+    if (trackedId && device->features().nvLowLatency2)
+      latencyInfo.pNext = std::exchange(submitInfo.pNext, &latencyInfo);
 
     VkResult vr = VK_SUCCESS;
 
@@ -200,7 +207,8 @@ namespace dxvk {
   
   VkResult DxvkCommandList::submit(
     const DxvkTimelineSemaphores&       semaphores,
-          DxvkTimelineSemaphoreValues&  timelines) {
+          DxvkTimelineSemaphoreValues&  timelines,
+          uint64_t                      trackedId) {
     VkResult status = VK_SUCCESS;
 
     static const std::array<DxvkCmdBuffer, 2> SdmaCmdBuffers =
@@ -259,7 +267,7 @@ namespace dxvk {
         m_commandSubmission.signalSemaphore(semaphores.transfer,
           ++timelines.transfer, VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT);
 
-        if ((status = m_commandSubmission.submit(m_device, transfer.queueHandle)))
+        if ((status = m_commandSubmission.submit(m_device, transfer.queueHandle, trackedId)))
           return status;
 
         m_commandSubmission.waitSemaphore(semaphores.transfer,
@@ -301,7 +309,7 @@ namespace dxvk {
         ++timelines.graphics, VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT);
 
       // Finally, submit all graphics commands of the current submission
-      if ((status = m_commandSubmission.submit(m_device, graphics.queueHandle)))
+      if ((status = m_commandSubmission.submit(m_device, graphics.queueHandle, trackedId)))
         return status;
 
       // If there are WSI semaphores involved, do another submit only
@@ -311,7 +319,7 @@ namespace dxvk {
         m_commandSubmission.signalSemaphore(semaphores.graphics,
           ++timelines.graphics, VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT);
 
-        if ((status = m_commandSubmission.submit(m_device, graphics.queueHandle)))
+        if ((status = m_commandSubmission.submit(m_device, graphics.queueHandle, trackedId)))
           return status;
       }
 
@@ -321,7 +329,7 @@ namespace dxvk {
         m_commandSubmission.waitSemaphore(semaphores.graphics,
           timelines.graphics, VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT);
 
-        if (isLast && (status = m_commandSubmission.submit(m_device, transfer.queueHandle)))
+        if (isLast && (status = m_commandSubmission.submit(m_device, transfer.queueHandle, trackedId)))
           return status;
       }
     }

--- a/src/dxvk/dxvk_cmdlist.h
+++ b/src/dxvk/dxvk_cmdlist.h
@@ -103,11 +103,13 @@ namespace dxvk {
      *
      * \param [in] device DXVK device
      * \param [in] queue Queue to submit to
+     * \param [in] trackedId Latency frame ID
      * \returns Submission return value
      */
     VkResult submit(
             DxvkDevice*           device,
-            VkQueue               queue);
+            VkQueue               queue,
+            uint64_t              trackedId);
 
     /**
      * \brief Resets object
@@ -215,11 +217,13 @@ namespace dxvk {
      *
      * \param [in] semaphores Timeline semaphore pair
      * \param [in] timelines Timeline semaphore values
+     * \param [in] trackedId Latency frame ID
      * \returns Submission status
      */
     VkResult submit(
       const DxvkTimelineSemaphores&       semaphores,
-            DxvkTimelineSemaphoreValues&  timelines);
+            DxvkTimelineSemaphoreValues&  timelines,
+            uint64_t                      trackedId);
     
     /**
      * \brief Stat counters

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -111,9 +111,9 @@ namespace dxvk {
 
 
   void DxvkContext::flushCommandList(DxvkSubmitStatus* status) {
-    m_device->submitCommandList(
-      this->endRecording(), status);
-    
+    m_device->submitCommandList(this->endRecording(),
+      nullptr, 0, status);
+
     this->beginRecording(
       m_device->createCommandList());
   }

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -113,7 +113,7 @@ namespace dxvk {
   void DxvkContext::beginLatencyTracking(
     const Rc<DxvkLatencyTracker>&     tracker,
           uint64_t                    frameId) {
-    if (tracker && !m_latencyTracker) {
+    if (tracker && (!m_latencyTracker || m_latencyTracker == tracker)) {
       tracker->notifyCsRenderBegin(frameId);
 
       m_latencyTracker = tracker;

--- a/src/dxvk/dxvk_context.h
+++ b/src/dxvk/dxvk_context.h
@@ -4,6 +4,7 @@
 #include "dxvk_bind_mask.h"
 #include "dxvk_cmdlist.h"
 #include "dxvk_context_state.h"
+#include "dxvk_latency.h"
 #include "dxvk_objects.h"
 #include "dxvk_queue.h"
 #include "dxvk_util.h"
@@ -67,6 +68,30 @@ namespace dxvk {
      * final call to \ref endRecording.
      */
     void endFrame();
+
+    /**
+     * \brief Begins latency tracking
+     *
+     * Notifies the beginning of a frame on the CS timeline
+     * an ensures that subsequent submissions are associated
+     * with the correct frame ID. Only one tracker can be
+     * active at any given time.
+     * \param [in] tracker Latency tracker object
+     * \param [in] frameId Current frame ID
+     */
+    void beginLatencyTracking(
+      const Rc<DxvkLatencyTracker>&     tracker,
+            uint64_t                    frameId);
+
+    /**
+     * \brief Ends latency tracking
+     *
+     * Notifies the end of the frame. Ignored if the
+     * tracker is not currently active.
+     * \param [in] tracker Latency tracker object
+     */
+    void endLatencyTracking(
+      const Rc<DxvkLatencyTracker>&     tracker);
 
     /**
      * \brief Flushes command buffer
@@ -1420,6 +1445,10 @@ namespace dxvk {
 
     std::vector<util::DxvkDebugLabel> m_debugLabelStack;
     bool                              m_debugLabelInternalActive = false;
+
+    Rc<DxvkLatencyTracker>  m_latencyTracker;
+    uint64_t                m_latencyFrameId = 0u;
+    bool                    m_endLatencyTracking = false;
 
     void blitImageFb(
             Rc<DxvkImageView>     dstView,

--- a/src/dxvk/dxvk_device.cpp
+++ b/src/dxvk/dxvk_device.cpp
@@ -312,7 +312,9 @@ namespace dxvk {
     if (m_options.latencySleep != Tristate::True)
       return nullptr;
 
-    if (m_features.nvLowLatency2)
+    // Latency sleep seems to be completely broken on 32-bit Nvidia
+    // drivers as of 565.77, let's use our built-in implementation
+    if (m_features.nvLowLatency2 && !env::is32BitHostPlatform())
       return new DxvkBuiltInLatencyTrackerNv(presenter);
 
     return new DxvkBuiltInLatencyTracker(

--- a/src/dxvk/dxvk_device.cpp
+++ b/src/dxvk/dxvk_device.cpp
@@ -318,12 +318,18 @@ namespace dxvk {
 
   void DxvkDevice::presentImage(
     const Rc<Presenter>&            presenter,
+    const Rc<DxvkLatencyTracker>&   tracker,
           uint64_t                  frameId,
           DxvkSubmitStatus*         status) {
     DxvkPresentInfo presentInfo = { };
     presentInfo.presenter = presenter;
     presentInfo.frameId = frameId;
-    m_submissionQueue.present(presentInfo, status);
+
+    DxvkLatencyInfo latencyInfo;
+    latencyInfo.tracker = tracker;
+    latencyInfo.frameId = frameId;
+
+    m_submissionQueue.present(presentInfo, latencyInfo, status);
     
     std::lock_guard<sync::Spinlock> statLock(m_statLock);
     m_statCounters.addCtr(DxvkStatCounter::QueuePresentCount, 1);
@@ -332,10 +338,17 @@ namespace dxvk {
 
   void DxvkDevice::submitCommandList(
     const Rc<DxvkCommandList>&      commandList,
+    const Rc<DxvkLatencyTracker>&   tracker,
+          uint64_t                  frameId,
           DxvkSubmitStatus*         status) {
     DxvkSubmitInfo submitInfo = { };
     submitInfo.cmdList = commandList;
-    m_submissionQueue.submit(submitInfo, status);
+
+    DxvkLatencyInfo latencyInfo;
+    latencyInfo.tracker = tracker;
+    latencyInfo.frameId = frameId;
+
+    m_submissionQueue.submit(submitInfo, latencyInfo, status);
 
     std::lock_guard<sync::Spinlock> statLock(m_statLock);
     m_statCounters.merge(commandList->statCounters());

--- a/src/dxvk/dxvk_device.cpp
+++ b/src/dxvk/dxvk_device.cpp
@@ -1,6 +1,7 @@
 #include "dxvk_device.h"
 #include "dxvk_instance.h"
 #include "dxvk_latency_builtin.h"
+#include "dxvk_latency_builtin_nv.h"
 
 namespace dxvk {
   
@@ -310,6 +311,9 @@ namespace dxvk {
     const Rc<Presenter>&            presenter) {
     if (m_options.latencySleep != Tristate::True)
       return nullptr;
+
+    if (m_features.nvLowLatency2)
+      return new DxvkBuiltInLatencyTrackerNv(presenter);
 
     return new DxvkBuiltInLatencyTracker(
       m_options.latencyTolerance);

--- a/src/dxvk/dxvk_device.cpp
+++ b/src/dxvk/dxvk_device.cpp
@@ -1,5 +1,6 @@
 #include "dxvk_device.h"
 #include "dxvk_instance.h"
+#include "dxvk_latency_builtin.h"
 
 namespace dxvk {
   
@@ -302,6 +303,16 @@ namespace dxvk {
   void DxvkDevice::requestCompileShader(
     const Rc<DxvkShader>&           shader) {
     m_objects.pipelineManager().requestCompileShader(shader);
+  }
+
+
+  Rc<DxvkLatencyTracker> DxvkDevice::createLatencyTracker(
+    const Rc<Presenter>&            presenter) {
+    if (m_options.latencySleep != Tristate::True)
+      return nullptr;
+
+    return new DxvkBuiltInLatencyTracker(
+      m_options.latencyTolerance);
   }
 
 

--- a/src/dxvk/dxvk_device.h
+++ b/src/dxvk/dxvk_device.h
@@ -10,6 +10,7 @@
 #include "dxvk_framebuffer.h"
 #include "dxvk_image.h"
 #include "dxvk_instance.h"
+#include "dxvk_latency.h"
 #include "dxvk_memory.h"
 #include "dxvk_meta_clear.h"
 #include "dxvk_objects.h"
@@ -477,6 +478,16 @@ namespace dxvk {
      */
     void requestCompileShader(
       const Rc<DxvkShader>&         shader);
+
+    /**
+     * \brief Creates latency tracker for a presenter
+     *
+     * The specicfic implementation and parameters used
+     * depend on user configuration.
+     * \param [in] presenter Presenter instance
+     */
+    Rc<DxvkLatencyTracker> createLatencyTracker(
+      const Rc<Presenter>&            presenter);
 
     /**
      * \brief Presents a swap chain image

--- a/src/dxvk/dxvk_device.h
+++ b/src/dxvk/dxvk_device.h
@@ -496,11 +496,13 @@ namespace dxvk {
      * the submission thread. The status of this operation
      * can be retrieved with \ref waitForSubmission.
      * \param [in] presenter The presenter
-     * \param [in] frameId Optional frame ID
+     * \param [in] tracker Latency tracker
+     * \param [in] frameId Frame ID
      * \param [out] status Present status
      */
     void presentImage(
       const Rc<Presenter>&            presenter,
+      const Rc<DxvkLatencyTracker>&   tracker,
             uint64_t                  frameId,
             DxvkSubmitStatus*         status);
     
@@ -510,10 +512,14 @@ namespace dxvk {
      * Submits the given command list to the device using
      * the given set of optional synchronization primitives.
      * \param [in] commandList The command list to submit
+     * \param [in] tracker Latency tracker
+     * \param [in] frameId Frame ID
      * \param [out] status Submission feedback
      */
     void submitCommandList(
       const Rc<DxvkCommandList>&      commandList,
+      const Rc<DxvkLatencyTracker>&   tracker,
+            uint64_t                  frameId,
             DxvkSubmitStatus*         status);
 
     /**

--- a/src/dxvk/dxvk_device_info.h
+++ b/src/dxvk/dxvk_device_info.h
@@ -73,6 +73,7 @@ namespace dxvk {
     VkPhysicalDevicePresentIdFeaturesKHR                      khrPresentId;
     VkPhysicalDevicePresentWaitFeaturesKHR                    khrPresentWait;
     VkPhysicalDeviceDescriptorPoolOverallocationFeaturesNV    nvDescriptorPoolOverallocation;
+    VkBool32                                                  nvLowLatency2;
     VkPhysicalDeviceRawAccessChainsFeaturesNV                 nvRawAccessChains;
     VkBool32                                                  nvxBinaryImport;
     VkBool32                                                  nvxImageViewHandle;

--- a/src/dxvk/dxvk_extensions.h
+++ b/src/dxvk/dxvk_extensions.h
@@ -327,6 +327,7 @@ namespace dxvk {
     DxvkExt khrSwapchain                      = { VK_KHR_SWAPCHAIN_EXTENSION_NAME,                          DxvkExtMode::Required };
     DxvkExt khrWin32KeyedMutex                = { VK_KHR_WIN32_KEYED_MUTEX_EXTENSION_NAME,                  DxvkExtMode::Optional };
     DxvkExt nvDescriptorPoolOverallocation    = { VK_NV_DESCRIPTOR_POOL_OVERALLOCATION_EXTENSION_NAME,      DxvkExtMode::Optional };
+    DxvkExt nvLowLatency2                     = { VK_NV_LOW_LATENCY_2_EXTENSION_NAME,                       DxvkExtMode::Optional };
     DxvkExt nvRawAccessChains                 = { VK_NV_RAW_ACCESS_CHAINS_EXTENSION_NAME,                   DxvkExtMode::Optional };
     DxvkExt nvxBinaryImport                   = { VK_NVX_BINARY_IMPORT_EXTENSION_NAME,                      DxvkExtMode::Disabled };
     DxvkExt nvxImageViewHandle                = { VK_NVX_IMAGE_VIEW_HANDLE_EXTENSION_NAME,                  DxvkExtMode::Disabled };

--- a/src/dxvk/dxvk_latency.h
+++ b/src/dxvk/dxvk_latency.h
@@ -1,0 +1,185 @@
+#pragma once
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+
+#include "../util/util_likely.h"
+#include "../util/util_time.h"
+
+#include "../util/rc/util_rc_ptr.h"
+
+#include "../vulkan/vulkan_loader.h"
+
+namespace dxvk {
+
+  /**
+   * \brief Latency tracker statistics
+   */
+  struct DxvkLatencyStats {
+    std::chrono::microseconds frameLatency;
+    std::chrono::microseconds sleepDuration;
+  };
+
+
+  /**
+   * \brief Latency tracker
+   *
+   * Accumulates time stamps of certain parts of a frame.
+   */
+  class DxvkLatencyTracker {
+
+  public:
+
+    virtual ~DxvkLatencyTracker() { }
+
+    /**
+     * \brief Increments ref count
+     */
+    void incRef() {
+      m_refCount.fetch_add(1, std::memory_order_acquire);
+    }
+
+    /**
+     * \brief Decrements ref count
+     *
+     * Destroys the object when there are no users left.
+     */
+    void decRef() {
+      if (m_refCount.fetch_sub(1, std::memory_order_release) == 1u)
+        delete this;
+    }
+
+    /**
+     * \brief Called when presentation begins on the CPU timeline
+     *
+     * Must happen before acquiring an image from the presenter.
+     * \param [in] frameId Current frame ID
+     */
+    virtual void notifyCpuPresentBegin(
+            uint64_t                  frameId) = 0;
+
+    /**
+     * \brief Called when the CS thread reaches a given frame
+     *
+     * Should be recorded into the CS thread after completing
+     * the previous frame on the application's CPU timeline.
+     * \param [in] frameId Current frame ID
+     */
+    virtual void notifyCsRenderBegin(
+            uint64_t                  frameId) = 0;
+
+    /**
+     * \brief Called when the CS thread completes a frame
+     *
+     * Should be recorded into the CS thread after recording
+     * presentation commands for that frame.
+     * \param [in] frameId Current frame ID
+     */
+    virtual void notifyCsRenderEnd(
+            uint64_t                  frameId) = 0;
+
+    /**
+     * \brief Called when presentation ends on the CPU timeline
+     *
+     * Must happen after acquiring an image for presentation, but
+     * before synchronizing with previous frames or performing
+     * latency sleep. The intention is to measure acquire delays.
+     * \param [in] frameId Current frame ID
+     */
+    virtual void notifyCpuPresentEnd(
+            uint64_t                  frameId) = 0;
+
+    /**
+     * \brief Called when a command list is submitted to the GPU
+     *
+     * \param [in] frameId Associated frame ID
+     */
+    virtual void notifyQueueSubmit(
+            uint64_t                  frameId) = 0;
+
+    /**
+     * \brief Called when a frame is queued for presentation
+     *
+     * \param [in] frameId Associated frame ID
+     */
+    virtual void notifyQueuePresentBegin(
+            uint64_t                  frameId) = 0;
+
+    /**
+     * \brief Called after a frame has been queued for presentation
+     *
+     * \param [in] frameId Associated frame ID
+     * \param [in] status Result of the present operation
+     */
+    virtual void notifyQueuePresentEnd(
+            uint64_t                  frameId,
+            VkResult                  status) = 0;
+
+    /**
+     * \brief Called when a submission begins execution on the GPU
+     *
+     * Any previous submissions will have completed by this time. This
+     * can be used to measure GPU idle time throughout a frame.
+     * \param [in] frameId Associated frame ID
+     */
+    virtual void notifyGpuExecutionBegin(
+            uint64_t                  frameId) = 0;
+
+    /**
+     * \brief Called when a submission completes execution on the GPU
+     *
+     * The previous submission will have completed by the time this
+     * gets called. This may be used to measure GPU idle time.
+     * \param [in] frameId Associated frame ID
+     */
+    virtual void notifyGpuExecutionEnd(
+            uint64_t                  frameId) = 0;
+
+    /**
+     * \brief Called when presentation of a given frame finishes on the GPU
+     *
+     * This is generally the last thing that happens within a frame.
+     * \param [in] frameId Associated frame ID
+     */
+    virtual void notifyGpuPresentEnd(
+            uint64_t                  frameId) = 0;
+
+    /**
+     * \brief Performs latency sleep and begins next frame
+     *
+     * Uses latency data from previous frames to estimate when to wake
+     * up the application thread in order to minimize input latency.
+     * \param [in] frameId Frame ID of the upcoming frame
+     * \param [in] maxFrameRate Maximum frame rate or refresh rate
+     */
+    virtual void sleepAndBeginFrame(
+            uint64_t                  frameId,
+            double                    maxFrameRate) = 0;
+
+    /**
+     * \brief Discards all current timing data
+     *
+     * Should be called to reset latency tracking in case
+     * presentation failed for any given frame.
+     */
+    virtual void discardTimings() = 0;
+
+    /**
+     * \brief Queries statistics for the given frame
+     *
+     * Returns statistics for the frame closest to \c frameId for
+     * which data is available. If no such frame exists, the stat
+     * counters will return 0.
+     * \param [in] frameId Frame to query
+     */
+    virtual DxvkLatencyStats getStatistics(
+            uint64_t                  frameId) = 0;
+
+  private:
+
+    std::atomic<uint64_t> m_refCount = { 0u };
+
+  };
+
+}

--- a/src/dxvk/dxvk_latency_builtin.cpp
+++ b/src/dxvk/dxvk_latency_builtin.cpp
@@ -1,0 +1,335 @@
+#include <cmath>
+
+#include "dxvk_latency_builtin.h"
+
+#include "../util/log/log.h"
+
+#include "../util/util_fps_limiter.h"
+#include "../util/util_string.h"
+
+namespace dxvk {
+
+  DxvkBuiltInLatencyTracker::DxvkBuiltInLatencyTracker(
+          int32_t                   toleranceUs)
+  : m_tolerance(std::chrono::duration_cast<duration>(
+      std::chrono::microseconds(std::max(toleranceUs, 0)))) {
+    Logger::info("Latency control enabled, using built-in algorithm");
+    auto limit = FpsLimiter::getEnvironmentOverride();
+
+    if (limit)
+      m_envFpsLimit = *limit;
+  }
+
+
+  DxvkBuiltInLatencyTracker::~DxvkBuiltInLatencyTracker() {
+
+  }
+
+
+  void DxvkBuiltInLatencyTracker::notifyCpuPresentBegin(
+          uint64_t                  frameId) {
+    // Not interesting here
+  }
+
+
+  void DxvkBuiltInLatencyTracker::notifyCpuPresentEnd(
+          uint64_t                  frameId) {
+    std::unique_lock lock(m_mutex);
+    auto frame = findFrame(frameId);
+
+    if (frame)
+      frame->cpuPresentEnd = dxvk::high_resolution_clock::now();
+  }
+
+
+  void DxvkBuiltInLatencyTracker::notifyCsRenderBegin(
+          uint64_t                  frameId) {
+    // Not interesting here
+  }
+
+
+  void DxvkBuiltInLatencyTracker::notifyCsRenderEnd(
+          uint64_t                  frameId) {
+    // Not interesting here
+  }
+
+
+  void DxvkBuiltInLatencyTracker::notifyQueueSubmit(
+          uint64_t                  frameId) {
+    std::unique_lock lock(m_mutex);
+    auto frame = findFrame(frameId);
+
+    if (frame && frame->queueSubmit == time_point())
+      frame->queueSubmit = dxvk::high_resolution_clock::now();
+  }
+
+
+  void DxvkBuiltInLatencyTracker::notifyQueuePresentBegin(
+          uint64_t                  frameId) {
+    std::unique_lock lock(m_mutex);
+    auto frame = findFrame(frameId);
+
+    if (frame)
+      frame->queuePresent = dxvk::high_resolution_clock::now();
+  }
+
+
+  void DxvkBuiltInLatencyTracker::notifyQueuePresentEnd(
+          uint64_t                  frameId,
+          VkResult                  status) {
+    std::unique_lock lock(m_mutex);
+    auto frame = findFrame(frameId);
+
+    if (frame)
+      frame->presentStatus = status;
+
+    m_cond.notify_one();
+  }
+
+
+  void DxvkBuiltInLatencyTracker::notifyGpuExecutionBegin(
+          uint64_t                  frameId) {
+    std::unique_lock lock(m_mutex);
+    auto frame = findFrame(frameId);
+
+    if (frame) {
+      auto now = dxvk::high_resolution_clock::now();
+
+      if (frame->gpuExecStart == time_point())
+        frame->gpuExecStart = now;
+
+      if (frame->gpuIdleStart != time_point()) {
+        frame->gpuIdleTime += now - frame->gpuIdleStart;
+        frame->gpuIdleEnd = now;
+      }
+    }
+
+    m_cond.notify_one();
+  }
+
+
+  void DxvkBuiltInLatencyTracker::notifyGpuExecutionEnd(
+          uint64_t                  frameId) {
+    std::unique_lock lock(m_mutex);
+    auto frame = findFrame(frameId);
+
+    if (frame) {
+      auto now = dxvk::high_resolution_clock::now();
+
+      frame->gpuExecEnd = now;
+      frame->gpuIdleStart = now;
+    }
+  }
+
+
+  void DxvkBuiltInLatencyTracker::notifyGpuPresentEnd(
+          uint64_t                  frameId) {
+    std::unique_lock lock(m_mutex);
+    auto frame = findFrame(frameId);
+
+    if (frame)
+      frame->gpuPresent = dxvk::high_resolution_clock::now();
+
+    m_cond.notify_one();
+  }
+
+
+  void DxvkBuiltInLatencyTracker::sleepAndBeginFrame(
+          uint64_t                  frameId,
+          double                    maxFrameRate) {
+    auto duration = sleep(frameId, maxFrameRate);
+
+    std::unique_lock lock(m_mutex);
+
+    auto next = initFrame(frameId);
+    next->frameStart = dxvk::high_resolution_clock::now();
+    next->sleepDuration = duration;
+  }
+
+
+  void DxvkBuiltInLatencyTracker::discardTimings() {
+    std::unique_lock lock(m_mutex);
+    m_validRangeBegin = m_validRangeEnd + 1u;
+  }
+
+
+  DxvkLatencyStats DxvkBuiltInLatencyTracker::getStatistics(
+          uint64_t                  frameId) {
+    std::unique_lock lock(m_mutex);
+
+    DxvkLatencyStats stats = { };
+
+    while (frameId && frameId >= m_validRangeBegin) {
+      auto f = findFrame(frameId--);
+
+      if (f && f->gpuPresent != time_point()) {
+        stats.frameLatency = std::chrono::duration_cast<std::chrono::microseconds>(f->gpuPresent - f->frameStart);
+        stats.sleepDuration = std::chrono::duration_cast<std::chrono::microseconds>(f->sleepDuration);
+        break;
+      }
+    }
+
+    return stats;
+  }
+
+
+  DxvkBuiltInLatencyTracker::duration DxvkBuiltInLatencyTracker::sleep(
+          uint64_t                  frameId,
+          double                    maxFrameRate) {
+    // Wait for all relevant timings to become available. This should
+    // generally not stall for very long if a maximum frame latency of
+    // 1 is enforced correctly by the swap chain.
+    std::unique_lock lock(m_mutex);
+
+    for (uint32_t i = 2; i <= FrameCount; i++) {
+      auto f = findFrame(frameId - i);
+
+      if (!f || f->cpuPresentEnd == time_point())
+        return duration(0u);
+
+      m_cond.wait(lock, [f] {
+        return f->gpuPresent != time_point();
+      });
+    }
+
+    // Wait for the current frame's present call to be processed. Our
+    // algorithm will otherwise get confused if Present stalls or if
+    // any CPU work from previous frames delays GPU execution of the
+    // current frame.
+    auto curr = findFrame(frameId - 1u);
+
+    if (curr && curr->cpuPresentEnd != time_point()) {
+      m_cond.wait(lock, [curr] {
+        return curr->presentStatus != VK_NOT_READY;
+      });
+    }
+
+    // Frame entry of the last frame that fully completed
+    auto prev = findFrame(frameId - 2u);
+
+    // The way we want to align subsequent frames depends on whether
+    // we are limited by GPU performance or display refresh.
+    //
+    // In either case, we estimate the amount of CPU time the game requires
+    // before any GPU work can start to be the delay between frame start and
+    // first submission, plus any GPU idle time during the frame. This is not
+    // accurate if there are forced GPU sync points, but we can't work around
+    // that in a meaningful way.
+    constexpr size_t EntryCount = FrameCount - 1u;
+
+    std::array<duration, EntryCount> cpuTimes = { };
+    std::array<duration, EntryCount> gpuTimes = { };
+
+    for (uint32_t i = 0; i < EntryCount; i++) {
+      auto f = findFrame(frameId - (i + 2u));
+
+      cpuTimes[i] = (f->queueSubmit - f->frameStart) + f->gpuIdleTime;
+      gpuTimes[i] = (f->gpuExecEnd - f->gpuExecStart) - f->gpuIdleTime;
+    }
+
+    duration nextCpuTime = estimateTime(cpuTimes.data(), cpuTimes.size());
+    duration nextGpuTime = estimateTime(gpuTimes.data(), gpuTimes.size());
+
+    // Compute the initial deadline based on GPU execution times
+    time_point gpuDeadline = prev->gpuExecEnd + 2u * nextGpuTime;
+
+    // If we're rendering faster than refresh, use present_wait timings from
+    // previous frames as a starting point and compute an average in order to
+    // account for potentially erratic present_wait delays.
+    duration frameInterval = computeFrameInterval(maxFrameRate);
+
+    if (frameInterval.count()) {
+      duration nextPresentFromPrev = duration(0u);
+
+      for (uint32_t i = 2; i <= FrameCount; i++) {
+        auto f = findFrame(frameId - i);
+
+        time_point deadline = f->gpuPresent + i * frameInterval - m_tolerance;
+        nextPresentFromPrev += deadline - prev->gpuPresent;
+      }
+
+      time_point wsiDeadline = prev->gpuPresent + (nextPresentFromPrev / int32_t(FrameCount - 1u));
+      gpuDeadline = std::max(gpuDeadline, wsiDeadline);
+    }
+
+    // Line up the next frame in such a way that the first GPU submission
+    // happens just before the current frame's final submission completes
+    time_point gpuStartTime = gpuDeadline - nextGpuTime;
+    time_point cpuStartTime = gpuStartTime - nextCpuTime - m_tolerance;
+
+    time_point now = dxvk::high_resolution_clock::now();
+
+    // Release lock before actually sleeping, or
+    // it will affect the time measurements.
+    lock.unlock();
+
+    Sleep::sleepUntil(now, cpuStartTime);
+    return std::max(duration(0u), cpuStartTime - now);
+  }
+
+
+  DxvkLatencyFrameData* DxvkBuiltInLatencyTracker::initFrame(
+          uint64_t                  frameId) {
+    if (m_validRangeEnd + 1u != frameId)
+      m_validRangeBegin = frameId;
+
+    if (m_validRangeBegin + FrameCount <= frameId)
+      m_validRangeBegin = frameId + 1u - FrameCount;
+
+    m_validRangeEnd = frameId;
+
+    auto& frame = m_frames[frameId % FrameCount];
+    frame = DxvkLatencyFrameData();
+    frame.frameId = frameId;
+    return &frame;
+  }
+
+
+  DxvkLatencyFrameData* DxvkBuiltInLatencyTracker::findFrame(
+          uint64_t                  frameId) {
+    return frameId >= m_validRangeBegin && frameId <= m_validRangeEnd
+      ? &m_frames[frameId % FrameCount]
+      : nullptr;
+  }
+
+
+  DxvkBuiltInLatencyTracker::duration DxvkBuiltInLatencyTracker::computeFrameInterval(
+          double                    maxFrameRate) {
+    if (m_envFpsLimit > 0.0)
+      maxFrameRate = m_envFpsLimit;
+
+    return computeIntervalFromRate(maxFrameRate);
+  }
+
+
+  DxvkBuiltInLatencyTracker::duration DxvkBuiltInLatencyTracker::computeIntervalFromRate(
+          double                    frameRate) {
+    if (frameRate <= 0.0 || !std::isnormal(frameRate))
+      return duration(0u);
+
+    uint64_t ns = uint64_t(1'000'000'000.0 / frameRate);
+    return std::chrono::duration_cast<duration>(std::chrono::nanoseconds(ns));
+  }
+
+
+  DxvkBuiltInLatencyTracker::duration DxvkBuiltInLatencyTracker::estimateTime(
+    const duration*                 frames,
+          size_t                    frameCount) {
+    // For each frame, find the median of its neighbours, then
+    // use the maximum of those medians as our estimate.
+    duration result = duration(0u);
+
+    for (size_t i = 0u; i < frameCount - 2u; i++) {
+      duration a = frames[i];
+      duration b = frames[i + 1];
+      duration c = frames[i + 2];
+
+      duration min = std::min(std::min(a, b), c);
+      duration max = std::max(std::max(a, b), c);
+
+      result = std::max(result, a + b + c - min - max);
+    }
+
+    return result;
+  }
+}

--- a/src/dxvk/dxvk_latency_builtin.h
+++ b/src/dxvk/dxvk_latency_builtin.h
@@ -1,0 +1,135 @@
+#pragma once
+
+#include <array>
+
+#include "dxvk_latency.h"
+
+#include "../util/thread.h"
+
+#include "../util/util_sleep.h"
+#include "../util/util_time.h"
+
+#include "../util/config/config.h"
+
+#include "../util/sync/sync_spinlock.h"
+
+namespace dxvk {
+
+  /**
+   * \brief Timings for a single tracked frame
+   */
+  struct DxvkLatencyFrameData {
+    using time_point = dxvk::high_resolution_clock::time_point;
+    using duration = dxvk::high_resolution_clock::duration;
+
+    uint64_t    frameId         = 0u;
+    time_point  frameStart      = time_point();
+    time_point  cpuPresentEnd   = time_point();
+    time_point  queueSubmit     = time_point();
+    time_point  queuePresent    = time_point();
+    time_point  gpuExecStart    = time_point();
+    time_point  gpuExecEnd      = time_point();
+    time_point  gpuIdleStart    = time_point();
+    time_point  gpuIdleEnd      = time_point();
+    duration    gpuIdleTime     = duration(0u);
+    time_point  gpuPresent      = time_point();
+    duration    sleepDuration   = duration(0u);
+    VkResult    presentStatus   = VK_NOT_READY;
+  };
+
+
+  /**
+   * \brief Built-in latency tracker
+   *
+   * Implements a simple latency reduction algorithm
+   * based on CPU timestamps received from the backend.
+   */
+  class DxvkBuiltInLatencyTracker : public DxvkLatencyTracker {
+    using time_point = typename DxvkLatencyFrameData::time_point;
+    using duration = typename DxvkLatencyFrameData::duration;
+
+    constexpr static size_t FrameCount = 8u;
+  public:
+
+    DxvkBuiltInLatencyTracker(
+            int32_t                   toleranceUs);
+
+    ~DxvkBuiltInLatencyTracker();
+
+    void notifyCpuPresentBegin(
+            uint64_t                  frameId);
+
+    void notifyCpuPresentEnd(
+            uint64_t                  frameId);
+
+    void notifyCsRenderBegin(
+            uint64_t                  frameId);
+
+    void notifyCsRenderEnd(
+            uint64_t                  frameId);
+
+    void notifyQueueSubmit(
+            uint64_t                  frameId);
+
+    void notifyQueuePresentBegin(
+            uint64_t                  frameId);
+
+    void notifyQueuePresentEnd(
+            uint64_t                  frameId,
+            VkResult                  status);
+
+    void notifyGpuExecutionBegin(
+            uint64_t                  frameId);
+
+    void notifyGpuExecutionEnd(
+            uint64_t                  frameId);
+
+    void notifyGpuPresentEnd(
+            uint64_t                  frameId);
+
+    void sleepAndBeginFrame(
+            uint64_t                  frameId,
+            double                    maxFrameRate);
+
+    void discardTimings();
+
+    DxvkLatencyStats getStatistics(
+            uint64_t                  frameId);
+
+  private:
+
+    dxvk::mutex               m_mutex;
+    dxvk::condition_variable  m_cond;
+
+    duration                  m_tolerance;
+
+    double                    m_envFpsLimit = 0.0;
+
+    std::array<DxvkLatencyFrameData, FrameCount> m_frames = { };
+
+    uint64_t m_validRangeBegin = 0u;
+    uint64_t m_validRangeEnd = 0u;
+
+    duration sleep(
+            uint64_t                  frameId,
+            double                    maxFrameRate);
+
+    DxvkLatencyFrameData* initFrame(
+            uint64_t                  frameId);
+
+    DxvkLatencyFrameData* findFrame(
+            uint64_t                  frameId);
+
+    duration computeFrameInterval(
+            double                    maxFrameRate);
+
+    static duration computeIntervalFromRate(
+            double                    frameRate);
+
+    static duration estimateTime(
+      const duration*                 frames,
+            size_t                    frameCount);
+
+  };
+
+}

--- a/src/dxvk/dxvk_latency_builtin_nv.cpp
+++ b/src/dxvk/dxvk_latency_builtin_nv.cpp
@@ -1,0 +1,213 @@
+#include "dxvk_latency_builtin_nv.h"
+
+namespace dxvk {
+
+  DxvkBuiltInLatencyTrackerNv::DxvkBuiltInLatencyTrackerNv(
+    const Rc<Presenter>&            presenter)
+  : m_presenter(presenter) {
+    Logger::info("Latency control enabled, using VK_NV_low_latency2");
+    auto limit = FpsLimiter::getEnvironmentOverride();
+
+    if (limit)
+      m_envFpsLimit = *limit;
+  }
+
+
+  DxvkBuiltInLatencyTrackerNv::~DxvkBuiltInLatencyTrackerNv() {
+    VkLatencySleepModeInfoNV latencyMode = { VK_STRUCTURE_TYPE_LATENCY_SLEEP_MODE_INFO_NV };
+    latencyMode.lowLatencyMode = VK_FALSE;
+    latencyMode.lowLatencyBoost = VK_FALSE;
+    latencyMode.minimumIntervalUs = 0;
+
+    m_presenter->setLatencySleepModeNv(latencyMode);
+  }
+
+
+  void DxvkBuiltInLatencyTrackerNv::notifyCpuPresentBegin(
+          uint64_t                  frameId) {
+    // Not interesting here
+  }
+
+
+  void DxvkBuiltInLatencyTrackerNv::notifyCpuPresentEnd(
+          uint64_t                  frameId) {
+    std::unique_lock lock(m_mutex);
+    auto frame = getFrame(frameId);
+
+    if (frame)
+      frame->presentPending = VK_TRUE;
+  }
+
+
+  void DxvkBuiltInLatencyTrackerNv::notifyCsRenderBegin(
+          uint64_t                  frameId) {
+    m_presenter->setLatencyMarkerNv(frameId,
+      VK_LATENCY_MARKER_SIMULATION_END_NV);
+    m_presenter->setLatencyMarkerNv(frameId,
+      VK_LATENCY_MARKER_RENDERSUBMIT_START_NV);
+  }
+
+
+  void DxvkBuiltInLatencyTrackerNv::notifyCsRenderEnd(
+          uint64_t                  frameId) {
+    m_presenter->setLatencyMarkerNv(frameId,
+      VK_LATENCY_MARKER_RENDERSUBMIT_END_NV);
+  }
+
+
+  void DxvkBuiltInLatencyTrackerNv::notifyQueueSubmit(
+          uint64_t                  frameId) {
+    // Handled by driver
+  }
+
+
+  void DxvkBuiltInLatencyTrackerNv::notifyQueuePresentBegin(
+          uint64_t                  frameId) {
+    m_presenter->setLatencyMarkerNv(frameId,
+      VK_LATENCY_MARKER_PRESENT_START_NV);
+  }
+
+
+  void DxvkBuiltInLatencyTrackerNv::notifyQueuePresentEnd(
+          uint64_t                  frameId,
+          VkResult                  status) {
+    m_presenter->setLatencyMarkerNv(frameId,
+      VK_LATENCY_MARKER_PRESENT_END_NV);
+
+    std::unique_lock lock(m_mutex);
+    auto frame = getFrame(frameId);
+
+    if (frame)
+      frame->presentResult = status;
+
+    m_cond.notify_one();
+  }
+
+
+  void DxvkBuiltInLatencyTrackerNv::notifyGpuExecutionBegin(
+          uint64_t                  frameId) {
+    // Handled by driver
+  }
+
+
+  void DxvkBuiltInLatencyTrackerNv::notifyGpuExecutionEnd(
+          uint64_t                  frameId) {
+    // Handled by driver
+  }
+
+
+  void DxvkBuiltInLatencyTrackerNv::notifyGpuPresentEnd(
+          uint64_t                  frameId) {
+    std::unique_lock lock(m_mutex);
+    auto frame = getFrame(frameId);
+
+    if (frame)
+      frame->frameEnd = dxvk::high_resolution_clock::now();
+  }
+
+
+  void DxvkBuiltInLatencyTrackerNv::sleepAndBeginFrame(
+          uint64_t                  frameId,
+          double                    maxFrameRate) {
+    bool presentSuccessful = false;
+
+    duration sleepDuration(0u);
+
+    { std::unique_lock lock(m_mutex);
+
+      // Don't try to sleep if we haven't set up
+      // low latency mode for the swapchain yet
+      if (m_lowLatencyEnabled) {
+        auto curr = getFrame(frameId - 1u);
+
+        if (curr && curr->presentPending) {
+          m_cond.wait(lock, [curr] {
+            return curr->presentResult != VK_NOT_READY;
+          });
+
+          presentSuccessful = curr->presentResult >= 0;
+        }
+      }
+    }
+
+    if (presentSuccessful) {
+      auto t0 = dxvk::high_resolution_clock::now();
+      m_presenter->latencySleepNv();
+
+      sleepDuration += dxvk::high_resolution_clock::now() - t0;
+    }
+
+    { std::unique_lock lock(m_mutex);
+      // Set up low latency mode for subsequent frames
+      VkLatencySleepModeInfoNV latencyMode = { VK_STRUCTURE_TYPE_LATENCY_SLEEP_MODE_INFO_NV };
+      latencyMode.lowLatencyMode = VK_TRUE;
+      latencyMode.lowLatencyBoost = VK_TRUE;
+      latencyMode.minimumIntervalUs = 0;
+
+      if (m_envFpsLimit > 0.0)
+        maxFrameRate = m_envFpsLimit;
+
+      if (maxFrameRate > 0.0)
+        latencyMode.minimumIntervalUs = uint64_t(1'000'000.0 / maxFrameRate);
+
+      m_presenter->setLatencySleepModeNv(latencyMode);
+      m_presenter->setLatencyMarkerNv(frameId,
+        VK_LATENCY_MARKER_INPUT_SAMPLE_NV);
+      m_presenter->setLatencyMarkerNv(frameId,
+        VK_LATENCY_MARKER_SIMULATION_START_NV);
+
+      auto next = initFrame(frameId);
+      next->frameStart = dxvk::high_resolution_clock::now();
+      next->sleepDuration = sleepDuration;
+
+      m_lowLatencyEnabled = true;
+    }
+  }
+
+
+  void DxvkBuiltInLatencyTrackerNv::discardTimings() {
+    std::unique_lock lock(m_mutex);
+    m_lastDiscard = m_lastFrameId;
+  }
+
+
+  DxvkLatencyStats DxvkBuiltInLatencyTrackerNv::getStatistics(
+          uint64_t                  frameId) {
+    std::unique_lock lock(m_mutex);
+
+    auto frame = getFrame(frameId);
+
+    while (frame && frame->frameEnd == time_point())
+      frame = getFrame(--frameId);
+
+    if (!frame)
+      return DxvkLatencyStats();
+
+    DxvkLatencyStats stats = { };
+    stats.frameLatency = std::chrono::duration_cast<std::chrono::microseconds>(frame->frameEnd - frame->frameStart);
+    stats.sleepDuration = std::chrono::duration_cast<std::chrono::microseconds>(frame->sleepDuration);
+    return stats;
+  }
+
+
+  DxvkLatencyFrameDataNv* DxvkBuiltInLatencyTrackerNv::initFrame(uint64_t frameId) {
+    auto& frame = m_frames[frameId % FrameCount];
+
+    frame = DxvkLatencyFrameDataNv();
+    frame.frameId = frameId;
+
+    m_lastFrameId = frameId;
+    return &m_frames[frameId % FrameCount];
+  }
+
+
+  DxvkLatencyFrameDataNv* DxvkBuiltInLatencyTrackerNv::getFrame(uint64_t frameId) {
+    auto& frame = m_frames[frameId % FrameCount];
+
+    if (frameId <= m_lastDiscard || frame.frameId != frameId)
+      return nullptr;
+
+    return &frame;
+  }
+
+}

--- a/src/dxvk/dxvk_latency_builtin_nv.h
+++ b/src/dxvk/dxvk_latency_builtin_nv.h
@@ -1,0 +1,114 @@
+#pragma once
+
+#include <array>
+
+#include "dxvk_latency.h"
+#include "dxvk_presenter.h"
+
+#include "../util/thread.h"
+
+#include "../util/util_sleep.h"
+#include "../util/util_time.h"
+
+#include "../util/config/config.h"
+
+#include "../util/sync/sync_spinlock.h"
+
+namespace dxvk {
+
+  /**
+   * \brief Internal timers for LL2 timing
+   */
+  struct DxvkLatencyFrameDataNv {
+    using time_point = dxvk::high_resolution_clock::time_point;
+    using duration = dxvk::high_resolution_clock::duration;
+
+    uint64_t    frameId         = 0u;
+    time_point  frameStart      = time_point();
+    time_point  frameEnd        = time_point();
+    duration    sleepDuration   = duration(0u);
+    VkResult    presentResult   = VK_NOT_READY;
+    VkBool32    presentPending  = VK_FALSE;
+  };
+
+
+  /**
+   * \brief Built-in latency tracker based on VK_NV_low_latency2
+   *
+   * Implements a simple latency reduction algorithm
+   * based on CPU timestamps received from the backend.
+   */
+  class DxvkBuiltInLatencyTrackerNv : public DxvkLatencyTracker {
+    using time_point = typename DxvkLatencyFrameDataNv::time_point;
+    using duration = typename DxvkLatencyFrameDataNv::duration;
+
+    constexpr static size_t FrameCount = 8u;
+  public:
+
+    DxvkBuiltInLatencyTrackerNv(
+      const Rc<Presenter>&            presenter);
+
+    ~DxvkBuiltInLatencyTrackerNv();
+
+    void notifyCpuPresentBegin(
+            uint64_t                  frameId);
+
+    void notifyCpuPresentEnd(
+            uint64_t                  frameId);
+
+    void notifyCsRenderBegin(
+            uint64_t                  frameId);
+
+    void notifyCsRenderEnd(
+            uint64_t                  frameId);
+
+    void notifyQueueSubmit(
+            uint64_t                  frameId);
+
+    void notifyQueuePresentBegin(
+            uint64_t                  frameId);
+
+    void notifyQueuePresentEnd(
+            uint64_t                  frameId,
+            VkResult                  status);
+
+    void notifyGpuExecutionBegin(
+            uint64_t                  frameId);
+
+    void notifyGpuExecutionEnd(
+            uint64_t                  frameId);
+
+    void notifyGpuPresentEnd(
+            uint64_t                  frameId);
+
+    void sleepAndBeginFrame(
+            uint64_t                  frameId,
+            double                    maxFrameRate);
+
+    void discardTimings();
+
+    DxvkLatencyStats getStatistics(
+            uint64_t                  frameId);
+
+  private:
+
+    Rc<Presenter>             m_presenter;
+    double                    m_envFpsLimit = 0.0;
+
+    dxvk::mutex               m_mutex;
+    dxvk::condition_variable  m_cond;
+
+    uint64_t                  m_lastFrameId = 0u;
+    uint64_t                  m_lastDiscard = 0u;
+
+    bool                      m_lowLatencyEnabled = false;
+
+    std::array<DxvkLatencyFrameDataNv, FrameCount> m_frames = { };
+
+    DxvkLatencyFrameDataNv* initFrame(uint64_t frameId);
+
+    DxvkLatencyFrameDataNv* getFrame(uint64_t frameId);
+
+  };
+
+}

--- a/src/dxvk/dxvk_options.cpp
+++ b/src/dxvk/dxvk_options.cpp
@@ -14,6 +14,7 @@ namespace dxvk {
     tearFree              = config.getOption<Tristate>("dxvk.tearFree",               Tristate::Auto);
     latencySleep          = config.getOption<Tristate>("dxvk.latencySleep",           Tristate::Auto);
     latencyTolerance      = config.getOption<int32_t> ("dxvk.latencyTolerance",       1000);
+    disableNvLowLatency2  = config.getOption<bool>    ("dxvk.disableNvLowLatency2",   false);
     hideIntegratedGraphics = config.getOption<bool>   ("dxvk.hideIntegratedGraphics", false);
     zeroMappedMemory      = config.getOption<bool>    ("dxvk.zeroMappedMemory",       false);
     allowFse              = config.getOption<bool>    ("dxvk.allowFse",               false);

--- a/src/dxvk/dxvk_options.cpp
+++ b/src/dxvk/dxvk_options.cpp
@@ -12,6 +12,8 @@ namespace dxvk {
     useRawSsbo            = config.getOption<Tristate>("dxvk.useRawSsbo",             Tristate::Auto);
     hud                   = config.getOption<std::string>("dxvk.hud", "");
     tearFree              = config.getOption<Tristate>("dxvk.tearFree",               Tristate::Auto);
+    latencySleep          = config.getOption<Tristate>("dxvk.latencySleep",           Tristate::Auto);
+    latencyTolerance      = config.getOption<int32_t> ("dxvk.latencyTolerance",       1000);
     hideIntegratedGraphics = config.getOption<bool>   ("dxvk.hideIntegratedGraphics", false);
     zeroMappedMemory      = config.getOption<bool>    ("dxvk.zeroMappedMemory",       false);
     allowFse              = config.getOption<bool>    ("dxvk.allowFse",               false);

--- a/src/dxvk/dxvk_options.h
+++ b/src/dxvk/dxvk_options.h
@@ -37,6 +37,12 @@ namespace dxvk {
     /// or FIFO_RELAXED (if false) present mode
     Tristate tearFree = Tristate::Auto;
 
+    /// Enables latency sleep
+    Tristate latencySleep = Tristate::Auto;
+
+    /// Latency tolerance, in microseconds
+    int32_t latencyTolerance = 0u;
+
     // Hides integrated GPUs if dedicated GPUs are
     // present. May be necessary for some games that
     // incorrectly assume monitor layouts.

--- a/src/dxvk/dxvk_options.h
+++ b/src/dxvk/dxvk_options.h
@@ -43,6 +43,9 @@ namespace dxvk {
     /// Latency tolerance, in microseconds
     int32_t latencyTolerance = 0u;
 
+    /// Disable VK_NV_low_latency2
+    bool disableNvLowLatency2 = false;
+
     // Hides integrated GPUs if dedicated GPUs are
     // present. May be necessary for some games that
     // incorrectly assume monitor layouts.

--- a/src/dxvk/dxvk_presenter.cpp
+++ b/src/dxvk/dxvk_presenter.cpp
@@ -224,7 +224,10 @@ namespace dxvk {
   }
 
 
-  void Presenter::signalFrame(VkResult result, uint64_t frameId) {
+  void Presenter::signalFrame(
+          VkResult                result,
+          uint64_t                frameId,
+    const Rc<DxvkLatencyTracker>& tracker) {
     if (m_signal == nullptr || !frameId)
       return;
 
@@ -232,15 +235,19 @@ namespace dxvk {
       std::lock_guard<dxvk::mutex> lock(m_frameMutex);
 
       PresenterFrame frame = { };
-      frame.result = result;
-      frame.mode = m_presentMode;
-      frame.frameId = frameId;
+      frame.frameId   = frameId;
+      frame.tracker   = tracker;
+      frame.mode      = m_presentMode;
+      frame.result    = result;
 
       m_frameQueue.push(frame);
       m_frameCond.notify_one();
     } else {
       m_fpsLimiter.delay();
       m_signal->signal(frameId);
+
+      if (tracker)
+        tracker->notifyGpuPresentEnd(frameId);
     }
 
     m_lastFrameId.store(frameId, std::memory_order_release);
@@ -1052,6 +1059,13 @@ namespace dxvk {
 
         if (vr < 0 && vr != VK_ERROR_OUT_OF_DATE_KHR && vr != VK_ERROR_SURFACE_LOST_KHR)
           Logger::err(str::format("Presenter: vkWaitForPresentKHR failed: ", vr));
+      }
+
+      // Signal latency tracker right away to get more accurate
+      // measurements if the frame rate limiter is enabled.
+      if (frame.tracker) {
+        frame.tracker->notifyGpuPresentEnd(frame.frameId);
+        frame.tracker = nullptr;
       }
 
       // Apply FPS limtier here to align it as closely with scanout as we can,

--- a/src/dxvk/dxvk_presenter.h
+++ b/src/dxvk/dxvk_presenter.h
@@ -124,10 +124,10 @@ namespace dxvk {
      * 
      * Presents the last successfuly acquired image.
      * \param [in] frameId Frame number.
-     *    Must increase monotonically.
      * \returns Status of the operation
      */
-    VkResult presentImage(uint64_t frameId);
+    VkResult presentImage(
+            uint64_t        frameId);
 
     /**
      * \brief Signals a given frame
@@ -217,6 +217,47 @@ namespace dxvk {
      */
     void destroyResources();
 
+    /**
+     * \brief Sets latency sleep mode
+     *
+     * Any changes will be applied on the next acquire operation.
+     * \param [in] sleepMode Latency mode info
+     */
+    void setLatencySleepModeNv(
+      const VkLatencySleepModeInfoNV& sleepMode);
+
+    /**
+     * \brief Sets latency marker
+     *
+     * Ignored if the current swapchain has not been
+     * created with low latency support.
+     * \param [in] frameId Frame ID
+     * \param [in] marker Marker
+     * \returns CPU timestamp of the marker
+     */
+    dxvk::high_resolution_clock::time_point setLatencyMarkerNv(
+            uint64_t                frameId,
+            VkLatencyMarkerNV       marker);
+
+    /**
+     * \brief Executes latency sleep
+     *
+     * Ignored if the current swapchain has not been
+     * created with low latency support.
+     */
+    void latencySleepNv();
+
+    /**
+     * \brief Queries latency timings
+     *
+     * \param [in] timingCount Number of timings to query
+     * \param [out] timings Latency timings
+     * \returns Number of frame reports returned
+     */
+    uint32_t getLatencyTimingsNv(
+            uint32_t                timingCount,
+            VkLatencyTimingsFrameReportNV* timings);
+
   private:
 
     Rc<DxvkDevice>              m_device;
@@ -257,6 +298,13 @@ namespace dxvk {
 
     std::optional<VkHdrMetadataEXT> m_hdrMetadata;
     bool                        m_hdrMetadataDirty = false;
+
+    std::optional<VkLatencySleepModeInfoNV> m_latencySleepMode;
+    VkSemaphore                 m_latencySemaphore = VK_NULL_HANDLE;
+    uint64_t                    m_latencySleepCounter = 0u;
+
+    bool                        m_latencySleepModeDirty = false;
+    bool                        m_latencySleepSupported = false;
 
     alignas(CACHE_LINE_SIZE)
     dxvk::mutex                 m_frameMutex;
@@ -317,9 +365,13 @@ namespace dxvk {
 
     VkResult createSurface();
 
+    VkResult createLatencySemaphore();
+
     void destroySwapchain();
 
     void destroySurface();
+
+    void destroyLatencySemaphore();
 
     void waitForSwapchainFence(
             PresenterSync&            sync);

--- a/src/dxvk/dxvk_presenter.h
+++ b/src/dxvk/dxvk_presenter.h
@@ -18,6 +18,7 @@
 
 #include "dxvk_format.h"
 #include "dxvk_image.h"
+#include "dxvk_latency.h"
 
 namespace dxvk {
 
@@ -55,9 +56,10 @@ namespace dxvk {
    * \brief Queued frame
    */
   struct PresenterFrame {
-    uint64_t          frameId = 0u;
-    VkPresentModeKHR  mode    = VK_PRESENT_MODE_FIFO_KHR;
-    VkResult          result  = VK_NOT_READY;
+    uint64_t                frameId   = 0u;
+    Rc<DxvkLatencyTracker>  tracker   = nullptr;
+    VkPresentModeKHR        mode      = VK_PRESENT_MODE_FIFO_KHR;
+    VkResult                result    = VK_NOT_READY;
   };
 
   /**
@@ -135,9 +137,13 @@ namespace dxvk {
      * called before GPU work prior to the present submission has
      * completed in order to maintain consistency.
      * \param [in] result Presentation result
-     * \param [in] frameId Frame number
+     * \param [in] frameId Frame ID
+     * \param [in] tracker Latency tracker
      */
-    void signalFrame(VkResult result, uint64_t frameId);
+    void signalFrame(
+            VkResult                result,
+            uint64_t                frameId,
+      const Rc<DxvkLatencyTracker>& tracker);
 
     /**
      * \brief Changes sync interval

--- a/src/dxvk/dxvk_queue.cpp
+++ b/src/dxvk/dxvk_queue.cpp
@@ -131,6 +131,9 @@ namespace dxvk {
 
     std::unique_lock<dxvk::mutex> lock(m_mutex);
 
+    uint64_t trackedSubmitId = 0u;
+    uint64_t trackedPresentId = 0u;
+
     while (!m_stopped.load()) {
       m_appendCond.wait(lock, [this] {
         return m_stopped.load() || !m_submitQueue.empty();
@@ -150,10 +153,15 @@ namespace dxvk {
           m_callback(true);
 
         if (entry.submit.cmdList != nullptr) {
-          if (entry.latency.tracker)
+          if (entry.latency.tracker) {
             entry.latency.tracker->notifyQueueSubmit(entry.latency.frameId);
 
-          entry.result = entry.submit.cmdList->submit(m_semaphores, m_timelines);
+            if (!trackedSubmitId && entry.latency.frameId > trackedPresentId)
+              trackedSubmitId = entry.latency.frameId;
+          }
+
+          entry.result = entry.submit.cmdList->submit(
+            m_semaphores, m_timelines, trackedSubmitId);
           entry.timelines = m_timelines;
         } else if (entry.present.presenter != nullptr) {
           if (entry.latency.tracker)
@@ -164,6 +172,9 @@ namespace dxvk {
           if (entry.latency.tracker) {
             entry.latency.tracker->notifyQueuePresentEnd(
               entry.latency.frameId, entry.result);
+
+            trackedPresentId = entry.latency.frameId;
+            trackedSubmitId = 0u;
           }
         }
 

--- a/src/dxvk/dxvk_queue.cpp
+++ b/src/dxvk/dxvk_queue.cpp
@@ -260,7 +260,8 @@ namespace dxvk {
         // Signal the frame and then immediately destroy the reference.
         // This is necessary since the front-end may want to explicitly
         // destroy the presenter object. 
-        entry.present.presenter->signalFrame(entry.result, entry.present.frameId);
+        entry.present.presenter->signalFrame(entry.result,
+          entry.present.frameId, entry.latency.tracker);
         entry.present.presenter = nullptr;
       }
 

--- a/src/dxvk/dxvk_queue.cpp
+++ b/src/dxvk/dxvk_queue.cpp
@@ -42,7 +42,10 @@ namespace dxvk {
   }
   
   
-  void DxvkSubmissionQueue::submit(DxvkSubmitInfo submitInfo, DxvkSubmitStatus* status) {
+  void DxvkSubmissionQueue::submit(
+          DxvkSubmitInfo            submitInfo,
+          DxvkLatencyInfo           latencyInfo,
+          DxvkSubmitStatus*         status) {
     std::unique_lock<dxvk::mutex> lock(m_mutex);
 
     m_finishCond.wait(lock, [this] {
@@ -52,18 +55,23 @@ namespace dxvk {
     DxvkSubmitEntry entry = { };
     entry.status = status;
     entry.submit = std::move(submitInfo);
+    entry.latency = std::move(latencyInfo);
 
     m_submitQueue.push(std::move(entry));
     m_appendCond.notify_all();
   }
 
 
-  void DxvkSubmissionQueue::present(DxvkPresentInfo presentInfo, DxvkSubmitStatus* status) {
+  void DxvkSubmissionQueue::present(
+          DxvkPresentInfo           presentInfo,
+          DxvkLatencyInfo           latencyInfo,
+          DxvkSubmitStatus*         status) {
     std::unique_lock<dxvk::mutex> lock(m_mutex);
 
     DxvkSubmitEntry entry = { };
     entry.status  = status;
     entry.present = std::move(presentInfo);
+    entry.latency = std::move(latencyInfo);
 
     m_submitQueue.push(std::move(entry));
     m_appendCond.notify_all();
@@ -142,10 +150,21 @@ namespace dxvk {
           m_callback(true);
 
         if (entry.submit.cmdList != nullptr) {
+          if (entry.latency.tracker)
+            entry.latency.tracker->notifyQueueSubmit(entry.latency.frameId);
+
           entry.result = entry.submit.cmdList->submit(m_semaphores, m_timelines);
           entry.timelines = m_timelines;
         } else if (entry.present.presenter != nullptr) {
+          if (entry.latency.tracker)
+            entry.latency.tracker->notifyQueuePresentBegin(entry.latency.frameId);
+
           entry.result = entry.present.presenter->presentImage(entry.present.frameId);
+
+          if (entry.latency.tracker) {
+            entry.latency.tracker->notifyQueuePresentEnd(
+              entry.latency.frameId, entry.result);
+          }
         }
 
         if (m_callback)
@@ -217,12 +236,18 @@ namespace dxvk {
           std::array<VkSemaphore, 2> semaphores = { m_semaphores.graphics, m_semaphores.transfer };
           std::array<uint64_t, 2> timelines = { entry.timelines.graphics, entry.timelines.transfer };
 
+          if (entry.latency.tracker)
+            entry.latency.tracker->notifyGpuExecutionBegin(entry.latency.frameId);
+
           VkSemaphoreWaitInfo waitInfo = { VK_STRUCTURE_TYPE_SEMAPHORE_WAIT_INFO };
           waitInfo.semaphoreCount = semaphores.size();
           waitInfo.pSemaphores = semaphores.data();
           waitInfo.pValues = timelines.data();
 
           status = vk->vkWaitSemaphores(vk->device(), &waitInfo, ~0ull);
+
+          if (entry.latency.tracker && status == VK_SUCCESS)
+            entry.latency.tracker->notifyGpuExecutionEnd(entry.latency.frameId);
         }
 
         if (status != VK_SUCCESS) {

--- a/src/dxvk/dxvk_queue.h
+++ b/src/dxvk/dxvk_queue.h
@@ -7,6 +7,7 @@
 #include "../util/thread.h"
 
 #include "dxvk_cmdlist.h"
+#include "dxvk_latency.h"
 #include "dxvk_presenter.h"
 
 namespace dxvk {
@@ -48,6 +49,18 @@ namespace dxvk {
 
 
   /**
+   * \brief Latency info
+   *
+   * Optionally stores a latency tracker
+   * and the associated frame ID.
+   */
+  struct DxvkLatencyInfo {
+    Rc<DxvkLatencyTracker>  tracker;
+    uint64_t                frameId = 0;
+  };
+
+
+  /**
    * \brief Submission queue entry
    */
   struct DxvkSubmitEntry {
@@ -55,6 +68,7 @@ namespace dxvk {
     DxvkSubmitStatus*   status;
     DxvkSubmitInfo      submit;
     DxvkPresentInfo     present;
+    DxvkLatencyInfo     latency;
     DxvkTimelineSemaphoreValues timelines;
   };
 
@@ -102,10 +116,12 @@ namespace dxvk {
      * dedicated submission thread. Use this to take
      * the submission overhead off the calling thread.
      * \param [in] submitInfo Submission parameters
+     * \param [in] latencyInfo Latency tracker info
      * \param [out] status Submission feedback
      */
     void submit(
             DxvkSubmitInfo      submitInfo,
+            DxvkLatencyInfo     latencyInfo,
             DxvkSubmitStatus*   status);
     
     /**
@@ -115,10 +131,12 @@ namespace dxvk {
      * and then presents the current swap chain image
      * of the presenter. May stall the calling thread.
      * \param [in] present Present parameters
+     * \param [in] latencyInfo Latency tracker info
      * \param [out] status Submission feedback
      */
     void present(
             DxvkPresentInfo     presentInfo,
+            DxvkLatencyInfo     latencyInfo,
             DxvkSubmitStatus*   status);
     
     /**

--- a/src/dxvk/hud/dxvk_hud_item.h
+++ b/src/dxvk/hud/dxvk_hud_item.h
@@ -734,4 +734,46 @@ namespace dxvk::hud {
 
   };
 
+
+  /**
+   * \brief Frame latency item
+   */
+  class HudLatencyItem : public HudItem {
+    constexpr static int64_t UpdateInterval = 500'000;
+
+    constexpr static uint32_t MaxInvalidUpdates = 20u;
+  public:
+
+    HudLatencyItem();
+
+    ~HudLatencyItem();
+
+    void accumulateStats(const DxvkLatencyStats& stats);
+
+    void update(dxvk::high_resolution_clock::time_point time);
+
+    HudPos render(
+      const DxvkContextObjects& ctx,
+      const HudPipelineKey&     key,
+      const HudOptions&         options,
+            HudRenderer&        renderer,
+            HudPos              position);
+
+  private:
+
+    sync::Spinlock      m_mutex;
+
+    DxvkLatencyStats    m_accumStats = { };
+    uint32_t            m_accumFrames = 0u;
+
+    uint32_t            m_invalidUpdates = MaxInvalidUpdates;
+
+    std::string         m_latencyString;
+    std::string         m_sleepString;
+
+    dxvk::high_resolution_clock::time_point m_lastUpdate
+      = dxvk::high_resolution_clock::now();
+
+  };
+
 }

--- a/src/dxvk/meson.build
+++ b/src/dxvk/meson.build
@@ -90,6 +90,7 @@ dxvk_src = [
   'dxvk_graphics.cpp',
   'dxvk_image.cpp',
   'dxvk_instance.cpp',
+  'dxvk_latency_builtin.cpp',
   'dxvk_memory.cpp',
   'dxvk_meta_blit.cpp',
   'dxvk_meta_clear.cpp',

--- a/src/dxvk/meson.build
+++ b/src/dxvk/meson.build
@@ -91,6 +91,7 @@ dxvk_src = [
   'dxvk_image.cpp',
   'dxvk_instance.cpp',
   'dxvk_latency_builtin.cpp',
+  'dxvk_latency_builtin_nv.cpp',
   'dxvk_memory.cpp',
   'dxvk_meta_blit.cpp',
   'dxvk_meta_clear.cpp',

--- a/src/util/util_fps_limiter.cpp
+++ b/src/util/util_fps_limiter.cpp
@@ -13,15 +13,11 @@ using namespace std::chrono_literals;
 namespace dxvk {
   
   FpsLimiter::FpsLimiter() {
-    std::string env = env::getEnvVar("DXVK_FRAME_RATE");
+    auto override = getEnvironmentOverride();
 
-    if (!env.empty()) {
-      try {
-        setTargetFrameRate(std::stod(env), 0);
-        m_envOverride = true;
-      } catch (const std::invalid_argument&) {
-        // no-op
-      }
+    if (override) {
+      setTargetFrameRate(*override, 0);
+      m_envOverride = true;
     }
   }
 
@@ -126,6 +122,21 @@ namespace dxvk {
 
     m_heuristicFrameCount += 1;
     return false;
+  }
+
+
+  std::optional<double> FpsLimiter::getEnvironmentOverride() {
+    std::string env = env::getEnvVar("DXVK_FRAME_RATE");
+
+    if (!env.empty()) {
+      try {
+        return std::stod(env);
+      } catch (const std::invalid_argument&) {
+        // no op
+      }
+    }
+
+    return std::nullopt;
   }
 
 }

--- a/src/util/util_fps_limiter.h
+++ b/src/util/util_fps_limiter.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <array>
+#include <optional>
 
 #include "thread.h"
 #include "util_time.h"
@@ -38,6 +39,12 @@ namespace dxvk {
      * shorter than the target interval.
      */
     void delay();
+
+    /**
+     * \brief Queries environment override
+     * \returns Frame rate given by environment override
+     */
+    static std::optional<double> getEnvironmentOverride();
 
   private:
 

--- a/src/util/util_small_vector.h
+++ b/src/util/util_small_vector.h
@@ -19,6 +19,10 @@ namespace dxvk {
 
     small_vector() { }
 
+    small_vector(size_t size) {
+      resize(size);
+    }
+
     small_vector(const small_vector& other) {
       reserve(other.m_size);
       for (size_t i = 0; i < other.m_size; i++) {

--- a/src/vulkan/vulkan_loader.h
+++ b/src/vulkan/vulkan_loader.h
@@ -458,6 +458,14 @@ namespace dxvk::vk {
     VULKAN_FN(wine_vkAcquireKeyedMutex);
     VULKAN_FN(wine_vkReleaseKeyedMutex);
     #endif
+
+    #ifdef VK_NV_low_latency2
+    VULKAN_FN(vkSetLatencySleepModeNV);
+    VULKAN_FN(vkLatencySleepNV);
+    VULKAN_FN(vkSetLatencyMarkerNV);
+    VULKAN_FN(vkGetLatencyTimingsNV);
+    VULKAN_FN(vkQueueNotifyOutOfBandNV);
+    #endif
   };
   
 }


### PR DESCRIPTION
This isn't Reflex integration yet, but sort of serves as groundwork for it.

`NV_low_latency2` requires us to pass frame IDs to queue submissions, and some markers will need to be submitted at different times due to internal threading, so we kind of need to pass a bunch of state and internal markers around anyway, which is already 90% of the work needed to support latency sleep in many (older) games.

This PR adds this on top of `NV_low_latency2` as well as a homebrew latency sleep solution that's based on our internal timings. This can be enabled by setting `dxvk.latencySleep = True` in the config file.

The next step would be to add another implementation that consumes markers from the application (and handles all sorts of potential bugs) and implement the `ID3DLowLatencyDevice` interface for dxvk-nvapi.

Obviously not tested very well, especially D3D9 is a mess.