### PR TITLE
[d3d8] Fix black screen after alt-tab for Trainz v1.3

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -1194,6 +1194,11 @@ namespace dxvk {
       { "d3d8.scaleDref",                     "24" },
       { "d3d9.deviceLossOnFocusLoss",       "True" },
     }} },
+    /* Trainz v1.3 (2001)                         *
+     * Fixes black screen after alt-tab           */
+    { R"(\\bin\\trainz\.exe$)", {{
+      { "d3d9.deviceLossOnFocusLoss",       "True" },
+    }} },
   }};
 
 


### PR DESCRIPTION
Adds profile for Trainz v1.3, which resolves black screen after alt-tab for Trainz.
Can close #4116 