### PR TITLE
[dxvk] Don't create GPL pipeline if we need to patch the vertex shader

### DIFF
--- a/src/dxvk/dxvk_graphics.cpp
+++ b/src/dxvk/dxvk_graphics.cpp
@@ -1176,6 +1176,17 @@ namespace dxvk {
      && !state.rs.depthClipEnable())
       return false;
 
+    // If the vertex shader uses any input locations not provided by
+    // the input layout, we need to patch the shader.
+    uint32_t vsInputMask = m_shaders.vs->info().inputMask;
+    uint32_t ilAttributeMask = 0u;
+
+    for (uint32_t i = 0; i < state.il.attributeCount(); i++)
+      ilAttributeMask |= 1u << state.ilAttributes[i].location();
+
+    if ((vsInputMask & ilAttributeMask) != vsInputMask)
+      return false;
+
     if (m_shaders.tcs != nullptr) {
       // If tessellation shaders are present, the input patch
       // vertex count must match the shader's definition.


### PR DESCRIPTION
Fixes the validation error in #4683, not sure if it also fixes the vertex explosions.