### PR TITLE
[dxvk] Fix potential race conditions w.r.t. swapchain destruction

### DIFF
--- a/src/dxvk/dxvk_presenter.h
+++ b/src/dxvk/dxvk_presenter.h
@@ -124,10 +124,12 @@ namespace dxvk {
      * 
      * Presents the last successfuly acquired image.
      * \param [in] frameId Frame number.
+     * \param [in] tracker Latency tracker
      * \returns Status of the operation
      */
     VkResult presentImage(
-            uint64_t        frameId);
+            uint64_t                frameId,
+      const Rc<DxvkLatencyTracker>& tracker);
 
     /**
      * \brief Signals a given frame
@@ -136,12 +138,10 @@ namespace dxvk {
      * the presenter signal with the given frame ID. Must not be
      * called before GPU work prior to the present submission has
      * completed in order to maintain consistency.
-     * \param [in] result Presentation result
      * \param [in] frameId Frame ID
      * \param [in] tracker Latency tracker
      */
     void signalFrame(
-            VkResult                result,
             uint64_t                frameId,
       const Rc<DxvkLatencyTracker>& tracker);
 
@@ -310,10 +310,11 @@ namespace dxvk {
     alignas(CACHE_LINE_SIZE)
     dxvk::mutex                 m_frameMutex;
     dxvk::condition_variable    m_frameCond;
+    dxvk::condition_variable    m_frameDrain;
     dxvk::thread                m_frameThread;
     std::queue<PresenterFrame>  m_frameQueue;
 
-    std::atomic<uint64_t>       m_lastFrameId = { 0ull };
+    uint64_t                    m_lastSignaled = 0u;
 
     alignas(CACHE_LINE_SIZE)
     FpsLimiter                  m_fpsLimiter;

--- a/src/dxvk/dxvk_queue.cpp
+++ b/src/dxvk/dxvk_queue.cpp
@@ -167,7 +167,8 @@ namespace dxvk {
           if (entry.latency.tracker)
             entry.latency.tracker->notifyQueuePresentBegin(entry.latency.frameId);
 
-          entry.result = entry.present.presenter->presentImage(entry.present.frameId);
+          entry.result = entry.present.presenter->presentImage(
+            entry.present.frameId, entry.latency.tracker);
 
           if (entry.latency.tracker) {
             entry.latency.tracker->notifyQueuePresentEnd(
@@ -271,8 +272,7 @@ namespace dxvk {
         // Signal the frame and then immediately destroy the reference.
         // This is necessary since the front-end may want to explicitly
         // destroy the presenter object. 
-        entry.present.presenter->signalFrame(entry.result,
-          entry.present.frameId, entry.latency.tracker);
+        entry.present.presenter->signalFrame(entry.present.frameId, entry.latency.tracker);
         entry.present.presenter = nullptr;
       }
 


### PR DESCRIPTION
The signaling thread can queue up a wait while the swapchain is being destroyed, which blows up. This also fixes a related race condition where we would queue up a wait using the wrong present mode.

This is somewhat fragile in the sense that the queue worker *must* call signalFrame for each and every present, or this will fall apart.

Needs testing.