### PR TITLE
Assign viewInfo.minLayer for D3D11VideoProcessorInputView

### DIFF
--- a/src/d3d11/d3d11_video.cpp
+++ b/src/d3d11/d3d11_video.cpp
@@ -200,7 +200,7 @@ namespace dxvk {
         viewInfo.viewType   = VK_IMAGE_VIEW_TYPE_2D;
         viewInfo.mipIndex   = m_desc.Texture2D.MipSlice;
         viewInfo.mipCount   = 1;
-        viewInfo.layerIndex = 0;
+        viewInfo.layerIndex = m_desc.Texture2D.ArraySlice;
         viewInfo.layerCount = 1;
         break;
 


### PR DESCRIPTION
Issue: D3D11VideoProcessorInputView constructor ignores D3D11_VIDEO_PROCESSOR_INPUT_VIEW_DESC::Texture2D.ArraySlice parameter and always sets viewInfo.minLayer to 0.

The fix assigns the correct array layer value.