### PR TITLE
[d3d8] Fix up swizzle for all opcodes requiring a replicate swizzle

### DIFF
--- a/src/d3d8/d3d8_device.cpp
+++ b/src/d3d8/d3d8_device.cpp
@@ -1788,8 +1788,8 @@ namespace dxvk {
 
     // Validate VS version for non-FF shaders
     if (pFunction != nullptr) {
-      const uint32_t majorVersion = (pFunction[0] >> 8) & 0xff;
-      const uint32_t minorVersion = pFunction[0] & 0xff;
+      const uint32_t majorVersion = D3DSHADER_VERSION_MAJOR(pFunction[0]);
+      const uint32_t minorVersion = D3DSHADER_VERSION_MINOR(pFunction[0]);
 
       if (unlikely(majorVersion != 1 || minorVersion > 1)) {
         Logger::err(str::format("D3D8Device::CreateVertexShader: Unsupported VS version ", majorVersion, ".", minorVersion));
@@ -2027,8 +2027,8 @@ namespace dxvk {
     if (unlikely(pFunction == nullptr || pHandle == nullptr))
       return D3DERR_INVALIDCALL;
 
-    const uint32_t majorVersion = (pFunction[0] >> 8) & 0xff;
-    const uint32_t minorVersion = pFunction[0] & 0xff;
+    const uint32_t majorVersion = D3DSHADER_VERSION_MAJOR(pFunction[0]);
+    const uint32_t minorVersion = D3DSHADER_VERSION_MINOR(pFunction[0]);
 
     if (unlikely(m_isFixedFunctionOnly || majorVersion != 1 || minorVersion > 4)) {
       Logger::err(str::format("D3D8Device::CreatePixelShader: Unsupported PS version ", majorVersion, ".", minorVersion));

--- a/src/d3d8/d3d8_main.cpp
+++ b/src/d3d8/d3d8_main.cpp
@@ -26,8 +26,8 @@ extern "C" {
     if (unlikely(pPixelShader == nullptr)) {
       errorMessage = "D3D8: ValidatePixelShader: Null pPixelShader";
     } else {
-      const uint32_t majorVersion = (pPixelShader[0] >> 8) & 0xff;
-      const uint32_t minorVersion = pPixelShader[0] & 0xff;
+      const uint32_t majorVersion = D3DSHADER_VERSION_MAJOR(pPixelShader[0]);
+      const uint32_t minorVersion = D3DSHADER_VERSION_MINOR(pPixelShader[0]);
 
       if (unlikely(majorVersion != 1 || minorVersion > 4)) {
         errorMessage = dxvk::str::format("D3D8: ValidatePixelShader: Unsupported PS version ",
@@ -69,8 +69,8 @@ extern "C" {
     if (unlikely(pVertexShader == nullptr)) {
       errorMessage = "D3D8: ValidateVertexShader: Null pVertexShader";
     } else {
-      const uint32_t majorVersion = (pVertexShader[0] >> 8) & 0xff;
-      const uint32_t minorVersion = pVertexShader[0] & 0xff;
+      const uint32_t majorVersion = D3DSHADER_VERSION_MAJOR(pVertexShader[0]);
+      const uint32_t minorVersion = D3DSHADER_VERSION_MINOR(pVertexShader[0]);
 
       if (unlikely(majorVersion != 1 || minorVersion > 1)) {
         errorMessage = dxvk::str::format("D3D8: ValidateVertexShader: Unsupported VS version ",

--- a/src/d3d8/d3d8_shader.cpp
+++ b/src/d3d8/d3d8_shader.cpp
@@ -313,8 +313,10 @@ namespace dxvk {
         // Instructions
         if ((token & VS_BIT_PARAM) == 0) {
 
-          // RSQ swizzle fixup
-          if (opcode == D3DSIO_RSQ) {
+          // Swizzle fixup for opcodes that require explicit use of a replicate swizzle.
+          if (opcode == D3DSIO_RSQ  || opcode == D3DSIO_RCP
+           || opcode == D3DSIO_EXP  || opcode == D3DSIO_LOG
+           || opcode == D3DSIO_EXPP || opcode == D3DSIO_LOGP) {
             tokens.push_back(token);                            // instr
             tokens.push_back(token = pFunction[i++]);           // dest
             token = pFunction[i++];                             // src0

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -3314,8 +3314,8 @@ namespace dxvk {
     if (unlikely(ppShader == nullptr))
       return D3DERR_INVALIDCALL;
 
-    const uint32_t majorVersion = (pFunction[0] >> 8) & 0xff;
-    const uint32_t minorVersion = pFunction[0] & 0xff;
+    const uint32_t majorVersion = D3DSHADER_VERSION_MAJOR(pFunction[0]);
+    const uint32_t minorVersion = D3DSHADER_VERSION_MINOR(pFunction[0]);
 
     // Late fixed-function capable hardware exposed support for VS 1.1
     const uint32_t shaderModelVS = m_d3d9Options.shaderModel == 0 ? 1 : m_d3d9Options.shaderModel;
@@ -3692,8 +3692,8 @@ namespace dxvk {
     if (unlikely(ppShader == nullptr))
       return D3DERR_INVALIDCALL;
 
-    const uint32_t majorVersion = (pFunction[0] >> 8) & 0xff;
-    const uint32_t minorVersion = pFunction[0] & 0xff;
+    const uint32_t majorVersion = D3DSHADER_VERSION_MAJOR(pFunction[0]);
+    const uint32_t minorVersion = D3DSHADER_VERSION_MINOR(pFunction[0]);
 
     if (unlikely(majorVersion > m_d3d9Options.shaderModel
              || (majorVersion == 1 && minorVersion > 4)

--- a/src/d3d9/d3d9_shader_validator.cpp
+++ b/src/d3d9/d3d9_shader_validator.cpp
@@ -156,8 +156,8 @@ namespace dxvk {
         "IDirect3DShaderValidator9::Instruction: Bad version token. It indicates neither a pixel shader nor a vertex shader.");
     }
 
-    m_majorVersion = (headerToken >> 8) & 0xff;
-    m_minorVersion = headerToken & 0xff;
+    m_majorVersion = D3DSHADER_VERSION_MAJOR(headerToken);
+    m_minorVersion = D3DSHADER_VERSION_MINOR(headerToken);
     m_ctx   = std::make_unique<DxsoDecodeContext>(DxsoProgramInfo{ programType, m_minorVersion, m_majorVersion });
     m_state = D3D9ShaderValidatorState::ValidatingInstructions;
 


### PR DESCRIPTION
Fixes #4113.

https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/d3d9types/ne-d3d9types-_d3dshader_instruction_opcode_type

The information in the docs isn't clear or complete, but it is at least clear that RSQ isn't the only opcode which requires the explicit use of a replicate swizzle for its inputs.

If the swizzle on inputs is somehow `.xyzw` / D3DVS_NOSWIZZLE (although that is technically illegal in the context of the affected opcodes) it appears native d3d8 does indeed impose a replicate swizzle, as @AlpyneDreams has already determined when looking at **Indiana Jones And The Emperor's Tomb**, and also based on empirical evidence it appears `.w` is the one that makes things look as expected, and in this case also fixes the missing fog in **NFS Hot Pursuit 2**.

Needs testing to ensure nothing regresses otherwise, but once that is done, I'll undraft.