### PR TITLE
[d3d9] Update software cursor position using SetCursorPosition

### DIFF
--- a/src/d3d9/d3d9_cursor.cpp
+++ b/src/d3d9/d3d9_cursor.cpp
@@ -29,20 +29,20 @@ namespace dxvk {
 
 
   void D3D9Cursor::UpdateCursor(int X, int Y) {
+    // SetCursorPosition is used to directly update the position of software cursors,
+    // but keep track of the cursor position even when using hardware cursors, in order
+    // to ensure a smooth transition/overlap from one type to the other.
+    m_sCursor.X = X;
+    m_sCursor.Y = Y;
+
+    if (unlikely(m_sCursor.Width > 0 && m_sCursor.Height > 0))
+      return;
+
     POINT currentPos = { };
     if (::GetCursorPos(&currentPos) && currentPos == POINT{ X, Y })
         return;
 
     ::SetCursorPos(X, Y);
-  }
-
-
-  void D3D9Cursor::RefreshSoftwareCursorPosition() {
-    POINT currentPos = { };
-    ::GetCursorPos(&currentPos);
-
-    m_sCursor.X = static_cast<int32_t>(currentPos.x) - m_sCursor.XHotSpot;
-    m_sCursor.Y = static_cast<int32_t>(currentPos.y) - m_sCursor.YHotSpot;
   }
 
 
@@ -124,11 +124,6 @@ namespace dxvk {
 
   void D3D9Cursor::UpdateCursor(int X, int Y) {
     Logger::warn("D3D9Cursor::UpdateCursor: Not supported on current platform.");
-  }
-
-
-  void D3D9Cursor::RefreshSoftwareCursorPosition() {
-    Logger::warn("D3D9Cursor::RefreshSoftwareCursorPosition: Not supported on current platform.");
   }
 
 

--- a/src/d3d9/d3d9_cursor.h
+++ b/src/d3d9/d3d9_cursor.h
@@ -47,8 +47,6 @@ namespace dxvk {
 
     void UpdateCursor(int X, int Y);
 
-    void RefreshSoftwareCursorPosition();
-
     BOOL ShowCursor(BOOL bShow);
 
     HRESULT SetHardwareCursor(UINT XHotSpot, UINT YHotSpot, const CursorBitmap& bitmap);

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -4052,14 +4052,13 @@ namespace dxvk {
           DWORD dwFlags) {
 
     if (m_cursor.IsSoftwareCursor()) {
-      m_cursor.RefreshSoftwareCursorPosition();
-
       D3D9_SOFTWARE_CURSOR* pSoftwareCursor = m_cursor.GetSoftwareCursor();
 
       UINT cursorWidth  = pSoftwareCursor->DrawCursor ? pSoftwareCursor->Width : 0;
       UINT cursorHeight = pSoftwareCursor->DrawCursor ? pSoftwareCursor->Height : 0;
 
-      m_implicitSwapchain->SetCursorPosition(pSoftwareCursor->X, pSoftwareCursor->Y,
+      m_implicitSwapchain->SetCursorPosition(pSoftwareCursor->X - pSoftwareCursor->XHotSpot,
+                                             pSoftwareCursor->Y - pSoftwareCursor->YHotSpot,
                                              cursorWidth, cursorHeight);
 
       // Once a hardware cursor has been set or the device has been reset,
@@ -4070,8 +4069,6 @@ namespace dxvk {
         pSoftwareCursor->Height = 0;
         pSoftwareCursor->XHotSpot = 0;
         pSoftwareCursor->YHotSpot = 0;
-        pSoftwareCursor->X = 0;
-        pSoftwareCursor->Y = 0;
         pSoftwareCursor->ResetCursor = false;
       }
     }


### PR DESCRIPTION
Fixes #3020 on Windows as well.

Games relying on software cursors apparently also call SetCursorPosition on each frame, and since we call ::SetCursorPos(X, Y) when that happens, on native Windows that tends to cause some strange movement feedback for some reason when we later retrieve the cursor position before present, using ::GetCursorPos(). And, you guessed it, this works just fine in Wine...

Regardless, what seems to work just as fine both on Windows and Wine is simply using the coordinates passed by the application with SetCursorPosition calls instead of us getting the position of the win32 cursor before present.

The downside is that if any game expects software cursors to work without it calling SetCursorPosition on each frame, it will be very very disappointed now.

Needs a bit more testing to confirm the above doesn't happen in practice. For now it has been confirmed to work on Windows and Linux with Dungeon Siege 2 at least.