### PR TITLE
[d3d8] Restore config for Splinter Cell

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -1202,6 +1202,12 @@ namespace dxvk {
       { "d3d9.maxFrameRate",                  "60" },
       { "d3d8.forceLegacyDiscard",          "True" },
     }} },
+    /* Tom Clancy's Splinter Cell                 *
+     * Fixes shadow buffers and alt-tab           */
+    { R"(\\splintercell\.exe$)", {{
+      { "d3d8.scaleDref",                     "24" },
+      { "d3d9.deviceLossOnFocusLoss",       "True" },
+    }} },
   }};
 
 


### PR DESCRIPTION
I'm having a good day so I decided to fix this game. Somehow the config options got lost when we merged d8vk in 2.4. This PR simply restores the intended configuration by setting `d3d8.scaleDref` to `24` which fixes shadow buffers (#4257). This PR also sets `deviceLossOnFocusLoss` to fix the game crashing when alt-tabbing.

For more info on Dref scaling, you can see [here](http://web.archive.org/web/20070104115249/http://www.nvidia.com/object/General_FAQ.html#G5), specifically:
> We've changed the behavior of hardware shadow maps between the DirectX8 and DirectX9 interfaces.  In DirectX8, you're required to scale the interpolated z component (that will be compared with the value in the shadow map) by the bit depth of the shadow map itself.  Starting with the DirectX9 interfaces, we've changed this behavior to no longer require this scale, so the z value should be in the range [0..1], regardless of bit depth.  Basically, we wanted to implement this new cleaner behavior, but didn't want to break shipping apps that rely on the old behavior, so we changed it only for the new DX9 interfaces.

I never found this page while working on d8vk and it took a very long time to figure this out through trial and error and reverse engineering. I never want to have to see the opening cutscene of this game again for as long as I live.