### PR TITLE
[d3d11] Fix missing argument reference

### DIFF
--- a/src/d3d11/d3d11_view.h
+++ b/src/d3d11/d3d11_view.h
@@ -55,7 +55,7 @@ namespace dxvk {
    * \param [in] b Second view to check
    * \returns \c true if the views overlap
    */
-  inline bool CheckViewOverlap(const D3D11_VK_VIEW_INFO& a, const D3D11_VK_VIEW_INFO b) {
+  inline bool CheckViewOverlap(const D3D11_VK_VIEW_INFO& a, const D3D11_VK_VIEW_INFO& b) {
     if (likely(a.pResource != b.pResource))
       return false;
     


### PR DESCRIPTION
I don't know if passing by value was intentional, but it seems to cause stack alignment issues when building DXVK with AVX2 and along with glibc assertions (`_GLIBCXX_ASSERTIONS`) enabled. DXVK crash is reproduced in game 20 Minute Till Dawn under the above conditions. GDB backtrace showed the following:

```gdb
Thread 57 "UnityGfxDeviceWorker" received signal SIGSEGV, Segmentation fault.
[Switching to Thread 528]
0x00006fffd95503ab in dxvk::CheckViewOverlap<dxvk::D3D11ShaderResourceView, dxvk::D3D11DepthStencilView> (a=0x66784000, b=0x72d2d0)
    at ../../dxvk/src/d3d11/d3d11_view.h:78
78	    return a && b && CheckViewOverlap(a->GetViewInfo(), b->GetViewInfo());
```

The crash issue is fixed when function takes both arguments by reference.