### PR TITLE
[d3d9] Relax SM2 minor version checks on shader creation

### DIFF
--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -3322,7 +3322,8 @@ namespace dxvk {
 
     if (unlikely(majorVersion > shaderModelVS
              || (majorVersion == 1 && minorVersion > 1)
-             || (majorVersion > 1  && minorVersion != 0))) {
+             // Skip checking the SM2 minor version, as it has a 2_x mode apparently
+             || (majorVersion == 3 && minorVersion != 0))) {
       Logger::err(str::format("D3D9DeviceEx::CreateVertexShader: Unsupported VS version ", majorVersion, ".", minorVersion));
       return D3DERR_INVALIDCALL;
     }
@@ -3696,7 +3697,8 @@ namespace dxvk {
 
     if (unlikely(majorVersion > m_d3d9Options.shaderModel
              || (majorVersion == 1 && minorVersion > 4)
-             || (majorVersion > 1  && minorVersion != 0))) {
+             // Skip checking the SM2 minor version, as it has a 2_x mode apparently
+             || (majorVersion == 3 && minorVersion != 0))) {
       Logger::err(str::format("D3D9DeviceEx::CreatePixelShader: Unsupported PS version ", majorVersion, ".", minorVersion));
       return D3DERR_INVALIDCALL;
     }

--- a/src/d3d9/d3d9_options.cpp
+++ b/src/d3d9/d3d9_options.cpp
@@ -79,6 +79,8 @@ namespace dxvk {
     // D3D8 options
     this->drefScaling                   = config.getOption<int32_t>     ("d3d8.scaleDref",                     0);
 
+    // Clamp the shader model value between 0 and 3
+    this->shaderModel    = dxvk::clamp(this->shaderModel, 0u, 3u);
     // Clamp LOD bias so that people don't abuse this in unintended ways
     this->samplerLodBias = dxvk::fclamp(this->samplerLodBias, -2.0f, 1.0f);
 


### PR DESCRIPTION
Thanks to @Blisto91 for noticing it.

D3D9 archeology strikes again, as some PS version 2.1 have been spotted in the wild. I can only assume they correspond to the more lenient 2_x SM2 mode, although that doesn't come with an equivalent cap at device level.

I have found obscure references that ATI provided an override to 2.1 at some point at least: https://www.bodnara.co.kr/bbs/article.html?num=49848 .

The conventions around 2_x are very unclear, so this PR relaxes the minor version checks with SM2, to ensure we don't cause any issues with late D3D9 games.