### PR TITLE
Fix possible presenter deadlock (hopefully)

### DIFF
--- a/src/dxvk/dxvk_latency_builtin.h
+++ b/src/dxvk/dxvk_latency_builtin.h
@@ -109,6 +109,9 @@ namespace dxvk {
     DxvkLatencyFrameData* findFrame(
             uint64_t                  frameId);
 
+    bool forwardLatencyMarkerNv(
+            uint64_t                  frameId);
+
     duration computeFrameInterval(
             double                    maxFrameRate);
 

--- a/src/dxvk/dxvk_presenter.h
+++ b/src/dxvk/dxvk_presenter.h
@@ -315,6 +315,7 @@ namespace dxvk {
     std::queue<PresenterFrame>  m_frameQueue;
 
     uint64_t                    m_lastSignaled = 0u;
+    uint64_t                    m_lastCompleted = 0u;
 
     alignas(CACHE_LINE_SIZE)
     FpsLimiter                  m_fpsLimiter;


### PR DESCRIPTION
TL;DR there are situations where swapchain destruction will wait for the frame worker to drain the queue, but the frame worker might lock up in the frame latency tracker because something is calling `setLatencyMarkerNV` which in turn stalls until swapchain recreation finishes and keeps the latency tracker locked.

It's a mess, needs testing.