### PR TITLE
[build] Use -mpreferred-stack-boundary=2 on 32-bit x86

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -80,11 +80,15 @@ if platform == 'windows'
       ]
     endif
 
-    # Enable stdcall fixup on 32-bit
     if cpu_family == 'x86'
+      # Enable stdcall fixup on 32-bit
       link_args += [
         '-Wl,--enable-stdcall-fixup',
         '-Wl,--kill-at',
+      ]
+      # Fix stack alignment issues with mingw on 32-bit
+      compiler_args += [
+        '-mpreferred-stack-boundary=2'
       ]
     endif
   else


### PR DESCRIPTION
I know DXVK doesn't officially support AVX builds, but I'd still like to suggest this flag to fix stack alignment issues when using mingw, since apparently i686-w64-mingw32 assumes that stack alignment is 16-bit when SSE is used, which is incorrect and causes game crashing issues. Wine experienced similar issues and added this flag about a year ago to workaround them by ensuring that the stack alignment is always 4 bytes, please see for more details:

https://gitlab.winehq.org/wine/wine/-/merge_requests/4030
https://gitlab.winehq.org/wine/wine/-/commit/4b458775bb8c9492ac859cfd167c5f54f245dec1

I'm fine if there any concerns why this can't be merged, as I realize that stack alignment issues need to be fixed either on the compiler side or by more courteous code, but it's too hard to debug, and things like https://github.com/doitsujin/dxvk/pull/4627 were more about luck.

Fixes: https://github.com/doitsujin/dxvk/issues/4447 (Not tested in Arma 3, but at least confirmed in Company Of Heroes 1)