### PR TITLE
[d3d9] Report vertex texture filtering support only for SM3

### DIFF
--- a/src/d3d9/d3d9_adapter.cpp
+++ b/src/d3d9/d3d9_adapter.cpp
@@ -650,7 +650,20 @@ namespace dxvk {
     pCaps->PS20Caps.StaticFlowControlDepth   = options.shaderModel >= 2 ? D3DPS20_MAX_STATICFLOWCONTROLDEPTH : 0;
     pCaps->PS20Caps.NumInstructionSlots      = options.shaderModel >= 2 ? D3DPS20_MAX_NUMINSTRUCTIONSLOTS : 0;
 
-    pCaps->VertexTextureFilterCaps           = pCaps->TextureFilterCaps;
+    // Vertex texture samplers are only available as part of SM3, the caps are 0 otherwise.
+    pCaps->VertexTextureFilterCaps           = options.shaderModel == 3 ? D3DPTFILTERCAPS_MINFPOINT
+                                                                        | D3DPTFILTERCAPS_MINFLINEAR
+                                                                     /* | D3DPTFILTERCAPS_MINFANISOTROPIC */
+                                                                     /* | D3DPTFILTERCAPS_MINFPYRAMIDALQUAD */
+                                                                     /* | D3DPTFILTERCAPS_MINFGAUSSIANQUAD */
+                                                                     /* | D3DPTFILTERCAPS_MIPFPOINT */
+                                                                     /* | D3DPTFILTERCAPS_MIPFLINEAR */
+                                                                     /* | D3DPTFILTERCAPS_CONVOLUTIONMONO */
+                                                                        | D3DPTFILTERCAPS_MAGFPOINT
+                                                                        | D3DPTFILTERCAPS_MAGFLINEAR
+                                                                     /* | D3DPTFILTERCAPS_MAGFANISOTROPIC */
+                                                                     /* | D3DPTFILTERCAPS_MAGFPYRAMIDALQUAD */
+                                                                     /* | D3DPTFILTERCAPS_MAGFGAUSSIANQUAD */ : 0;
 
     pCaps->MaxVShaderInstructionsExecuted    = options.shaderModel >= 2 ? 4294967295 : 0;
     pCaps->MaxPShaderInstructionsExecuted    = options.shaderModel >= 2 ? 4294967295 : 0;


### PR DESCRIPTION
Missed this earlier, as it is apparently a SM3-specific thing. Docs say: 

> VertexTextureFilterCaps indicates what kind of filters are allowed at the vertex texture samplers. D3DPTFILTERCAPS_MINFANISOTROPIC and D3DPTFILTERCAPS_MAGFANISOTROPIC are disallowed.

However modern Nvidia supports:

```
Listing VertexTextureFilterCaps support:
  - D3DPTFILTERCAPS_CONVOLUTIONMONO is not supported
  + D3DPTFILTERCAPS_MAGFPOINT is supported
  + D3DPTFILTERCAPS_MAGFLINEAR is supported
  - D3DPTFILTERCAPS_MAGFANISOTROPIC is not supported
  - D3DPTFILTERCAPS_MAGFPYRAMIDALQUAD is not supported
  - D3DPTFILTERCAPS_MAGFGAUSSIANQUAD is not supported
  + D3DPTFILTERCAPS_MINFPOINT is supported
  + D3DPTFILTERCAPS_MINFLINEAR is supported
  + D3DPTFILTERCAPS_MINFANISOTROPIC is supported
  - D3DPTFILTERCAPS_MINFPYRAMIDALQUAD is not supported
  - D3DPTFILTERCAPS_MINFGAUSSIANQUAD is not supported
  + D3DPTFILTERCAPS_MIPFPOINT is supported
  + D3DPTFILTERCAPS_MIPFLINEAR is supported
```

Which is one D3DPTFILTERCAPS_MAGFANISOTROPIC away from what we're reporting at the moment.

I'll wait until @Blisto91 can test native Intel and AMD, hopefully that will clear things up a bit (maybe :frog:).

P.S.: The previous literal value of 50332416 maps out to:

```
Listing VertexTextureFilterCaps support:
  - D3DPTFILTERCAPS_CONVOLUTIONMONO is not supported
  + D3DPTFILTERCAPS_MAGFPOINT is supported
  + D3DPTFILTERCAPS_MAGFLINEAR is supported
  - D3DPTFILTERCAPS_MAGFANISOTROPIC is not supported
  - D3DPTFILTERCAPS_MAGFPYRAMIDALQUAD is not supported
  - D3DPTFILTERCAPS_MAGFGAUSSIANQUAD is not supported
  + D3DPTFILTERCAPS_MINFPOINT is supported
  + D3DPTFILTERCAPS_MINFLINEAR is supported
  - D3DPTFILTERCAPS_MINFANISOTROPIC is not supported
  - D3DPTFILTERCAPS_MINFPYRAMIDALQUAD is not supported
  - D3DPTFILTERCAPS_MINFGAUSSIANQUAD is not supported
  - D3DPTFILTERCAPS_MIPFPOINT is not supported
  - D3DPTFILTERCAPS_MIPFLINEAR is not supported

```
Which makes a lot more sense. If that's what modern AMD drivers report, we can go with that.