### PR TITLE
[d3d8] Add shadow perspective divide workaround for Splinter Cell

### DIFF
--- a/src/d3d8/d3d8_device.h
+++ b/src/d3d8/d3d8_device.h
@@ -393,6 +393,8 @@ namespace dxvk {
       m_backBuffers.resize(m_presentParams.BackBufferCount);
 
       m_autoDepthStencil = nullptr;
+
+      m_shadowPerspectiveDivide = false;
     }
 
     inline void RecreateBackBuffersAndAutoDepthStencil() {
@@ -431,6 +433,8 @@ namespace dxvk {
 
     // Controls fixed-function exclusive mode (no PS support)
     bool                  m_isFixedFunctionOnly = false;
+
+    bool                  m_shadowPerspectiveDivide = false;
 
     D3D8StateBlock*                            m_recorder = nullptr;
     DWORD                                      m_recorderToken = 0;

--- a/src/d3d8/d3d8_options.h
+++ b/src/d3d8/d3d8_options.h
@@ -42,13 +42,19 @@ namespace dxvk {
     /// it was brought in line with standard D3D9 behavior.
     bool forceLegacyDiscard = false;
 
+    /// Splinter Cell expects shadow map texture coordinates to be perspective divided
+    /// even though D3DTTFF_PROJECTED is never set for any texture coordinates. This flag
+    /// forces that flag for the necessary stages when a depth texture is bound to slot 0
+    bool shadowPerspectiveDivide = false;
+
     D3D8Options() {}
 
     D3D8Options(const Config& config) {
-      auto forceVsDeclStr     = config.getOption<std::string>("d3d8.forceVsDecl",            "");
-      batching                = config.getOption<bool>       ("d3d8.batching",               batching);
-      placeP8InScratch        = config.getOption<bool>       ("d3d8.placeP8InScratch",       placeP8InScratch);
-      forceLegacyDiscard      = config.getOption<bool>       ("d3d8.forceLegacyDiscard",     forceLegacyDiscard);
+      auto forceVsDeclStr     = config.getOption<std::string>("d3d8.forceVsDecl",             "");
+      batching                = config.getOption<bool>       ("d3d8.batching",                batching);
+      placeP8InScratch        = config.getOption<bool>       ("d3d8.placeP8InScratch",        placeP8InScratch);
+      forceLegacyDiscard      = config.getOption<bool>       ("d3d8.forceLegacyDiscard",      forceLegacyDiscard);
+      shadowPerspectiveDivide = config.getOption<bool>       ("d3d8.shadowPerspectiveDivide", shadowPerspectiveDivide);
 
       parseVsDecl(forceVsDeclStr);
     }

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -1192,6 +1192,7 @@ namespace dxvk {
      * Fixes shadow buffers and alt-tab           */
     { R"(\\splintercell\.exe$)", {{
       { "d3d8.scaleDref",                     "24" },
+      { "d3d8.shadowPerspectiveDivide",     "True" },
       { "d3d9.deviceLossOnFocusLoss",       "True" },
     }} },
   }};


### PR DESCRIPTION
Splinter Cell seems to expect its shaders to do a perspective divide when sampling shadow maps even though it never sets `D3DTTFF_PROJECTED`. As far I'm aware, this game never worked properly except for on legacy D3D8 drivers for Windows XP with earlier GeForce cards, so I have to assume this was a driver hack. At some point D3D8 drivers or the frontend were updated to match the D3D9 behavior, breaking the game entirely. [This document](https://web.archive.org/web/20020202051908/http://developer.nvidia.com/docs/IO/1830/ATT/shadow_mapping.pdf) from NVIDIA says that the XYZ coordinates are divided by W (it calls them STR and Q), but never mentions `D3DTTFF_PROJECTED`.

Without the perspective divide, shadows are broken in some (but not all) scenes rendering the game unplayable as they need to be visible for stealth. To further complicate things, the shader also seems to expect that the second texcoord (texcoord 1) also has perspective divide applied, even though texture 1 is a non-depth light cookie texture so it's not as simple as applying perspective divide for all depth textures.

What this hack does is it will simply force perspective divide for stages 0 and 1 when a depth texture/shadow map is bound to stage 0, and ignore any pleas from the game to set the texture transform flags back to zero while the shadow map is bound.

I have not been able to find any indicators the game might provide to the driver to enable a hack somehow (e.g. a FOURCC code) and a deep dive on the web has returned nothing. I was not able to find any nonstandard texture stage states passed in, and the shaders don't seem to have any special flags or extensions used. It has been nearly impossible to fully know if the game is doing anything like that because the game crashes on my machine when using renderdoc, apitrace, and d3d8to9 on Linux. The only way I was able to get a trace was using apitrace with d3d8to9 and dxvk d3d9 on Windows, so my information is incomplete. Therefore, this hack might not necessarily perfectly emulate what those drivers are doing but it makes the game work.

If someone could get a d3d8 apitrace of the game running with shadows enabled, we might be able to work out a bit more about what's going on here. I have attached a relevant save game file that would need to be traced:
- [ShadowyCrates.zip](https://github.com/user-attachments/files/18623532/ShadowyCrates.zip)