### PR TITLE
Nvidia Reflex support

### DIFF
--- a/dxvk.conf
+++ b/dxvk.conf
@@ -106,6 +106,16 @@
 # dxvk.latencyTolerance = 1000
 
 
+# Disables the use of VK_NV_low_latency2. This will make Reflex unavailable
+# in games, and if dxvk.latencySleep is set to True, a custom algorithm will
+# be used for latency control. By default, the extension will not be used in
+# 32-bit applications due to driver issues.
+#
+# Supported values: Auto, True, False
+
+# dxvk.disableNvLowLatency2 = Auto
+
+
 # Override PCI vendor and device IDs reported to the application. Can
 # cause the app to adjust behaviour depending on the selected values.
 #

--- a/dxvk.conf
+++ b/dxvk.conf
@@ -76,6 +76,36 @@
 # d3d9.maxFrameRate = 0
 
 
+# Controls latency sleep and Nvidia Reflex support.
+#
+# Supported values:
+# - Auto: By default, DXVK only supports latency sleep in D3D11 games that
+#         use Reflex if the graphics driver supports VK_NV_low_latency2,
+#         and if dxvk-nvapi is enabled in Proton.
+# - True: Enables built-in latency reduction based on internal timings.
+#         This assumes that input sampling for any given frame happens after
+#         the D3D9 or DXGI Present call returns; games that render and present
+#         asynchronously will not behave as intended.
+#         Similarly, this will not have any effect in games with built-in frame
+#         rate limiters, or if an external limiter (such as MangoHud) is used.
+#         In some games, enabling this may reduce performance or lead to less
+#         consistent frame pacing.
+#         The implementation will either use VK_NV_low_latency2 if supported
+#         by the driver, or a custom algorithm.
+# - False: Disable Reflex support as well as built-in latency reduction.
+  
+# dxvk.latencySleep = Auto
+
+
+# Tolerance for the latency sleep heuristic, in microseconds. Higher values
+# increase latency, but may lead to better frame pacing in some cases. Does
+# not have any effect if NV_low_latency2 is used.
+#
+# Supported values: Any non-negative number
+
+# dxvk.latencyTolerance = 1000
+
+
 # Override PCI vendor and device IDs reported to the application. Can
 # cause the app to adjust behaviour depending on the selected values.
 #

--- a/src/d3d11/d3d11_buffer.cpp
+++ b/src/d3d11/d3d11_buffer.cpp
@@ -214,7 +214,7 @@ namespace dxvk {
 
   void D3D11Buffer::SetDebugName(const char* pName) {
     if (m_buffer) {
-      m_parent->GetContext()->InjectCs([
+      m_parent->GetContext()->InjectCs(DxvkCsQueue::HighPriority, [
         cBuffer = m_buffer,
         cName   = std::string(pName ? pName : "")
       ] (DxvkContext* ctx) {

--- a/src/d3d11/d3d11_context_imm.cpp
+++ b/src/d3d11/d3d11_context_imm.cpp
@@ -924,7 +924,7 @@ namespace dxvk {
           bool                        Synchronize) {
     // Do not update the sequence number when emitting a chunk
     // from an external source since that would break tracking
-    m_csThread.injectChunk(std::move(Chunk), Synchronize);
+    m_csThread.injectChunk(DxvkCsQueue::HighPriority, std::move(Chunk), Synchronize);
   }
 
 

--- a/src/d3d11/d3d11_context_imm.cpp
+++ b/src/d3d11/d3d11_context_imm.cpp
@@ -920,11 +920,12 @@ namespace dxvk {
   
   
   void D3D11ImmediateContext::InjectCsChunk(
+          DxvkCsQueue                 Queue,
           DxvkCsChunkRef&&            Chunk,
           bool                        Synchronize) {
     // Do not update the sequence number when emitting a chunk
     // from an external source since that would break tracking
-    m_csThread.injectChunk(DxvkCsQueue::HighPriority, std::move(Chunk), Synchronize);
+    m_csThread.injectChunk(Queue, std::move(Chunk), Synchronize);
   }
 
 

--- a/src/d3d11/d3d11_context_imm.cpp
+++ b/src/d3d11/d3d11_context_imm.cpp
@@ -861,11 +861,17 @@ namespace dxvk {
   }
   
   
-  void D3D11ImmediateContext::EndFrame() {
+  void D3D11ImmediateContext::EndFrame(
+          Rc<DxvkLatencyTracker>      LatencyTracker) {
     D3D10DeviceLock lock = LockContext();
 
-    EmitCs<false>([] (DxvkContext* ctx) {
+    EmitCs<false>([
+      cTracker = std::move(LatencyTracker)
+    ] (DxvkContext* ctx) {
       ctx->endFrame();
+
+      if (cTracker && cTracker->needsAutoMarkers())
+        ctx->endLatencyTracking(cTracker);
     });
   }
 

--- a/src/d3d11/d3d11_context_imm.h
+++ b/src/d3d11/d3d11_context_imm.h
@@ -98,16 +98,18 @@ namespace dxvk {
     }
 
     void InjectCsChunk(
+            DxvkCsQueue                 Queue,
             DxvkCsChunkRef&&            Chunk,
             bool                        Synchronize);
 
     template<typename Fn>
     void InjectCs(
+            DxvkCsQueue                 Queue,
             Fn&&                        Command) {
       auto chunk = AllocCsChunk();
       chunk->push(std::move(Command));
 
-      InjectCsChunk(std::move(chunk), false);
+      InjectCsChunk(Queue, std::move(chunk), false);
     }
 
   private:

--- a/src/d3d11/d3d11_context_imm.h
+++ b/src/d3d11/d3d11_context_imm.h
@@ -169,7 +169,8 @@ namespace dxvk {
 
     void SynchronizeDevice();
 
-    void EndFrame();
+    void EndFrame(
+            Rc<DxvkLatencyTracker>      LatencyTracker);
     
     bool WaitForResource(
       const DxvkPagedResource&          Resource,

--- a/src/d3d11/d3d11_device.cpp
+++ b/src/d3d11/d3d11_device.cpp
@@ -2828,7 +2828,7 @@ namespace dxvk {
       feedback = ctx->ensureImageCompatibility(cImage, usageInfo);
     });
 
-    m_device->GetContext()->InjectCsChunk(std::move(chunk), true);
+    m_device->GetContext()->InjectCsChunk(DxvkCsQueue::HighPriority, std::move(chunk), true);
 
     if (!feedback) {
       Logger::err(str::format("Failed to lock image:"
@@ -2852,7 +2852,7 @@ namespace dxvk {
       ctx->ensureBufferAddress(cBuffer);
     });
 
-    m_device->GetContext()->InjectCsChunk(std::move(chunk), true);
+    m_device->GetContext()->InjectCsChunk(DxvkCsQueue::HighPriority, std::move(chunk), true);
   }
 
 

--- a/src/d3d11/d3d11_device.cpp
+++ b/src/d3d11/d3d11_device.cpp
@@ -3058,6 +3058,70 @@ namespace dxvk {
 
 
 
+  D3D11ReflexDevice::D3D11ReflexDevice(
+          D3D11DXGIDevice*        pContainer,
+          D3D11Device*            pDevice)
+  : m_container(pContainer), m_device(pDevice) {
+
+  }
+
+
+  D3D11ReflexDevice::~D3D11ReflexDevice() {
+
+  }
+
+
+  ULONG STDMETHODCALLTYPE D3D11ReflexDevice::AddRef() {
+    return m_container->AddRef();
+  }
+
+
+  ULONG STDMETHODCALLTYPE D3D11ReflexDevice::Release() {
+    return m_container->Release();
+  }
+
+
+  HRESULT STDMETHODCALLTYPE D3D11ReflexDevice::QueryInterface(
+          REFIID                        riid,
+          void**                        ppvObject) {
+    return m_container->QueryInterface(riid, ppvObject);
+  }
+
+
+  BOOL STDMETHODCALLTYPE D3D11ReflexDevice::SupportsLowLatency() {
+    return FALSE;
+  }
+
+
+  HRESULT STDMETHODCALLTYPE D3D11ReflexDevice::LatencySleep() {
+    return E_NOTIMPL;
+  }
+
+
+  HRESULT STDMETHODCALLTYPE D3D11ReflexDevice::SetLatencySleepMode(
+          BOOL                          LowLatencyEnable,
+          BOOL                          LowLatencyBoost,
+          UINT32                        MinIntervalUs) {
+    return E_NOTIMPL;
+  }
+
+
+  HRESULT STDMETHODCALLTYPE D3D11ReflexDevice::SetLatencyMarker(
+          UINT64                        FrameId,
+          UINT32                        MarkerType) {
+    return E_NOTIMPL;
+  }
+
+
+  HRESULT STDMETHODCALLTYPE D3D11ReflexDevice::GetLatencyInfo(
+          D3D_LOW_LATENCY_RESULTS*      pLowLatencyResults) {
+    *pLowLatencyResults = D3D_LOW_LATENCY_RESULTS();
+    return E_NOTIMPL;
+  }
+
+
+
+
   DXGIVkSwapChainFactory::DXGIVkSwapChainFactory(
           D3D11DXGIDevice*        pContainer,
           D3D11Device*            pDevice)
@@ -3159,6 +3223,7 @@ namespace dxvk {
     m_d3d11DeviceExt(this, &m_d3d11Device),
     m_d3d11Interop  (this, &m_d3d11Device),
     m_d3d11Video    (this, &m_d3d11Device),
+    m_d3d11Reflex   (this, &m_d3d11Device),
     m_d3d11on12     (this, &m_d3d11Device, pD3D12Device, pD3D12Queue),
     m_metaDevice    (this),
     m_dxvkFactory   (this, &m_d3d11Device) {
@@ -3228,6 +3293,11 @@ namespace dxvk {
 
     if (riid == __uuidof(ID3D11VideoDevice)) {
       *ppvObject = ref(&m_d3d11Video);
+      return S_OK;
+    }
+
+    if (riid == __uuidof(ID3DLowLatencyDevice)) {
+      *ppvObject = ref(&m_d3d11Reflex);
       return S_OK;
     }
 

--- a/src/d3d11/d3d11_device.h
+++ b/src/d3d11/d3d11_device.h
@@ -752,6 +752,51 @@ namespace dxvk {
 
 
   /**
+   * \brief Nvidia Reflex interop
+   */
+  class D3D11ReflexDevice : public ID3DLowLatencyDevice {
+
+  public:
+
+    D3D11ReflexDevice(
+            D3D11DXGIDevice*        pContainer,
+            D3D11Device*            pDevice);
+
+    ~D3D11ReflexDevice();
+
+    ULONG STDMETHODCALLTYPE AddRef();
+
+    ULONG STDMETHODCALLTYPE Release();
+
+    HRESULT STDMETHODCALLTYPE QueryInterface(
+            REFIID                        riid,
+            void**                        ppvObject);
+
+    BOOL STDMETHODCALLTYPE SupportsLowLatency();
+
+    HRESULT STDMETHODCALLTYPE LatencySleep();
+
+    HRESULT STDMETHODCALLTYPE SetLatencySleepMode(
+            BOOL                          LowLatencyEnable,
+            BOOL                          LowLatencyBoost,
+            UINT32                        MinIntervalUs);
+
+    HRESULT STDMETHODCALLTYPE SetLatencyMarker(
+            UINT64                        FrameId,
+            UINT32                        MarkerType);
+
+    HRESULT STDMETHODCALLTYPE GetLatencyInfo(
+            D3D_LOW_LATENCY_RESULTS*      pLowLatencyResults);
+
+  private:
+
+    D3D11DXGIDevice*  m_container;
+    D3D11Device*      m_device;
+
+  };
+
+
+  /**
    * \brief DXVK swap chain factory
    */
   class DXGIVkSwapChainFactory : public IDXGIVkSwapChainFactory {
@@ -914,6 +959,7 @@ namespace dxvk {
     D3D11DeviceExt      m_d3d11DeviceExt;
     D3D11VkInterop      m_d3d11Interop;
     D3D11VideoDevice    m_d3d11Video;
+    D3D11ReflexDevice   m_d3d11Reflex;
     D3D11on12Device     m_d3d11on12;
     DXGIDXVKDevice      m_metaDevice;
     

--- a/src/d3d11/d3d11_device.h
+++ b/src/d3d11/d3d11_device.h
@@ -9,6 +9,7 @@
 #include "../dxgi/dxgi_interfaces.h"
 
 #include "../dxvk/dxvk_cs.h"
+#include "../dxvk/dxvk_latency_reflex.h"
 
 #include "../d3d10/d3d10_device.h"
 
@@ -788,11 +789,26 @@ namespace dxvk {
     HRESULT STDMETHODCALLTYPE GetLatencyInfo(
             D3D_LOW_LATENCY_RESULTS*      pLowLatencyResults);
 
+    void RegisterLatencyTracker(
+            Rc<DxvkLatencyTracker>          Tracker);
+
+    void UnregisterLatencyTracker(
+            Rc<DxvkLatencyTracker>          Tracker);
+
   private:
 
     D3D11DXGIDevice*  m_container;
     D3D11Device*      m_device;
 
+    bool              m_reflexEnabled = false;
+
+    dxvk::mutex       m_mutex;
+
+    bool              m_enableLowLatency  = false;
+    bool              m_enableBoost       = false;
+    uint64_t          m_minIntervalUs     = 0u;
+
+    Rc<DxvkReflexLatencyTrackerNv>  m_tracker;
   };
 
 

--- a/src/d3d11/d3d11_initializer.cpp
+++ b/src/d3d11/d3d11_initializer.cpp
@@ -371,7 +371,7 @@ namespace dxvk {
 
 
   void D3D11Initializer::FlushCsChunkLocked() {
-    m_parent->GetContext()->InjectCsChunk(std::move(m_csChunk), false);
+    m_parent->GetContext()->InjectCsChunk(DxvkCsQueue::HighPriority, std::move(m_csChunk), false);
     m_csChunk = m_parent->AllocCsChunk(DxvkCsChunkFlag::SingleUse);
   }
 

--- a/src/d3d11/d3d11_interfaces.h
+++ b/src/d3d11/d3d11_interfaces.h
@@ -183,10 +183,70 @@ ID3D11VkExtContext1 : public ID3D11VkExtContext {
 };
 
 
+/**
+ * \brief Frame reports used for Reflex interop
+ */
+struct D3D_LOW_LATENCY_FRAME_REPORT
+{
+    UINT64 frameID;
+    UINT64 inputSampleTime;
+    UINT64 simStartTime;
+    UINT64 simEndTime;
+    UINT64 renderSubmitStartTime;
+    UINT64 renderSubmitEndTime;
+    UINT64 presentStartTime;
+    UINT64 presentEndTime;
+    UINT64 driverStartTime;
+    UINT64 driverEndTime;
+    UINT64 osRenderQueueStartTime;
+    UINT64 osRenderQueueEndTime;
+    UINT64 gpuRenderStartTime;
+    UINT64 gpuRenderEndTime;
+    UINT32 gpuActiveRenderTimeUs;
+    UINT32 gpuFrameTimeUs;
+    UINT8 rsvd[120];
+};
+
+
+/**
+ * \brief Data structure used for Reflex interop
+ */
+struct D3D_LOW_LATENCY_RESULTS
+{
+    UINT32 version;
+    D3D_LOW_LATENCY_FRAME_REPORT frameReports[64];
+    UINT8 rsvd[32];
+};
+
+
+/**
+ * \brief D3D interop interface for Nvidia Reflex
+ */
+MIDL_INTERFACE("f3112584-41f9-348d-a59b-00b7e1d285d6")
+ID3DLowLatencyDevice : public IUnknown {
+  virtual BOOL STDMETHODCALLTYPE SupportsLowLatency() = 0;
+
+  virtual HRESULT STDMETHODCALLTYPE LatencySleep() = 0;
+
+  virtual HRESULT STDMETHODCALLTYPE SetLatencySleepMode(
+          BOOL                          LowLatencyEnable,
+          BOOL                          LowLatencyBoost,
+          UINT32                        MinIntervalUs) = 0;
+
+  virtual HRESULT STDMETHODCALLTYPE SetLatencyMarker(
+          UINT64                        FrameId,
+          UINT32                        MarkerType) = 0;
+
+  virtual HRESULT STDMETHODCALLTYPE GetLatencyInfo(
+          D3D_LOW_LATENCY_RESULTS*      pLowLatencyResults) = 0;
+};
+
+
 #ifndef _MSC_VER
 __CRT_UUID_DECL(ID3D11VkExtShader,         0xbb8a4fb9,0x3935,0x4762,0xb4,0x4b,0x35,0x18,0x9a,0x26,0x41,0x4a);
 __CRT_UUID_DECL(ID3D11VkExtDevice,         0x8a6e3c42,0xf74c,0x45b7,0x82,0x65,0xa2,0x31,0xb6,0x77,0xca,0x17);
 __CRT_UUID_DECL(ID3D11VkExtDevice1,        0xcfcf64ef,0x9586,0x46d0,0xbc,0xa4,0x97,0xcf,0x2c,0xa6,0x1b,0x06);
 __CRT_UUID_DECL(ID3D11VkExtContext,        0xfd0bca13,0x5cb6,0x4c3a,0x98,0x7e,0x47,0x50,0xde,0x2c,0xa7,0x91);
 __CRT_UUID_DECL(ID3D11VkExtContext1,       0x874b09b2,0xae0b,0x41d8,0x84,0x76,0x5f,0x3b,0x7a,0x0e,0x87,0x9d);
+__CRT_UUID_DECL(ID3DLowLatencyDevice,      0xf3112584,0x41f9,0x348d,0xa5,0x9b,0x00,0xb7,0xe1,0xd2,0x85,0xd6);
 #endif

--- a/src/d3d11/d3d11_swapchain.cpp
+++ b/src/d3d11/d3d11_swapchain.cpp
@@ -425,7 +425,7 @@ namespace dxvk {
       ctx->synchronizeWsi(cSync);
       ctx->flushCommandList(nullptr);
 
-      cDevice->presentImage(cPresenter, cFrameId, nullptr);
+      cDevice->presentImage(cPresenter, nullptr, cFrameId, nullptr);
     });
 
     if (m_backBuffers.size() > 1u)

--- a/src/d3d11/d3d11_swapchain.cpp
+++ b/src/d3d11/d3d11_swapchain.cpp
@@ -576,7 +576,7 @@ namespace dxvk {
 
     // Initialize images so that we can use them. Clearing
     // to black prevents garbled output for the first frame.
-    m_parent->GetContext()->InjectCs([
+    m_parent->GetContext()->InjectCs(DxvkCsQueue::HighPriority, [
       cImages = std::move(images)
     ] (DxvkContext* ctx) {
       for (size_t i = 0; i < cImages.size(); i++) {
@@ -612,7 +612,7 @@ namespace dxvk {
   void D3D11SwapChain::DestroyLatencyTracker() {
     // Need to make sure the context stops using
     // the tracker for submissions
-    m_parent->GetContext()->InjectCs([
+    m_parent->GetContext()->InjectCs(DxvkCsQueue::Ordered, [
       cLatency = m_latency
     ] (DxvkContext* ctx) {
       ctx->endLatencyTracking(cLatency);

--- a/src/d3d11/d3d11_swapchain.cpp
+++ b/src/d3d11/d3d11_swapchain.cpp
@@ -517,6 +517,9 @@ namespace dxvk {
     m_presenter->setFrameRateLimit(m_targetFrameRate, GetActualFrameLatency());
 
     m_latency = m_device->createLatencyTracker(m_presenter);
+
+    Com<D3D11ReflexDevice> reflex = GetReflexDevice();
+    reflex->RegisterLatencyTracker(m_latency);
   }
 
 
@@ -617,6 +620,9 @@ namespace dxvk {
     ] (DxvkContext* ctx) {
       ctx->endLatencyTracking(cLatency);
     });
+
+    Com<D3D11ReflexDevice> reflex = GetReflexDevice();
+    reflex->UnregisterLatencyTracker(m_latency);
   }
 
 
@@ -675,6 +681,14 @@ namespace dxvk {
       case DXGI_FORMAT_R16G16B16A16_FLOAT:
         return { VK_FORMAT_R16G16B16A16_SFLOAT, m_colorSpace };
     }
+  }
+
+
+  Com<D3D11ReflexDevice> D3D11SwapChain::GetReflexDevice() {
+    Com<ID3DLowLatencyDevice> llDevice;
+    m_parent->QueryInterface(__uuidof(ID3DLowLatencyDevice), reinterpret_cast<void**>(&llDevice));
+
+    return static_cast<D3D11ReflexDevice*>(llDevice.ptr());
   }
 
 

--- a/src/d3d11/d3d11_swapchain.cpp
+++ b/src/d3d11/d3d11_swapchain.cpp
@@ -2,6 +2,8 @@
 #include "d3d11_device.h"
 #include "d3d11_swapchain.h"
 
+#include "../dxvk/dxvk_latency_builtin.h"
+
 #include "../util/util_win32_compat.h"
 
 namespace dxvk {
@@ -80,6 +82,7 @@ namespace dxvk {
     m_presenter->destroyResources();
     
     DestroyFrameLatencyEvent();
+    DestroyLatencyTracker();
   }
 
 
@@ -279,6 +282,18 @@ namespace dxvk {
     // applications using the semaphore may deadlock. This works because
     // we do not increment the frame ID in those situations.
     SyncFrameLatency();
+
+    // Ignore latency stuff if presentation failed
+    DxvkLatencyStats latencyStats = { };
+
+    if (hr == S_OK && m_latency) {
+      latencyStats = m_latency->getStatistics(m_frameId);
+      m_latency->sleepAndBeginFrame(m_frameId + 1, std::abs(m_targetFrameRate));
+    }
+
+    if (m_latencyHud)
+      m_latencyHud->accumulateStats(latencyStats);
+
     return hr;
   }
 
@@ -364,16 +379,22 @@ namespace dxvk {
     auto immediateContext = m_parent->GetContext();
     auto immediateContextLock = immediateContext->LockContext();
 
-    immediateContext->EndFrame();
+    immediateContext->EndFrame(m_latency);
     immediateContext->Flush();
 
     m_presenter->setSyncInterval(SyncInterval);
 
     // Presentation semaphores and WSI swap chain image
+    if (m_latency)
+      m_latency->notifyCpuPresentBegin(m_frameId + 1u);
+
     PresenterSync sync;
     Rc<DxvkImage> backBuffer;
 
     VkResult status = m_presenter->acquireNextImage(sync, backBuffer);
+
+    if (status != VK_SUCCESS && m_latency)
+      m_latency->discardTimings();
 
     if (status < 0)
       return E_FAIL;
@@ -402,6 +423,7 @@ namespace dxvk {
       cSwapImage      = GetBackBufferView(),
       cSync           = sync,
       cPresenter      = m_presenter,
+      cLatency        = m_latency,
       cColorSpace     = m_colorSpace,
       cFrameId        = m_frameId
     ] (DxvkContext* ctx) {
@@ -425,13 +447,27 @@ namespace dxvk {
       ctx->synchronizeWsi(cSync);
       ctx->flushCommandList(nullptr);
 
-      cDevice->presentImage(cPresenter, nullptr, cFrameId, nullptr);
+      cDevice->presentImage(cPresenter, cLatency, cFrameId, nullptr);
     });
 
     if (m_backBuffers.size() > 1u)
       RotateBackBuffers(immediateContext);
 
     immediateContext->FlushCsChunk();
+
+    if (m_latency) {
+      m_latency->notifyCpuPresentEnd(m_frameId);
+
+      if (m_latency->needsAutoMarkers()) {
+        immediateContext->EmitCs([
+          cLatency = m_latency,
+          cFrameId = m_frameId
+        ] (DxvkContext* ctx) {
+          ctx->beginLatencyTracking(cLatency, cFrameId + 1u);
+        });
+      }
+    }
+
     return S_OK;
   }
 
@@ -479,6 +515,8 @@ namespace dxvk {
     m_presenter->setSurfaceFormat(GetSurfaceFormat(m_desc.Format));
     m_presenter->setSurfaceExtent({ m_desc.Width, m_desc.Height });
     m_presenter->setFrameRateLimit(m_targetFrameRate, GetActualFrameLatency());
+
+    m_latency = m_device->createLatencyTracker(m_presenter);
   }
 
 
@@ -555,8 +593,12 @@ namespace dxvk {
   void D3D11SwapChain::CreateBlitter() {
     Rc<hud::Hud> hud = hud::Hud::createHud(m_device);
 
-    if (hud)
+    if (hud) {
       hud->addItem<hud::HudClientApiItem>("api", 1, GetApiName());
+
+      if (m_latency)
+        m_latencyHud = hud->addItem<hud::HudLatencyItem>("latency", 4);
+    }
 
     m_blitter = new DxvkSwapchainBlitter(m_device, std::move(hud));
   }
@@ -564,6 +606,17 @@ namespace dxvk {
 
   void D3D11SwapChain::DestroyFrameLatencyEvent() {
     CloseHandle(m_frameLatencyEvent);
+  }
+
+
+  void D3D11SwapChain::DestroyLatencyTracker() {
+    // Need to make sure the context stops using
+    // the tracker for submissions
+    m_parent->GetContext()->InjectCs([
+      cLatency = m_latency
+    ] (DxvkContext* ctx) {
+      ctx->endLatencyTracking(cLatency);
+    });
   }
 
 

--- a/src/d3d11/d3d11_swapchain.h
+++ b/src/d3d11/d3d11_swapchain.h
@@ -148,9 +148,11 @@ namespace dxvk {
     void SyncFrameLatency();
 
     uint32_t GetActualFrameLatency();
-    
+
     VkSurfaceFormatKHR GetSurfaceFormat(DXGI_FORMAT Format);
-    
+
+    Com<D3D11ReflexDevice> GetReflexDevice();
+
     std::string GetApiName() const;
 
   };

--- a/src/d3d11/d3d11_swapchain.h
+++ b/src/d3d11/d3d11_swapchain.h
@@ -4,6 +4,7 @@
 
 #include "../dxvk/hud/dxvk_hud.h"
 
+#include "../dxvk/dxvk_latency.h"
 #include "../dxvk/dxvk_swapchain_blitter.h"
 
 #include "../util/sync/sync_signal.h"
@@ -107,6 +108,7 @@ namespace dxvk {
     Rc<Presenter>             m_presenter;
 
     Rc<DxvkSwapchainBlitter>  m_blitter;
+    Rc<DxvkLatencyTracker>    m_latency;
 
     small_vector<Com<D3D11Texture2D, false>, 4> m_backBuffers;
 
@@ -123,6 +125,8 @@ namespace dxvk {
     dxvk::mutex               m_frameStatisticsLock;
     DXGI_VK_FRAME_STATISTICS  m_frameStatistics = { };
 
+    Rc<hud::HudLatencyItem>   m_latencyHud;
+
     Rc<DxvkImageView> GetBackBufferView();
 
     HRESULT PresentImage(UINT SyncInterval);
@@ -138,6 +142,8 @@ namespace dxvk {
     void CreateBlitter();
 
     void DestroyFrameLatencyEvent();
+
+    void DestroyLatencyTracker();
 
     void SyncFrameLatency();
 

--- a/src/d3d11/d3d11_texture.cpp
+++ b/src/d3d11/d3d11_texture.cpp
@@ -377,7 +377,7 @@ namespace dxvk {
 
   void D3D11CommonTexture::SetDebugName(const char* pName) {
     if (m_image) {
-      m_device->GetContext()->InjectCs([
+      m_device->GetContext()->InjectCs(DxvkCsQueue::HighPriority, [
         cImage  = m_image,
         cName   = std::string(pName ? pName : "")
       ] (DxvkContext* ctx) {
@@ -387,7 +387,7 @@ namespace dxvk {
 
     if (m_mapMode == D3D11_COMMON_TEXTURE_MAP_MODE_STAGING) {
       for (uint32_t i = 0; i < m_buffers.size(); i++) {
-        m_device->GetContext()->InjectCs([
+        m_device->GetContext()->InjectCs(DxvkCsQueue::HighPriority, [
           cBuffer = m_buffers[i].buffer,
           cName   = std::string(pName ? pName : "")
         ] (DxvkContext* ctx) {

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -5649,7 +5649,7 @@ namespace dxvk {
   void D3D9DeviceEx::InjectCsChunk(
           DxvkCsChunkRef&&            Chunk,
           bool                        Synchronize) {
-    m_csThread.injectChunk(std::move(Chunk), Synchronize);
+    m_csThread.injectChunk(DxvkCsQueue::HighPriority, std::move(Chunk), Synchronize);
   }
 
 

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -4270,7 +4270,7 @@ namespace dxvk {
     m_implicitSwapchain->Invalidate(pPresentationParameters->hDeviceWindow);
 
     try {
-      auto* swapchain = new D3D9SwapChainEx(this, pPresentationParameters, pFullscreenDisplayMode);
+      auto* swapchain = new D3D9SwapChainEx(this, pPresentationParameters, pFullscreenDisplayMode, false);
       *ppSwapChain = ref(swapchain);
       m_losableResourceCounter++;
     }
@@ -6098,11 +6098,29 @@ namespace dxvk {
   }
 
 
-  void D3D9DeviceEx::EndFrame() {
+  void D3D9DeviceEx::BeginFrame(Rc<DxvkLatencyTracker> LatencyTracker, uint64_t FrameId) {
     D3D9DeviceLock lock = LockDevice();
 
-    EmitCs<false>([] (DxvkContext* ctx) {
+    EmitCs<false>([
+      cTracker = std::move(LatencyTracker),
+      cFrameId = FrameId
+    ] (DxvkContext* ctx) {
+      if (cTracker && cTracker->needsAutoMarkers())
+        ctx->beginLatencyTracking(cTracker, cFrameId);
+    });
+  }
+
+
+  void D3D9DeviceEx::EndFrame(Rc<DxvkLatencyTracker> LatencyTracker) {
+    D3D9DeviceLock lock = LockDevice();
+
+    EmitCs<false>([
+      cTracker = std::move(LatencyTracker)
+    ] (DxvkContext* ctx) {
       ctx->endFrame();
+
+      if (cTracker && cTracker->needsAutoMarkers())
+        ctx->endLatencyTracking(cTracker);
     });
   }
 
@@ -8445,7 +8463,7 @@ namespace dxvk {
         return hr;
     }
     else {
-      m_implicitSwapchain = new D3D9SwapChainEx(this, pPresentationParameters, pFullscreenDisplayMode);
+      m_implicitSwapchain = new D3D9SwapChainEx(this, pPresentationParameters, pFullscreenDisplayMode, true);
       m_mostRecentlyUsedSwapchain = m_implicitSwapchain.ptr();
     }
 

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -800,7 +800,8 @@ namespace dxvk {
     void Flush();
     void FlushAndSync9On12();
 
-    void EndFrame();
+    void BeginFrame(Rc<DxvkLatencyTracker> LatencyTracker, uint64_t FrameId);
+    void EndFrame(Rc<DxvkLatencyTracker> LatencyTracker);
 
     void UpdateActiveRTs(uint32_t index);
 

--- a/src/d3d9/d3d9_swapchain.cpp
+++ b/src/d3d9/d3d9_swapchain.cpp
@@ -23,10 +23,12 @@ namespace dxvk {
   D3D9SwapChainEx::D3D9SwapChainEx(
           D3D9DeviceEx*          pDevice,
           D3DPRESENT_PARAMETERS* pPresentParams,
-    const D3DDISPLAYMODEEX*      pFullscreenDisplayMode)
+    const D3DDISPLAYMODEEX*      pFullscreenDisplayMode,
+          bool                   EnableLatencyTracking)
     : D3D9SwapChainExBase(pDevice)
     , m_device           (pDevice->GetDXVKDevice())
     , m_frameLatencyCap  (pDevice->GetOptions()->maxFrameLatency)
+    , m_latencyTracking  (EnableLatencyTracking)
     , m_swapchainExt     (this) {
     this->NormalizePresentParameters(pPresentParams);
     m_presentParams = *pPresentParams;
@@ -186,7 +188,7 @@ namespace dxvk {
   #define DCX_USESTYLE 0x00010000
 
   HRESULT D3D9SwapChainEx::PresentImageGDI(HWND Window) {
-    m_parent->EndFrame();
+    m_parent->EndFrame(nullptr);
     m_parent->Flush();
 
     if (!std::exchange(m_warnedAboutGDIFallback, true))
@@ -717,6 +719,9 @@ namespace dxvk {
       if (entry->second.presenter) {
         entry->second.presenter->destroyResources();
         entry->second.presenter = nullptr;
+
+        if (m_presentParams.hDeviceWindow == hWindow)
+          DestroyLatencyTracker();
       }
 
       if (m_wctx == &entry->second)
@@ -802,10 +807,15 @@ namespace dxvk {
 
 
   void D3D9SwapChainEx::PresentImage(UINT SyncInterval) {
-    m_parent->EndFrame();
+    m_parent->EndFrame(m_latencyTracker);
     m_parent->Flush();
 
+    if (m_latencyTracker)
+      m_latencyTracker->notifyCpuPresentBegin(m_wctx->frameId + 1u);
+
     // Retrieve the image and image view to present
+    VkResult status = VK_SUCCESS;
+
     Rc<DxvkImage> swapImage = m_backBuffers[0]->GetCommonTexture()->GetImage();
     Rc<DxvkImageView> swapImageView = m_backBuffers[0]->GetImageView(false);
 
@@ -814,10 +824,12 @@ namespace dxvk {
       PresenterSync sync = { };
       Rc<DxvkImage> backBuffer;
 
-      VkResult status = m_wctx->presenter->acquireNextImage(sync, backBuffer);
+      status = m_wctx->presenter->acquireNextImage(sync, backBuffer);
 
-      if (status < 0 || status == VK_NOT_READY)
+      if (status < 0 || status == VK_NOT_READY) {
+        status = i ? VK_SUCCESS : status;
         break;
+      }
 
       VkRect2D srcRect = {
         {  int32_t(m_srcRect.left),                    int32_t(m_srcRect.top)                    },
@@ -854,7 +866,8 @@ namespace dxvk {
         cDstRect        = dstRect,
         cRepeat         = i,
         cSync           = sync,
-        cFrameId        = m_wctx->frameId
+        cFrameId        = m_wctx->frameId,
+        cLatency        = m_latencyTracker
       ] (DxvkContext* ctx) {
         // Update back buffer color space as necessary
         if (cSrcView->image()->info().colorSpace != cColorSpace) {
@@ -876,13 +889,32 @@ namespace dxvk {
 
         uint64_t frameId = cRepeat ? 0 : cFrameId;
 
-        cDevice->presentImage(cPresenter, nullptr, frameId, nullptr);
+        cDevice->presentImage(cPresenter, cLatency, frameId, nullptr);
       });
 
       m_parent->FlushCsChunk();
     }
 
+    if (m_latencyTracker) {
+      if (status == VK_SUCCESS)
+        m_latencyTracker->notifyCpuPresentEnd(m_wctx->frameId);
+      else
+        m_latencyTracker->discardTimings();
+    }
+
     SyncFrameLatency();
+
+    DxvkLatencyStats latencyStats = { };
+
+    if (m_latencyTracker && status == VK_SUCCESS) {
+      latencyStats = m_latencyTracker->getStatistics(m_wctx->frameId);
+      m_latencyTracker->sleepAndBeginFrame(m_wctx->frameId + 1, std::abs(m_targetFrameRate));
+
+      m_parent->BeginFrame(m_latencyTracker, m_wctx->frameId + 1u);
+    }
+
+    if (m_latencyHud)
+      m_latencyHud->accumulateStats(latencyStats);
 
     // Rotate swap chain buffers so that the back
     // buffer at index 0 becomes the front buffer.
@@ -941,6 +973,9 @@ namespace dxvk {
 
       entry->second.frameLatencySignal = new sync::Fence(entry->second.frameId);
       entry->second.presenter = CreatePresenter(m_window, entry->second.frameLatencySignal);
+
+      if (m_presentParams.hDeviceWindow == m_window && m_latencyTracking)
+        m_latencyTracker = m_device->createLatencyTracker(entry->second.presenter);
     }
 
     m_wctx = &entry->second;
@@ -1017,6 +1052,10 @@ namespace dxvk {
 
     if (hud) {
       m_apiHud = hud->addItem<hud::HudClientApiItem>("api", 1, GetApiName());
+
+      if (m_latencyTracking)
+        m_latencyHud = hud->addItem<hud::HudLatencyItem>("latency", 4);
+
       hud->addItem<hud::HudSamplerCount>("samplers", -1, m_parent);
       hud->addItem<hud::HudFixedFunctionShaders>("ffshaders", -1, m_parent);
       hud->addItem<hud::HudSWVPState>("swvp", -1, m_parent);
@@ -1041,6 +1080,18 @@ namespace dxvk {
   }
 
 
+  void D3D9SwapChainEx::DestroyLatencyTracker() {
+    if (!m_latencyTracker)
+      return;
+
+    m_parent->InjectCs([
+      cTracker = std::move(m_latencyTracker)
+    ] (DxvkContext* ctx) {
+      ctx->endLatencyTracking(cTracker);
+    });
+  }
+
+
   void D3D9SwapChainEx::UpdateTargetFrameRate(uint32_t SyncInterval) {
     double frameRateOption = double(m_parent->GetOptions()->maxFrameRate);
     double frameRate = std::max(frameRateOption, 0.0);
@@ -1049,6 +1100,7 @@ namespace dxvk {
       frameRate = -m_displayRefreshRate / double(SyncInterval);
 
     m_wctx->presenter->setFrameRateLimit(frameRate, GetActualFrameLatency());
+    m_targetFrameRate = frameRate;
   }
 
 

--- a/src/d3d9/d3d9_swapchain.cpp
+++ b/src/d3d9/d3d9_swapchain.cpp
@@ -876,7 +876,7 @@ namespace dxvk {
 
         uint64_t frameId = cRepeat ? 0 : cFrameId;
 
-        cDevice->presentImage(cPresenter, frameId, nullptr);
+        cDevice->presentImage(cPresenter, nullptr, frameId, nullptr);
       });
 
       m_parent->FlushCsChunk();

--- a/src/d3d9/d3d9_swapchain.h
+++ b/src/d3d9/d3d9_swapchain.h
@@ -69,7 +69,8 @@ namespace dxvk {
     D3D9SwapChainEx(
             D3D9DeviceEx*          pDevice,
             D3DPRESENT_PARAMETERS* pPresentParams,
-      const D3DDISPLAYMODEEX*      pFullscreenDisplayMode);
+      const D3DDISPLAYMODEEX*      pFullscreenDisplayMode,
+            bool                   EnableLatencyTracking);
 
     ~D3D9SwapChainEx();
 
@@ -173,12 +174,17 @@ namespace dxvk {
     wsi::DxvkWindowState      m_windowState;
 
     double                    m_displayRefreshRate = 0.0;
+    double                    m_targetFrameRate = 0.0;
 
     bool                      m_warnedAboutGDIFallback = false;
 
     VkColorSpaceKHR           m_colorspace = VK_COLOR_SPACE_SRGB_NONLINEAR_KHR;
 
+    bool                      m_latencyTracking = false;
+    Rc<DxvkLatencyTracker>    m_latencyTracker = nullptr;
+
     Rc<hud::HudClientApiItem> m_apiHud;
+    Rc<hud::HudLatencyItem>   m_latencyHud;
 
     std::optional<VkHdrMetadataEXT> m_hdrMetadata;
     bool m_unlockAdditionalFormats = false;
@@ -196,6 +202,8 @@ namespace dxvk {
             DWORD               Flags);
 
     void CreateBlitter();
+
+    void DestroyLatencyTracker();
 
     void InitRamp();
 

--- a/src/d3d9/d3d9_swapchain.h
+++ b/src/d3d9/d3d9_swapchain.h
@@ -173,8 +173,10 @@ namespace dxvk {
 
     wsi::DxvkWindowState      m_windowState;
 
-    double                    m_displayRefreshRate = 0.0;
     double                    m_targetFrameRate = 0.0;
+
+    double                    m_displayRefreshRate = 0.0;
+    bool                      m_displayRefreshRateDirty = true;
 
     bool                      m_warnedAboutGDIFallback = false;
 
@@ -215,8 +217,7 @@ namespace dxvk {
     
     void NormalizePresentParameters(D3DPRESENT_PARAMETERS* pPresentParams);
 
-    void NotifyDisplayRefreshRate(
-            double                  RefreshRate);
+    void UpdateWindowedRefreshRate();
 
     HRESULT EnterFullscreenMode(
             D3DPRESENT_PARAMETERS*  pPresentParams,

--- a/src/dxgi/dxgi_swapchain.cpp
+++ b/src/dxgi/dxgi_swapchain.cpp
@@ -43,6 +43,14 @@ namespace dxvk {
 
     // Ensure that RGBA16 swap chains are scRGB if supported
     UpdateColorSpace(m_desc.Format, m_colorSpace);
+
+    // Somewhat hacky way to determine whether to forward the
+    // display refresh rate in windowed mode even with a sync
+    // interval of 1.
+    if (!m_is_d3d12) {
+      auto instance = pFactory->GetDXVKInstance();
+      m_hasLatencyControl = instance->options().latencySleep == Tristate::True;
+    }
   }
   
   
@@ -1000,10 +1008,12 @@ namespace dxvk {
     // Engage the frame limiter with large sync intervals even in windowed
     // mode since we want to avoid double-presenting to the swap chain.
     if (SyncInterval != m_frameRateSyncInterval && m_descFs.Windowed) {
+      bool engageLimiter = (SyncInterval > 1u) || (SyncInterval && m_hasLatencyControl);
+
       m_frameRateSyncInterval = SyncInterval;
       m_frameRateRefresh = 0.0f;
 
-      if (SyncInterval > 1 && wsi::isWindow(m_window)) {
+      if (engageLimiter && wsi::isWindow(m_window)) {
         wsi::WsiMode mode = { };
 
         if (wsi::getCurrentDisplayMode(wsi::getWindowMonitor(m_window), &mode)) {

--- a/src/dxgi/dxgi_swapchain.h
+++ b/src/dxgi/dxgi_swapchain.h
@@ -205,6 +205,7 @@ namespace dxvk {
     DXGI_COLOR_SPACE_TYPE           m_colorSpace = DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P709;
 
     uint32_t                        m_globalHDRStateSerial = 0;
+    bool                            m_hasLatencyControl = false;
     
     HRESULT EnterFullscreenMode(
             IDXGIOutput1            *pTarget);

--- a/src/dxvk/dxvk_adapter.cpp
+++ b/src/dxvk/dxvk_adapter.cpp
@@ -293,6 +293,14 @@ namespace dxvk {
       enabledFeatures.vk12.bufferDeviceAddress = VK_TRUE;
     }
 
+    // Disable NV_low_latency2 on 32-bit due to buggy latency sleep
+    // behaviour, or if explicitly set via the onfig file.
+    bool disableNvLowLatency2 = env::is32BitHostPlatform();
+    applyTristate(disableNvLowLatency2, instance->options().disableNvLowLatency2);
+
+    if (disableNvLowLatency2)
+      devExtensions.nvLowLatency2.setMode(DxvkExtMode::Disabled);
+
     // If we don't have pageable device memory support, at least use
     // the legacy AMD extension to ensure we can oversubscribe VRAM
     if (!m_deviceExtensions.supports(devExtensions.extPageableDeviceLocalMemory.name()))

--- a/src/dxvk/dxvk_adapter.cpp
+++ b/src/dxvk/dxvk_adapter.cpp
@@ -1027,6 +1027,7 @@ namespace dxvk {
       &devExtensions.khrSwapchain,
       &devExtensions.khrWin32KeyedMutex,
       &devExtensions.nvDescriptorPoolOverallocation,
+      &devExtensions.nvLowLatency2,
       &devExtensions.nvRawAccessChains,
       &devExtensions.nvxBinaryImport,
       &devExtensions.nvxImageViewHandle,
@@ -1176,6 +1177,9 @@ namespace dxvk {
       enabledFeatures.nvDescriptorPoolOverallocation.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_POOL_OVERALLOCATION_FEATURES_NV;
       enabledFeatures.nvDescriptorPoolOverallocation.pNext = std::exchange(enabledFeatures.core.pNext, &enabledFeatures.nvDescriptorPoolOverallocation);
     }
+
+    if (devExtensions.nvLowLatency2.revision() >= 2)
+      enabledFeatures.nvLowLatency2 = VK_TRUE;
 
     if (devExtensions.nvRawAccessChains) {
       enabledFeatures.nvRawAccessChains.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAW_ACCESS_CHAINS_FEATURES_NV;
@@ -1332,6 +1336,8 @@ namespace dxvk {
       "\n  presentWait                            : ", features.khrPresentWait.presentWait ? "1" : "0",
       "\n", VK_NV_DESCRIPTOR_POOL_OVERALLOCATION_EXTENSION_NAME,
       "\n  descriptorPoolOverallocation           : ", features.nvDescriptorPoolOverallocation.descriptorPoolOverallocation ? "1" : "0",
+      "\n", VK_NV_LOW_LATENCY_2_EXTENSION_NAME,
+      "\n  extension supported                    : ", features.nvLowLatency2 ? "1" : "0",
       "\n", VK_NV_RAW_ACCESS_CHAINS_EXTENSION_NAME,
       "\n  shaderRawAccessChains                  : ", features.nvRawAccessChains.shaderRawAccessChains ? "1" : "0",
       "\n", VK_NVX_BINARY_IMPORT_EXTENSION_NAME,

--- a/src/dxvk/dxvk_cmdlist.h
+++ b/src/dxvk/dxvk_cmdlist.h
@@ -103,11 +103,13 @@ namespace dxvk {
      *
      * \param [in] device DXVK device
      * \param [in] queue Queue to submit to
+     * \param [in] frameId Latency frame ID
      * \returns Submission return value
      */
     VkResult submit(
             DxvkDevice*           device,
-            VkQueue               queue);
+            VkQueue               queue,
+            uint64_t              frameId);
 
     /**
      * \brief Resets object
@@ -215,11 +217,13 @@ namespace dxvk {
      *
      * \param [in] semaphores Timeline semaphore pair
      * \param [in] timelines Timeline semaphore values
+     * \param [in] frameId Latency frame ID
      * \returns Submission status
      */
     VkResult submit(
       const DxvkTimelineSemaphores&       semaphores,
-            DxvkTimelineSemaphoreValues&  timelines);
+            DxvkTimelineSemaphoreValues&  timelines,
+            uint64_t                      frameId);
     
     /**
      * \brief Stat counters

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -111,9 +111,9 @@ namespace dxvk {
 
 
   void DxvkContext::flushCommandList(DxvkSubmitStatus* status) {
-    m_device->submitCommandList(
-      this->endRecording(), status);
-    
+    m_device->submitCommandList(this->endRecording(),
+      nullptr, 0, status);
+
     this->beginRecording(
       m_device->createCommandList());
   }

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -113,7 +113,7 @@ namespace dxvk {
   void DxvkContext::beginLatencyTracking(
     const Rc<DxvkLatencyTracker>&     tracker,
           uint64_t                    frameId) {
-    if (tracker && !m_latencyTracker) {
+    if (tracker && (!m_latencyTracker || m_latencyTracker == tracker)) {
       tracker->notifyCsRenderBegin(frameId);
 
       m_latencyTracker = tracker;

--- a/src/dxvk/dxvk_context.h
+++ b/src/dxvk/dxvk_context.h
@@ -4,6 +4,7 @@
 #include "dxvk_bind_mask.h"
 #include "dxvk_cmdlist.h"
 #include "dxvk_context_state.h"
+#include "dxvk_latency.h"
 #include "dxvk_objects.h"
 #include "dxvk_queue.h"
 #include "dxvk_util.h"
@@ -67,6 +68,30 @@ namespace dxvk {
      * final call to \ref endRecording.
      */
     void endFrame();
+
+    /**
+     * \brief Begins latency tracking
+     *
+     * Notifies the beginning of a frame on the CS timeline
+     * an ensures that subsequent submissions are associated
+     * with the correct frame ID. Only one tracker can be
+     * active at any given time.
+     * \param [in] tracker Latency tracker object
+     * \param [in] frameId Current frame ID
+     */
+    void beginLatencyTracking(
+      const Rc<DxvkLatencyTracker>&     tracker,
+            uint64_t                    frameId);
+
+    /**
+     * \brief Ends latency tracking
+     *
+     * Notifies the end of the frame. Ignored if the
+     * tracker is not currently active.
+     * \param [in] tracker Latency tracker object
+     */
+    void endLatencyTracking(
+      const Rc<DxvkLatencyTracker>&     tracker);
 
     /**
      * \brief Flushes command buffer
@@ -1420,6 +1445,10 @@ namespace dxvk {
 
     std::vector<util::DxvkDebugLabel> m_debugLabelStack;
     bool                              m_debugLabelInternalActive = false;
+
+    Rc<DxvkLatencyTracker>  m_latencyTracker;
+    uint64_t                m_latencyFrameId = 0u;
+    bool                    m_endLatencyTracking = false;
 
     void blitImageFb(
             Rc<DxvkImageView>     dstView,

--- a/src/dxvk/dxvk_device.cpp
+++ b/src/dxvk/dxvk_device.cpp
@@ -1,6 +1,7 @@
 #include "dxvk_device.h"
 #include "dxvk_instance.h"
 #include "dxvk_latency_builtin.h"
+#include "dxvk_latency_reflex.h"
 
 namespace dxvk {
   
@@ -308,8 +309,15 @@ namespace dxvk {
 
   Rc<DxvkLatencyTracker> DxvkDevice::createLatencyTracker(
     const Rc<Presenter>&            presenter) {
-    if (m_options.latencySleep != Tristate::True)
+    if (m_options.latencySleep == Tristate::False)
       return nullptr;
+
+    if (m_options.latencySleep == Tristate::Auto) {
+      if (m_features.nvLowLatency2)
+        return new DxvkReflexLatencyTrackerNv(presenter);
+      else
+        return nullptr;
+    }
 
     return new DxvkBuiltInLatencyTracker(presenter,
       m_options.latencyTolerance, m_features.nvLowLatency2);

--- a/src/dxvk/dxvk_device.cpp
+++ b/src/dxvk/dxvk_device.cpp
@@ -318,12 +318,18 @@ namespace dxvk {
 
   void DxvkDevice::presentImage(
     const Rc<Presenter>&            presenter,
+    const Rc<DxvkLatencyTracker>&   tracker,
           uint64_t                  frameId,
           DxvkSubmitStatus*         status) {
     DxvkPresentInfo presentInfo = { };
     presentInfo.presenter = presenter;
     presentInfo.frameId = frameId;
-    m_submissionQueue.present(presentInfo, status);
+
+    DxvkLatencyInfo latencyInfo;
+    latencyInfo.tracker = tracker;
+    latencyInfo.frameId = frameId;
+
+    m_submissionQueue.present(presentInfo, latencyInfo, status);
     
     std::lock_guard<sync::Spinlock> statLock(m_statLock);
     m_statCounters.addCtr(DxvkStatCounter::QueuePresentCount, 1);
@@ -332,10 +338,17 @@ namespace dxvk {
 
   void DxvkDevice::submitCommandList(
     const Rc<DxvkCommandList>&      commandList,
+    const Rc<DxvkLatencyTracker>&   tracker,
+          uint64_t                  frameId,
           DxvkSubmitStatus*         status) {
     DxvkSubmitInfo submitInfo = { };
     submitInfo.cmdList = commandList;
-    m_submissionQueue.submit(submitInfo, status);
+
+    DxvkLatencyInfo latencyInfo;
+    latencyInfo.tracker = tracker;
+    latencyInfo.frameId = frameId;
+
+    m_submissionQueue.submit(submitInfo, latencyInfo, status);
 
     std::lock_guard<sync::Spinlock> statLock(m_statLock);
     m_statCounters.merge(commandList->statCounters());

--- a/src/dxvk/dxvk_device.cpp
+++ b/src/dxvk/dxvk_device.cpp
@@ -311,8 +311,8 @@ namespace dxvk {
     if (m_options.latencySleep != Tristate::True)
       return nullptr;
 
-    return new DxvkBuiltInLatencyTracker(
-      m_options.latencyTolerance);
+    return new DxvkBuiltInLatencyTracker(presenter,
+      m_options.latencyTolerance, m_features.nvLowLatency2);
   }
 
 

--- a/src/dxvk/dxvk_device.cpp
+++ b/src/dxvk/dxvk_device.cpp
@@ -1,5 +1,6 @@
 #include "dxvk_device.h"
 #include "dxvk_instance.h"
+#include "dxvk_latency_builtin.h"
 
 namespace dxvk {
   
@@ -302,6 +303,16 @@ namespace dxvk {
   void DxvkDevice::requestCompileShader(
     const Rc<DxvkShader>&           shader) {
     m_objects.pipelineManager().requestCompileShader(shader);
+  }
+
+
+  Rc<DxvkLatencyTracker> DxvkDevice::createLatencyTracker(
+    const Rc<Presenter>&            presenter) {
+    if (m_options.latencySleep != Tristate::True)
+      return nullptr;
+
+    return new DxvkBuiltInLatencyTracker(
+      m_options.latencyTolerance);
   }
 
 

--- a/src/dxvk/dxvk_device.h
+++ b/src/dxvk/dxvk_device.h
@@ -10,6 +10,7 @@
 #include "dxvk_framebuffer.h"
 #include "dxvk_image.h"
 #include "dxvk_instance.h"
+#include "dxvk_latency.h"
 #include "dxvk_memory.h"
 #include "dxvk_meta_clear.h"
 #include "dxvk_objects.h"
@@ -477,6 +478,16 @@ namespace dxvk {
      */
     void requestCompileShader(
       const Rc<DxvkShader>&         shader);
+
+    /**
+     * \brief Creates latency tracker for a presenter
+     *
+     * The specicfic implementation and parameters used
+     * depend on user configuration.
+     * \param [in] presenter Presenter instance
+     */
+    Rc<DxvkLatencyTracker> createLatencyTracker(
+      const Rc<Presenter>&            presenter);
 
     /**
      * \brief Presents a swap chain image

--- a/src/dxvk/dxvk_device.h
+++ b/src/dxvk/dxvk_device.h
@@ -496,11 +496,13 @@ namespace dxvk {
      * the submission thread. The status of this operation
      * can be retrieved with \ref waitForSubmission.
      * \param [in] presenter The presenter
-     * \param [in] frameId Optional frame ID
+     * \param [in] tracker Latency tracker
+     * \param [in] frameId Frame ID
      * \param [out] status Present status
      */
     void presentImage(
       const Rc<Presenter>&            presenter,
+      const Rc<DxvkLatencyTracker>&   tracker,
             uint64_t                  frameId,
             DxvkSubmitStatus*         status);
     
@@ -510,10 +512,14 @@ namespace dxvk {
      * Submits the given command list to the device using
      * the given set of optional synchronization primitives.
      * \param [in] commandList The command list to submit
+     * \param [in] tracker Latency tracker
+     * \param [in] frameId Frame ID
      * \param [out] status Submission feedback
      */
     void submitCommandList(
       const Rc<DxvkCommandList>&      commandList,
+      const Rc<DxvkLatencyTracker>&   tracker,
+            uint64_t                  frameId,
             DxvkSubmitStatus*         status);
 
     /**

--- a/src/dxvk/dxvk_device_info.h
+++ b/src/dxvk/dxvk_device_info.h
@@ -73,6 +73,7 @@ namespace dxvk {
     VkPhysicalDevicePresentIdFeaturesKHR                      khrPresentId;
     VkPhysicalDevicePresentWaitFeaturesKHR                    khrPresentWait;
     VkPhysicalDeviceDescriptorPoolOverallocationFeaturesNV    nvDescriptorPoolOverallocation;
+    VkBool32                                                  nvLowLatency2;
     VkPhysicalDeviceRawAccessChainsFeaturesNV                 nvRawAccessChains;
     VkBool32                                                  nvxBinaryImport;
     VkBool32                                                  nvxImageViewHandle;

--- a/src/dxvk/dxvk_extensions.h
+++ b/src/dxvk/dxvk_extensions.h
@@ -327,6 +327,7 @@ namespace dxvk {
     DxvkExt khrSwapchain                      = { VK_KHR_SWAPCHAIN_EXTENSION_NAME,                          DxvkExtMode::Required };
     DxvkExt khrWin32KeyedMutex                = { VK_KHR_WIN32_KEYED_MUTEX_EXTENSION_NAME,                  DxvkExtMode::Optional };
     DxvkExt nvDescriptorPoolOverallocation    = { VK_NV_DESCRIPTOR_POOL_OVERALLOCATION_EXTENSION_NAME,      DxvkExtMode::Optional };
+    DxvkExt nvLowLatency2                     = { VK_NV_LOW_LATENCY_2_EXTENSION_NAME,                       DxvkExtMode::Optional };
     DxvkExt nvRawAccessChains                 = { VK_NV_RAW_ACCESS_CHAINS_EXTENSION_NAME,                   DxvkExtMode::Optional };
     DxvkExt nvxBinaryImport                   = { VK_NVX_BINARY_IMPORT_EXTENSION_NAME,                      DxvkExtMode::Disabled };
     DxvkExt nvxImageViewHandle                = { VK_NVX_IMAGE_VIEW_HANDLE_EXTENSION_NAME,                  DxvkExtMode::Disabled };

--- a/src/dxvk/dxvk_latency.h
+++ b/src/dxvk/dxvk_latency.h
@@ -23,6 +23,36 @@ namespace dxvk {
 
 
   /**
+   * \brief Timings for a single tracked frame
+   */
+  struct DxvkLatencyFrameData {
+    using time_point = dxvk::high_resolution_clock::time_point;
+    using duration = dxvk::high_resolution_clock::duration;
+
+    uint64_t    frameId         = 0u;
+    uint64_t    appFrameId      = 0u;
+    time_point  frameStart      = time_point();
+    time_point  frameEnd        = time_point();
+    time_point  cpuInputSample  = time_point();
+    time_point  cpuSimBegin     = time_point();
+    time_point  cpuSimEnd       = time_point();
+    time_point  cpuRenderBegin  = time_point();
+    time_point  cpuRenderEnd    = time_point();
+    time_point  cpuPresentBegin = time_point();
+    time_point  cpuPresentEnd   = time_point();
+    time_point  queueSubmit     = time_point();
+    time_point  queuePresent    = time_point();
+    time_point  gpuExecStart    = time_point();
+    time_point  gpuExecEnd      = time_point();
+    time_point  gpuIdleStart    = time_point();
+    time_point  gpuIdleEnd      = time_point();
+    duration    gpuIdleTime     = duration(0u);
+    duration    sleepDuration   = duration(0u);
+    VkResult    presentStatus   = VK_NOT_READY;
+  };
+
+
+  /**
    * \brief Latency tracker
    *
    * Accumulates time stamps of certain parts of a frame.

--- a/src/dxvk/dxvk_latency.h
+++ b/src/dxvk/dxvk_latency.h
@@ -1,0 +1,193 @@
+#pragma once
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+
+#include "../util/util_likely.h"
+#include "../util/util_time.h"
+
+#include "../util/rc/util_rc_ptr.h"
+
+#include "../vulkan/vulkan_loader.h"
+
+namespace dxvk {
+
+  /**
+   * \brief Latency tracker statistics
+   */
+  struct DxvkLatencyStats {
+    std::chrono::microseconds frameLatency;
+    std::chrono::microseconds sleepDuration;
+  };
+
+
+  /**
+   * \brief Latency tracker
+   *
+   * Accumulates time stamps of certain parts of a frame.
+   */
+  class DxvkLatencyTracker {
+
+  public:
+
+    virtual ~DxvkLatencyTracker() { }
+
+    /**
+     * \brief Increments ref count
+     */
+    void incRef() {
+      m_refCount.fetch_add(1, std::memory_order_acquire);
+    }
+
+    /**
+     * \brief Decrements ref count
+     *
+     * Destroys the object when there are no users left.
+     */
+    void decRef() {
+      if (m_refCount.fetch_sub(1, std::memory_order_release) == 1u)
+        delete this;
+    }
+
+    /**
+     * \brief Checks whether automatic markers are needed
+     *
+     * Relevant for forwarding the latency tracker to the context.
+     * \returns \c true if automatic markers are necessary.
+     */
+    virtual bool needsAutoMarkers() = 0;
+
+    /**
+     * \brief Called when presentation begins on the CPU timeline
+     *
+     * Must happen before acquiring an image from the presenter.
+     * \param [in] frameId Current frame ID
+     */
+    virtual void notifyCpuPresentBegin(
+            uint64_t                  frameId) = 0;
+
+    /**
+     * \brief Called when the CS thread reaches a given frame
+     *
+     * Should be recorded into the CS thread after completing
+     * the previous frame on the application's CPU timeline.
+     * \param [in] frameId Current frame ID
+     */
+    virtual void notifyCsRenderBegin(
+            uint64_t                  frameId) = 0;
+
+    /**
+     * \brief Called when the CS thread completes a frame
+     *
+     * Should be recorded into the CS thread after recording
+     * presentation commands for that frame.
+     * \param [in] frameId Current frame ID
+     */
+    virtual void notifyCsRenderEnd(
+            uint64_t                  frameId) = 0;
+
+    /**
+     * \brief Called when presentation ends on the CPU timeline
+     *
+     * Must happen after acquiring an image for presentation, but
+     * before synchronizing with previous frames or performing
+     * latency sleep. The intention is to measure acquire delays.
+     * \param [in] frameId Current frame ID
+     */
+    virtual void notifyCpuPresentEnd(
+            uint64_t                  frameId) = 0;
+
+    /**
+     * \brief Called when a command list is submitted to the GPU
+     *
+     * \param [in] frameId Associated frame ID
+     */
+    virtual void notifyQueueSubmit(
+            uint64_t                  frameId) = 0;
+
+    /**
+     * \brief Called when a frame is queued for presentation
+     *
+     * \param [in] frameId Associated frame ID
+     */
+    virtual void notifyQueuePresentBegin(
+            uint64_t                  frameId) = 0;
+
+    /**
+     * \brief Called after a frame has been queued for presentation
+     *
+     * \param [in] frameId Associated frame ID
+     * \param [in] status Result of the present operation
+     */
+    virtual void notifyQueuePresentEnd(
+            uint64_t                  frameId,
+            VkResult                  status) = 0;
+
+    /**
+     * \brief Called when a submission begins execution on the GPU
+     *
+     * Any previous submissions will have completed by this time. This
+     * can be used to measure GPU idle time throughout a frame.
+     * \param [in] frameId Associated frame ID
+     */
+    virtual void notifyGpuExecutionBegin(
+            uint64_t                  frameId) = 0;
+
+    /**
+     * \brief Called when a submission completes execution on the GPU
+     *
+     * The previous submission will have completed by the time this
+     * gets called. This may be used to measure GPU idle time.
+     * \param [in] frameId Associated frame ID
+     */
+    virtual void notifyGpuExecutionEnd(
+            uint64_t                  frameId) = 0;
+
+    /**
+     * \brief Called when presentation of a given frame finishes on the GPU
+     *
+     * This is generally the last thing that happens within a frame.
+     * \param [in] frameId Associated frame ID
+     */
+    virtual void notifyGpuPresentEnd(
+            uint64_t                  frameId) = 0;
+
+    /**
+     * \brief Performs latency sleep and begins next frame
+     *
+     * Uses latency data from previous frames to estimate when to wake
+     * up the application thread in order to minimize input latency.
+     * \param [in] frameId Frame ID of the upcoming frame
+     * \param [in] maxFrameRate Maximum frame rate or refresh rate
+     */
+    virtual void sleepAndBeginFrame(
+            uint64_t                  frameId,
+            double                    maxFrameRate) = 0;
+
+    /**
+     * \brief Discards all current timing data
+     *
+     * Should be called to reset latency tracking in case
+     * presentation failed for any given frame.
+     */
+    virtual void discardTimings() = 0;
+
+    /**
+     * \brief Queries statistics for the given frame
+     *
+     * Returns statistics for the frame closest to \c frameId for
+     * which data is available. If no such frame exists, the stat
+     * counters will return 0.
+     * \param [in] frameId Frame to query
+     */
+    virtual DxvkLatencyStats getStatistics(
+            uint64_t                  frameId) = 0;
+
+  private:
+
+    std::atomic<uint64_t> m_refCount = { 0u };
+
+  };
+
+}

--- a/src/dxvk/dxvk_latency_builtin.cpp
+++ b/src/dxvk/dxvk_latency_builtin.cpp
@@ -1,0 +1,340 @@
+#include <cmath>
+
+#include "dxvk_latency_builtin.h"
+
+#include "../util/log/log.h"
+
+#include "../util/util_fps_limiter.h"
+#include "../util/util_string.h"
+
+namespace dxvk {
+
+  DxvkBuiltInLatencyTracker::DxvkBuiltInLatencyTracker(
+          int32_t                   toleranceUs)
+  : m_tolerance(std::chrono::duration_cast<duration>(
+      std::chrono::microseconds(std::max(toleranceUs, 0)))) {
+    Logger::info("Latency control enabled, using built-in algorithm");
+    auto limit = FpsLimiter::getEnvironmentOverride();
+
+    if (limit)
+      m_envFpsLimit = *limit;
+  }
+
+
+  DxvkBuiltInLatencyTracker::~DxvkBuiltInLatencyTracker() {
+
+  }
+
+
+  bool DxvkBuiltInLatencyTracker::needsAutoMarkers() {
+    return true;
+  }
+
+
+  void DxvkBuiltInLatencyTracker::notifyCpuPresentBegin(
+          uint64_t                  frameId) {
+    std::unique_lock lock(m_mutex);
+    auto frame = findFrame(frameId);
+
+    if (frame)
+      frame->cpuPresentBegin = dxvk::high_resolution_clock::now();
+  }
+
+
+  void DxvkBuiltInLatencyTracker::notifyCpuPresentEnd(
+          uint64_t                  frameId) {
+    std::unique_lock lock(m_mutex);
+    auto frame = findFrame(frameId);
+
+    if (frame)
+      frame->cpuPresentEnd = dxvk::high_resolution_clock::now();
+  }
+
+
+  void DxvkBuiltInLatencyTracker::notifyCsRenderBegin(
+          uint64_t                  frameId) {
+    // Not interesting here
+  }
+
+
+  void DxvkBuiltInLatencyTracker::notifyCsRenderEnd(
+          uint64_t                  frameId) {
+    // Not interesting here
+  }
+
+
+  void DxvkBuiltInLatencyTracker::notifyQueueSubmit(
+          uint64_t                  frameId) {
+    std::unique_lock lock(m_mutex);
+    auto frame = findFrame(frameId);
+
+    if (frame && frame->queueSubmit == time_point())
+      frame->queueSubmit = dxvk::high_resolution_clock::now();
+  }
+
+
+  void DxvkBuiltInLatencyTracker::notifyQueuePresentBegin(
+          uint64_t                  frameId) {
+    // Not overly interesting
+  }
+
+
+  void DxvkBuiltInLatencyTracker::notifyQueuePresentEnd(
+          uint64_t                  frameId,
+          VkResult                  status) {
+    std::unique_lock lock(m_mutex);
+    auto frame = findFrame(frameId);
+
+    if (frame) {
+      frame->presentStatus = status;
+      frame->queuePresent = dxvk::high_resolution_clock::now();
+    }
+
+    m_cond.notify_one();
+  }
+
+
+  void DxvkBuiltInLatencyTracker::notifyGpuExecutionBegin(
+          uint64_t                  frameId) {
+    std::unique_lock lock(m_mutex);
+    auto frame = findFrame(frameId);
+
+    if (frame) {
+      auto now = dxvk::high_resolution_clock::now();
+
+      if (frame->gpuExecStart == time_point())
+        frame->gpuExecStart = now;
+
+      if (frame->gpuIdleStart != time_point()) {
+        frame->gpuIdleTime += now - frame->gpuIdleStart;
+        frame->gpuIdleEnd = now;
+      }
+    }
+  }
+
+
+  void DxvkBuiltInLatencyTracker::notifyGpuExecutionEnd(
+          uint64_t                  frameId) {
+    std::unique_lock lock(m_mutex);
+    auto frame = findFrame(frameId);
+
+    if (frame) {
+      auto now = dxvk::high_resolution_clock::now();
+
+      frame->gpuExecEnd = now;
+      frame->gpuIdleStart = now;
+    }
+  }
+
+
+  void DxvkBuiltInLatencyTracker::notifyGpuPresentEnd(
+          uint64_t                  frameId) {
+    std::unique_lock lock(m_mutex);
+    auto frame = findFrame(frameId);
+
+    if (frame)
+      frame->frameEnd = dxvk::high_resolution_clock::now();
+
+    m_cond.notify_one();
+  }
+
+
+  void DxvkBuiltInLatencyTracker::sleepAndBeginFrame(
+          uint64_t                  frameId,
+          double                    maxFrameRate) {
+    auto duration = sleep(frameId, maxFrameRate);
+
+    std::unique_lock lock(m_mutex);
+
+    auto next = initFrame(frameId);
+    next->frameStart = dxvk::high_resolution_clock::now();
+    next->sleepDuration = duration;
+  }
+
+
+  void DxvkBuiltInLatencyTracker::discardTimings() {
+    std::unique_lock lock(m_mutex);
+    m_validRangeBegin = m_validRangeEnd + 1u;
+  }
+
+
+  DxvkLatencyStats DxvkBuiltInLatencyTracker::getStatistics(
+          uint64_t                  frameId) {
+    std::unique_lock lock(m_mutex);
+
+    DxvkLatencyStats stats = { };
+
+    while (frameId && frameId >= m_validRangeBegin) {
+      auto f = findFrame(frameId--);
+
+      if (f && f->frameEnd != time_point()) {
+        stats.frameLatency = std::chrono::duration_cast<std::chrono::microseconds>(f->frameEnd - f->frameStart);
+        stats.sleepDuration = std::chrono::duration_cast<std::chrono::microseconds>(f->sleepDuration);
+        break;
+      }
+    }
+
+    return stats;
+  }
+
+
+  DxvkBuiltInLatencyTracker::duration DxvkBuiltInLatencyTracker::sleep(
+          uint64_t                  frameId,
+          double                    maxFrameRate) {
+    // Wait for all relevant timings to become available. This should
+    // generally not stall for very long if a maximum frame latency of
+    // 1 is enforced correctly by the swap chain.
+    std::unique_lock lock(m_mutex);
+
+    for (uint32_t i = 2; i <= FrameCount; i++) {
+      auto f = findFrame(frameId - i);
+
+      if (!f || f->cpuPresentEnd == time_point())
+        return duration(0u);
+
+      m_cond.wait(lock, [f] {
+        return f->frameEnd != time_point();
+      });
+    }
+
+    // Wait for the current frame's present call to be processed. Our
+    // algorithm will otherwise get confused if Present stalls or if
+    // any CPU work from previous frames delays GPU execution of the
+    // current frame.
+    auto curr = findFrame(frameId - 1u);
+
+    if (curr && curr->cpuPresentEnd != time_point()) {
+      m_cond.wait(lock, [curr] {
+        return curr->presentStatus != VK_NOT_READY;
+      });
+    }
+
+    // Frame entry of the last frame that fully completed
+    auto prev = findFrame(frameId - 2u);
+
+    // The way we want to align subsequent frames depends on whether
+    // we are limited by GPU performance or display refresh.
+    //
+    // In either case, we estimate the amount of CPU time the game requires
+    // before any GPU work can start to be the delay between frame start and
+    // first submission, plus any GPU idle time during the frame. This is not
+    // accurate if there are forced GPU sync points, but we can't work around
+    // that in a meaningful way.
+    constexpr size_t EntryCount = FrameCount - 1u;
+
+    std::array<duration, EntryCount> cpuTimes = { };
+    std::array<duration, EntryCount> gpuTimes = { };
+
+    for (uint32_t i = 0; i < EntryCount; i++) {
+      auto f = findFrame(frameId - (i + 2u));
+
+      cpuTimes[i] = (f->queueSubmit - f->frameStart) + f->gpuIdleTime;
+      gpuTimes[i] = (f->gpuExecEnd - f->gpuExecStart) - f->gpuIdleTime;
+    }
+
+    duration nextCpuTime = estimateTime(cpuTimes.data(), cpuTimes.size());
+    duration nextGpuTime = estimateTime(gpuTimes.data(), gpuTimes.size());
+
+    // Compute the initial deadline based on GPU execution times
+    time_point gpuDeadline = prev->gpuExecEnd + 2u * nextGpuTime;
+
+    // If we're rendering faster than refresh, use present_wait timings from
+    // previous frames as a starting point and compute an average in order to
+    // account for potentially erratic present_wait delays.
+    duration frameInterval = computeFrameInterval(maxFrameRate);
+
+    if (frameInterval.count()) {
+      duration nextPresentFromPrev = duration(0u);
+
+      for (uint32_t i = 2; i <= FrameCount; i++) {
+        auto f = findFrame(frameId - i);
+
+        time_point deadline = f->frameEnd + i * frameInterval - m_tolerance;
+        nextPresentFromPrev += deadline - prev->frameEnd;
+      }
+
+      time_point wsiDeadline = prev->frameEnd + (nextPresentFromPrev / int32_t(FrameCount - 1u));
+      gpuDeadline = std::max(gpuDeadline, wsiDeadline);
+    }
+
+    // Line up the next frame in such a way that the first GPU submission
+    // happens just before the current frame's final submission completes
+    time_point gpuStartTime = gpuDeadline - nextGpuTime;
+    time_point cpuStartTime = gpuStartTime - nextCpuTime - m_tolerance;
+
+    time_point now = dxvk::high_resolution_clock::now();
+
+    // Release lock before actually sleeping, or
+    // it will affect the time measurements.
+    lock.unlock();
+
+    Sleep::sleepUntil(now, cpuStartTime);
+    return std::max(duration(0u), cpuStartTime - now);
+  }
+
+
+  DxvkLatencyFrameData* DxvkBuiltInLatencyTracker::initFrame(
+          uint64_t                  frameId) {
+    if (m_validRangeEnd + 1u != frameId)
+      m_validRangeBegin = frameId;
+
+    if (m_validRangeBegin + FrameCount <= frameId)
+      m_validRangeBegin = frameId + 1u - FrameCount;
+
+    m_validRangeEnd = frameId;
+
+    auto& frame = m_frames[frameId % FrameCount];
+    frame = DxvkLatencyFrameData();
+    frame.frameId = frameId;
+    return &frame;
+  }
+
+
+  DxvkLatencyFrameData* DxvkBuiltInLatencyTracker::findFrame(
+          uint64_t                  frameId) {
+    return frameId >= m_validRangeBegin && frameId <= m_validRangeEnd
+      ? &m_frames[frameId % FrameCount]
+      : nullptr;
+  }
+
+
+  DxvkBuiltInLatencyTracker::duration DxvkBuiltInLatencyTracker::computeFrameInterval(
+          double                    maxFrameRate) {
+    if (m_envFpsLimit > 0.0)
+      maxFrameRate = m_envFpsLimit;
+
+    return computeIntervalFromRate(maxFrameRate);
+  }
+
+
+  DxvkBuiltInLatencyTracker::duration DxvkBuiltInLatencyTracker::computeIntervalFromRate(
+          double                    frameRate) {
+    if (frameRate <= 0.0 || !std::isnormal(frameRate))
+      return duration(0u);
+
+    uint64_t ns = uint64_t(1'000'000'000.0 / frameRate);
+    return std::chrono::duration_cast<duration>(std::chrono::nanoseconds(ns));
+  }
+
+
+  DxvkBuiltInLatencyTracker::duration DxvkBuiltInLatencyTracker::estimateTime(
+    const duration*                 frames,
+          size_t                    frameCount) {
+    // For each frame, find the median of its neighbours, then
+    // use the maximum of those medians as our estimate.
+    duration result = duration(0u);
+
+    for (size_t i = 0u; i < frameCount - 2u; i++) {
+      duration a = frames[i];
+      duration b = frames[i + 1];
+      duration c = frames[i + 2];
+
+      duration min = std::min(std::min(a, b), c);
+      duration max = std::max(std::max(a, b), c);
+
+      result = std::max(result, a + b + c - min - max);
+    }
+
+    return result;
+  }
+}

--- a/src/dxvk/dxvk_latency_builtin.h
+++ b/src/dxvk/dxvk_latency_builtin.h
@@ -1,0 +1,138 @@
+#pragma once
+
+#include <array>
+
+#include "dxvk_latency.h"
+
+#include "../util/thread.h"
+
+#include "../util/util_sleep.h"
+#include "../util/util_time.h"
+
+#include "../util/config/config.h"
+
+#include "../util/sync/sync_spinlock.h"
+
+namespace dxvk {
+
+  /**
+   * \brief Timings for a single tracked frame
+   */
+  struct DxvkLatencyFrameData {
+    using time_point = dxvk::high_resolution_clock::time_point;
+    using duration = dxvk::high_resolution_clock::duration;
+
+    uint64_t    frameId         = 0u;
+    time_point  frameStart      = time_point();
+    time_point  frameEnd        = time_point();
+    time_point  cpuPresentBegin = time_point();
+    time_point  cpuPresentEnd   = time_point();
+    time_point  queueSubmit     = time_point();
+    time_point  queuePresent    = time_point();
+    time_point  gpuExecStart    = time_point();
+    time_point  gpuExecEnd      = time_point();
+    time_point  gpuIdleStart    = time_point();
+    time_point  gpuIdleEnd      = time_point();
+    duration    gpuIdleTime     = duration(0u);
+    duration    sleepDuration   = duration(0u);
+    VkResult    presentStatus   = VK_NOT_READY;
+  };
+
+
+  /**
+   * \brief Built-in latency tracker
+   *
+   * Implements a simple latency reduction algorithm
+   * based on CPU timestamps received from the backend.
+   */
+  class DxvkBuiltInLatencyTracker : public DxvkLatencyTracker {
+    using time_point = typename DxvkLatencyFrameData::time_point;
+    using duration = typename DxvkLatencyFrameData::duration;
+
+    constexpr static size_t FrameCount = 8u;
+  public:
+
+    DxvkBuiltInLatencyTracker(
+            int32_t                   toleranceUs);
+
+    ~DxvkBuiltInLatencyTracker();
+
+    bool needsAutoMarkers();
+
+    void notifyCpuPresentBegin(
+            uint64_t                  frameId);
+
+    void notifyCpuPresentEnd(
+            uint64_t                  frameId);
+
+    void notifyCsRenderBegin(
+            uint64_t                  frameId);
+
+    void notifyCsRenderEnd(
+            uint64_t                  frameId);
+
+    void notifyQueueSubmit(
+            uint64_t                  frameId);
+
+    void notifyQueuePresentBegin(
+            uint64_t                  frameId);
+
+    void notifyQueuePresentEnd(
+            uint64_t                  frameId,
+            VkResult                  status);
+
+    void notifyGpuExecutionBegin(
+            uint64_t                  frameId);
+
+    void notifyGpuExecutionEnd(
+            uint64_t                  frameId);
+
+    void notifyGpuPresentEnd(
+            uint64_t                  frameId);
+
+    void sleepAndBeginFrame(
+            uint64_t                  frameId,
+            double                    maxFrameRate);
+
+    void discardTimings();
+
+    DxvkLatencyStats getStatistics(
+            uint64_t                  frameId);
+
+  private:
+
+    dxvk::mutex               m_mutex;
+    dxvk::condition_variable  m_cond;
+
+    duration                  m_tolerance;
+
+    double                    m_envFpsLimit = 0.0;
+
+    std::array<DxvkLatencyFrameData, FrameCount> m_frames = { };
+
+    uint64_t m_validRangeBegin = 0u;
+    uint64_t m_validRangeEnd = 0u;
+
+    duration sleep(
+            uint64_t                  frameId,
+            double                    maxFrameRate);
+
+    DxvkLatencyFrameData* initFrame(
+            uint64_t                  frameId);
+
+    DxvkLatencyFrameData* findFrame(
+            uint64_t                  frameId);
+
+    duration computeFrameInterval(
+            double                    maxFrameRate);
+
+    static duration computeIntervalFromRate(
+            double                    frameRate);
+
+    static duration estimateTime(
+      const duration*                 frames,
+            size_t                    frameCount);
+
+  };
+
+}

--- a/src/dxvk/dxvk_latency_builtin.h
+++ b/src/dxvk/dxvk_latency_builtin.h
@@ -17,30 +17,6 @@
 namespace dxvk {
 
   /**
-   * \brief Timings for a single tracked frame
-   */
-  struct DxvkLatencyFrameData {
-    using time_point = dxvk::high_resolution_clock::time_point;
-    using duration = dxvk::high_resolution_clock::duration;
-
-    uint64_t    frameId         = 0u;
-    time_point  frameStart      = time_point();
-    time_point  frameEnd        = time_point();
-    time_point  cpuPresentBegin = time_point();
-    time_point  cpuPresentEnd   = time_point();
-    time_point  queueSubmit     = time_point();
-    time_point  queuePresent    = time_point();
-    time_point  gpuExecStart    = time_point();
-    time_point  gpuExecEnd      = time_point();
-    time_point  gpuIdleStart    = time_point();
-    time_point  gpuIdleEnd      = time_point();
-    duration    gpuIdleTime     = duration(0u);
-    duration    sleepDuration   = duration(0u);
-    VkResult    presentStatus   = VK_NOT_READY;
-  };
-
-
-  /**
    * \brief Built-in latency tracker
    *
    * Implements a simple latency reduction algorithm

--- a/src/dxvk/dxvk_latency_builtin.h
+++ b/src/dxvk/dxvk_latency_builtin.h
@@ -3,6 +3,7 @@
 #include <array>
 
 #include "dxvk_latency.h"
+#include "dxvk_presenter.h"
 
 #include "../util/thread.h"
 
@@ -53,7 +54,9 @@ namespace dxvk {
   public:
 
     DxvkBuiltInLatencyTracker(
-            int32_t                   toleranceUs);
+            Rc<Presenter>             presenter,
+            int32_t                   toleranceUs,
+            bool                      useNvLowLatency2);
 
     ~DxvkBuiltInLatencyTracker();
 
@@ -101,19 +104,26 @@ namespace dxvk {
 
   private:
 
+    Rc<Presenter>             m_presenter;
+
     dxvk::mutex               m_mutex;
     dxvk::condition_variable  m_cond;
 
     duration                  m_tolerance;
 
     double                    m_envFpsLimit = 0.0;
+    bool                      m_useNvLowLatency2 = false;
 
     std::array<DxvkLatencyFrameData, FrameCount> m_frames = { };
 
     uint64_t m_validRangeBegin = 0u;
     uint64_t m_validRangeEnd = 0u;
 
-    duration sleep(
+    duration sleepNv(
+            uint64_t                  frameId,
+            double                    maxFrameRate);
+
+    duration sleepBuiltin(
             uint64_t                  frameId,
             double                    maxFrameRate);
 

--- a/src/dxvk/dxvk_latency_reflex.cpp
+++ b/src/dxvk/dxvk_latency_reflex.cpp
@@ -1,0 +1,484 @@
+#include "dxvk_latency_reflex.h"
+
+namespace dxvk {
+
+  DxvkReflexLatencyTrackerNv::DxvkReflexLatencyTrackerNv(
+    const Rc<Presenter>&            presenter)
+  : m_presenter(presenter) {
+
+  }
+
+  DxvkReflexLatencyTrackerNv::~DxvkReflexLatencyTrackerNv() {
+
+  }
+
+
+  bool DxvkReflexLatencyTrackerNv::needsAutoMarkers() {
+    // In markerless mode we want to avoid submitting
+    // any markers at all and ignore the context
+    return false;
+  }
+
+
+  void DxvkReflexLatencyTrackerNv::notifyCpuPresentBegin(
+          uint64_t                  frameId) {
+    std::lock_guard lock(m_mutex);
+
+    if (m_lastPresentAppFrameId) {
+      uint64_t expectedFrameId = lookupFrameId(m_lastPresentAppFrameId);
+
+      if (frameId != expectedFrameId) {
+        // This is a normal occurence after a swapchain recreation, or if
+        // tracking got reset for any reason. Remap the current app frame
+        // to the current internal frame, and map any app frames with a
+        // higher frame ID to subsequent frame IDs in order to fix the
+        // mapping; we should catch up within a few frames.
+        Logger::warn(str::format("Reflex: Expected internal frame ID ",
+          expectedFrameId, " for ", m_lastPresentAppFrameId, ", got ", frameId));
+
+        uint64_t nextAppFrameId = m_lastPresentAppFrameId;
+        uint64_t nextDxvkFrameId = frameId;
+
+        auto entry = m_appToDxvkFrameIds.find(nextAppFrameId);
+
+        while (entry != m_appToDxvkFrameIds.end()) {
+          nextAppFrameId = entry->first;
+
+          mapFrameId(nextAppFrameId, nextDxvkFrameId++);
+
+          entry = m_appToDxvkFrameIds.upper_bound(nextAppFrameId);
+        }
+
+        m_nextAllocFrameId = nextDxvkFrameId;
+        m_nextValidFrameId = nextDxvkFrameId + 1u;
+      }
+
+      m_lowLatencyNoMarkers = false;
+    } else if (m_lowLatencyMode) {
+      // Game seemingly doesn't use markers?
+      if (!m_lowLatencyNoMarkers) {
+        Logger::warn("Reflex: No latency markers provided");
+        m_lowLatencyNoMarkers = true;
+        reset();
+      }
+
+      // Update sleep duration since we haven't had the chance yet
+      auto& frame = getFrameData(frameId);
+      frame.sleepDuration = m_lastSleepDuration;
+
+      m_lastSleepDuration = duration(0u);
+    }
+
+    m_lastPresentAppFrameId = 0u;
+  }
+
+
+  void DxvkReflexLatencyTrackerNv::notifyCpuPresentEnd(
+          uint64_t                  frameId) {
+    std::lock_guard lock(m_mutex);
+    m_lastPresentQueued = frameId;
+  }
+
+
+  void DxvkReflexLatencyTrackerNv::notifyCsRenderBegin(
+          uint64_t                  frameId) {
+    std::lock_guard lock(m_mutex);
+    auto& frame = getFrameData(frameId);
+
+    if (frame.appFrameId && frameId >= m_nextValidFrameId)
+      m_presenter->setLatencyMarkerNv(frameId, VK_LATENCY_MARKER_RENDERSUBMIT_START_NV);
+  }
+
+
+  void DxvkReflexLatencyTrackerNv::notifyCsRenderEnd(
+          uint64_t                  frameId) {
+    std::lock_guard lock(m_mutex);
+    auto& frame = getFrameData(frameId);
+
+    if (frame.appFrameId && frameId >= m_nextValidFrameId)
+      m_presenter->setLatencyMarkerNv(frameId, VK_LATENCY_MARKER_RENDERSUBMIT_END_NV);
+  }
+
+
+  void DxvkReflexLatencyTrackerNv::notifyQueueSubmit(
+          uint64_t                  frameId) {
+    std::lock_guard lock(m_mutex);
+    auto& frame = getFrameData(frameId);
+
+    if (frame.queueSubmit == time_point())
+      frame.queueSubmit = dxvk::high_resolution_clock::now();
+  }
+
+
+  void DxvkReflexLatencyTrackerNv::notifyQueuePresentBegin(
+          uint64_t                  frameId) {
+    std::lock_guard lock(m_mutex);
+    auto& frame = getFrameData(frameId);
+
+    if (frame.appFrameId && frameId >= m_nextValidFrameId)
+      m_presenter->setLatencyMarkerNv(frameId, VK_LATENCY_MARKER_PRESENT_START_NV);
+  }
+
+
+  void DxvkReflexLatencyTrackerNv::notifyQueuePresentEnd(
+          uint64_t                  frameId,
+          VkResult                  status) {
+    std::lock_guard lock(m_mutex);
+    auto& frame = getFrameData(frameId);
+
+    if (frame.appFrameId && frameId >= m_nextValidFrameId) {
+      frame.queuePresent = m_presenter->setLatencyMarkerNv(frameId, VK_LATENCY_MARKER_PRESENT_END_NV);
+      frame.presentStatus = status;
+    }
+
+    // Ignore errors or we might never wake up a waiting thread
+    m_lastPresentComplete = frameId;
+
+    m_cond.notify_all();
+  }
+
+
+  void DxvkReflexLatencyTrackerNv::notifyGpuExecutionBegin(
+          uint64_t                  frameId) {
+    std::lock_guard lock(m_mutex);
+
+    auto now = dxvk::high_resolution_clock::now();
+
+    auto& frame = getFrameData(frameId);
+    frame.gpuIdleEnd = now;
+
+    if (frame.gpuExecStart == time_point())
+      frame.gpuExecStart = now;
+
+    if (frame.gpuIdleStart != time_point())
+      frame.gpuIdleTime += frame.gpuIdleEnd - frame.gpuIdleStart;
+  }
+
+
+  void DxvkReflexLatencyTrackerNv::notifyGpuExecutionEnd(
+          uint64_t                  frameId) {
+    std::lock_guard lock(m_mutex);
+
+    auto now = dxvk::high_resolution_clock::now();
+
+    auto& frame = getFrameData(frameId);
+    frame.gpuExecEnd = now;
+    frame.gpuIdleStart = now;
+  }
+
+
+  void DxvkReflexLatencyTrackerNv::notifyGpuPresentEnd(
+          uint64_t                  frameId) {
+    std::lock_guard lock(m_mutex);
+
+    auto& frame = getFrameData(frameId);
+    frame.frameEnd = dxvk::high_resolution_clock::now();
+
+    m_lastCompletedFrameId = frameId;
+  }
+
+
+  void DxvkReflexLatencyTrackerNv::sleepAndBeginFrame(
+          uint64_t                  frameId,
+          double                    maxFrameRate) {
+    std::lock_guard lock(m_mutex);
+    m_lastNoMarkerFrameId = frameId;
+
+    if (m_lowLatencyMode) {
+      auto& frame = getFrameData(frameId);
+      frame.frameStart = dxvk::high_resolution_clock::now();
+    }
+  }
+
+
+  void DxvkReflexLatencyTrackerNv::discardTimings() {
+    std::lock_guard lock(m_mutex);
+    reset();
+  }
+
+
+  DxvkLatencyStats DxvkReflexLatencyTrackerNv::getStatistics(
+          uint64_t                  frameId) {
+    std::lock_guard lock(m_mutex);
+
+    if (!m_lastCompletedFrameId)
+      return DxvkLatencyStats();
+
+    auto& frame = getFrameData(m_lastCompletedFrameId);
+
+    if (frame.frameEnd == time_point())
+      return DxvkLatencyStats();
+
+    time_point frameStart = frame.cpuSimBegin;
+
+    if (frame.cpuInputSample != time_point())
+      frameStart = frame.cpuInputSample;
+
+    if (frameStart == time_point())
+      frameStart = frame.frameStart;
+
+    if (frameStart == time_point())
+      return DxvkLatencyStats();
+
+    DxvkLatencyStats stats = { };
+    stats.frameLatency = std::chrono::duration_cast<std::chrono::microseconds>(frame.frameEnd - frameStart);
+    stats.sleepDuration = std::chrono::duration_cast<std::chrono::microseconds>(frame.sleepDuration);
+    return stats;
+  }
+
+
+  void DxvkReflexLatencyTrackerNv::setLatencySleepMode(
+          bool                      enableLowLatency,
+          bool                      enableBoost,
+          uint64_t                  minIntervalUs) {
+    if (m_lowLatencyMode != enableLowLatency)
+      Logger::info(str::format("Reflex: Low latency mode ", enableLowLatency ? "enabled" : "disabled"));
+
+    VkLatencySleepModeInfoNV modeInfo = { VK_STRUCTURE_TYPE_LATENCY_SLEEP_MODE_INFO_NV };
+    modeInfo.lowLatencyMode = enableLowLatency;
+    modeInfo.lowLatencyBoost = enableBoost;
+    modeInfo.minimumIntervalUs = minIntervalUs;
+
+    m_presenter->setLatencySleepModeNv(modeInfo);
+
+    m_lowLatencyMode = enableLowLatency;
+  }
+
+
+  void DxvkReflexLatencyTrackerNv::setLatencyMarker(
+          uint64_t                  appFrameId,
+          VkLatencyMarkerNV         marker) {
+    std::lock_guard lock(m_mutex);
+
+    // Find frame ID. If this is the first marker in a new frame,
+    // try to map it to a new internal frame ID.
+    uint64_t frameId = lookupFrameId(appFrameId);
+
+    if (!frameId && (marker == VK_LATENCY_MARKER_SIMULATION_START_NV
+                  || marker == VK_LATENCY_MARKER_INPUT_SAMPLE_NV))
+      frameId = allocateFrameId(appFrameId);
+
+    // This can hapen if we reset tracking state and receive
+    // a stray present or render submit marker. Ignore these
+    // so that the next presents can recalibrate properly.
+    if (!frameId)
+      return;
+
+    // We use present markers to correlate app frame IDs
+    // with internal frame IDs, so always write this back.
+    if (marker == VK_LATENCY_MARKER_PRESENT_START_NV)
+      m_lastPresentAppFrameId = appFrameId;
+
+    // Don't submit markers for invalid frames since
+    // that could potentially confuse the algorithm
+    if (frameId < m_nextValidFrameId)
+      return;
+
+    auto& frame = getFrameData(frameId);
+
+    switch (marker) {
+      case VK_LATENCY_MARKER_INPUT_SAMPLE_NV:
+        frame.cpuInputSample = m_presenter->setLatencyMarkerNv(frameId, marker);
+        break;
+
+      case VK_LATENCY_MARKER_SIMULATION_START_NV:
+        frame.cpuSimBegin = m_presenter->setLatencyMarkerNv(frameId, marker);
+
+        if (m_lastSleepDuration != duration(0u))
+          frame.sleepDuration = std::exchange(m_lastSleepDuration, duration(0u));
+        break;
+
+      case VK_LATENCY_MARKER_SIMULATION_END_NV:
+        frame.cpuSimEnd = m_presenter->setLatencyMarkerNv(frameId, marker);
+        break;
+
+      case VK_LATENCY_MARKER_RENDERSUBMIT_START_NV:
+        frame.cpuRenderBegin = dxvk::high_resolution_clock::now();
+        break;
+
+      case VK_LATENCY_MARKER_RENDERSUBMIT_END_NV:
+        frame.cpuRenderEnd = dxvk::high_resolution_clock::now();
+        break;
+
+      case VK_LATENCY_MARKER_PRESENT_START_NV:
+        frame.cpuPresentBegin = dxvk::high_resolution_clock::now();
+        break;
+
+      case VK_LATENCY_MARKER_PRESENT_END_NV:
+        frame.cpuPresentEnd = dxvk::high_resolution_clock::now();
+        break;
+
+      default:
+        Logger::warn(str::format("Reflex: Unknown marker ", marker));
+    }
+  }
+
+
+  void DxvkReflexLatencyTrackerNv::latencySleep() {
+    { std::unique_lock lock(m_mutex);
+      // If the app doesn't use markers, wait for the previous present
+      // call to complete so that we don't confuse the algorithm by
+      // sleeping at random times relative to actual graphics work.
+      if (m_lowLatencyNoMarkers) {
+        m_cond.wait(lock, [this] {
+          return m_lastPresentComplete >= m_lastPresentQueued;
+        });
+      }
+    }
+
+    // Actually sleep and write back sleep duration for the next frame
+    auto sleepDuration = m_presenter->latencySleepNv();
+
+    std::lock_guard lock(m_mutex);
+    m_lastSleepAppFrameId = m_lastBeginAppFrameId;
+    m_lastSleepDuration = sleepDuration;
+
+    if (m_lowLatencyNoMarkers && m_lastNoMarkerFrameId > m_lastPresentQueued) {
+      // In markerless mode, assume that this gets called before any
+      // work is done for the next frame and update the frame start
+      // time accordingly.
+      auto& frame = getFrameData(m_lastNoMarkerFrameId);
+      frame.frameStart = dxvk::high_resolution_clock::now();
+    }
+  }
+
+
+  uint32_t DxvkReflexLatencyTrackerNv::getFrameReports(
+          uint32_t                  maxCount,
+          DxvkReflexFrameReport*    reports) {
+    std::lock_guard lock(m_mutex);
+
+    small_vector<VkLatencyTimingsFrameReportNV, 64> nvReports(maxCount);
+
+    for (uint32_t i = 0; i < maxCount; i++)
+      nvReports[i] = { VK_STRUCTURE_TYPE_LATENCY_TIMINGS_FRAME_REPORT_NV };
+
+    // Adjust some statistics so that we actually return the
+    // correct timestamps for the application-defined markers
+    uint32_t count = m_presenter->getLatencyTimingsNv(maxCount, nvReports.data());
+
+    for (uint32_t i = 0; i < count; i++) {
+      auto& report = nvReports[i];
+      const auto& currFrame = m_frames[report.presentID % FrameCount];
+
+      if (report.presentID != currFrame.frameId || report.presentID < m_nextValidFrameId)
+        return 0;
+
+      report.presentID = currFrame.appFrameId;
+
+      // These represent when the CS thread starts processing the frame
+      report.driverStartTimeUs = report.renderSubmitStartTimeUs;
+      report.driverEndTimeUs = report.renderSubmitEndTimeUs;
+
+      // Return when the app set these markers rather than the time when
+      // we forward them to the driver
+      report.renderSubmitStartTimeUs = mapFrameTimestampToReportUs(currFrame, report, currFrame.cpuRenderBegin);
+      report.renderSubmitEndTimeUs = mapFrameTimestampToReportUs(currFrame, report, currFrame.cpuRenderEnd);
+      report.presentStartTimeUs = mapFrameTimestampToReportUs(currFrame, report, currFrame.cpuPresentBegin);
+      report.presentEndTimeUs = mapFrameTimestampToReportUs(currFrame, report, currFrame.cpuPresentEnd);
+
+      // Documentation for the OS timers seems nonsensical, but it seems to
+      // be the time from the the first submission to the end of the frame
+      report.osRenderQueueStartTimeUs = mapFrameTimestampToReportUs(currFrame, report, currFrame.queueSubmit);
+      report.osRenderQueueEndTimeUs = report.gpuRenderEndTimeUs;
+
+      // Apparently gpuRenderEndTime is when presentation completes rather
+      // than rendering, so we need to compute the active render time using
+      // our own timestamps
+      auto gpuActiveTime = currFrame.gpuExecEnd - currFrame.gpuExecStart - currFrame.gpuIdleTime;
+
+      reports[i].report = report;
+      reports[i].gpuActiveTimeUs = std::max<uint64_t>(0u,
+        std::chrono::duration_cast<std::chrono::microseconds>(gpuActiveTime).count());
+    }
+
+    return count;
+  }
+
+
+  uint64_t DxvkReflexLatencyTrackerNv::frameIdFromAppFrameId(
+          uint64_t                  appFrameId) {
+    std::lock_guard lock(m_mutex);
+    return lookupFrameId(appFrameId);
+  }
+
+
+  DxvkReflexLatencyFrameData& DxvkReflexLatencyTrackerNv::getFrameData(
+          uint64_t                  dxvkFrameId) {
+    auto& frameData = m_frames[dxvkFrameId % FrameCount];
+
+    if (frameData.frameId != dxvkFrameId) {
+      m_appToDxvkFrameIds.erase(frameData.appFrameId);
+
+      frameData = DxvkReflexLatencyFrameData();
+      frameData.frameId = dxvkFrameId;
+    }
+
+    return frameData;
+  }
+
+
+  uint64_t DxvkReflexLatencyTrackerNv::lookupFrameId(
+          uint64_t                  appFrameId) {
+    auto entry = m_appToDxvkFrameIds.find(appFrameId);
+
+    if (entry == m_appToDxvkFrameIds.end())
+      return 0u;
+
+    return entry->second;
+  }
+
+
+  uint64_t DxvkReflexLatencyTrackerNv::allocateFrameId(
+          uint64_t                  appFrameId) {
+    if (appFrameId <= m_lastBeginAppFrameId) {
+      Logger::warn(str::format("Reflex: Frame ID ", appFrameId, " not monotonic, last was ", m_lastBeginAppFrameId));
+      reset();
+    }
+
+    uint64_t frameId = m_nextAllocFrameId++;
+    mapFrameId(appFrameId, frameId);
+
+    m_lastBeginAppFrameId = appFrameId;
+    return frameId;
+  }
+
+
+  void DxvkReflexLatencyTrackerNv::mapFrameId(
+          uint64_t                  appFrameId,
+          uint64_t                  dxvkFrameId) {
+    while (m_appToDxvkFrameIds.size() > FrameCount)
+      m_appToDxvkFrameIds.erase(m_appToDxvkFrameIds.begin());
+
+    m_appToDxvkFrameIds.insert_or_assign(appFrameId, dxvkFrameId);
+    getFrameData(dxvkFrameId).appFrameId = appFrameId;
+  }
+
+
+  void DxvkReflexLatencyTrackerNv::reset() {
+    m_nextValidFrameId = uint64_t(-1);
+
+    m_lastSleepDuration = duration(0u);
+
+    m_lastBeginAppFrameId = 0u;
+    m_lastPresentAppFrameId = 0u;
+
+    for (size_t i = 0; i < FrameCount; i++)
+      m_frames[i].appFrameId = 0u;
+
+    m_appToDxvkFrameIds.clear();
+  }
+
+
+  uint64_t DxvkReflexLatencyTrackerNv::mapFrameTimestampToReportUs(
+    const DxvkReflexLatencyFrameData&     frame,
+    const VkLatencyTimingsFrameReportNV&  report,
+          time_point                      timestamp) {
+    if (frame.cpuSimBegin == time_point() || !report.simStartTimeUs)
+      return 0u;
+
+    int64_t diffUs = std::chrono::duration_cast<std::chrono::microseconds>(timestamp - frame.cpuSimBegin).count();
+    return report.simStartTimeUs + diffUs;
+  }
+
+}

--- a/src/dxvk/dxvk_latency_reflex.h
+++ b/src/dxvk/dxvk_latency_reflex.h
@@ -1,0 +1,199 @@
+#pragma once
+
+#include <array>
+#include <map>
+
+#include "dxvk_latency.h"
+#include "dxvk_presenter.h"
+
+#include "../util/thread.h"
+
+#include "../util/util_sleep.h"
+#include "../util/util_time.h"
+
+#include "../util/config/config.h"
+
+#include "../util/sync/sync_spinlock.h"
+
+namespace dxvk {
+
+  /**
+   * \brief Reflex frame info
+   *
+   * Stores frame ID mapping and all sorts of time stamps
+   * that are used for latency sleep or frame reports.
+   */
+  using DxvkReflexLatencyFrameData = DxvkLatencyFrameData;
+
+
+  /**
+   * \brief Additional frame report info
+   */
+  struct DxvkReflexFrameReport {
+    VkLatencyTimingsFrameReportNV report;
+    uint64_t gpuActiveTimeUs;
+  };
+
+
+  /**
+   * \brief Built-in latency tracker based on VK_NV_low_latency2
+   *
+   * Implements a simple latency reduction algorithm
+   * based on CPU timestamps received from the backend.
+   */
+  class DxvkReflexLatencyTrackerNv : public DxvkLatencyTracker {
+    using time_point = typename DxvkReflexLatencyFrameData::time_point;
+    using duration = typename DxvkReflexLatencyFrameData::duration;
+
+    // Keep data for a large number of frames around to support
+    // retrieving statistics from the driver properly.
+    constexpr static size_t FrameCount = 256u;
+  public:
+
+    DxvkReflexLatencyTrackerNv(
+      const Rc<Presenter>&            presenter);
+
+    ~DxvkReflexLatencyTrackerNv();
+
+    bool needsAutoMarkers();
+
+    void notifyCpuPresentBegin(
+            uint64_t                  frameId);
+
+    void notifyCpuPresentEnd(
+            uint64_t                  frameId);
+
+    void notifyCsRenderBegin(
+            uint64_t                  frameId);
+
+    void notifyCsRenderEnd(
+            uint64_t                  frameId);
+
+    void notifyQueueSubmit(
+            uint64_t                  frameId);
+
+    void notifyQueuePresentBegin(
+            uint64_t                  frameId);
+
+    void notifyQueuePresentEnd(
+            uint64_t                  frameId,
+            VkResult                  status);
+
+    void notifyGpuExecutionBegin(
+            uint64_t                  frameId);
+
+    void notifyGpuExecutionEnd(
+            uint64_t                  frameId);
+
+    void notifyGpuPresentEnd(
+            uint64_t                  frameId);
+
+    void sleepAndBeginFrame(
+            uint64_t                  frameId,
+            double                    maxFrameRate);
+
+    void discardTimings();
+
+    DxvkLatencyStats getStatistics(
+            uint64_t                  frameId);
+
+    /**
+     * \brief Sets Reflex state
+     *
+     * \param [in] enableLowLatency Whether to enable latency control
+     * \param [in] enableBoost Whether to enable boost
+     * \param [in] minIntervalUs Minimum frame interval
+     */
+    void setLatencySleepMode(
+            bool                      enableLowLatency,
+            bool                      enableBoost,
+            uint64_t                  minIntervalUs);
+
+    /**
+     * \brief Sets latency marker from application
+     *
+     * \param [in] appFrameId Application-provided frame ID
+     * \param [in] marker Marker to set
+     */
+    void setLatencyMarker(
+            uint64_t                  appFrameId,
+            VkLatencyMarkerNV         marker);
+
+    /**
+     * \brief Performs latency sleep
+     */
+    void latencySleep();
+
+    /**
+     * \brief Retrieves frame reports
+     *
+     * \param [in] maxCount Maximum number of reports
+     * \param [out] reports Frame reports
+     * \returns Number of reports retrieved
+     */
+    uint32_t getFrameReports(
+            uint32_t                  maxCount,
+            DxvkReflexFrameReport*    reports);
+
+    /**
+     * \brief Looks up frame ID from application frame ID
+     *
+     * \param [in] appFrameId Application-provided frame ID
+     * \returns Internal frame ID, or 0 if none was found
+     */
+    uint64_t frameIdFromAppFrameId(
+            uint64_t                  appFrameId);
+
+  private:
+
+    Rc<Presenter>             m_presenter;
+
+    dxvk::mutex               m_mutex;
+    dxvk::condition_variable  m_cond;
+
+    uint64_t                  m_lastBeginAppFrameId = 0u;
+    uint64_t                  m_lastSleepAppFrameId = 0u;
+    uint64_t                  m_lastPresentAppFrameId = 0u;
+
+    uint64_t                  m_nextAllocFrameId = 1u;
+    uint64_t                  m_nextValidFrameId = uint64_t(-1);
+
+    uint64_t                  m_lastCompletedFrameId = 0u;
+
+    uint64_t                  m_lastPresentQueued   = 0u;
+    uint64_t                  m_lastPresentComplete = 0u;
+
+    uint64_t                  m_lastNoMarkerFrameId = 0u;
+
+    duration                  m_lastSleepDuration = duration(0u);
+
+    bool                      m_lowLatencyMode      = false;
+    bool                      m_lowLatencyNoMarkers = false;
+
+    std::array<DxvkReflexLatencyFrameData, FrameCount> m_frames = { };
+
+    std::map<uint64_t, uint64_t> m_appToDxvkFrameIds;
+
+    DxvkReflexLatencyFrameData& getFrameData(
+            uint64_t                  dxvkFrameId);
+
+    uint64_t lookupFrameId(
+            uint64_t                  appFrameId);
+
+    uint64_t allocateFrameId(
+            uint64_t                  appFrameId);
+
+    void mapFrameId(
+            uint64_t                  appFrameId,
+            uint64_t                  dxvkFrameId);
+
+    void reset();
+
+    static uint64_t mapFrameTimestampToReportUs(
+      const DxvkReflexLatencyFrameData&     frame,
+      const VkLatencyTimingsFrameReportNV&  report,
+            time_point                      timestamp);
+
+  };
+
+}

--- a/src/dxvk/dxvk_options.cpp
+++ b/src/dxvk/dxvk_options.cpp
@@ -14,6 +14,7 @@ namespace dxvk {
     tearFree              = config.getOption<Tristate>("dxvk.tearFree",               Tristate::Auto);
     latencySleep          = config.getOption<Tristate>("dxvk.latencySleep",           Tristate::Auto);
     latencyTolerance      = config.getOption<int32_t> ("dxvk.latencyTolerance",       1000);
+    disableNvLowLatency2  = config.getOption<Tristate>("dxvk.disableNvLowLatency2",   Tristate::Auto);
     hideIntegratedGraphics = config.getOption<bool>   ("dxvk.hideIntegratedGraphics", false);
     zeroMappedMemory      = config.getOption<bool>    ("dxvk.zeroMappedMemory",       false);
     allowFse              = config.getOption<bool>    ("dxvk.allowFse",               false);

--- a/src/dxvk/dxvk_options.cpp
+++ b/src/dxvk/dxvk_options.cpp
@@ -12,6 +12,8 @@ namespace dxvk {
     useRawSsbo            = config.getOption<Tristate>("dxvk.useRawSsbo",             Tristate::Auto);
     hud                   = config.getOption<std::string>("dxvk.hud", "");
     tearFree              = config.getOption<Tristate>("dxvk.tearFree",               Tristate::Auto);
+    latencySleep          = config.getOption<Tristate>("dxvk.latencySleep",           Tristate::Auto);
+    latencyTolerance      = config.getOption<int32_t> ("dxvk.latencyTolerance",       1000);
     hideIntegratedGraphics = config.getOption<bool>   ("dxvk.hideIntegratedGraphics", false);
     zeroMappedMemory      = config.getOption<bool>    ("dxvk.zeroMappedMemory",       false);
     allowFse              = config.getOption<bool>    ("dxvk.allowFse",               false);

--- a/src/dxvk/dxvk_options.h
+++ b/src/dxvk/dxvk_options.h
@@ -43,6 +43,10 @@ namespace dxvk {
     /// Latency tolerance, in microseconds
     int32_t latencyTolerance = 0u;
 
+    /// Disable VK_NV_low_latency2. This extension
+    /// appears to be all sorts of broken on 32-bit.
+    Tristate disableNvLowLatency2 = Tristate::Auto;
+
     // Hides integrated GPUs if dedicated GPUs are
     // present. May be necessary for some games that
     // incorrectly assume monitor layouts.

--- a/src/dxvk/dxvk_options.h
+++ b/src/dxvk/dxvk_options.h
@@ -37,6 +37,12 @@ namespace dxvk {
     /// or FIFO_RELAXED (if false) present mode
     Tristate tearFree = Tristate::Auto;
 
+    /// Enables latency sleep
+    Tristate latencySleep = Tristate::Auto;
+
+    /// Latency tolerance, in microseconds
+    int32_t latencyTolerance = 0u;
+
     // Hides integrated GPUs if dedicated GPUs are
     // present. May be necessary for some games that
     // incorrectly assume monitor layouts.

--- a/src/dxvk/dxvk_presenter.cpp
+++ b/src/dxvk/dxvk_presenter.cpp
@@ -50,6 +50,7 @@ namespace dxvk {
   Presenter::~Presenter() {
     destroySwapchain();
     destroySurface();
+    destroyLatencySemaphore();
 
     if (m_frameThread.joinable()) {
       { std::lock_guard<dxvk::mutex> lock(m_frameMutex);
@@ -140,6 +141,16 @@ namespace dxvk {
       if (m_device->features().extHdrMetadata) {
         m_vkd->vkSetHdrMetadataEXT(m_vkd->device(),
           1, &m_swapchain, &(*m_hdrMetadata));
+      }
+    }
+
+    // Apply latency sleep mode if the swapchain supports it
+    if (m_latencySleepModeDirty && m_latencySleepMode) {
+      m_latencySleepModeDirty = false;
+
+      if (m_latencySleepSupported) {
+        m_vkd->vkSetLatencySleepModeNV(m_vkd->device(),
+          m_swapchain, &(*m_latencySleepMode));
       }
     }
 
@@ -302,6 +313,120 @@ namespace dxvk {
 
     destroySwapchain();
     destroySurface();
+  }
+
+
+  void Presenter::setLatencySleepModeNv(
+    const VkLatencySleepModeInfoNV& sleepMode) {
+    std::unique_lock lock(m_surfaceMutex);
+
+    if (sleepMode.sType != VK_STRUCTURE_TYPE_LATENCY_SLEEP_MODE_INFO_NV)
+      return;
+
+    if (sleepMode.pNext)
+      Logger::warn("Presenter: Extended sleep mode info not supported");
+
+    // Avoid creating a swapchain with low-latency features
+    // enabled if the functionality isn't required
+    bool isDefault = !sleepMode.lowLatencyMode
+                  && !sleepMode.lowLatencyBoost
+                  && !sleepMode.minimumIntervalUs;
+
+    if (!m_latencySleepMode && isDefault)
+      return;
+
+    m_dirtySwapchain |= !m_latencySleepMode;
+
+    if (m_latencySleepMode) {
+      m_latencySleepModeDirty |=
+        m_latencySleepMode->lowLatencyMode != sleepMode.lowLatencyMode ||
+        m_latencySleepMode->lowLatencyBoost != sleepMode.lowLatencyBoost ||
+        m_latencySleepMode->minimumIntervalUs != sleepMode.minimumIntervalUs;
+    }
+
+    m_latencySleepMode = sleepMode;
+    m_latencySleepMode->pNext = nullptr;
+  }
+
+
+  dxvk::high_resolution_clock::time_point Presenter::setLatencyMarkerNv(
+          uint64_t                frameId,
+          VkLatencyMarkerNV       marker) {
+    std::unique_lock lock(m_surfaceMutex);
+
+    if (!m_latencySleepMode) {
+      // Applications may use latency markers without enabling
+      // low-latency mode, make sure we have a compatible swapchain
+      m_latencySleepMode = { VK_STRUCTURE_TYPE_LATENCY_SLEEP_MODE_INFO_NV };
+      m_dirtySwapchain = true;
+
+      return dxvk::high_resolution_clock::now();
+    }
+
+    // Return a CPU timestamp to correlate timestamps from
+    // latency frame reports with actual CPU timestamps
+    auto t0 = dxvk::high_resolution_clock::now();
+
+    if (m_latencySleepSupported) {
+      VkSetLatencyMarkerInfoNV info = { VK_STRUCTURE_TYPE_SET_LATENCY_MARKER_INFO_NV };
+      info.presentID = frameId;
+      info.marker = marker;
+
+      m_vkd->vkSetLatencyMarkerNV(m_vkd->device(), m_swapchain, &info);
+    }
+
+    auto t1 = dxvk::high_resolution_clock::now();
+    return t0 + (t1 - t0) / 2u;
+  }
+
+
+  dxvk::high_resolution_clock::duration Presenter::latencySleepNv() {
+    std::unique_lock lock(m_surfaceMutex);
+
+    if (!m_latencySleepSupported)
+      return dxvk::high_resolution_clock::duration(0u);
+
+    if (!m_latencySemaphore) {
+      if (createLatencySemaphore() != VK_SUCCESS)
+        return dxvk::high_resolution_clock::duration(0u);
+    }
+
+    VkLatencySleepInfoNV info = { VK_STRUCTURE_TYPE_LATENCY_SLEEP_INFO_NV };
+    info.signalSemaphore = m_latencySemaphore;
+    info.value = ++m_latencySleepCounter;
+
+    m_vkd->vkLatencySleepNV(m_vkd->device(), m_swapchain, &info);
+
+    lock.unlock();
+
+    auto t0 = dxvk::high_resolution_clock::now();
+
+    VkSemaphoreWaitInfo waitInfo = { VK_STRUCTURE_TYPE_SEMAPHORE_WAIT_INFO };
+    waitInfo.semaphoreCount = 1;
+    waitInfo.pSemaphores = &info.signalSemaphore;
+    waitInfo.pValues = &info.value;
+
+    m_vkd->vkWaitSemaphores(m_vkd->device(), &waitInfo, ~0ull);
+
+    auto t1 = dxvk::high_resolution_clock::now();
+    return t1 - t0;
+  }
+
+
+  uint32_t Presenter::getLatencyTimingsNv(
+          uint32_t                timingCount,
+          VkLatencyTimingsFrameReportNV* timings) {
+    std::unique_lock lock(m_surfaceMutex);
+
+    if (!m_latencySleepSupported)
+      return 0u;
+
+    VkGetLatencyMarkerInfoNV info = { VK_STRUCTURE_TYPE_GET_LATENCY_MARKER_INFO_NV };
+    info.timingCount = timingCount;
+    info.pTimings = timings;
+
+    m_vkd->vkGetLatencyTimingsNV(m_vkd->device(), m_swapchain, &info);
+    return info.timingCount;
   }
 
 
@@ -541,6 +666,9 @@ namespace dxvk {
     modeInfo.presentModeCount       = compatibleModes.size();
     modeInfo.pPresentModes          = compatibleModes.data();
 
+    VkSwapchainLatencyCreateInfoNV latencyInfo = { VK_STRUCTURE_TYPE_SWAPCHAIN_LATENCY_CREATE_INFO_NV };
+    latencyInfo.latencyModeEnable   = m_latencySleepMode.has_value();
+
     VkSwapchainCreateInfoKHR swapInfo = { VK_STRUCTURE_TYPE_SWAPCHAIN_CREATE_INFO_KHR };
     swapInfo.surface                = m_surface;
     swapInfo.minImageCount          = pickImageCount(minImageCount, maxImageCount);
@@ -561,6 +689,9 @@ namespace dxvk {
 
     if (m_device->features().extSwapchainMaintenance1.swapchainMaintenance1)
       modeInfo.pNext = std::exchange(swapInfo.pNext, &modeInfo);
+
+    if (m_device->features().nvLowLatency2)
+      latencyInfo.pNext = std::exchange(swapInfo.pNext, &latencyInfo);
 
     Logger::info(str::format(
       "Presenter: Actual swapchain properties:"
@@ -639,7 +770,7 @@ namespace dxvk {
     }
     
     // Invalidate indices
-    m_hdrMetadataDirty = true;
+    m_latencySleepSupported = m_device->features().nvLowLatency2 && latencyInfo.latencyModeEnable;
 
     m_imageIndex = 0;
     m_frameIndex = 0;
@@ -984,6 +1115,20 @@ namespace dxvk {
   }
 
 
+  VkResult Presenter::createLatencySemaphore() {
+    VkSemaphoreTypeCreateInfo typeInfo = { VK_STRUCTURE_TYPE_SEMAPHORE_TYPE_CREATE_INFO };
+    typeInfo.semaphoreType = VK_SEMAPHORE_TYPE_TIMELINE;
+
+    VkSemaphoreCreateInfo info = { VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO, &typeInfo };
+    VkResult vr = m_vkd->vkCreateSemaphore(m_vkd->device(), &info, nullptr, &m_latencySemaphore);
+
+    if (vr != VK_SUCCESS)
+      Logger::err(str::format("Presenter: Failed to create latency semaphore: ", vr));
+
+    return vr;
+  }
+
+
   void Presenter::destroySwapchain() {
     if (m_signal != nullptr)
       m_signal->wait(m_lastFrameId.load(std::memory_order_acquire));
@@ -1007,6 +1152,11 @@ namespace dxvk {
     m_acquireStatus = VK_NOT_READY;
 
     m_presentPending = false;
+
+    m_hdrMetadataDirty = true;
+
+    m_latencySleepModeDirty = true;
+    m_latencySleepSupported = false;
   }
 
 
@@ -1014,6 +1164,13 @@ namespace dxvk {
     m_vki->vkDestroySurfaceKHR(m_vki->instance(), m_surface, nullptr);
 
     m_surface = VK_NULL_HANDLE;
+  }
+
+
+  void Presenter::destroyLatencySemaphore() {
+    m_vkd->vkDestroySemaphore(m_vkd->device(), m_latencySemaphore, nullptr);
+
+    m_latencySemaphore = VK_NULL_HANDLE;
   }
 
 

--- a/src/dxvk/dxvk_presenter.h
+++ b/src/dxvk/dxvk_presenter.h
@@ -124,10 +124,10 @@ namespace dxvk {
      * 
      * Presents the last successfuly acquired image.
      * \param [in] frameId Frame number.
-     *    Must increase monotonically.
      * \returns Status of the operation
      */
-    VkResult presentImage(uint64_t frameId);
+    VkResult presentImage(
+            uint64_t        frameId);
 
     /**
      * \brief Signals a given frame
@@ -217,6 +217,48 @@ namespace dxvk {
      */
     void destroyResources();
 
+    /**
+     * \brief Sets latency sleep mode
+     *
+     * Any changes will be applied on the next acquire operation.
+     * \param [in] sleepMode Latency mode info
+     */
+    void setLatencySleepModeNv(
+      const VkLatencySleepModeInfoNV& sleepMode);
+
+    /**
+     * \brief Sets latency marker
+     *
+     * Ignored if the current swapchain has not been
+     * created with low latency support.
+     * \param [in] frameId Frame ID
+     * \param [in] marker Marker
+     * \returns CPU timestamp of the marker
+     */
+    dxvk::high_resolution_clock::time_point setLatencyMarkerNv(
+            uint64_t                frameId,
+            VkLatencyMarkerNV       marker);
+
+    /**
+     * \brief Executes latency sleep
+     *
+     * Ignored if the current swapchain has not been
+     * created with low latency support.
+     * \returns Sleep duration
+     */
+    dxvk::high_resolution_clock::duration latencySleepNv();
+
+    /**
+     * \brief Queries latency timings
+     *
+     * \param [in] timingCount Number of timings to query
+     * \param [out] timings Latency timings
+     * \returns Number of frame reports returned
+     */
+    uint32_t getLatencyTimingsNv(
+            uint32_t                timingCount,
+            VkLatencyTimingsFrameReportNV* timings);
+
   private:
 
     Rc<DxvkDevice>              m_device;
@@ -257,6 +299,13 @@ namespace dxvk {
 
     std::optional<VkHdrMetadataEXT> m_hdrMetadata;
     bool                        m_hdrMetadataDirty = false;
+
+    std::optional<VkLatencySleepModeInfoNV> m_latencySleepMode;
+    VkSemaphore                 m_latencySemaphore = VK_NULL_HANDLE;
+    uint64_t                    m_latencySleepCounter = 0u;
+
+    bool                        m_latencySleepModeDirty = false;
+    bool                        m_latencySleepSupported = false;
 
     alignas(CACHE_LINE_SIZE)
     dxvk::mutex                 m_frameMutex;
@@ -317,9 +366,13 @@ namespace dxvk {
 
     VkResult createSurface();
 
+    VkResult createLatencySemaphore();
+
     void destroySwapchain();
 
     void destroySurface();
+
+    void destroyLatencySemaphore();
 
     void waitForSwapchainFence(
             PresenterSync&            sync);

--- a/src/dxvk/dxvk_presenter.h
+++ b/src/dxvk/dxvk_presenter.h
@@ -18,6 +18,7 @@
 
 #include "dxvk_format.h"
 #include "dxvk_image.h"
+#include "dxvk_latency.h"
 
 namespace dxvk {
 
@@ -55,9 +56,10 @@ namespace dxvk {
    * \brief Queued frame
    */
   struct PresenterFrame {
-    uint64_t          frameId = 0u;
-    VkPresentModeKHR  mode    = VK_PRESENT_MODE_FIFO_KHR;
-    VkResult          result  = VK_NOT_READY;
+    uint64_t                frameId   = 0u;
+    Rc<DxvkLatencyTracker>  tracker   = nullptr;
+    VkPresentModeKHR        mode      = VK_PRESENT_MODE_FIFO_KHR;
+    VkResult                result    = VK_NOT_READY;
   };
 
   /**
@@ -135,9 +137,13 @@ namespace dxvk {
      * called before GPU work prior to the present submission has
      * completed in order to maintain consistency.
      * \param [in] result Presentation result
-     * \param [in] frameId Frame number
+     * \param [in] frameId Frame ID
+     * \param [in] tracker Latency tracker
      */
-    void signalFrame(VkResult result, uint64_t frameId);
+    void signalFrame(
+            VkResult                result,
+            uint64_t                frameId,
+      const Rc<DxvkLatencyTracker>& tracker);
 
     /**
      * \brief Changes sync interval

--- a/src/dxvk/dxvk_queue.cpp
+++ b/src/dxvk/dxvk_queue.cpp
@@ -131,6 +131,9 @@ namespace dxvk {
 
     std::unique_lock<dxvk::mutex> lock(m_mutex);
 
+    uint64_t trackedSubmitId = 0u;
+    uint64_t trackedPresentId = 0u;
+
     while (!m_stopped.load()) {
       m_appendCond.wait(lock, [this] {
         return m_stopped.load() || !m_submitQueue.empty();
@@ -150,10 +153,15 @@ namespace dxvk {
           m_callback(true);
 
         if (entry.submit.cmdList != nullptr) {
-          if (entry.latency.tracker)
+          if (entry.latency.tracker) {
             entry.latency.tracker->notifyQueueSubmit(entry.latency.frameId);
 
-          entry.result = entry.submit.cmdList->submit(m_semaphores, m_timelines);
+            if (!trackedSubmitId && entry.latency.frameId > trackedPresentId)
+              trackedSubmitId = entry.latency.frameId;
+          }
+
+          entry.result = entry.submit.cmdList->submit(
+            m_semaphores, m_timelines, trackedSubmitId);
           entry.timelines = m_timelines;
         } else if (entry.present.presenter != nullptr) {
           if (entry.latency.tracker)
@@ -164,6 +172,9 @@ namespace dxvk {
           if (entry.latency.tracker) {
             entry.latency.tracker->notifyQueuePresentEnd(
               entry.latency.frameId, entry.result);
+
+            trackedPresentId = entry.latency.frameId;
+            trackedSubmitId = 0u;
           }
         }
 

--- a/src/dxvk/dxvk_queue.cpp
+++ b/src/dxvk/dxvk_queue.cpp
@@ -260,7 +260,8 @@ namespace dxvk {
         // Signal the frame and then immediately destroy the reference.
         // This is necessary since the front-end may want to explicitly
         // destroy the presenter object. 
-        entry.present.presenter->signalFrame(entry.result, entry.present.frameId);
+        entry.present.presenter->signalFrame(entry.result,
+          entry.present.frameId, entry.latency.tracker);
         entry.present.presenter = nullptr;
       }
 

--- a/src/dxvk/dxvk_queue.cpp
+++ b/src/dxvk/dxvk_queue.cpp
@@ -42,7 +42,10 @@ namespace dxvk {
   }
   
   
-  void DxvkSubmissionQueue::submit(DxvkSubmitInfo submitInfo, DxvkSubmitStatus* status) {
+  void DxvkSubmissionQueue::submit(
+          DxvkSubmitInfo            submitInfo,
+          DxvkLatencyInfo           latencyInfo,
+          DxvkSubmitStatus*         status) {
     std::unique_lock<dxvk::mutex> lock(m_mutex);
 
     m_finishCond.wait(lock, [this] {
@@ -52,18 +55,23 @@ namespace dxvk {
     DxvkSubmitEntry entry = { };
     entry.status = status;
     entry.submit = std::move(submitInfo);
+    entry.latency = std::move(latencyInfo);
 
     m_submitQueue.push(std::move(entry));
     m_appendCond.notify_all();
   }
 
 
-  void DxvkSubmissionQueue::present(DxvkPresentInfo presentInfo, DxvkSubmitStatus* status) {
+  void DxvkSubmissionQueue::present(
+          DxvkPresentInfo           presentInfo,
+          DxvkLatencyInfo           latencyInfo,
+          DxvkSubmitStatus*         status) {
     std::unique_lock<dxvk::mutex> lock(m_mutex);
 
     DxvkSubmitEntry entry = { };
     entry.status  = status;
     entry.present = std::move(presentInfo);
+    entry.latency = std::move(latencyInfo);
 
     m_submitQueue.push(std::move(entry));
     m_appendCond.notify_all();
@@ -142,10 +150,21 @@ namespace dxvk {
           m_callback(true);
 
         if (entry.submit.cmdList != nullptr) {
+          if (entry.latency.tracker)
+            entry.latency.tracker->notifyQueueSubmit(entry.latency.frameId);
+
           entry.result = entry.submit.cmdList->submit(m_semaphores, m_timelines);
           entry.timelines = m_timelines;
         } else if (entry.present.presenter != nullptr) {
+          if (entry.latency.tracker)
+            entry.latency.tracker->notifyQueuePresentBegin(entry.latency.frameId);
+
           entry.result = entry.present.presenter->presentImage(entry.present.frameId);
+
+          if (entry.latency.tracker) {
+            entry.latency.tracker->notifyQueuePresentEnd(
+              entry.latency.frameId, entry.result);
+          }
         }
 
         if (m_callback)
@@ -217,12 +236,18 @@ namespace dxvk {
           std::array<VkSemaphore, 2> semaphores = { m_semaphores.graphics, m_semaphores.transfer };
           std::array<uint64_t, 2> timelines = { entry.timelines.graphics, entry.timelines.transfer };
 
+          if (entry.latency.tracker)
+            entry.latency.tracker->notifyGpuExecutionBegin(entry.latency.frameId);
+
           VkSemaphoreWaitInfo waitInfo = { VK_STRUCTURE_TYPE_SEMAPHORE_WAIT_INFO };
           waitInfo.semaphoreCount = semaphores.size();
           waitInfo.pSemaphores = semaphores.data();
           waitInfo.pValues = timelines.data();
 
           status = vk->vkWaitSemaphores(vk->device(), &waitInfo, ~0ull);
+
+          if (entry.latency.tracker && status == VK_SUCCESS)
+            entry.latency.tracker->notifyGpuExecutionEnd(entry.latency.frameId);
         }
 
         if (status != VK_SUCCESS) {

--- a/src/dxvk/dxvk_queue.h
+++ b/src/dxvk/dxvk_queue.h
@@ -7,6 +7,7 @@
 #include "../util/thread.h"
 
 #include "dxvk_cmdlist.h"
+#include "dxvk_latency.h"
 #include "dxvk_presenter.h"
 
 namespace dxvk {
@@ -48,6 +49,18 @@ namespace dxvk {
 
 
   /**
+   * \brief Latency info
+   *
+   * Optionally stores a latency tracker
+   * and the associated frame ID.
+   */
+  struct DxvkLatencyInfo {
+    Rc<DxvkLatencyTracker>  tracker;
+    uint64_t                frameId = 0;
+  };
+
+
+  /**
    * \brief Submission queue entry
    */
   struct DxvkSubmitEntry {
@@ -55,6 +68,7 @@ namespace dxvk {
     DxvkSubmitStatus*   status;
     DxvkSubmitInfo      submit;
     DxvkPresentInfo     present;
+    DxvkLatencyInfo     latency;
     DxvkTimelineSemaphoreValues timelines;
   };
 
@@ -102,10 +116,12 @@ namespace dxvk {
      * dedicated submission thread. Use this to take
      * the submission overhead off the calling thread.
      * \param [in] submitInfo Submission parameters
+     * \param [in] latencyInfo Latency tracker info
      * \param [out] status Submission feedback
      */
     void submit(
             DxvkSubmitInfo      submitInfo,
+            DxvkLatencyInfo     latencyInfo,
             DxvkSubmitStatus*   status);
     
     /**
@@ -115,10 +131,12 @@ namespace dxvk {
      * and then presents the current swap chain image
      * of the presenter. May stall the calling thread.
      * \param [in] present Present parameters
+     * \param [in] latencyInfo Latency tracker info
      * \param [out] status Submission feedback
      */
     void present(
             DxvkPresentInfo     presentInfo,
+            DxvkLatencyInfo     latencyInfo,
             DxvkSubmitStatus*   status);
     
     /**

--- a/src/dxvk/hud/dxvk_hud_item.h
+++ b/src/dxvk/hud/dxvk_hud_item.h
@@ -734,4 +734,46 @@ namespace dxvk::hud {
 
   };
 
+
+  /**
+   * \brief Frame latency item
+   */
+  class HudLatencyItem : public HudItem {
+    constexpr static int64_t UpdateInterval = 500'000;
+
+    constexpr static uint32_t MaxInvalidUpdates = 20u;
+  public:
+
+    HudLatencyItem();
+
+    ~HudLatencyItem();
+
+    void accumulateStats(const DxvkLatencyStats& stats);
+
+    void update(dxvk::high_resolution_clock::time_point time);
+
+    HudPos render(
+      const DxvkContextObjects& ctx,
+      const HudPipelineKey&     key,
+      const HudOptions&         options,
+            HudRenderer&        renderer,
+            HudPos              position);
+
+  private:
+
+    sync::Spinlock      m_mutex;
+
+    DxvkLatencyStats    m_accumStats = { };
+    uint32_t            m_accumFrames = 0u;
+
+    uint32_t            m_invalidUpdates = MaxInvalidUpdates;
+
+    std::string         m_latencyString;
+    std::string         m_sleepString;
+
+    dxvk::high_resolution_clock::time_point m_lastUpdate
+      = dxvk::high_resolution_clock::now();
+
+  };
+
 }

--- a/src/dxvk/meson.build
+++ b/src/dxvk/meson.build
@@ -91,6 +91,7 @@ dxvk_src = [
   'dxvk_image.cpp',
   'dxvk_instance.cpp',
   'dxvk_latency_builtin.cpp',
+  'dxvk_latency_reflex.cpp',
   'dxvk_memory.cpp',
   'dxvk_meta_blit.cpp',
   'dxvk_meta_clear.cpp',

--- a/src/dxvk/meson.build
+++ b/src/dxvk/meson.build
@@ -90,6 +90,7 @@ dxvk_src = [
   'dxvk_graphics.cpp',
   'dxvk_image.cpp',
   'dxvk_instance.cpp',
+  'dxvk_latency_builtin.cpp',
   'dxvk_memory.cpp',
   'dxvk_meta_blit.cpp',
   'dxvk_meta_clear.cpp',

--- a/src/util/util_fps_limiter.cpp
+++ b/src/util/util_fps_limiter.cpp
@@ -13,15 +13,11 @@ using namespace std::chrono_literals;
 namespace dxvk {
   
   FpsLimiter::FpsLimiter() {
-    std::string env = env::getEnvVar("DXVK_FRAME_RATE");
+    auto override = getEnvironmentOverride();
 
-    if (!env.empty()) {
-      try {
-        setTargetFrameRate(std::stod(env), 0);
-        m_envOverride = true;
-      } catch (const std::invalid_argument&) {
-        // no-op
-      }
+    if (override) {
+      setTargetFrameRate(*override, 0);
+      m_envOverride = true;
     }
   }
 
@@ -126,6 +122,21 @@ namespace dxvk {
 
     m_heuristicFrameCount += 1;
     return false;
+  }
+
+
+  std::optional<double> FpsLimiter::getEnvironmentOverride() {
+    std::string env = env::getEnvVar("DXVK_FRAME_RATE");
+
+    if (!env.empty()) {
+      try {
+        return std::stod(env);
+      } catch (const std::invalid_argument&) {
+        // no op
+      }
+    }
+
+    return std::nullopt;
   }
 
 }

--- a/src/util/util_fps_limiter.h
+++ b/src/util/util_fps_limiter.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <array>
+#include <optional>
 
 #include "thread.h"
 #include "util_time.h"
@@ -38,6 +39,12 @@ namespace dxvk {
      * shorter than the target interval.
      */
     void delay();
+
+    /**
+     * \brief Queries environment override
+     * \returns Frame rate given by environment override
+     */
+    static std::optional<double> getEnvironmentOverride();
 
   private:
 

--- a/src/util/util_small_vector.h
+++ b/src/util/util_small_vector.h
@@ -19,6 +19,10 @@ namespace dxvk {
 
     small_vector() { }
 
+    small_vector(size_t size) {
+      resize(size);
+    }
+
     small_vector(const small_vector& other) {
       reserve(other.m_size);
       for (size_t i = 0; i < other.m_size; i++) {

--- a/src/vulkan/vulkan_loader.h
+++ b/src/vulkan/vulkan_loader.h
@@ -458,6 +458,14 @@ namespace dxvk::vk {
     VULKAN_FN(wine_vkAcquireKeyedMutex);
     VULKAN_FN(wine_vkReleaseKeyedMutex);
     #endif
+
+    #ifdef VK_NV_low_latency2
+    VULKAN_FN(vkSetLatencySleepModeNV);
+    VULKAN_FN(vkLatencySleepNV);
+    VULKAN_FN(vkSetLatencyMarkerNV);
+    VULKAN_FN(vkGetLatencyTimingsNV);
+    VULKAN_FN(vkQueueNotifyOutOfBandNV);
+    #endif
   };
   
 }


### PR DESCRIPTION
This implements Reflex support through dxvk-nvapi's `ID3DLowLatencyDevice` on drivers that support `VK_NV_low_latency2`. Fairly invasive change since we need to pass frame IDs all over the place and mess around with certain markers to account for internal threading.

Tested in a few games:
- **Ghostrunner**: Broken, game never even calls the function to enable Reflex at all, let alone the sleep function.
- **Ghostrunner 2**: Works as expected.
- **God of War**: Works as expected.
- **Mordhau**: Game sets present markers but thinks that Reflex is unsupported, so you can't enable it in game. (???)
- **Overwatch 2**: Works, but only if Vsync is disabled. I don't know if this is expected behaviour.
- **Quake Champions**: Doesn't use markers, but appears to work.

Not sure if there are any other Reflex-enabled D3D11 games that aren't simultaneously blocked by anti-cheat measures, ~~it's a bit unfortunate that the only UE4 test case seems to be bugged at a game level~~.

This also adds a HUD item (`latency`) that will show up when a game uses latency markers, and will display the average time it takes from the game setting the `SIMULATION_START` (or `INPUT_SAMPLING`, if it uses that) marker to presentation of the given frame completing on the GPU, as well as the average latency sleep duration.

![Bildschirmfoto-829](https://github.com/user-attachments/assets/a363a614-da10-4c53-9408-b0b918aacd24)

Things that are not really supported very well include non-monitonic frame IDs (dxvk-nvapi sorts these out for us so that should never happen anyway), and the whole thing probably isn't very well behaved when a game randomly skips markers for a frame since it breaks our way of correlating app-provided frame IDs with the ones we use for the Vulkan swapchain.

Finally, this adds an option to enable latency sleep for older games; the obvious downside here is that we can only really sleep after Present, so this isn't going to do all that much in games that have an asynchronous render thread, besides reducing some buffering inside DXVK. This can be enabled by setting `dxvk.latencySleep = True` in the configuration file.

Supersedes #4623, #3690.