### PR TITLE
[d3d8/9] Properly handle resource priority

### DIFF
--- a/src/d3d8/d3d8_batch.h
+++ b/src/d3d8/d3d8_batch.h
@@ -6,7 +6,6 @@
 
 #include <vector>
 #include <cstdint>
-#include <climits>
 
 namespace dxvk {
 
@@ -83,7 +82,7 @@ namespace dxvk {
       D3DPRIMITIVETYPE PrimitiveType = D3DPT_INVALID;
       std::vector<uint16_t> Indices;
       UINT Offset = 0;
-      UINT MinVertex = UINT_MAX;
+      UINT MinVertex = std::numeric_limits<uint32_t>::max();
       UINT MaxVertex = 0;
       UINT PrimitiveCount = 0;
       UINT DrawCallCount = 0;
@@ -126,7 +125,7 @@ namespace dxvk {
 
         draw.PrimitiveType = D3DPRIMITIVETYPE(0);
         draw.Offset = 0;
-        draw.MinVertex = UINT_MAX;
+        draw.MinVertex = std::numeric_limits<uint32_t>::max();
         draw.MaxVertex = 0;
         draw.PrimitiveCount = 0;
         draw.DrawCallCount = 0;

--- a/src/d3d8/d3d8_buffer.h
+++ b/src/d3d8/d3d8_buffer.h
@@ -16,8 +16,7 @@ namespace dxvk {
             Com<D3D9>&&     pBuffer,
             D3DPOOL         Pool,
             DWORD           Usage)
-      : D3D8Resource<D3D9, D3D8> (pDevice, std::move(pBuffer))
-      , m_pool                   (Pool)
+      : D3D8Resource<D3D9, D3D8> (pDevice, Pool, std::move(pBuffer))
       , m_usage                  (Usage) {
       m_options = this->GetParent()->GetOptions();
     }
@@ -52,7 +51,6 @@ namespace dxvk {
   protected:
 
     const D3D8Options* m_options;
-    const D3DPOOL      m_pool;
     const DWORD        m_usage;
 
   };

--- a/src/d3d8/d3d8_d3d9_util.h
+++ b/src/d3d8/d3d8_d3d9_util.h
@@ -59,30 +59,30 @@ namespace dxvk {
     // Add D3D8-specific caps:
 
     // Removed in D3D9, since it can always render windowed
-    pCaps8->Caps2                     |= D3DCAPS2_CANRENDERWINDOWED;
+    pCaps8->Caps2                     |= D3DCAPS2_CANRENDERWINDOWED
     // A remnant from a bygone age of ddraw interop most likely
-    //                                 | D3DCAPS2_NO2DDURING3DSCENE;
+    /*                                 | D3DCAPS2_NO2DDURING3DSCENE*/;
 
     // Used in conjunction with D3DPRASTERCAPS_PAT, but generally unadvertised
-    //pCaps8->PrimitiveMiscCaps       |= D3DPMISCCAPS_LINEPATTERNREP;
+    /*pCaps8->PrimitiveMiscCaps       |= D3DPMISCCAPS_LINEPATTERNREP;*/
 
     // Replaced by D3DPRASTERCAPS_DEPTHBIAS in D3D9
-    pCaps8->RasterCaps                |= D3DPRASTERCAPS_ZBIAS;
+    pCaps8->RasterCaps                |= D3DPRASTERCAPS_ZBIAS
     // Advertised on Nvidia cards by modern drivers, but not on AMD or Intel
-    //                                 | D3DPRASTERCAPS_ANTIALIASEDGES
+    /*                                 | D3DPRASTERCAPS_ANTIALIASEDGES*/
     // Advertised on Nvidia cards, but not on AMD or Intel
-    //                                 | D3DPRASTERCAPS_STRETCHBLTMULTISAMPLE
+    /*                                 | D3DPRASTERCAPS_STRETCHBLTMULTISAMPLE*/
     // TODO: Implement D3DRS_LINEPATTERN - vkCmdSetLineRasterizationModeEXT
-    //                                 | D3DPRASTERCAPS_PAT;
+    /*                                 | D3DPRASTERCAPS_PAT*/;
 
     // MAG only filter caps, generally unsupported
-    //pCaps8->TextureFilterCaps       |= D3DPTFILTERCAPS_MAGFAFLATCUBIC
-    //                                 | D3DPTFILTERCAPS_MAGFGAUSSIANCUBIC;
-    //pCaps8->CubeTextureFilterCaps    = pCaps8->TextureFilterCaps;
-    //pCaps8->VolumeTextureFilterCaps  = pCaps8->TextureFilterCaps;
+    /*pCaps8->TextureFilterCaps       |= D3DPTFILTERCAPS_MAGFAFLATCUBIC*/
+    /*                                 | D3DPTFILTERCAPS_MAGFGAUSSIANCUBIC;*/
+    /*pCaps8->CubeTextureFilterCaps    = pCaps8->TextureFilterCaps;*/
+    /*pCaps8->VolumeTextureFilterCaps  = pCaps8->TextureFilterCaps;*/
 
     // Not advertised on any modern hardware
-    //pCaps8->VertexProcessingCaps    |= D3DVTXPCAPS_NO_VSDT_UBYTE4;
+    /*pCaps8->VertexProcessingCaps    |= D3DVTXPCAPS_NO_VSDT_UBYTE4;*/
   }
 
   // (9<-8) D3DD3DPRESENT_PARAMETERS: Returns D3D9's params given an input for D3D8

--- a/src/d3d8/d3d8_device.cpp
+++ b/src/d3d8/d3d8_device.cpp
@@ -287,7 +287,7 @@ namespace dxvk {
       HRESULT res = GetD3D9()->GetBackBuffer(0, iBackBuffer, (d3d9::D3DBACKBUFFER_TYPE)Type, &pSurface9);
 
       if (likely(SUCCEEDED(res))) {
-        m_backBuffers[iBackBuffer] = new D3D8Surface(this, std::move(pSurface9));
+        m_backBuffers[iBackBuffer] = new D3D8Surface(this, D3DPOOL_DEFAULT, std::move(pSurface9));
         *ppBackBuffer = m_backBuffers[iBackBuffer].ref();
       }
 
@@ -347,7 +347,7 @@ namespace dxvk {
       NULL);
 
     if (likely(SUCCEEDED(res)))
-      *ppTexture = ref(new D3D8Texture2D(this, std::move(pTex9)));
+      *ppTexture = ref(new D3D8Texture2D(this, Pool, std::move(pTex9)));
 
     return res;
   }
@@ -381,7 +381,7 @@ namespace dxvk {
       NULL);
 
     if (likely(SUCCEEDED(res)))
-      *ppVolumeTexture = ref(new D3D8Texture3D(this, std::move(pVolume9)));
+      *ppVolumeTexture = ref(new D3D8Texture3D(this, Pool, std::move(pVolume9)));
 
     return res;
   }
@@ -414,7 +414,7 @@ namespace dxvk {
       NULL);
 
     if (likely(SUCCEEDED(res)))
-      *ppCubeTexture = ref(new D3D8TextureCube(this, std::move(pCube9)));
+      *ppCubeTexture = ref(new D3D8TextureCube(this, Pool, std::move(pCube9)));
 
     return res;
   }
@@ -493,7 +493,7 @@ namespace dxvk {
       NULL);
 
     if (likely(SUCCEEDED(res)))
-      *ppSurface = ref(new D3D8Surface(this, std::move(pSurf9)));
+      *ppSurface = ref(new D3D8Surface(this, D3DPOOL_DEFAULT, std::move(pSurf9)));
 
     return res;
   }
@@ -526,7 +526,7 @@ namespace dxvk {
       NULL);
 
     if (likely(SUCCEEDED(res)))
-      *ppSurface = ref(new D3D8Surface(this, std::move(pSurf9)));
+      *ppSurface = ref(new D3D8Surface(this, D3DPOOL_DEFAULT, std::move(pSurf9)));
 
     return res;
   }
@@ -558,7 +558,7 @@ namespace dxvk {
       NULL);
 
     if (likely(SUCCEEDED(res)))
-      *ppSurface = ref(new D3D8Surface(this, std::move(pSurf)));
+      *ppSurface = ref(new D3D8Surface(this, pool, std::move(pSurf)));
 
     return res;
   }
@@ -1064,7 +1064,7 @@ namespace dxvk {
       HRESULT res = GetD3D9()->GetRenderTarget(0, &pRT9); // use RT index 0
 
       if (likely(SUCCEEDED(res))) {
-        m_renderTarget = new D3D8Surface(this, std::move(pRT9));
+        m_renderTarget = new D3D8Surface(this, D3DPOOL_DEFAULT, std::move(pRT9));
         *ppRenderTarget = m_renderTarget.ref();
       }
 
@@ -1088,7 +1088,7 @@ namespace dxvk {
       HRESULT res = GetD3D9()->GetDepthStencilSurface(&pStencil9);
 
       if (likely(SUCCEEDED(res))) {
-        m_depthStencil = new D3D8Surface(this, std::move(pStencil9));
+        m_depthStencil = new D3D8Surface(this, D3DPOOL_DEFAULT, std::move(pStencil9));
         *ppZStencilSurface = m_depthStencil.ref();
       }
 

--- a/src/d3d8/d3d8_device.cpp
+++ b/src/d3d8/d3d8_device.cpp
@@ -1453,7 +1453,7 @@ namespace dxvk {
 
     return GetD3D9()->DrawIndexedPrimitive(
       d3d9::D3DPRIMITIVETYPE(PrimitiveType),
-      static_cast<INT>(std::min(m_baseVertexIndex, static_cast<UINT>(INT_MAX))), // set by SetIndices
+      static_cast<INT>(std::min(m_baseVertexIndex, static_cast<UINT>(std::numeric_limits<int32_t>::max()))), // set by SetIndices
       MinVertexIndex,
       NumVertices,
       StartIndex,
@@ -1593,7 +1593,7 @@ namespace dxvk {
     if (unlikely(ShouldRecord()))
       return m_recorder->SetIndices(pIndexData, BaseVertexIndex);
 
-    if (unlikely(BaseVertexIndex > INT_MAX))
+    if (unlikely(BaseVertexIndex > std::numeric_limits<int32_t>::max()))
       Logger::warn("D3D8Device::SetIndices: BaseVertexIndex exceeds INT_MAX");
 
     // used by DrawIndexedPrimitive

--- a/src/d3d8/d3d8_device.h
+++ b/src/d3d8/d3d8_device.h
@@ -399,14 +399,14 @@ namespace dxvk {
       for (UINT i = 0; i < m_presentParams.BackBufferCount; i++) {
         Com<d3d9::IDirect3DSurface9> pSurface9;
         GetD3D9()->GetBackBuffer(0, i, d3d9::D3DBACKBUFFER_TYPE_MONO, &pSurface9);
-        m_backBuffers[i] = new D3D8Surface(this, std::move(pSurface9));
+        m_backBuffers[i] = new D3D8Surface(this, D3DPOOL_DEFAULT, std::move(pSurface9));
       }
 
       Com<d3d9::IDirect3DSurface9> pStencil9;
       // This call will fail if the D3D9 device is created without
       // the EnableAutoDepthStencil presentation parameter set to TRUE.
       HRESULT res = GetD3D9()->GetDepthStencilSurface(&pStencil9);
-      m_autoDepthStencil = FAILED(res) ? nullptr : new D3D8Surface(this, std::move(pStencil9));
+      m_autoDepthStencil = FAILED(res) ? nullptr : new D3D8Surface(this, D3DPOOL_DEFAULT, std::move(pStencil9));
 
       m_renderTarget = m_backBuffers[0];
       m_depthStencil = m_autoDepthStencil;

--- a/src/d3d8/d3d8_include.h
+++ b/src/d3d8/d3d8_include.h
@@ -63,21 +63,21 @@ interface DECLSPEC_UUID("4B8AAAFA-140F-42BA-9131-597EAFAA2EAD") IDirect3DVolumeT
 #endif
 
 #ifdef __MINGW32__
-#define __CRT_UUID_DECL(type,l,w1,w2,b1,b2,b3,b4,b5,b6,b7,b8)         \
-}                                                                     \
+#define __CRT_UUID_DECL(type,l,w1,w2,b1,b2,b3,b4,b5,b6,b7,b8)                                                                               \
+}                                                                                                                                           \
   extern "C++" template<> struct __mingw_uuidof_s<d3d9::type> { static constexpr IID __uuid_inst = {l,w1,w2, {b1,b2,b3,b4,b5,b6,b7,b8}}; }; \
   extern "C++" template<> constexpr const GUID &__mingw_uuidof<d3d9::type>() { return __mingw_uuidof_s<d3d9::type>::__uuid_inst; }          \
   extern "C++" template<> constexpr const GUID &__mingw_uuidof<d3d9::type*>() { return __mingw_uuidof_s<d3d9::type>::__uuid_inst; }         \
 namespace d3d9 {
 
 #elif defined(__GNUC__)
-#define __CRT_UUID_DECL(type, a, b, c, d, e, f, g, h, i, j, k) \
-}                                                                                                                               \
-  extern "C++" { template <> constexpr GUID __uuidof_helper<d3d9::type>() { return GUID{a,b,c,{d,e,f,g,h,i,j,k}}; } }           \
-  extern "C++" { template <> constexpr GUID __uuidof_helper<d3d9::type*>() { return __uuidof_helper<d3d9::type>(); } }          \
-  extern "C++" { template <> constexpr GUID __uuidof_helper<const d3d9::type*>() { return __uuidof_helper<d3d9::type>(); } }    \
-  extern "C++" { template <> constexpr GUID __uuidof_helper<d3d9::type&>() { return __uuidof_helper<d3d9::type>(); } }          \
-  extern "C++" { template <> constexpr GUID __uuidof_helper<const d3d9::type&>() { return __uuidof_helper<d3d9::type>(); } }    \
+#define __CRT_UUID_DECL(type, a, b, c, d, e, f, g, h, i, j, k)                                                               \
+}                                                                                                                            \
+  extern "C++" { template <> constexpr GUID __uuidof_helper<d3d9::type>() { return GUID{a,b,c,{d,e,f,g,h,i,j,k}}; } }        \
+  extern "C++" { template <> constexpr GUID __uuidof_helper<d3d9::type*>() { return __uuidof_helper<d3d9::type>(); } }       \
+  extern "C++" { template <> constexpr GUID __uuidof_helper<const d3d9::type*>() { return __uuidof_helper<d3d9::type>(); } } \
+  extern "C++" { template <> constexpr GUID __uuidof_helper<d3d9::type&>() { return __uuidof_helper<d3d9::type>(); } }       \
+  extern "C++" { template <> constexpr GUID __uuidof_helper<const d3d9::type&>() { return __uuidof_helper<d3d9::type>(); } } \
 namespace d3d9 {
 #endif
 
@@ -126,27 +126,27 @@ namespace d3d9 {
 // Missed definitions in Wine/MinGW.
 
 #ifndef D3DPRESENT_BACK_BUFFERS_MAX_EX
-#define D3DPRESENT_BACK_BUFFERS_MAX_EX 30
+#define D3DPRESENT_BACK_BUFFERS_MAX_EX    30
 #endif
 
 #ifndef D3DSI_OPCODE_MASK
-#define D3DSI_OPCODE_MASK 0x0000FFFF
+#define D3DSI_OPCODE_MASK                 0x0000FFFF
 #endif
 
 #ifndef D3DSP_TEXTURETYPE_MASK
-#define D3DSP_TEXTURETYPE_MASK 0x78000000
+#define D3DSP_TEXTURETYPE_MASK            0x78000000
 #endif
 
 #ifndef D3DUSAGE_AUTOGENMIPMAP
-#define D3DUSAGE_AUTOGENMIPMAP 0x00000400L
+#define D3DUSAGE_AUTOGENMIPMAP            0x00000400L
 #endif
 
 #ifndef D3DSP_DCL_USAGE_MASK
-#define D3DSP_DCL_USAGE_MASK 0x0000000f
+#define D3DSP_DCL_USAGE_MASK              0x0000000f
 #endif
 
 #ifndef D3DSP_OPCODESPECIFICCONTROL_MASK
-#define D3DSP_OPCODESPECIFICCONTROL_MASK 0x00ff0000
+#define D3DSP_OPCODESPECIFICCONTROL_MASK  0x00ff0000
 #endif
 
 #ifndef D3DSP_OPCODESPECIFICCONTROL_SHIFT
@@ -154,31 +154,31 @@ namespace d3d9 {
 #endif
 
 #ifndef D3DCURSOR_IMMEDIATE_UPDATE
-#define D3DCURSOR_IMMEDIATE_UPDATE             0x00000001L
+#define D3DCURSOR_IMMEDIATE_UPDATE        0x00000001L
 #endif
 
 #ifndef D3DPRESENT_FORCEIMMEDIATE
-#define D3DPRESENT_FORCEIMMEDIATE              0x00000100L
+#define D3DPRESENT_FORCEIMMEDIATE         0x00000100L
 #endif
 
 // From d3dtypes.h
 
 #ifndef D3DDEVINFOID_TEXTUREMANAGER
-#define D3DDEVINFOID_TEXTUREMANAGER    1
+#define D3DDEVINFOID_TEXTUREMANAGER       1
 #endif
 
 #ifndef D3DDEVINFOID_D3DTEXTUREMANAGER
-#define D3DDEVINFOID_D3DTEXTUREMANAGER 2
+#define D3DDEVINFOID_D3DTEXTUREMANAGER    2
 #endif
 
 #ifndef D3DDEVINFOID_TEXTURING
-#define D3DDEVINFOID_TEXTURING         3
+#define D3DDEVINFOID_TEXTURING            3
 #endif
 
 // From d3dhal.h
 
 #ifndef D3DDEVINFOID_VCACHE
-#define D3DDEVINFOID_VCACHE            4
+#define D3DDEVINFOID_VCACHE               4
 #endif
 
 // MinGW headers are broken. Who'dve guessed?
@@ -186,21 +186,21 @@ namespace d3d9 {
 
 // Missing from d3d8types.h
 #ifndef D3DDEVINFOID_RESOURCEMANAGER
-#define D3DDEVINFOID_RESOURCEMANAGER    5
+#define D3DDEVINFOID_RESOURCEMANAGER      5
 #endif
 
 #ifndef D3DDEVINFOID_VERTEXSTATS
-#define D3DDEVINFOID_VERTEXSTATS        6   // Aka D3DDEVINFOID_D3DVERTEXSTATS
+#define D3DDEVINFOID_VERTEXSTATS          6 // Aka D3DDEVINFOID_D3DVERTEXSTATS
 #endif
 
 #ifndef D3DPRESENT_RATE_UNLIMITED
-#define D3DPRESENT_RATE_UNLIMITED       0x7FFFFFFF
+#define D3DPRESENT_RATE_UNLIMITED         0x7FFFFFFF
 #endif
 
 #else // _MSC_VER
 
 // These are enum typedefs in the MinGW headers, but not defined by Microsoft
-#define D3DVSDT_TYPE     DWORD
-#define D3DVSDE_REGISTER DWORD
+#define D3DVSDT_TYPE                      DWORD
+#define D3DVSDE_REGISTER                  DWORD
 
 #endif

--- a/src/d3d8/d3d8_main.cpp
+++ b/src/d3d8/d3d8_main.cpp
@@ -19,12 +19,15 @@ extern "C" {
   DLLEXPORT HRESULT __stdcall ValidatePixelShader(
       const DWORD*     pPixelShader,
       const D3DCAPS8*  pCaps,
-      BOOL             errorReturn,
+      BOOL             ErrorReturn,
       char**           pErrorString) {
+    HRESULT res = S_OK;
     std::string errorMessage = "";
 
+    // ValidatePixelShader returns immediately in case of a NULL pPixelShader
     if (unlikely(pPixelShader == nullptr)) {
-      errorMessage = "D3D8: ValidatePixelShader: Null pPixelShader";
+      dxvk::Logger::warn("D3D8: ValidatePixelShader: Null pPixelShader");
+      return E_FAIL;
     } else {
       const uint32_t majorVersion = D3DSHADER_VERSION_MAJOR(pPixelShader[0]);
       const uint32_t minorVersion = D3DSHADER_VERSION_MINOR(pPixelShader[0]);
@@ -32,16 +35,24 @@ extern "C" {
       if (unlikely(majorVersion != 1 || minorVersion > 4)) {
         errorMessage = dxvk::str::format("D3D8: ValidatePixelShader: Unsupported PS version ",
                                           majorVersion, ".", minorVersion);
+        res = E_FAIL;
       } else if (unlikely(pCaps && pPixelShader[0] > pCaps->PixelShaderVersion)) {
         errorMessage = dxvk::str::format("D3D8: ValidatePixelShader: Caps: Unsupported PS version ",
                                           majorVersion, ".", minorVersion);
+        res = E_FAIL;
       }
     }
 
-    const size_t errorMessageSize = errorMessage.size() + 1;
+    if (unlikely(res != S_OK)) {
+      dxvk::Logger::warn(errorMessage);
+
+      if (!ErrorReturn)
+        errorMessage = "";
+    }
 
 #ifdef _WIN32
-    if (pErrorString != nullptr && errorReturn) {
+    if (pErrorString != nullptr) {
+      const size_t errorMessageSize = errorMessage.size() + 1;
       // Wine tests call HeapFree() on the returned error string,
       // so the expectation is for it to be allocated on the heap.
       *pErrorString = (char*) HeapAlloc(GetProcessHeap(), 0, errorMessageSize);
@@ -50,24 +61,21 @@ extern "C" {
     }
 #endif
 
-    if (errorMessageSize > 1) {
-      dxvk::Logger::warn(errorMessage);
-      return E_FAIL;
-    }
-
-    return S_OK;
+    return res;
   }
 
   DLLEXPORT HRESULT __stdcall ValidateVertexShader(
       const DWORD*     pVertexShader,
       const DWORD*     pVertexDecl,
       const D3DCAPS8*  pCaps,
-      BOOL             errorReturn,
+      BOOL             ErrorReturn,
       char**           pErrorString) {
+    HRESULT res = S_OK;
     std::string errorMessage = "";
 
     if (unlikely(pVertexShader == nullptr)) {
       errorMessage = "D3D8: ValidateVertexShader: Null pVertexShader";
+      res = E_FAIL;
     } else {
       const uint32_t majorVersion = D3DSHADER_VERSION_MAJOR(pVertexShader[0]);
       const uint32_t minorVersion = D3DSHADER_VERSION_MINOR(pVertexShader[0]);
@@ -75,16 +83,24 @@ extern "C" {
       if (unlikely(majorVersion != 1 || minorVersion > 1)) {
         errorMessage = dxvk::str::format("D3D8: ValidateVertexShader: Unsupported VS version ",
                                           majorVersion, ".", minorVersion);
+        res = E_FAIL;
       } else if (unlikely(pCaps && pVertexShader[0] > pCaps->VertexShaderVersion)) {
         errorMessage = dxvk::str::format("D3D8: ValidateVertexShader: Caps: Unsupported VS version ",
                                           majorVersion, ".", minorVersion);
+        res = E_FAIL;
       }
     }
 
-    const size_t errorMessageSize = errorMessage.size() + 1;
+    if (unlikely(res != S_OK)) {
+      dxvk::Logger::warn(errorMessage);
+
+      if (!ErrorReturn)
+        errorMessage = "";
+    }
 
 #ifdef _WIN32
-    if (pErrorString != nullptr && errorReturn) {
+    if (pErrorString != nullptr) {
+      const size_t errorMessageSize = errorMessage.size() + 1;
       // Wine tests call HeapFree() on the returned error string,
       // so the expectation is for it to be allocated on the heap.
       *pErrorString = (char*) HeapAlloc(GetProcessHeap(), 0, errorMessageSize);
@@ -93,12 +109,7 @@ extern "C" {
     }
 #endif
 
-    if (errorMessageSize > 1) {
-      dxvk::Logger::warn(errorMessage);
-      return E_FAIL;
-    }
-
-    return S_OK;
+    return res;
   }
 
   DLLEXPORT void __stdcall DebugSetMute() {}

--- a/src/d3d8/d3d8_resource.h
+++ b/src/d3d8/d3d8_resource.h
@@ -18,8 +18,9 @@ namespace dxvk {
 
   public:
 
-    D3D8Resource(D3D8Device* pDevice, Com<D3D9>&& Object)
+    D3D8Resource(D3D8Device* pDevice, D3DPOOL Pool, Com<D3D9>&& Object)
       : D3D8DeviceChild<D3D9, D3D8>(pDevice, std::move(Object))
+      , m_pool                     ( Pool )
       , m_priority                 ( 0 ) { }
 
     HRESULT STDMETHODCALLTYPE SetPrivateData(
@@ -79,9 +80,14 @@ namespace dxvk {
     }
 
     DWORD STDMETHODCALLTYPE SetPriority(DWORD PriorityNew) {
-      DWORD oldPriority = m_priority;
-      m_priority = PriorityNew;
-      return oldPriority;
+      // Priority can only be set for D3DPOOL_MANAGED resources
+      if (likely(m_pool == D3DPOOL_MANAGED)) {
+        DWORD oldPriority = m_priority;
+        m_priority = PriorityNew;
+        return oldPriority;
+      }
+
+      return m_priority;
     }
 
     DWORD STDMETHODCALLTYPE GetPriority() {
@@ -99,7 +105,8 @@ namespace dxvk {
 
   protected:
 
-    DWORD m_priority;
+    const D3DPOOL        m_pool;
+          DWORD          m_priority;
 
   private:
 

--- a/src/d3d8/d3d8_shader.cpp
+++ b/src/d3d8/d3d8_shader.cpp
@@ -1,4 +1,3 @@
-
 #include "d3d8_shader.h"
 
 #define VSD_SHIFT_MASK(token, field) ((token & field ## MASK) >> field ## SHIFT)

--- a/src/d3d8/d3d8_subresource.h
+++ b/src/d3d8/d3d8_subresource.h
@@ -16,9 +16,10 @@ namespace dxvk {
 
     D3D8Subresource(
             D3D8Device*             pDevice,
+      const D3DPOOL                 Pool,
             Com<D3D9>&&             Object,
             IDirect3DBaseTexture8*  pBaseTexture)
-    : Resource(pDevice, std::move(Object)),
+    : Resource(pDevice, Pool, std::move(Object)),
       m_container(pBaseTexture) {
     }
 

--- a/src/d3d8/d3d8_surface.cpp
+++ b/src/d3d8/d3d8_surface.cpp
@@ -7,16 +7,18 @@ namespace dxvk {
 
   D3D8Surface::D3D8Surface(
           D3D8Device*                     pDevice,
+    const D3DPOOL                         Pool,
           IDirect3DBaseTexture8*          pTexture,
           Com<d3d9::IDirect3DSurface9>&&  pSurface)
-    : D3D8SurfaceBase (pDevice, std::move(pSurface), pTexture) {
+    : D3D8SurfaceBase (pDevice, Pool, std::move(pSurface), pTexture) {
   }
 
   // A surface does not need to be attached to a texture
   D3D8Surface::D3D8Surface(
           D3D8Device*                     pDevice,
+    const D3DPOOL                         Pool,
           Com<d3d9::IDirect3DSurface9>&&  pSurface)
-    : D3D8Surface (pDevice, nullptr, std::move(pSurface)) {
+    : D3D8Surface (pDevice, Pool, nullptr, std::move(pSurface)) {
   }
 
   HRESULT STDMETHODCALLTYPE D3D8Surface::GetDesc(D3DSURFACE_DESC* pDesc) {

--- a/src/d3d8/d3d8_surface.cpp
+++ b/src/d3d8/d3d8_surface.cpp
@@ -1,4 +1,3 @@
-
 #include "d3d8_surface.h"
 #include "d3d8_device.h"
 

--- a/src/d3d8/d3d8_surface.h
+++ b/src/d3d8/d3d8_surface.h
@@ -15,11 +15,13 @@ namespace dxvk {
 
     D3D8Surface(
             D3D8Device*                     pDevice,
+      const D3DPOOL                         Pool,
             IDirect3DBaseTexture8*          pTexture,
             Com<d3d9::IDirect3DSurface9>&&  pSurface);
 
     D3D8Surface(
             D3D8Device*                     pDevice,
+      const D3DPOOL                         Pool,
             Com<d3d9::IDirect3DSurface9>&&  pSurface);
 
     HRESULT STDMETHODCALLTYPE GetDesc(D3DSURFACE_DESC* pDesc) final;

--- a/src/d3d8/d3d8_swapchain.cpp
+++ b/src/d3d8/d3d8_swapchain.cpp
@@ -27,7 +27,7 @@ namespace dxvk {
       HRESULT res = GetD3D9()->GetBackBuffer(BackBuffer, (d3d9::D3DBACKBUFFER_TYPE)Type, &pSurface9);
 
       if (likely(SUCCEEDED(res))) {
-        m_backBuffers[BackBuffer] = new D3D8Surface(GetParent(), std::move(pSurface9));
+        m_backBuffers[BackBuffer] = new D3D8Surface(GetParent(), D3DPOOL_DEFAULT, std::move(pSurface9));
         *ppBackBuffer = m_backBuffers[BackBuffer].ref();
       }
 

--- a/src/d3d8/d3d8_texture.cpp
+++ b/src/d3d8/d3d8_texture.cpp
@@ -8,8 +8,9 @@ namespace dxvk {
 
   D3D8Texture2D::D3D8Texture2D(
           D3D8Device*                    pDevice,
+    const D3DPOOL                        Pool,
           Com<d3d9::IDirect3DTexture9>&& pTexture)
-    : D3D8Texture2DBase(pDevice, std::move(pTexture), pTexture->GetLevelCount()) {
+    : D3D8Texture2DBase(pDevice, Pool, std::move(pTexture), pTexture->GetLevelCount()) {
   }
 
   D3DRESOURCETYPE STDMETHODCALLTYPE D3D8Texture2D::GetType() { return D3DRTYPE_TEXTURE; }
@@ -51,8 +52,9 @@ namespace dxvk {
 
   D3D8Texture3D::D3D8Texture3D(
           D3D8Device*                           pDevice,
+    const D3DPOOL                               Pool,
           Com<d3d9::IDirect3DVolumeTexture9>&&  pVolumeTexture)
-    : D3D8Texture3DBase(pDevice, std::move(pVolumeTexture), pVolumeTexture->GetLevelCount()) {}
+    : D3D8Texture3DBase(pDevice, Pool, std::move(pVolumeTexture), pVolumeTexture->GetLevelCount()) {}
 
   D3DRESOURCETYPE STDMETHODCALLTYPE D3D8Texture3D::GetType() { return D3DRTYPE_VOLUMETEXTURE; }
 
@@ -98,8 +100,9 @@ namespace dxvk {
 
   D3D8TextureCube::D3D8TextureCube(
           D3D8Device*                         pDevice,
+    const D3DPOOL                             Pool,
           Com<d3d9::IDirect3DCubeTexture9>&&  pTexture)
-    : D3D8TextureCubeBase(pDevice, std::move(pTexture), pTexture->GetLevelCount() * CUBE_FACES) {
+    : D3D8TextureCubeBase(pDevice, Pool, std::move(pTexture), pTexture->GetLevelCount() * CUBE_FACES) {
   }
 
   D3DRESOURCETYPE STDMETHODCALLTYPE D3D8TextureCube::GetType() { return D3DRTYPE_CUBETEXTURE; }

--- a/src/d3d8/d3d8_texture.h
+++ b/src/d3d8/d3d8_texture.h
@@ -21,9 +21,10 @@ namespace dxvk {
 
     D3D8BaseTexture(
             D3D8Device*                         pDevice,
+      const D3DPOOL                             Pool,
             Com<D3D9>&&                         pBaseTexture,
             UINT                                SubresourceCount)
-        : D3D8Resource<D3D9, D3D8> ( pDevice, std::move(pBaseTexture) ) {
+        : D3D8Resource<D3D9, D3D8> ( pDevice, Pool, std::move(pBaseTexture) ) {
       m_subresources.resize(SubresourceCount, nullptr);
     }
 
@@ -74,7 +75,7 @@ namespace dxvk {
           Com<SubresourceType9> subresource = LookupSubresource(Index);
 
           // Cache the subresource
-          m_subresources[Index] = new SubresourceType(this->m_parent, this, std::move(subresource));
+          m_subresources[Index] = new SubresourceType(this->m_parent, this->m_pool, this, std::move(subresource));
         } catch (HRESULT res) {
           return res;
         }
@@ -112,6 +113,7 @@ namespace dxvk {
 
     D3D8Texture2D(
             D3D8Device*                    pDevice,
+      const D3DPOOL                        Pool,
             Com<d3d9::IDirect3DTexture9>&& pTexture);
 
     D3DRESOURCETYPE STDMETHODCALLTYPE GetType() final;
@@ -139,6 +141,7 @@ namespace dxvk {
 
     D3D8Texture3D(
             D3D8Device*                           pDevice,
+      const D3DPOOL                               Pool,
             Com<d3d9::IDirect3DVolumeTexture9>&&  pVolumeTexture);
 
     D3DRESOURCETYPE STDMETHODCALLTYPE GetType() final;
@@ -166,6 +169,7 @@ namespace dxvk {
 
     D3D8TextureCube(
             D3D8Device*                         pDevice,
+      const D3DPOOL                             Pool,
             Com<d3d9::IDirect3DCubeTexture9>&&  pTexture);
 
     D3DRESOURCETYPE STDMETHODCALLTYPE GetType() final;

--- a/src/d3d8/d3d8_volume.cpp
+++ b/src/d3d8/d3d8_volume.cpp
@@ -6,9 +6,10 @@ namespace dxvk {
 
   D3D8Volume::D3D8Volume(
           D3D8Device*                   pDevice,
+    const D3DPOOL                       Pool,
           IDirect3DVolumeTexture8*      pTexture,
           Com<d3d9::IDirect3DVolume9>&& pVolume)
-    : D3D8VolumeBase(pDevice, std::move(pVolume), pTexture) {
+    : D3D8VolumeBase(pDevice, Pool, std::move(pVolume), pTexture) {
   }
 
   HRESULT STDMETHODCALLTYPE D3D8Volume::GetDesc(D3DVOLUME_DESC* pDesc) {

--- a/src/d3d8/d3d8_volume.h
+++ b/src/d3d8/d3d8_volume.h
@@ -11,6 +11,7 @@ namespace dxvk {
 
     D3D8Volume(
             D3D8Device*                   pDevice,
+      const D3DPOOL                       Pool,
             IDirect3DVolumeTexture8*      pTexture,
             Com<d3d9::IDirect3DVolume9>&& pVolume);
 

--- a/src/d3d9/d3d9_buffer.cpp
+++ b/src/d3d9/d3d9_buffer.cpp
@@ -8,8 +8,9 @@ namespace dxvk {
 
   D3D9VertexBuffer::D3D9VertexBuffer(
           D3D9DeviceEx*      pDevice,
-    const D3D9_BUFFER_DESC*  pDesc)
-  : D3D9VertexBufferBase(pDevice, pDesc) {
+    const D3D9_BUFFER_DESC*  pDesc,
+    const bool               Extended)
+  : D3D9VertexBufferBase(pDevice, pDesc, Extended) {
 
   }
 
@@ -68,8 +69,9 @@ namespace dxvk {
 
   D3D9IndexBuffer::D3D9IndexBuffer(
           D3D9DeviceEx*      pDevice,
-    const D3D9_BUFFER_DESC*  pDesc)
-  : D3D9IndexBufferBase(pDevice, pDesc) {
+    const D3D9_BUFFER_DESC*  pDesc,
+    const bool               Extended)
+  : D3D9IndexBufferBase(pDevice, pDesc, Extended) {
 
   }
 

--- a/src/d3d9/d3d9_buffer.h
+++ b/src/d3d9/d3d9_buffer.h
@@ -13,8 +13,9 @@ namespace dxvk {
 
     D3D9Buffer(
             D3D9DeviceEx*      pDevice,
-      const D3D9_BUFFER_DESC*  pDesc)
-    : D3D9Resource<Type...> (pDevice),
+      const D3D9_BUFFER_DESC*  pDesc,
+      const bool               Extended)
+    : D3D9Resource<Type...> (pDevice, pDesc->Pool, Extended ),
       m_buffer              (pDevice, pDesc) {
 
     }
@@ -57,7 +58,8 @@ namespace dxvk {
 
     D3D9VertexBuffer(
             D3D9DeviceEx*      pDevice,
-      const D3D9_BUFFER_DESC*  pDesc);
+      const D3D9_BUFFER_DESC*  pDesc,
+      const bool               Extended);
 
     HRESULT STDMETHODCALLTYPE QueryInterface(
             REFIID  riid,
@@ -76,7 +78,8 @@ namespace dxvk {
 
     D3D9IndexBuffer(
             D3D9DeviceEx*      pDevice,
-      const D3D9_BUFFER_DESC*  pDesc);
+      const D3D9_BUFFER_DESC*  pDesc,
+      const bool               Extended);
 
     HRESULT STDMETHODCALLTYPE QueryInterface(
             REFIID  riid,

--- a/src/d3d9/d3d9_common_texture.h
+++ b/src/d3d9/d3d9_common_texture.h
@@ -325,6 +325,8 @@ namespace dxvk {
 
     uint32_t GetPlaneCount() const;
 
+    D3DPOOL GetPool() const { return m_desc.Pool; }
+
     const D3D9_VK_FORMAT_MAPPING& GetMapping() { return m_mapping; }
 
     void SetLocked(UINT Subresource, bool value) { m_locked.set(Subresource, value); }

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -7692,6 +7692,10 @@ namespace dxvk {
     const     uint32_t regCountHardware = DetermineHardwareRegCount<ProgramType, ConstantType>();
     constexpr uint32_t regCountSoftware = DetermineSoftwareRegCount<ProgramType, ConstantType>();
 
+    // Error out in case of StartRegister + Count overflow
+    if (unlikely(StartRegister > std::numeric_limits<uint32_t>::max() - Count))
+      return D3DERR_INVALIDCALL;
+
     if (unlikely(StartRegister + Count > regCountSoftware))
       return D3DERR_INVALIDCALL;
 

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -657,7 +657,7 @@ namespace dxvk {
       if (pSharedHandle != nullptr && Pool != D3DPOOL_DEFAULT)
         return D3DERR_INVALIDCALL;
 
-      const Com<D3D9Texture2D> texture = new D3D9Texture2D(this, &desc, pSharedHandle);
+      const Com<D3D9Texture2D> texture = new D3D9Texture2D(this, &desc, IsExtended(), pSharedHandle);
 
       m_initializer->InitTexture(texture->GetCommonTexture(), initialData);
       *ppTexture = texture.ref();
@@ -717,7 +717,7 @@ namespace dxvk {
       return D3DERR_INVALIDCALL;
 
     try {
-      const Com<D3D9Texture3D> texture = new D3D9Texture3D(this, &desc);
+      const Com<D3D9Texture3D> texture = new D3D9Texture3D(this, &desc, IsExtended());
       m_initializer->InitTexture(texture->GetCommonTexture());
       *ppVolumeTexture = texture.ref();
 
@@ -775,7 +775,7 @@ namespace dxvk {
       return D3DERR_INVALIDCALL;
 
     try {
-      const Com<D3D9TextureCube> texture = new D3D9TextureCube(this, &desc);
+      const Com<D3D9TextureCube> texture = new D3D9TextureCube(this, &desc, IsExtended());
       m_initializer->InitTexture(texture->GetCommonTexture());
       *ppCubeTexture = texture.ref();
 
@@ -819,7 +819,7 @@ namespace dxvk {
       return D3DERR_INVALIDCALL;
 
     try {
-      const Com<D3D9VertexBuffer> buffer = new D3D9VertexBuffer(this, &desc);
+      const Com<D3D9VertexBuffer> buffer = new D3D9VertexBuffer(this, &desc, IsExtended());
       m_initializer->InitBuffer(buffer->GetCommonBuffer());
       *ppVertexBuffer = buffer.ref();
 
@@ -862,7 +862,7 @@ namespace dxvk {
       return D3DERR_INVALIDCALL;
 
     try {
-      const Com<D3D9IndexBuffer> buffer = new D3D9IndexBuffer(this, &desc);
+      const Com<D3D9IndexBuffer> buffer = new D3D9IndexBuffer(this, &desc, IsExtended());
       m_initializer->InitBuffer(buffer->GetCommonBuffer());
       *ppIndexBuffer = buffer.ref();
 
@@ -4126,7 +4126,7 @@ namespace dxvk {
       return D3DERR_INVALIDCALL;
 
     try {
-      const Com<D3D9Surface> surface = new D3D9Surface(this, &desc, nullptr, pSharedHandle);
+      const Com<D3D9Surface> surface = new D3D9Surface(this, &desc, IsExtended(), nullptr, pSharedHandle);
       m_initializer->InitTexture(surface->GetCommonTexture());
       *ppSurface = surface.ref();
       m_losableResourceCounter++;
@@ -4177,7 +4177,7 @@ namespace dxvk {
       return D3DERR_INVALIDCALL;
 
     try {
-      const Com<D3D9Surface> surface = new D3D9Surface(this, &desc, nullptr, pSharedHandle);
+      const Com<D3D9Surface> surface = new D3D9Surface(this, &desc, IsExtended(), nullptr, pSharedHandle);
       m_initializer->InitTexture(surface->GetCommonTexture());
       *ppSurface = surface.ref();
       
@@ -4228,7 +4228,7 @@ namespace dxvk {
       return D3DERR_INVALIDCALL;
 
     try {
-      const Com<D3D9Surface> surface = new D3D9Surface(this, &desc, nullptr, pSharedHandle);
+      const Com<D3D9Surface> surface = new D3D9Surface(this, &desc, IsExtended(), nullptr, pSharedHandle);
       m_initializer->InitTexture(surface->GetCommonTexture());
       *ppSurface = surface.ref();
       m_losableResourceCounter++;
@@ -8509,7 +8509,7 @@ namespace dxvk {
       if (FAILED(D3D9CommonTexture::NormalizeTextureProperties(this, D3DRTYPE_SURFACE, &desc)))
         return D3DERR_NOTAVAILABLE;
 
-      m_autoDepthStencil = new D3D9Surface(this, &desc, nullptr, nullptr);
+      m_autoDepthStencil = new D3D9Surface(this, &desc, IsExtended(), nullptr, nullptr);
       m_initializer->InitTexture(m_autoDepthStencil->GetCommonTexture());
       SetDepthStencilSurface(m_autoDepthStencil.ptr());
       m_losableResourceCounter++;

--- a/src/d3d9/d3d9_interop.cpp
+++ b/src/d3d9/d3d9_interop.cpp
@@ -349,7 +349,7 @@ namespace dxvk {
           const D3D9_COMMON_TEXTURE_DESC& desc,
           IDirect3DResource9**            ppResult) {
     try {
-      const Com<ResourceType> texture = new ResourceType(m_device, &desc);
+      const Com<ResourceType> texture = new ResourceType(m_device, &desc, m_device->IsExtended());
       m_device->m_initializer->InitTexture(texture->GetCommonTexture());
       *ppResult = texture.ref();
 

--- a/src/d3d9/d3d9_subresource.h
+++ b/src/d3d9/d3d9_subresource.h
@@ -12,12 +12,13 @@ namespace dxvk {
 
     D3D9Subresource(
             D3D9DeviceEx*           pDevice,
+      const bool                    Extended,
             D3D9CommonTexture*      pTexture,
             UINT                    Face,
             UINT                    MipLevel,
             IDirect3DBaseTexture9*  pBaseTexture,
             IUnknown*               pContainer)
-    : D3D9Resource<Type...>(pDevice),
+    : D3D9Resource<Type...>(pDevice, pTexture->GetPool(), Extended),
       m_container          (pContainer),
       m_baseTexture        (pBaseTexture),
       m_texture            (pTexture),

--- a/src/d3d9/d3d9_surface.cpp
+++ b/src/d3d9/d3d9_surface.cpp
@@ -11,10 +11,12 @@ namespace dxvk {
   D3D9Surface::D3D9Surface(
           D3D9DeviceEx*             pDevice,
     const D3D9_COMMON_TEXTURE_DESC* pDesc,
+    const bool                      Extended,
           IUnknown*                 pContainer,
           HANDLE*                   pSharedHandle)
     : D3D9SurfaceBase(
         pDevice,
+        Extended,
         new D3D9CommonTexture( pDevice, this, pDesc, D3DRTYPE_SURFACE, pSharedHandle),
         0, 0,
         nullptr,
@@ -22,21 +24,25 @@ namespace dxvk {
 
   D3D9Surface::D3D9Surface(
           D3D9DeviceEx*             pDevice,
-    const D3D9_COMMON_TEXTURE_DESC* pDesc)
+    const D3D9_COMMON_TEXTURE_DESC* pDesc,
+    const bool                      Extended)
     : D3D9Surface(
         pDevice,
         pDesc,
+        Extended,
         nullptr,
         nullptr) { }
 
   D3D9Surface::D3D9Surface(
           D3D9DeviceEx*             pDevice,
+    const bool                      Extended,
           D3D9CommonTexture*        pTexture,
           UINT                      Face,
           UINT                      MipLevel,
           IDirect3DBaseTexture9*    pBaseTexture)
     : D3D9SurfaceBase(
         pDevice,
+        Extended,
         pTexture,
         Face, MipLevel,
         pBaseTexture,

--- a/src/d3d9/d3d9_surface.h
+++ b/src/d3d9/d3d9_surface.h
@@ -20,15 +20,18 @@ namespace dxvk {
     D3D9Surface(
             D3D9DeviceEx*             pDevice,
       const D3D9_COMMON_TEXTURE_DESC* pDesc,
+      const bool                      Extended,
             IUnknown*                 pContainer,
             HANDLE*                   pSharedHandle);
 
     D3D9Surface(
             D3D9DeviceEx*             pDevice,
-      const D3D9_COMMON_TEXTURE_DESC* pDesc);
+      const D3D9_COMMON_TEXTURE_DESC* pDesc,
+      const bool                      Extended);
 
     D3D9Surface(
             D3D9DeviceEx*             pDevice,
+      const bool                      Extended,
             D3D9CommonTexture*        pTexture,
             UINT                      Face,
             UINT                      MipLevel,

--- a/src/d3d9/d3d9_swapchain.cpp
+++ b/src/d3d9/d3d9_swapchain.cpp
@@ -1022,7 +1022,7 @@ namespace dxvk {
     for (uint32_t i = 0; i < NumBuffers; i++) {
       D3D9Surface* surface;
       try {
-        surface = new D3D9Surface(m_parent, &desc, this, nullptr);
+        surface = new D3D9Surface(m_parent, &desc, m_parent->IsExtended(), this, nullptr);
         m_parent->IncrementLosableCounter();
       } catch (const DxvkError& e) {
         DestroyBackBuffers();

--- a/src/d3d9/d3d9_texture.cpp
+++ b/src/d3d9/d3d9_texture.cpp
@@ -9,13 +9,15 @@ namespace dxvk {
   D3D9Texture2D::D3D9Texture2D(
           D3D9DeviceEx*             pDevice,
     const D3D9_COMMON_TEXTURE_DESC* pDesc,
+    const bool                      Extended,
           HANDLE*                   pSharedHandle)
-    : D3D9Texture2DBase( pDevice, pDesc, D3DRTYPE_TEXTURE, pSharedHandle ) { }
+    : D3D9Texture2DBase( pDevice, pDesc, Extended, D3DRTYPE_TEXTURE, pSharedHandle ) { }
 
   D3D9Texture2D::D3D9Texture2D(
           D3D9DeviceEx*             pDevice,
-    const D3D9_COMMON_TEXTURE_DESC* pDesc)
-    : D3D9Texture2D( pDevice, pDesc, nullptr ) { }
+    const D3D9_COMMON_TEXTURE_DESC* pDesc,
+    const bool                      Extended)
+    : D3D9Texture2D( pDevice, pDesc, Extended, nullptr ) { }
 
   HRESULT STDMETHODCALLTYPE D3D9Texture2D::QueryInterface(REFIID riid, void** ppvObject) {
     if (ppvObject == nullptr)
@@ -112,8 +114,9 @@ namespace dxvk {
 
   D3D9Texture3D::D3D9Texture3D(
           D3D9DeviceEx*             pDevice,
-    const D3D9_COMMON_TEXTURE_DESC* pDesc)
-    : D3D9Texture3DBase( pDevice, pDesc, D3DRTYPE_VOLUMETEXTURE, nullptr ) { }
+    const D3D9_COMMON_TEXTURE_DESC* pDesc,
+    const bool                      Extended)
+    : D3D9Texture3DBase( pDevice, pDesc, Extended, D3DRTYPE_VOLUMETEXTURE, nullptr ) { }
 
 
   HRESULT STDMETHODCALLTYPE D3D9Texture3D::QueryInterface(REFIID riid, void** ppvObject) {
@@ -205,8 +208,9 @@ namespace dxvk {
 
   D3D9TextureCube::D3D9TextureCube(
           D3D9DeviceEx*             pDevice,
-    const D3D9_COMMON_TEXTURE_DESC* pDesc)
-    : D3D9TextureCubeBase( pDevice, pDesc, D3DRTYPE_CUBETEXTURE, nullptr ) { }
+    const D3D9_COMMON_TEXTURE_DESC* pDesc,
+    const bool                      Extended)
+    : D3D9TextureCubeBase( pDevice, pDesc, Extended, D3DRTYPE_CUBETEXTURE, nullptr ) { }
 
 
   HRESULT STDMETHODCALLTYPE D3D9TextureCube::QueryInterface(REFIID riid, void** ppvObject) {

--- a/src/d3d9/d3d9_texture.h
+++ b/src/d3d9/d3d9_texture.h
@@ -23,9 +23,10 @@ namespace dxvk {
     D3D9BaseTexture(
             D3D9DeviceEx*             pDevice,
       const D3D9_COMMON_TEXTURE_DESC* pDesc,
+      const bool                      Extended,
             D3DRESOURCETYPE           ResourceType,
             HANDLE*                   pSharedHandle)
-      : D3D9Resource<Base...> ( pDevice )
+      : D3D9Resource<Base...> ( pDevice, pDesc->Pool, Extended )
       , m_texture             ( pDevice, this, pDesc, ResourceType, pSharedHandle )
       , m_lod                 ( 0 ) {
       const uint32_t arraySlices = m_texture.Desc()->ArraySize;
@@ -41,6 +42,7 @@ namespace dxvk {
 
           new (subObj) SubresourceType(
             pDevice,
+            Extended,
             &m_texture,
             i, j,
             this);
@@ -132,11 +134,13 @@ namespace dxvk {
     D3D9Texture2D(
             D3D9DeviceEx*             pDevice,
       const D3D9_COMMON_TEXTURE_DESC* pDesc,
+      const bool                      Extended,
             HANDLE*                   pSharedHandle);
 
     D3D9Texture2D(
             D3D9DeviceEx*             pDevice,
-      const D3D9_COMMON_TEXTURE_DESC* pDesc);
+      const D3D9_COMMON_TEXTURE_DESC* pDesc,
+      const bool                      Extended);
 
 
     HRESULT STDMETHODCALLTYPE QueryInterface(REFIID riid, void** ppvObject);
@@ -162,7 +166,8 @@ namespace dxvk {
 
     D3D9Texture3D(
             D3D9DeviceEx*             pDevice,
-      const D3D9_COMMON_TEXTURE_DESC* pDesc);
+      const D3D9_COMMON_TEXTURE_DESC* pDesc,
+      const bool                      Extended);
 
     HRESULT STDMETHODCALLTYPE QueryInterface(REFIID riid, void** ppvObject);
 
@@ -187,7 +192,8 @@ namespace dxvk {
 
     D3D9TextureCube(
             D3D9DeviceEx*             pDevice,
-      const D3D9_COMMON_TEXTURE_DESC* pDesc);
+      const D3D9_COMMON_TEXTURE_DESC* pDesc,
+      const bool                      Extended);
 
     HRESULT STDMETHODCALLTYPE QueryInterface(REFIID riid, void** ppvObject);
 

--- a/src/d3d9/d3d9_volume.cpp
+++ b/src/d3d9/d3d9_volume.cpp
@@ -7,9 +7,11 @@ namespace dxvk {
 
   D3D9Volume::D3D9Volume(
           D3D9DeviceEx*             pDevice,
-    const D3D9_COMMON_TEXTURE_DESC* pDesc)
+    const D3D9_COMMON_TEXTURE_DESC* pDesc,
+    const bool                      Extended)
     : D3D9VolumeBase(
         pDevice,
+        Extended,
         new D3D9CommonTexture( pDevice, this, pDesc, D3DRTYPE_VOLUMETEXTURE, nullptr ),
         0, 0,
         nullptr,
@@ -18,12 +20,14 @@ namespace dxvk {
 
   D3D9Volume::D3D9Volume(
           D3D9DeviceEx*             pDevice,
+    const bool                      Extended,
           D3D9CommonTexture*        pTexture,
           UINT                      Face,
           UINT                      MipLevel,
           IDirect3DBaseTexture9*    pContainer)
     : D3D9VolumeBase(
         pDevice,
+        Extended,
         pTexture,
         Face, MipLevel,
         pContainer,

--- a/src/d3d9/d3d9_volume.h
+++ b/src/d3d9/d3d9_volume.h
@@ -13,10 +13,12 @@ namespace dxvk {
 
     D3D9Volume(
             D3D9DeviceEx*             pDevice,
-      const D3D9_COMMON_TEXTURE_DESC* pDesc);
+      const D3D9_COMMON_TEXTURE_DESC* pDesc,
+      const bool                      Extended);
 
     D3D9Volume(
             D3D9DeviceEx*             pDevice,
+      const bool                      Extended,
             D3D9CommonTexture*        pTexture,
             UINT                      Face,
             UINT                      MipLevel,


### PR DESCRIPTION
The d3d8/9 behavior with regards  to resource priorities is pretty straight forward:
- `D3D8/9Resource::SetPriority()` only works for resources in D3DPOOL_MANAGED
- everything else returns 0 above and on `D3D8/9Resource::GetPriority()` (esentially the value used above is ignored)

d3d9Ex, in its eternal wisdom decided to switch this up and:
- `D3D9Resource::SetPriority()` only works for resources in D3DPOOL_DEFAULT
- everything else returns 0 above and on `D3D9Resource::GetPriority()`, including anything in D3DPOOL_MANAGED
- there's a list of constants you can use with `SetPriority()`, but they're not mandatory and apps can basically set pretty much anything they want

I'm aware our backend doesn't use the priority for anything really, but I guess some games *might* depend on it for their own internal stuff. Oh, and Wine has a d3d8/9 test for it that fails without this PR, which annoyed me.

So this is now pretty much native behavior, as annoying as it was to get everything in place within templateing nightmares and whatnot.

Still need to double check if the tests are happy, and I'll undraft after I've confirmed.