### PR TITLE
[d3d8] Use D3D8 compatibilty mode to set HUD API level

### DIFF
--- a/src/d3d8/d3d8_device.cpp
+++ b/src/d3d8/d3d8_device.cpp
@@ -51,8 +51,6 @@ namespace dxvk {
       throw DxvkError("D3D8Device: ERROR! Failed to get D3D9 Bridge. d3d9.dll might not be DXVK!");
     }
 
-    m_bridge->SetAPIName("D3D8");
-
     ResetState();
     RecreateBackBuffersAndAutoDepthStencil();
 

--- a/src/d3d9/d3d9_bridge.cpp
+++ b/src/d3d9/d3d9_bridge.cpp
@@ -28,10 +28,6 @@ namespace dxvk {
     return m_device->QueryInterface(riid, ppvObject);
   }
 
-  void DxvkD3D8Bridge::SetAPIName(const char* name) {
-    m_device->m_implicitSwapchain->SetApiName(name);
-  }
-
   HRESULT DxvkD3D8Bridge::UpdateTextureFromBuffer(
         IDirect3DSurface9*  pDestSurface,
         IDirect3DSurface9*  pSrcSurface,

--- a/src/d3d9/d3d9_bridge.h
+++ b/src/d3d9/d3d9_bridge.h
@@ -22,13 +22,6 @@ IDxvkD3D8Bridge : public IUnknown {
   #endif
 
   /**
-   * \brief Changes the API name displayed on the HUD
-   *
-   * \param [in] name The new API name
-   */
-  virtual void SetAPIName(const char* name) = 0;
-
-  /**
    * \brief Updates a D3D9 surface from a D3D9 buffer
    *
    * \param [in] pDestSurface Destination surface (typically in VRAM)
@@ -86,8 +79,6 @@ namespace dxvk {
     HRESULT STDMETHODCALLTYPE QueryInterface(
             REFIID  riid,
             void** ppvObject);
-
-    void SetAPIName(const char* name);
 
     HRESULT UpdateTextureFromBuffer(
         IDirect3DSurface9*        pDestSurface,

--- a/src/d3d9/d3d9_swapchain.cpp
+++ b/src/d3d9/d3d9_swapchain.cpp
@@ -1121,11 +1121,6 @@ namespace dxvk {
     m_wctx->frameLatencySignal->wait(m_wctx->frameId - GetActualFrameLatency());
   }
 
-  void D3D9SwapChainEx::SetApiName(const char* name) {
-    if (m_apiHud && name)
-      m_apiHud->setApiName(name);
-  }
-
   uint32_t D3D9SwapChainEx::GetActualFrameLatency() {
     uint32_t maxFrameLatency = m_parent->GetFrameLatency();
 
@@ -1356,7 +1351,8 @@ namespace dxvk {
 
 
   std::string D3D9SwapChainEx::GetApiName() {
-    return this->GetParent()->IsExtended() ? "D3D9Ex" : "D3D9";
+    return this->GetParent()->IsD3D8Compatible() ? "D3D8" :
+           this->GetParent()->IsExtended() ? "D3D9Ex" : "D3D9";
   }
 
 

--- a/src/d3d9/d3d9_swapchain.h
+++ b/src/d3d9/d3d9_swapchain.h
@@ -136,8 +136,6 @@ namespace dxvk {
 
     void DestroyBackBuffers();
 
-    void SetApiName(const char* name);
-
     bool UpdateWindowCtx();
 
   private:

--- a/src/dxvk/hud/dxvk_hud_item.cpp
+++ b/src/dxvk/hud/dxvk_hud_item.cpp
@@ -122,12 +122,6 @@ namespace dxvk::hud {
   }
 
 
-  void HudClientApiItem::setApiName(std::string api) {
-    std::lock_guard lock(m_mutex);
-    m_api = std::move(api);
-  }
-
-
   HudPos HudClientApiItem::render(
     const DxvkContextObjects& ctx,
     const HudPipelineKey&     key,

--- a/src/dxvk/hud/dxvk_hud_item.h
+++ b/src/dxvk/hud/dxvk_hud_item.h
@@ -171,8 +171,6 @@ namespace dxvk::hud {
 
     ~HudClientApiItem();
 
-    void setApiName(std::string api);
-
     HudPos render(
       const DxvkContextObjects& ctx,
       const HudPipelineKey&     key,


### PR DESCRIPTION
Kind of a minor derp that went unnoticed so far: in d8vk we were only setting the correct API level for the implicit swapchain. If games decided to create any additional swapchains, the HUD would incorrectly show D3D9.

I've uncovered this thanks to Serious Sam (The First/Second Encounter), which does just that.

The PR removes the needless `SetAPIName` cascading calls from the d3d9 bridge and simply relies on the D3D8 compatibility mode when determining the HUD API level.