### PR TITLE
meson: Fix version construct by dropping the "v" prefix

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,4 @@
-project('dxvk', ['c', 'cpp'], version : 'v2.5.3', meson_version : '>= 0.58', default_options : [ 'cpp_std=c++17', 'b_vscrt=static_from_buildtype', 'warning_level=2' ])
+project('dxvk', ['c', 'cpp'], version : '2.5.3', meson_version : '>= 0.58', default_options : [ 'cpp_std=c++17', 'b_vscrt=static_from_buildtype', 'warning_level=2' ])
 
 pkg = import('pkgconfig')
 cpu_family = target_machine.cpu_family()


### PR DESCRIPTION
The "v" prefix was causing the version to be incorrectly set for generated files (such as pc files for pkg-config).

Dropping the prefix fixes the issue.