### PR TITLE
Optimize barriers around order-invariant atomic operations

### DIFF
--- a/src/d3d11/d3d11_context.cpp
+++ b/src/d3d11/d3d11_context.cpp
@@ -1121,7 +1121,7 @@ namespace dxvk {
     } else {
       cmdData = EmitCsCmd<D3D11CmdDrawIndirectData>(
         [] (DxvkContext* ctx, const D3D11CmdDrawIndirectData* data) {
-          ctx->drawIndexedIndirect(data->offset, data->count, data->stride);
+          ctx->drawIndexedIndirect(data->offset, data->count, data->stride, true);
         });
 
       cmdData->type   = D3D11CmdType::DrawIndirectIndexed;
@@ -1156,7 +1156,7 @@ namespace dxvk {
     } else {
       cmdData = EmitCsCmd<D3D11CmdDrawIndirectData>(
         [] (DxvkContext* ctx, const D3D11CmdDrawIndirectData* data) {
-          ctx->drawIndirect(data->offset, data->count, data->stride);
+          ctx->drawIndirect(data->offset, data->count, data->stride, true);
         });
 
       cmdData->type   = D3D11CmdType::DrawIndirect;

--- a/src/d3d11/d3d11_context_ext.cpp
+++ b/src/d3d11/d3d11_context_ext.cpp
@@ -53,7 +53,7 @@ namespace dxvk {
       cOffset = ByteOffsetForArgs,
       cStride = ByteStrideForArgs
     ] (DxvkContext* ctx) {
-      ctx->drawIndirect(cOffset, cCount, cStride);
+      ctx->drawIndirect(cOffset, cCount, cStride, false);
     });
   }
   
@@ -72,7 +72,7 @@ namespace dxvk {
       cOffset = ByteOffsetForArgs,
       cStride = ByteStrideForArgs
     ] (DxvkContext* ctx) {
-      ctx->drawIndexedIndirect(cOffset, cCount, cStride);
+      ctx->drawIndexedIndirect(cOffset, cCount, cStride, false);
     });
   }
   

--- a/src/dxbc/dxbc_analysis.h
+++ b/src/dxbc/dxbc_analysis.h
@@ -17,9 +17,11 @@ namespace dxvk {
    * will be used to generate image types.
    */
   struct DxbcUavInfo {
-    bool accessTypedLoad = false;
-    bool accessAtomicOp  = false;
-    bool sparseFeedback  = false;
+    bool accessTypedLoad    = false;
+    bool accessAtomicOp     = false;
+    bool sparseFeedback     = false;
+    bool nonInvariantAccess = false;
+    DxvkAccessOp atomicStore = DxvkAccessOp::None;
     VkAccessFlags accessFlags = 0;
   };
   

--- a/src/dxvk/dxvk_barrier.h
+++ b/src/dxvk/dxvk_barrier.h
@@ -43,6 +43,14 @@ namespace dxvk {
 
 
   /**
+   * \brief Barrier node payload
+   */
+  struct DxvkBarrierPayload {
+    DxvkAccessOps accessOps = 0u;
+  };
+
+
+  /**
    * \brief Barrier tree node
    *
    * Node of a red-black tree, consisting of a packed node
@@ -61,6 +69,9 @@ namespace dxvk {
 
     // Address range of the node
     DxvkAddressRange addressRange = { };
+
+    // Node payload
+    DxvkBarrierPayload payload = { };
 
     void setRed(bool red) {
       header &= ~uint64_t(1u);
@@ -117,21 +128,25 @@ namespace dxvk {
      *
      * \param [in] range Resource range
      * \param [in] accessType Access type
+     * \param [in] accessOp Access operation
      * \returns \c true if the range has a pending access
      */
     bool findRange(
       const DxvkAddressRange&           range,
-            DxvkAccess                  accessType) const;
+            DxvkAccess                  accessType,
+            DxvkAccessOp                accessOp) const;
 
     /**
      * \brief Inserts address range for a given access type
      *
      * \param [in] range Resource range
      * \param [in] accessType Access type
+     * \param [in] accessOp Access operation
      */
     void insertRange(
       const DxvkAddressRange&           range,
-            DxvkAccess                  accessType);
+            DxvkAccess                  accessType,
+            DxvkAccessOp                accessOp);
 
     /**
      * \brief Clears the entire structure
@@ -166,7 +181,8 @@ namespace dxvk {
 
     uint32_t insertNode(
       const DxvkAddressRange&           range,
-            uint32_t                    rootIndex);
+            uint32_t                    rootIndex,
+            DxvkBarrierPayload          payload);
 
     void removeNode(
             uint32_t                    nodeIndex,

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -7796,9 +7796,9 @@ namespace dxvk {
                        + (subresources.baseArrayLayer + subresources.layerCount - 1u);
 
         if (hasWrite)
-          m_barrierTracker.insertRange(range, DxvkAccess::Write);
+          m_barrierTracker.insertRange(range, DxvkAccess::Write, accessOp);
         if (hasRead)
-          m_barrierTracker.insertRange(range, DxvkAccess::Read);
+          m_barrierTracker.insertRange(range, DxvkAccess::Read, accessOp);
       } else {
         DxvkAddressRange range;
         range.resource = image.getResourceId();
@@ -7808,9 +7808,9 @@ namespace dxvk {
           range.rangeEnd = range.rangeStart + subresources.layerCount - 1u;
 
           if (hasWrite)
-            m_barrierTracker.insertRange(range, DxvkAccess::Write);
+            m_barrierTracker.insertRange(range, DxvkAccess::Write, accessOp);
           if (hasRead)
-            m_barrierTracker.insertRange(range, DxvkAccess::Read);
+            m_barrierTracker.insertRange(range, DxvkAccess::Read, accessOp);
         }
       }
     }
@@ -7863,9 +7863,9 @@ namespace dxvk {
       range.rangeEnd = offset + size - 1;
 
       if (srcAccess & vk::AccessWriteMask)
-        m_barrierTracker.insertRange(range, DxvkAccess::Write);
+        m_barrierTracker.insertRange(range, DxvkAccess::Write, accessOp);
       if (srcAccess & vk::AccessReadMask)
-        m_barrierTracker.insertRange(range, DxvkAccess::Read);
+        m_barrierTracker.insertRange(range, DxvkAccess::Read, accessOp);
     }
   }
 
@@ -8037,7 +8037,7 @@ namespace dxvk {
     range.rangeStart = offset;
     range.rangeEnd = offset + size - 1;
 
-    return m_barrierTracker.findRange(range, access);
+    return m_barrierTracker.findRange(range, access, accessOp);
   }
 
 
@@ -8071,7 +8071,7 @@ namespace dxvk {
     // Probe all subresources first, only check individual mip levels
     // if there are overlaps and if we are checking a subset of array
     // layers of multiple mips.
-    bool dirty = m_barrierTracker.findRange(range, access);
+    bool dirty = m_barrierTracker.findRange(range, access, accessOp);
 
     if (!dirty || subresources.levelCount == 1u || subresources.layerCount == layerCount)
       return dirty;
@@ -8080,7 +8080,7 @@ namespace dxvk {
       range.rangeStart = i * layerCount + subresources.baseArrayLayer;
       range.rangeEnd = range.rangeStart + subresources.layerCount - 1u;
 
-      dirty = m_barrierTracker.findRange(range, access);
+      dirty = m_barrierTracker.findRange(range, access, accessOp);
     }
 
     return dirty;

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -236,7 +236,7 @@ namespace dxvk {
 
       accessImage(DxvkCmdBuffer::ExecBuffer, *image, subresources,
         image->info().layout, image->info().stages, 0,
-        layout, image->info().stages, image->info().access);
+        layout, image->info().stages, image->info().access, DxvkAccessOp::None);
 
       image->setLayout(layout);
 
@@ -288,10 +288,9 @@ namespace dxvk {
         &value);
     }
 
-    accessBuffer(cmdBuffer,
-      *buffer, offset, length,
-      VK_PIPELINE_STAGE_2_TRANSFER_BIT,
-      VK_ACCESS_2_TRANSFER_WRITE_BIT);
+    accessBuffer(cmdBuffer, *buffer, offset, length,
+      VK_PIPELINE_STAGE_2_TRANSFER_BIT, VK_ACCESS_2_TRANSFER_WRITE_BIT,
+      DxvkAccessOp::None);
 
     m_cmd->track(buffer, DxvkAccess::Write);
   }
@@ -361,7 +360,7 @@ namespace dxvk {
 
     accessBuffer(cmdBuffer, *bufferView,
       VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT,
-      VK_ACCESS_2_SHADER_WRITE_BIT);
+      VK_ACCESS_2_SHADER_WRITE_BIT, DxvkAccessOp::None);
 
     if (unlikely(m_features.test(DxvkContextFeature::DebugUtils)))
       m_cmd->cmdEndDebugUtilsLabel(cmdBuffer);
@@ -478,15 +477,13 @@ namespace dxvk {
 
     m_cmd->cmdCopyBuffer(cmdBuffer, &copyInfo);
 
-    accessBuffer(cmdBuffer,
-      *srcBuffer, srcOffset, numBytes,
-      VK_PIPELINE_STAGE_2_TRANSFER_BIT,
-      VK_ACCESS_2_TRANSFER_READ_BIT);
+    accessBuffer(cmdBuffer, *srcBuffer, srcOffset, numBytes,
+      VK_PIPELINE_STAGE_2_TRANSFER_BIT, VK_ACCESS_2_TRANSFER_READ_BIT,
+      DxvkAccessOp::None);
 
-    accessBuffer(cmdBuffer,
-      *dstBuffer, dstOffset, numBytes,
-      VK_PIPELINE_STAGE_2_TRANSFER_BIT,
-      VK_ACCESS_2_TRANSFER_WRITE_BIT);
+    accessBuffer(cmdBuffer, *dstBuffer, dstOffset, numBytes,
+      VK_PIPELINE_STAGE_2_TRANSFER_BIT, VK_ACCESS_2_TRANSFER_WRITE_BIT,
+      DxvkAccessOp::None);
 
     m_cmd->track(dstBuffer, DxvkAccess::Write);
     m_cmd->track(srcBuffer, DxvkAccess::Read);
@@ -818,10 +815,12 @@ namespace dxvk {
       extent.depth);
     
     accessBuffer(DxvkCmdBuffer::ExecBuffer, *dstView,
-      VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT, VK_ACCESS_2_SHADER_WRITE_BIT);
+      VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT, VK_ACCESS_2_SHADER_WRITE_BIT,
+      DxvkAccessOp::None);
 
     accessBuffer(DxvkCmdBuffer::ExecBuffer, *srcView,
-      VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT, VK_ACCESS_2_SHADER_READ_BIT);
+      VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT, VK_ACCESS_2_SHADER_READ_BIT,
+      DxvkAccessOp::None);
 
     // Track all involved resources
     m_cmd->track(dstBuffer, DxvkAccess::Write);
@@ -1123,7 +1122,7 @@ namespace dxvk {
     if (initialLayout == VK_IMAGE_LAYOUT_PREINITIALIZED) {
       accessImage(DxvkCmdBuffer::InitBuffer,
         *image, subresources, initialLayout,
-        VK_PIPELINE_STAGE_2_NONE, 0);
+        VK_PIPELINE_STAGE_2_NONE, 0, DxvkAccessOp::None);
 
       m_cmd->track(image, DxvkAccess::None);
     } else {
@@ -1202,10 +1201,8 @@ namespace dxvk {
         }
       }
 
-      accessImage(DxvkCmdBuffer::InitBuffer,
-        *image, subresources, clearLayout,
-        VK_PIPELINE_STAGE_2_TRANSFER_BIT,
-        VK_ACCESS_2_TRANSFER_WRITE_BIT);
+      accessImage(DxvkCmdBuffer::InitBuffer, *image, subresources, clearLayout,
+        VK_PIPELINE_STAGE_2_TRANSFER_BIT, VK_ACCESS_2_TRANSFER_WRITE_BIT, DxvkAccessOp::None);
 
       m_cmd->track(image, DxvkAccess::Write);
     }
@@ -1253,9 +1250,8 @@ namespace dxvk {
     }
 
     // Perform initial layout transition
-    accessImage(DxvkCmdBuffer::InitBuffer,
-      *image, image->getAvailableSubresources(),
-      VK_IMAGE_LAYOUT_UNDEFINED, VK_PIPELINE_STAGE_2_NONE, 0);
+    accessImage(DxvkCmdBuffer::InitBuffer, *image, image->getAvailableSubresources(),
+      VK_IMAGE_LAYOUT_UNDEFINED, VK_PIPELINE_STAGE_2_NONE, 0, DxvkAccessOp::None);
 
     m_cmd->track(image, DxvkAccess::Write);
   }
@@ -1293,7 +1289,8 @@ namespace dxvk {
 
     accessBuffer(DxvkCmdBuffer::ExecBuffer,
       *resource, 0, resource->info().size,
-      srcStages, srcAccess, dstStages, dstAccess);
+      srcStages, srcAccess, dstStages, dstAccess,
+      DxvkAccessOp::None);
 
     m_cmd->track(resource, DxvkAccess::Write);
   }
@@ -1315,7 +1312,8 @@ namespace dxvk {
     accessImage(DxvkCmdBuffer::ExecBuffer,
       *resource, resource->getAvailableSubresources(),
       srcLayout, srcStages, srcAccess,
-      dstLayout, dstStages, dstAccess);
+      dstLayout, dstStages, dstAccess,
+      DxvkAccessOp::None);
 
     m_cmd->track(resource, DxvkAccess::Write);
   }
@@ -1472,19 +1470,22 @@ namespace dxvk {
         VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT |
         VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT,
         VK_ACCESS_2_COLOR_ATTACHMENT_WRITE_BIT |
-        VK_ACCESS_2_SHADER_READ_BIT);
+        VK_ACCESS_2_SHADER_READ_BIT,
+        DxvkAccessOp::None);
     } else {
       accessImage(DxvkCmdBuffer::ExecBuffer,
         *imageView->image(), mipGenerator.getAllSourceSubresources(), srcLayout,
         VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT |
         VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT,
         VK_ACCESS_2_COLOR_ATTACHMENT_WRITE_BIT |
-        VK_ACCESS_2_SHADER_READ_BIT);
+        VK_ACCESS_2_SHADER_READ_BIT,
+        DxvkAccessOp::None);
 
       accessImage(DxvkCmdBuffer::ExecBuffer,
         *imageView->image(), mipGenerator.getBottomSubresource(), dstLayout,
         VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT,
-        VK_ACCESS_2_COLOR_ATTACHMENT_WRITE_BIT);
+        VK_ACCESS_2_COLOR_ATTACHMENT_WRITE_BIT,
+        DxvkAccessOp::None);
     }
 
     if (unlikely(m_features.test(DxvkContextFeature::DebugUtils)))
@@ -1584,7 +1585,7 @@ namespace dxvk {
 
     // If the image has any pending layout transitions, flush them accordingly.
     // There might be false positives here, but those do not affect correctness.
-    if (resourceHasAccess(*image, image->getAvailableSubresources(), DxvkAccess::Write)) {
+    if (resourceHasAccess(*image, image->getAvailableSubresources(), DxvkAccess::Write, DxvkAccessOp::None)) {
       spillRenderPass(true);
 
       flushBarriers();
@@ -1652,7 +1653,8 @@ namespace dxvk {
 
       accessImage(DxvkCmdBuffer::ExecBuffer, *image, image->getAvailableSubresources(),
         oldLayout, image->info().stages, image->info().access,
-        newLayout, image->info().stages, image->info().access);
+        newLayout, image->info().stages, image->info().access,
+        DxvkAccessOp::None);
 
       m_cmd->track(image, DxvkAccess::Write);
       return true;
@@ -1863,7 +1865,8 @@ namespace dxvk {
       accessImage(DxvkCmdBuffer::ExecBuffer,
         *dstImage, dstSubresources,
         srcLayout, dstImage->info().stages, dstImage->info().access,
-        dstLayout, dstImage->info().stages, dstImage->info().access);
+        dstLayout, dstImage->info().stages, dstImage->info().access,
+        DxvkAccessOp::None);
       
       m_cmd->track(dstImage, DxvkAccess::Write);
     }
@@ -2029,7 +2032,7 @@ namespace dxvk {
         *imageView->image(), imageView->imageSubresources(),
         imageLayout, clearStages, clearAccess, storeLayout,
         imageView->image()->info().stages,
-        imageView->image()->info().access);
+        imageView->image()->info().access, DxvkAccessOp::None);
 
       if (unlikely(m_features.test(DxvkContextFeature::DebugUtils)))
         m_cmd->cmdEndDebugUtilsLabel(DxvkCmdBuffer::ExecBuffer);
@@ -2232,7 +2235,7 @@ namespace dxvk {
       // Record layout transition from attachment layout back to default
       // layout. This will be flushed after the render pass has ended.
       accessImage(DxvkCmdBuffer::ExecBuffer, *dstImage,
-        dstSubresource, newLayout, stages, access);
+        dstSubresource, newLayout, stages, access, DxvkAccessOp::None);
 
       if (!isDepthStencil) {
         uint32_t index = m_state.om.framebufferInfo.getColorAttachmentIndex(i);
@@ -2343,7 +2346,7 @@ namespace dxvk {
 
     accessBuffer(cmdBuffer, *buffer, offset, size,
       VK_PIPELINE_STAGE_2_TRANSFER_BIT,
-      VK_ACCESS_2_TRANSFER_WRITE_BIT);
+      VK_ACCESS_2_TRANSFER_WRITE_BIT, DxvkAccessOp::None);
 
     m_cmd->track(buffer, DxvkAccess::Write);
   }
@@ -2794,7 +2797,8 @@ namespace dxvk {
 
       accessBuffer(DxvkCmdBuffer::ExecBuffer,
         *r.first, 0, r.first->info().size,
-        VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT, accessFlags);
+        VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT,
+        accessFlags, DxvkAccessOp::None);
 
       m_cmd->track(r.first, r.second.test(DxvkAccess::Write) ? DxvkAccess::Write : DxvkAccess::Read);
     }
@@ -2804,7 +2808,7 @@ namespace dxvk {
                                 | (r.second.test(DxvkAccess::Write) * VK_ACCESS_SHADER_WRITE_BIT);
       accessImage(DxvkCmdBuffer::ExecBuffer, *r.first,
         r.first->getAvailableSubresources(), r.first->info().layout,
-        VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT, accessFlags);
+        VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT, accessFlags, DxvkAccessOp::None);
 
       m_cmd->track(r.first, r.second.test(DxvkAccess::Write) ? DxvkAccess::Write : DxvkAccess::Read);
     }
@@ -3089,12 +3093,12 @@ namespace dxvk {
     accessImage(DxvkCmdBuffer::ExecBuffer,
       *dstView->image(), dstView->imageSubresources(), dstLayout,
       VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT,
-      VK_ACCESS_2_COLOR_ATTACHMENT_WRITE_BIT);
+      VK_ACCESS_2_COLOR_ATTACHMENT_WRITE_BIT, DxvkAccessOp::None);
     
     accessImage(DxvkCmdBuffer::ExecBuffer,
       *srcView->image(), srcView->imageSubresources(), srcLayout,
       VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT,
-      VK_ACCESS_2_SHADER_READ_BIT);
+      VK_ACCESS_2_SHADER_READ_BIT, DxvkAccessOp::None);
 
     if (unlikely(m_features.test(DxvkContextFeature::DebugUtils)))
       m_cmd->cmdEndDebugUtilsLabel(DxvkCmdBuffer::ExecBuffer);
@@ -3144,14 +3148,12 @@ namespace dxvk {
     blitInfo.filter = filter;
 
     m_cmd->cmdBlitImage(&blitInfo);
-    
-    accessImage(DxvkCmdBuffer::ExecBuffer,
-      *dstView->image(), dstView->imageSubresources(), dstLayout,
-      VK_PIPELINE_STAGE_2_TRANSFER_BIT, VK_ACCESS_2_TRANSFER_WRITE_BIT);
-    
-    accessImage(DxvkCmdBuffer::ExecBuffer,
-      *srcView->image(), srcView->imageSubresources(), srcLayout,
-      VK_PIPELINE_STAGE_2_TRANSFER_BIT, VK_ACCESS_2_TRANSFER_READ_BIT);
+
+    accessImage(DxvkCmdBuffer::ExecBuffer, *dstView->image(), dstView->imageSubresources(), dstLayout,
+      VK_PIPELINE_STAGE_2_TRANSFER_BIT, VK_ACCESS_2_TRANSFER_WRITE_BIT, DxvkAccessOp::None);
+
+    accessImage(DxvkCmdBuffer::ExecBuffer, *srcView->image(), srcView->imageSubresources(), srcLayout,
+      VK_PIPELINE_STAGE_2_TRANSFER_BIT, VK_ACCESS_2_TRANSFER_READ_BIT, DxvkAccessOp::None);
 
     m_cmd->track(dstView->image(), DxvkAccess::Write);
     m_cmd->track(srcView->image(), DxvkAccess::Read);
@@ -3302,10 +3304,10 @@ namespace dxvk {
       bufferSlice, bufferRowAlignment, bufferSliceAlignment);
 
     accessImage(cmdBuffer, *image, dstSubresourceRange, dstImageLayoutTransfer,
-      VK_PIPELINE_STAGE_2_TRANSFER_BIT, VK_ACCESS_2_TRANSFER_WRITE_BIT);
+      VK_PIPELINE_STAGE_2_TRANSFER_BIT, VK_ACCESS_2_TRANSFER_WRITE_BIT, DxvkAccessOp::None);
 
     accessBuffer(cmdBuffer, *buffer, bufferOffset, dataSize,
-      VK_PIPELINE_STAGE_2_TRANSFER_BIT, VK_ACCESS_2_TRANSFER_READ_BIT);
+      VK_PIPELINE_STAGE_2_TRANSFER_BIT, VK_ACCESS_2_TRANSFER_READ_BIT, DxvkAccessOp::None);
 
     m_cmd->track(image, DxvkAccess::Write);
     m_cmd->track(buffer, DxvkAccess::Read);
@@ -3541,11 +3543,11 @@ namespace dxvk {
 
     accessImage(DxvkCmdBuffer::ExecBuffer,
       *image, vk::makeSubresourceRange(imageSubresource),
-      imageLayout, stages, access);
+      imageLayout, stages, access, DxvkAccessOp::None);
 
     accessBuffer(DxvkCmdBuffer::ExecBuffer, *bufferView,
       VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT,
-      VK_ACCESS_2_SHADER_READ_BIT);
+      VK_ACCESS_2_SHADER_READ_BIT, DxvkAccessOp::None);
 
     if (unlikely(m_features.test(DxvkContextFeature::DebugUtils)))
       m_cmd->cmdEndDebugUtilsLabel(DxvkCmdBuffer::ExecBuffer);
@@ -3593,12 +3595,11 @@ namespace dxvk {
       image, imageSubresource, imageOffset, imageExtent, srcImageLayoutTransfer,
       bufferSlice, bufferRowAlignment, bufferSliceAlignment);
 
-    accessImage(DxvkCmdBuffer::ExecBuffer,
-      *image, srcSubresourceRange, srcImageLayoutTransfer,
-      VK_PIPELINE_STAGE_2_TRANSFER_BIT, VK_ACCESS_2_TRANSFER_READ_BIT);
+    accessImage(DxvkCmdBuffer::ExecBuffer, *image, srcSubresourceRange, srcImageLayoutTransfer,
+      VK_PIPELINE_STAGE_2_TRANSFER_BIT, VK_ACCESS_2_TRANSFER_READ_BIT, DxvkAccessOp::None);
 
     accessBuffer(DxvkCmdBuffer::ExecBuffer, *buffer, bufferOffset, dataSize,
-      VK_PIPELINE_STAGE_2_TRANSFER_BIT, VK_ACCESS_2_TRANSFER_WRITE_BIT);
+      VK_PIPELINE_STAGE_2_TRANSFER_BIT, VK_ACCESS_2_TRANSFER_WRITE_BIT, DxvkAccessOp::None);
 
     m_cmd->track(buffer, DxvkAccess::Write);
     m_cmd->track(image, DxvkAccess::Read);
@@ -3769,11 +3770,10 @@ namespace dxvk {
       workgroupCount.depth);
 
     accessBuffer(DxvkCmdBuffer::ExecBuffer, *bufferView,
-      VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT, VK_ACCESS_2_SHADER_WRITE_BIT);
+      VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT, VK_ACCESS_2_SHADER_WRITE_BIT, DxvkAccessOp::None);
 
-    accessImage(DxvkCmdBuffer::ExecBuffer, *image,
-      vk::makeSubresourceRange(imageSubresource), imageLayout,
-      VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT, VK_ACCESS_2_SHADER_READ_BIT);
+    accessImage(DxvkCmdBuffer::ExecBuffer, *image, vk::makeSubresourceRange(imageSubresource), imageLayout,
+      VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT, VK_ACCESS_2_SHADER_READ_BIT, DxvkAccessOp::None);
 
     m_flags.set(DxvkContextFlag::ForceWriteAfterWriteSync);
 
@@ -3894,7 +3894,7 @@ namespace dxvk {
 
       accessImage(DxvkCmdBuffer::ExecBuffer,
         *imageView->image(), imageView->imageSubresources(),
-        clearLayout, clearStages, clearAccess);
+        clearLayout, clearStages, clearAccess, DxvkAccessOp::None);
 
       if (unlikely(m_features.test(DxvkContextFeature::DebugUtils)))
         m_cmd->cmdEndDebugUtilsLabel(DxvkCmdBuffer::ExecBuffer);
@@ -3983,10 +3983,9 @@ namespace dxvk {
     m_cmd->cmdDispatch(cmdBuffer,
       workgroups.width, workgroups.height, workgroups.depth);
 
-    accessImage(cmdBuffer,
-      *imageView->image(), imageView->imageSubresources(),
+    accessImage(cmdBuffer, *imageView->image(), imageView->imageSubresources(),
       VK_IMAGE_LAYOUT_GENERAL, VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT,
-      VK_ACCESS_2_SHADER_WRITE_BIT);
+      VK_ACCESS_2_SHADER_WRITE_BIT, DxvkAccessOp::None);
 
     if (cmdBuffer == DxvkCmdBuffer::ExecBuffer)
       m_flags.set(DxvkContextFlag::ForceWriteAfterWriteSync);
@@ -4057,13 +4056,11 @@ namespace dxvk {
       m_cmd->cmdCopyImage(DxvkCmdBuffer::ExecBuffer, &copyInfo);
     }
 
-    accessImage(DxvkCmdBuffer::ExecBuffer,
-      *dstImage, dstSubresourceRange, dstImageLayout,
-      VK_PIPELINE_STAGE_2_TRANSFER_BIT, VK_ACCESS_2_TRANSFER_WRITE_BIT);
+    accessImage(DxvkCmdBuffer::ExecBuffer, *dstImage, dstSubresourceRange, dstImageLayout,
+      VK_PIPELINE_STAGE_2_TRANSFER_BIT, VK_ACCESS_2_TRANSFER_WRITE_BIT, DxvkAccessOp::None);
 
-    accessImage(DxvkCmdBuffer::ExecBuffer,
-      *srcImage, srcSubresourceRange, srcImageLayout,
-      VK_PIPELINE_STAGE_2_TRANSFER_BIT, VK_ACCESS_2_TRANSFER_READ_BIT);
+    accessImage(DxvkCmdBuffer::ExecBuffer, *srcImage, srcSubresourceRange, srcImageLayout,
+      VK_PIPELINE_STAGE_2_TRANSFER_BIT, VK_ACCESS_2_TRANSFER_READ_BIT, DxvkAccessOp::None);
 
     m_cmd->track(dstImage, DxvkAccess::Write);
     m_cmd->track(srcImage, DxvkAccess::Read);
@@ -4259,14 +4256,12 @@ namespace dxvk {
     m_cmd->cmdDraw(3, dstSubresource.layerCount, 0, 0);
     m_cmd->cmdEndRendering();
 
-    accessImage(DxvkCmdBuffer::ExecBuffer,
-      *srcImage, srcSubresourceRange, srcLayout,
-      VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT,
-      VK_ACCESS_2_SHADER_READ_BIT);
+    accessImage(DxvkCmdBuffer::ExecBuffer, *srcImage, srcSubresourceRange,
+      srcLayout, VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT,
+      VK_ACCESS_2_SHADER_READ_BIT, DxvkAccessOp::None);
 
-    accessImage(DxvkCmdBuffer::ExecBuffer,
-      *dstImage, dstSubresourceRange,
-      dstLayout, dstStages, dstAccess);
+    accessImage(DxvkCmdBuffer::ExecBuffer, *dstImage, dstSubresourceRange,
+      dstLayout, dstStages, dstAccess, DxvkAccessOp::None);
 
     if (unlikely(m_features.test(DxvkContextFeature::DebugUtils)))
       m_cmd->cmdEndDebugUtilsLabel(DxvkCmdBuffer::ExecBuffer);
@@ -4357,7 +4352,8 @@ namespace dxvk {
     accessBuffer(DxvkCmdBuffer::ExecBuffer, *buffer,
       offset, SparseMemoryPageSize * pageCount,
       VK_PIPELINE_STAGE_2_TRANSFER_BIT,
-      ToBuffer ? VK_ACCESS_2_TRANSFER_WRITE_BIT : VK_ACCESS_2_TRANSFER_READ_BIT);
+      ToBuffer ? VK_ACCESS_2_TRANSFER_WRITE_BIT : VK_ACCESS_2_TRANSFER_READ_BIT,
+      DxvkAccessOp::None);
   }
 
 
@@ -4406,7 +4402,8 @@ namespace dxvk {
 
     accessBuffer(DxvkCmdBuffer::ExecBuffer,
       *sparse, 0, sparse->info().size, VK_PIPELINE_STAGE_2_TRANSFER_BIT,
-      ToBuffer ? VK_ACCESS_2_TRANSFER_READ_BIT : VK_ACCESS_2_TRANSFER_WRITE_BIT);
+      ToBuffer ? VK_ACCESS_2_TRANSFER_READ_BIT : VK_ACCESS_2_TRANSFER_WRITE_BIT,
+      DxvkAccessOp::None);
 
     m_cmd->track(sparse, ToBuffer ? DxvkAccess::Read : DxvkAccess::Write);
     m_cmd->track(buffer, ToBuffer ? DxvkAccess::Write : DxvkAccess::Read);
@@ -4484,7 +4481,7 @@ namespace dxvk {
 
     accessImage(DxvkCmdBuffer::ExecBuffer,
       *sparse, sparseSubresources, transferLayout,
-      VK_PIPELINE_STAGE_2_TRANSFER_BIT, transferAccess);
+      VK_PIPELINE_STAGE_2_TRANSFER_BIT, transferAccess, DxvkAccessOp::None);
 
     m_cmd->track(sparse, ToBuffer ? DxvkAccess::Read : DxvkAccess::Write);
     m_cmd->track(buffer, ToBuffer ? DxvkAccess::Write : DxvkAccess::Read);
@@ -4533,12 +4530,12 @@ namespace dxvk {
     accessImage(DxvkCmdBuffer::ExecBuffer,
       *dstImage, dstSubresourceRange, dstLayout,
       VK_PIPELINE_STAGE_2_TRANSFER_BIT,
-      VK_ACCESS_2_TRANSFER_WRITE_BIT);
+      VK_ACCESS_2_TRANSFER_WRITE_BIT, DxvkAccessOp::None);
 
     accessImage(DxvkCmdBuffer::ExecBuffer,
       *srcImage, srcSubresourceRange, srcLayout,
       VK_PIPELINE_STAGE_2_TRANSFER_BIT,
-      VK_ACCESS_2_TRANSFER_READ_BIT);
+      VK_ACCESS_2_TRANSFER_READ_BIT, DxvkAccessOp::None);
 
     m_cmd->track(dstImage, DxvkAccess::Write);
     m_cmd->track(srcImage, DxvkAccess::Read);
@@ -4631,13 +4628,15 @@ namespace dxvk {
       *srcImage, srcSubresourceRange, srcLayout,
       VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT |
       VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT,
-      VK_ACCESS_2_DEPTH_STENCIL_ATTACHMENT_READ_BIT);
+      VK_ACCESS_2_DEPTH_STENCIL_ATTACHMENT_READ_BIT,
+      DxvkAccessOp::None);
 
     accessImage(DxvkCmdBuffer::ExecBuffer,
       *dstImage, dstSubresourceRange, dstLayout,
       VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT |
       VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT,
-      VK_ACCESS_2_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT);
+      VK_ACCESS_2_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT,
+      DxvkAccessOp::None);
 
     if (unlikely(m_features.test(DxvkContextFeature::DebugUtils)))
       m_cmd->cmdEndDebugUtilsLabel(DxvkCmdBuffer::ExecBuffer);
@@ -4844,14 +4843,12 @@ namespace dxvk {
     m_cmd->cmdDraw(3, region.dstSubresource.layerCount, 0, 0);
     m_cmd->cmdEndRendering();
 
-    accessImage(DxvkCmdBuffer::ExecBuffer,
-      *srcImage, srcSubresourceRange, srcLayout,
-      VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT,
-      VK_ACCESS_2_SHADER_READ_BIT);
+    accessImage(DxvkCmdBuffer::ExecBuffer, *srcImage, srcSubresourceRange,
+      srcLayout, VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT,
+      VK_ACCESS_2_SHADER_READ_BIT, DxvkAccessOp::None);
 
-    accessImage(DxvkCmdBuffer::ExecBuffer,
-      *dstImage, dstSubresourceRange,
-      dstLayout, dstStages, dstAccess);
+    accessImage(DxvkCmdBuffer::ExecBuffer, *dstImage, dstSubresourceRange,
+      dstLayout, dstStages, dstAccess, DxvkAccessOp::None);
 
     if (unlikely(m_features.test(DxvkContextFeature::DebugUtils)))
       m_cmd->cmdEndDebugUtilsLabel(DxvkCmdBuffer::ExecBuffer);
@@ -5148,9 +5145,9 @@ namespace dxvk {
 
       m_initBarriers.addImageBarrier(barrier);
     } else {
-      accessImage(DxvkCmdBuffer::SdmaBuffer,
-        *image, image->getAvailableSubresources(), transferLayout,
-        VK_PIPELINE_STAGE_2_TRANSFER_BIT, VK_ACCESS_2_TRANSFER_WRITE_BIT);
+      accessImage(DxvkCmdBuffer::SdmaBuffer, *image, image->getAvailableSubresources(),
+        transferLayout, VK_PIPELINE_STAGE_2_TRANSFER_BIT, VK_ACCESS_2_TRANSFER_WRITE_BIT,
+        DxvkAccessOp::None);
     }
 
     m_cmd->track(source, DxvkAccess::Read);
@@ -5296,7 +5293,7 @@ namespace dxvk {
         ops.depthOps.loadLayout,
         depthStages, 0,
         depthAttachment.layout,
-        depthStages, depthAccess);
+        depthStages, depthAccess, DxvkAccessOp::None);
     }
 
     for (uint32_t i = 0; i < MaxNumRenderTargets; i++) {
@@ -5316,7 +5313,7 @@ namespace dxvk {
           VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT, 0,
           colorAttachment.layout,
           VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT,
-          colorAccess);
+          colorAccess, DxvkAccessOp::None);
       }
     }
 
@@ -5346,7 +5343,8 @@ namespace dxvk {
         VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT,
         srcAccess, ops.depthOps.storeLayout,
         depthAttachment.view->image()->info().stages,
-        depthAttachment.view->image()->info().access);
+        depthAttachment.view->image()->info().access,
+        DxvkAccessOp::None);
     }
 
     for (uint32_t i = 0; i < MaxNumRenderTargets; i++) {
@@ -5362,7 +5360,8 @@ namespace dxvk {
           VK_ACCESS_2_COLOR_ATTACHMENT_WRITE_BIT,
           ops.colorOps[i].storeLayout,
           colorAttachment.view->image()->info().stages,
-          colorAttachment.view->image()->info().access);
+          colorAttachment.view->image()->info().access,
+          DxvkAccessOp::None);
       }
     }
 
@@ -5583,7 +5582,8 @@ namespace dxvk {
           accessBuffer(DxvkCmdBuffer::ExecBuffer, m_state.xfb.activeCounters[i],
             VK_PIPELINE_STAGE_2_TRANSFORM_FEEDBACK_BIT_EXT,
             VK_ACCESS_2_TRANSFORM_FEEDBACK_COUNTER_READ_BIT_EXT |
-            VK_ACCESS_2_TRANSFORM_FEEDBACK_COUNTER_WRITE_BIT_EXT);
+            VK_ACCESS_2_TRANSFORM_FEEDBACK_COUNTER_WRITE_BIT_EXT,
+            DxvkAccessOp::None);
 
           m_cmd->track(m_state.xfb.activeCounters[i].buffer(), DxvkAccess::Write);
         }
@@ -5968,7 +5968,7 @@ namespace dxvk {
               descriptorInfo.image.imageLayout = res.imageView->image()->info().layout;
 
               if (BindPoint == VK_PIPELINE_BIND_POINT_COMPUTE || unlikely(res.imageView->image()->hasGfxStores()))
-                accessImage(DxvkCmdBuffer::ExecBuffer, *res.imageView, util::pipelineStages(binding.stage), binding.access);
+                accessImage(DxvkCmdBuffer::ExecBuffer, *res.imageView, util::pipelineStages(binding.stage), binding.access, DxvkAccessOp::None);
 
               m_cmd->track(res.imageView->image(), DxvkAccess::Read);
             } else {
@@ -5992,7 +5992,7 @@ namespace dxvk {
               descriptorInfo.image.imageLayout = res.imageView->image()->info().layout;
 
               if (BindPoint == VK_PIPELINE_BIND_POINT_COMPUTE || res.imageView->image()->hasGfxStores())
-                accessImage(DxvkCmdBuffer::ExecBuffer, *res.imageView, util::pipelineStages(binding.stage), binding.access);
+                accessImage(DxvkCmdBuffer::ExecBuffer, *res.imageView, util::pipelineStages(binding.stage), binding.access, binding.accessOp);
 
               m_cmd->track(res.imageView->image(), (binding.access & vk::AccessWriteMask)
                 ? DxvkAccess::Write : DxvkAccess::Read);
@@ -6017,7 +6017,7 @@ namespace dxvk {
               descriptorInfo.image.imageLayout = res.imageView->image()->info().layout;
 
               if (BindPoint == VK_PIPELINE_BIND_POINT_COMPUTE || unlikely(res.imageView->image()->hasGfxStores()))
-                accessImage(DxvkCmdBuffer::ExecBuffer, *res.imageView, util::pipelineStages(binding.stage), binding.access);
+                accessImage(DxvkCmdBuffer::ExecBuffer, *res.imageView, util::pipelineStages(binding.stage), binding.access, DxvkAccessOp::None);
 
               m_cmd->track(res.sampler);
               m_cmd->track(res.imageView->image(), DxvkAccess::Read);
@@ -6035,7 +6035,7 @@ namespace dxvk {
               descriptorInfo.texelBuffer = res.bufferView->handle();
 
               if (BindPoint == VK_PIPELINE_BIND_POINT_COMPUTE || unlikely(res.bufferView->buffer()->hasGfxStores()))
-                accessBuffer(DxvkCmdBuffer::ExecBuffer, *res.bufferView, util::pipelineStages(binding.stage), binding.access);
+                accessBuffer(DxvkCmdBuffer::ExecBuffer, *res.bufferView, util::pipelineStages(binding.stage), binding.access, DxvkAccessOp::None);
 
               m_cmd->track(res.bufferView->buffer(), DxvkAccess::Read);
             } else {
@@ -6050,7 +6050,7 @@ namespace dxvk {
               descriptorInfo.texelBuffer = res.bufferView->handle();
 
               if (BindPoint == VK_PIPELINE_BIND_POINT_COMPUTE || res.bufferView->buffer()->hasGfxStores())
-                accessBuffer(DxvkCmdBuffer::ExecBuffer, *res.bufferView, util::pipelineStages(binding.stage), binding.access);
+                accessBuffer(DxvkCmdBuffer::ExecBuffer, *res.bufferView, util::pipelineStages(binding.stage), binding.access, binding.accessOp);
 
               m_cmd->track(res.bufferView->buffer(), (binding.access & vk::AccessWriteMask)
                 ? DxvkAccess::Write : DxvkAccess::Read);
@@ -6066,7 +6066,7 @@ namespace dxvk {
               descriptorInfo = res.bufferSlice.getDescriptor();
 
               if (BindPoint == VK_PIPELINE_BIND_POINT_COMPUTE || unlikely(res.bufferSlice.buffer()->hasGfxStores()))
-                accessBuffer(DxvkCmdBuffer::ExecBuffer, res.bufferSlice, util::pipelineStages(binding.stage), binding.access);
+                accessBuffer(DxvkCmdBuffer::ExecBuffer, res.bufferSlice, util::pipelineStages(binding.stage), binding.access, DxvkAccessOp::None);
 
               m_cmd->track(res.bufferSlice.buffer(), DxvkAccess::Read);
             } else {
@@ -6083,7 +6083,7 @@ namespace dxvk {
               descriptorInfo = res.bufferSlice.getDescriptor();
 
               if (BindPoint == VK_PIPELINE_BIND_POINT_COMPUTE || unlikely(res.bufferSlice.buffer()->hasGfxStores()))
-                accessBuffer(DxvkCmdBuffer::ExecBuffer, res.bufferSlice, util::pipelineStages(binding.stage), binding.access);
+                accessBuffer(DxvkCmdBuffer::ExecBuffer, res.bufferSlice, util::pipelineStages(binding.stage), binding.access, binding.accessOp);
 
               m_cmd->track(res.bufferSlice.buffer(), (binding.access & vk::AccessWriteMask)
                 ? DxvkAccess::Write : DxvkAccess::Read);
@@ -6222,7 +6222,8 @@ namespace dxvk {
         *attachment.view->image(),
         attachment.view->imageSubresources(), oldLayout,
         VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT,
-        VK_ACCESS_2_COLOR_ATTACHMENT_WRITE_BIT);
+        VK_ACCESS_2_COLOR_ATTACHMENT_WRITE_BIT |
+        VK_ACCESS_2_COLOR_ATTACHMENT_READ_BIT, DxvkAccessOp::None);
 
       m_cmd->track(attachment.view->image(), DxvkAccess::Write);
     }
@@ -6233,14 +6234,17 @@ namespace dxvk {
     const DxvkAttachment&         attachment,
           VkImageLayout           oldLayout) {
     if (oldLayout != attachment.view->image()->info().layout) {
+      VkAccessFlags2 access = VK_ACCESS_2_DEPTH_STENCIL_ATTACHMENT_READ_BIT;
+
+      if (oldLayout != VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL)
+        access |= VK_ACCESS_2_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
+
       accessImage(DxvkCmdBuffer::ExecBuffer,
         *attachment.view->image(),
         attachment.view->imageSubresources(), oldLayout,
         VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT |
         VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT,
-        oldLayout != VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL
-          ? VK_ACCESS_2_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT
-          : VK_ACCESS_2_NONE);
+        access, DxvkAccessOp::None);
 
       m_cmd->track(attachment.view->image(), DxvkAccess::Write);
     }
@@ -6385,7 +6389,7 @@ namespace dxvk {
 
     if (unlikely(m_state.vi.indexBuffer.buffer()->hasGfxStores())) {
       accessBuffer(DxvkCmdBuffer::ExecBuffer, m_state.vi.indexBuffer,
-        VK_PIPELINE_STAGE_VERTEX_INPUT_BIT, VK_ACCESS_INDEX_READ_BIT);
+        VK_PIPELINE_STAGE_VERTEX_INPUT_BIT, VK_ACCESS_INDEX_READ_BIT, DxvkAccessOp::None);
     }
 
     m_cmd->track(m_state.vi.indexBuffer.buffer(), DxvkAccess::Read);
@@ -6427,7 +6431,7 @@ namespace dxvk {
 
         if (unlikely(m_state.vi.vertexBuffers[binding].buffer()->hasGfxStores())) {
           accessBuffer(DxvkCmdBuffer::ExecBuffer, m_state.vi.vertexBuffers[binding],
-            VK_PIPELINE_STAGE_VERTEX_INPUT_BIT, VK_ACCESS_VERTEX_ATTRIBUTE_READ_BIT);
+            VK_PIPELINE_STAGE_VERTEX_INPUT_BIT, VK_ACCESS_VERTEX_ATTRIBUTE_READ_BIT, DxvkAccessOp::None);
         }
 
         m_cmd->track(m_state.vi.vertexBuffers[binding].buffer(), DxvkAccess::Read);
@@ -6489,7 +6493,7 @@ namespace dxvk {
 
         accessBuffer(DxvkCmdBuffer::ExecBuffer, m_state.xfb.buffers[i],
           VK_PIPELINE_STAGE_2_TRANSFORM_FEEDBACK_BIT_EXT,
-          VK_ACCESS_2_TRANSFORM_FEEDBACK_WRITE_BIT_EXT);
+          VK_ACCESS_2_TRANSFORM_FEEDBACK_WRITE_BIT_EXT, DxvkAccessOp::None);
 
         m_cmd->track(std::move(buffer), DxvkAccess::Write);
       }
@@ -6814,7 +6818,7 @@ namespace dxvk {
           case VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER: {
             if (slot.bufferView) {
               if (!IsGraphics || slot.bufferView->buffer()->hasGfxStores())
-                requiresBarrier |= checkBufferViewBarrier<BindPoint>(slot.bufferView, binding.access);
+                requiresBarrier |= checkBufferViewBarrier<BindPoint>(slot.bufferView, binding.access, binding.accessOp);
               else if (binding.access & vk::AccessWriteMask)
                 requiresBarrier |= !slot.bufferView->buffer()->trackGfxStores();
             }
@@ -6822,18 +6826,18 @@ namespace dxvk {
 
           case VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER: {
             if (slot.bufferView && (!IsGraphics || slot.bufferView->buffer()->hasGfxStores()))
-              requiresBarrier |= checkBufferViewBarrier<BindPoint>(slot.bufferView, binding.access);
+              requiresBarrier |= checkBufferViewBarrier<BindPoint>(slot.bufferView, binding.access, DxvkAccessOp::None);
           } break;
 
           case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER: {
             if (slot.bufferSlice.length() && (!IsGraphics || slot.bufferSlice.buffer()->hasGfxStores()))
-              requiresBarrier |= checkBufferBarrier<BindPoint>(slot.bufferSlice, binding.access);
+              requiresBarrier |= checkBufferBarrier<BindPoint>(slot.bufferSlice, binding.access, DxvkAccessOp::None);
           } break;
 
           case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER: {
             if (slot.bufferSlice.length()) {
               if (!IsGraphics || slot.bufferSlice.buffer()->hasGfxStores())
-                requiresBarrier |= checkBufferBarrier<BindPoint>(slot.bufferSlice, binding.access);
+                requiresBarrier |= checkBufferBarrier<BindPoint>(slot.bufferSlice, binding.access, binding.accessOp);
               else if (binding.access & vk::AccessWriteMask)
                 requiresBarrier |= !slot.bufferSlice.buffer()->trackGfxStores();
             }
@@ -6842,7 +6846,7 @@ namespace dxvk {
           case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE: {
             if (slot.imageView) {
               if (!IsGraphics || slot.imageView->image()->hasGfxStores())
-                requiresBarrier |= checkImageViewBarrier<BindPoint>(slot.imageView, binding.access);
+                requiresBarrier |= checkImageViewBarrier<BindPoint>(slot.imageView, binding.access, binding.accessOp);
               else if (binding.access & vk::AccessWriteMask)
                 requiresBarrier |= !slot.imageView->image()->trackGfxStores();
             }
@@ -6851,7 +6855,7 @@ namespace dxvk {
           case VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE:
           case VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER: {
             if (slot.imageView && (!IsGraphics || slot.imageView->image()->hasGfxStores()))
-              requiresBarrier |= checkImageViewBarrier<BindPoint>(slot.imageView, binding.access);
+              requiresBarrier |= checkImageViewBarrier<BindPoint>(slot.imageView, binding.access, DxvkAccessOp::None);
           } break;
 
           default:
@@ -6904,13 +6908,14 @@ namespace dxvk {
         if (xfbBufferSlice.length()) {
           requiresBarrier |= !xfbBufferSlice.buffer()->trackGfxStores();
           requiresBarrier |= checkBufferBarrier<VK_PIPELINE_BIND_POINT_GRAPHICS>(
-            xfbBufferSlice, VK_ACCESS_TRANSFORM_FEEDBACK_WRITE_BIT_EXT);
+            xfbBufferSlice, VK_ACCESS_TRANSFORM_FEEDBACK_WRITE_BIT_EXT, DxvkAccessOp::None);
 
           if (xfbCounterSlice.length()) {
             requiresBarrier |= !xfbCounterSlice.buffer()->trackGfxStores();
             requiresBarrier |= checkBufferBarrier<VK_PIPELINE_BIND_POINT_GRAPHICS>(xfbCounterSlice,
               VK_ACCESS_TRANSFORM_FEEDBACK_COUNTER_READ_BIT_EXT |
-              VK_ACCESS_TRANSFORM_FEEDBACK_COUNTER_WRITE_BIT_EXT);
+              VK_ACCESS_TRANSFORM_FEEDBACK_COUNTER_WRITE_BIT_EXT,
+              DxvkAccessOp::None);
           }
         }
       }
@@ -6930,7 +6935,8 @@ namespace dxvk {
 
       for (uint32_t i = 0; i < slices.size(); i++) {
         if (slices[i]->length() && slices[i]->buffer()->hasGfxStores()) {
-          if (checkBufferBarrier<VK_PIPELINE_BIND_POINT_GRAPHICS>(*slices[i], VK_ACCESS_INDIRECT_COMMAND_READ_BIT))
+          if (checkBufferBarrier<VK_PIPELINE_BIND_POINT_GRAPHICS>(*slices[i],
+              VK_ACCESS_INDIRECT_COMMAND_READ_BIT, DxvkAccessOp::None))
             return true;
         }
       }
@@ -6942,7 +6948,8 @@ namespace dxvk {
       const auto& indexBufferSlice = m_state.vi.indexBuffer;
 
       if (indexBufferSlice.length() && indexBufferSlice.buffer()->hasGfxStores()) {
-        if (checkBufferBarrier<VK_PIPELINE_BIND_POINT_GRAPHICS>(indexBufferSlice, VK_ACCESS_INDEX_READ_BIT))
+        if (checkBufferBarrier<VK_PIPELINE_BIND_POINT_GRAPHICS>(indexBufferSlice,
+            VK_ACCESS_INDEX_READ_BIT, DxvkAccessOp::None))
           return true;
       }
     }
@@ -6956,7 +6963,8 @@ namespace dxvk {
         const auto& vertexBufferSlice = m_state.vi.vertexBuffers[binding];
 
         if (vertexBufferSlice.length() && vertexBufferSlice.buffer()->hasGfxStores()) {
-          if (checkBufferBarrier<VK_PIPELINE_BIND_POINT_GRAPHICS>(vertexBufferSlice, VK_ACCESS_VERTEX_ATTRIBUTE_READ_BIT))
+          if (checkBufferBarrier<VK_PIPELINE_BIND_POINT_GRAPHICS>(vertexBufferSlice,
+              VK_ACCESS_VERTEX_ATTRIBUTE_READ_BIT, DxvkAccessOp::None))
             return true;
         }
       }
@@ -6969,10 +6977,11 @@ namespace dxvk {
   template<VkPipelineBindPoint BindPoint>
   bool DxvkContext::checkBufferBarrier(
     const DxvkBufferSlice&          bufferSlice,
-          VkAccessFlags             access) {
-    return checkResourceBarrier<BindPoint>([this, &bufferSlice] (DxvkAccess access) {
+          VkAccessFlags             access,
+          DxvkAccessOp              accessOp) {
+    return checkResourceBarrier<BindPoint>([this, &bufferSlice, accessOp] (DxvkAccess access) {
       return resourceHasAccess(*bufferSlice.buffer(),
-        bufferSlice.offset(), bufferSlice.length(), access);
+        bufferSlice.offset(), bufferSlice.length(), access, accessOp);
     }, access);
   }
 
@@ -6980,9 +6989,10 @@ namespace dxvk {
   template<VkPipelineBindPoint BindPoint>
   bool DxvkContext::checkBufferViewBarrier(
     const Rc<DxvkBufferView>&       bufferView,
-          VkAccessFlags             access) {
-    return checkResourceBarrier<BindPoint>([this, &bufferView] (DxvkAccess access) {
-      return resourceHasAccess(*bufferView, access);
+          VkAccessFlags             access,
+          DxvkAccessOp              accessOp) {
+    return checkResourceBarrier<BindPoint>([this, &bufferView, accessOp] (DxvkAccess access) {
+      return resourceHasAccess(*bufferView, access, accessOp);
     }, access);
   }
 
@@ -6990,9 +7000,10 @@ namespace dxvk {
   template<VkPipelineBindPoint BindPoint>
   bool DxvkContext::checkImageViewBarrier(
     const Rc<DxvkImageView>&        imageView,
-          VkAccessFlags             access) {
-    return checkResourceBarrier<BindPoint>([this, &imageView] (DxvkAccess access) {
-      return resourceHasAccess(*imageView, access);
+          VkAccessFlags             access,
+          DxvkAccessOp              accessOp) {
+    return checkResourceBarrier<BindPoint>([this, &imageView, accessOp] (DxvkAccess access) {
+      return resourceHasAccess(*imageView, access, accessOp);
     }, access);
   }
 
@@ -7717,12 +7728,14 @@ namespace dxvk {
     const VkImageSubresourceRange&  subresources,
           VkImageLayout             srcLayout,
           VkPipelineStageFlags2     srcStages,
-          VkAccessFlags2            srcAccess) {
+          VkAccessFlags2            srcAccess,
+          DxvkAccessOp              accessOp) {
     accessImage(cmdBuffer, image, subresources,
       srcLayout, srcStages, srcAccess,
       image.info().layout,
       image.info().stages,
-      image.info().access);
+      image.info().access,
+      accessOp);
   }
 
 
@@ -7730,11 +7743,12 @@ namespace dxvk {
           DxvkCmdBuffer             cmdBuffer,
     const DxvkImageView&            imageView,
           VkPipelineStageFlags2     srcStages,
-          VkAccessFlags2            srcAccess) {
+          VkAccessFlags2            srcAccess,
+          DxvkAccessOp              accessOp) {
     accessImage(cmdBuffer, *imageView.image(),
       imageView.imageSubresources(),
       imageView.image()->info().layout,
-      srcStages, srcAccess);
+      srcStages, srcAccess, accessOp);
   }
 
 
@@ -7747,7 +7761,8 @@ namespace dxvk {
           VkAccessFlags2            srcAccess,
           VkImageLayout             dstLayout,
           VkPipelineStageFlags2     dstStages,
-          VkAccessFlags2            dstAccess) {
+          VkAccessFlags2            dstAccess,
+          DxvkAccessOp              accessOp) {
     auto& batch = getBarrierBatch(cmdBuffer);
 
     if (srcLayout == VK_IMAGE_LAYOUT_UNDEFINED || srcLayout == VK_IMAGE_LAYOUT_PREINITIALIZED)
@@ -7808,11 +7823,13 @@ namespace dxvk {
           VkDeviceSize              offset,
           VkDeviceSize              size,
           VkPipelineStageFlags2     srcStages,
-          VkAccessFlags2            srcAccess) {
+          VkAccessFlags2            srcAccess,
+          DxvkAccessOp              accessOp) {
     accessBuffer(cmdBuffer, buffer, offset, size,
       srcStages, srcAccess,
       buffer.info().stages,
-      buffer.info().access);
+      buffer.info().access,
+      accessOp);
   }
 
 
@@ -7824,7 +7841,8 @@ namespace dxvk {
           VkPipelineStageFlags2     srcStages,
           VkAccessFlags2            srcAccess,
           VkPipelineStageFlags2     dstStages,
-          VkAccessFlags2            dstAccess) {
+          VkAccessFlags2            dstAccess,
+          DxvkAccessOp              accessOp) {
     if (unlikely(!size))
       return;
 
@@ -7856,12 +7874,14 @@ namespace dxvk {
           DxvkCmdBuffer             cmdBuffer,
     const DxvkBufferSlice&          bufferSlice,
           VkPipelineStageFlags2     srcStages,
-          VkAccessFlags2            srcAccess) {
+          VkAccessFlags2            srcAccess,
+          DxvkAccessOp              accessOp) {
     accessBuffer(cmdBuffer,
       *bufferSlice.buffer(),
       bufferSlice.offset(),
       bufferSlice.length(),
-      srcStages, srcAccess);
+      srcStages, srcAccess,
+      accessOp);
   }
 
 
@@ -7871,13 +7891,15 @@ namespace dxvk {
           VkPipelineStageFlags2     srcStages,
           VkAccessFlags2            srcAccess,
           VkPipelineStageFlags2     dstStages,
-          VkAccessFlags2            dstAccess) {
+          VkAccessFlags2            dstAccess,
+          DxvkAccessOp              accessOp) {
     accessBuffer(cmdBuffer,
       *bufferSlice.buffer(),
       bufferSlice.offset(),
       bufferSlice.length(),
       srcStages, srcAccess,
-      dstStages, dstAccess);
+      dstStages, dstAccess,
+      accessOp);
   }
 
 
@@ -7885,12 +7907,13 @@ namespace dxvk {
           DxvkCmdBuffer             cmdBuffer,
           DxvkBufferView&           bufferView,
           VkPipelineStageFlags2     srcStages,
-          VkAccessFlags2            srcAccess) {
+          VkAccessFlags2            srcAccess,
+          DxvkAccessOp              accessOp) {
     accessBuffer(cmdBuffer,
       *bufferView.buffer(),
       bufferView.info().offset,
       bufferView.info().size,
-      srcStages, srcAccess);
+      srcStages, srcAccess, accessOp);
   }
 
 
@@ -7900,13 +7923,15 @@ namespace dxvk {
           VkPipelineStageFlags2     srcStages,
           VkAccessFlags2            srcAccess,
           VkPipelineStageFlags2     dstStages,
-          VkAccessFlags2            dstAccess) {
+          VkAccessFlags2            dstAccess,
+          DxvkAccessOp              accessOp) {
     accessBuffer(cmdBuffer,
       *bufferView.buffer(),
       bufferView.info().offset,
       bufferView.info().size,
       srcStages, srcAccess,
-      dstStages, dstAccess);
+      dstStages, dstAccess,
+      accessOp);
   }
 
 
@@ -7921,7 +7946,8 @@ namespace dxvk {
       *m_state.id.argBuffer.buffer(),
       m_state.id.argBuffer.offset() + offset, dataSize,
       VK_PIPELINE_STAGE_2_DRAW_INDIRECT_BIT,
-      VK_ACCESS_2_INDIRECT_COMMAND_READ_BIT_KHR);
+      VK_ACCESS_2_INDIRECT_COMMAND_READ_BIT_KHR,
+      DxvkAccessOp::None);
   }
 
 
@@ -7931,7 +7957,8 @@ namespace dxvk {
       *m_state.id.cntBuffer.buffer(),
       m_state.id.cntBuffer.offset() + offset, sizeof(uint32_t),
       VK_PIPELINE_STAGE_2_DRAW_INDIRECT_BIT,
-      VK_ACCESS_2_INDIRECT_COMMAND_READ_BIT_KHR);
+      VK_ACCESS_2_INDIRECT_COMMAND_READ_BIT_KHR,
+      DxvkAccessOp::None);
   }
 
 
@@ -7940,10 +7967,13 @@ namespace dxvk {
           VkDeviceSize              offset,
           VkDeviceSize              size,
           DxvkAccess                access) {
-    bool flush = resourceHasAccess(buffer, offset, size, DxvkAccess::Write);
+    bool flush = resourceHasAccess(buffer, offset, size,
+      DxvkAccess::Write, DxvkAccessOp::None);
 
-    if (access == DxvkAccess::Write && !flush)
-      flush = resourceHasAccess(buffer, offset, size, DxvkAccess::Read);
+    if (access == DxvkAccess::Write && !flush) {
+      flush = resourceHasAccess(buffer, offset, size,
+        DxvkAccess::Read, DxvkAccessOp::None);
+    }
 
     if (flush)
       flushBarriers();
@@ -7964,10 +7994,13 @@ namespace dxvk {
           DxvkImage&                image,
     const VkImageSubresourceRange&  subresources,
           DxvkAccess                access) {
-    bool flush = resourceHasAccess(image, subresources, DxvkAccess::Write);
+    bool flush = resourceHasAccess(image, subresources,
+      DxvkAccess::Write, DxvkAccessOp::None);
 
-    if (access == DxvkAccess::Write && !flush)
-      flush = resourceHasAccess(image, subresources, DxvkAccess::Read);
+    if (access == DxvkAccess::Write && !flush) {
+      flush = resourceHasAccess(image, subresources,
+        DxvkAccess::Read, DxvkAccessOp::None);
+    }
 
     if (flush)
       flushBarriers();
@@ -7994,7 +8027,8 @@ namespace dxvk {
           DxvkBuffer&               buffer,
           VkDeviceSize              offset,
           VkDeviceSize              size,
-          DxvkAccess                access) {
+          DxvkAccess                access,
+          DxvkAccessOp              accessOp) {
     if (unlikely(!size))
       return false;
 
@@ -8009,17 +8043,19 @@ namespace dxvk {
 
   bool DxvkContext::resourceHasAccess(
           DxvkBufferView&           bufferView,
-          DxvkAccess                access) {
+          DxvkAccess                access,
+          DxvkAccessOp              accessOp) {
     return resourceHasAccess(*bufferView.buffer(),
       bufferView.info().offset,
-      bufferView.info().size, access);
+      bufferView.info().size, access, accessOp);
   }
 
 
   bool DxvkContext::resourceHasAccess(
           DxvkImage&                image,
     const VkImageSubresourceRange&  subresources,
-          DxvkAccess                access) {
+          DxvkAccess                access,
+          DxvkAccessOp              accessOp) {
     uint32_t layerCount = image.info().numLayers;
 
     // Subresources are enumerated in such a way that array layers of
@@ -8053,8 +8089,9 @@ namespace dxvk {
 
   bool DxvkContext::resourceHasAccess(
           DxvkImageView&            imageView,
-          DxvkAccess                access) {
-    return resourceHasAccess(*imageView.image(), imageView.imageSubresources(), access);
+          DxvkAccess                access,
+          DxvkAccessOp              accessOp) {
+    return resourceHasAccess(*imageView.image(), imageView.imageSubresources(), access, accessOp);
   }
 
 

--- a/src/dxvk/dxvk_context.h
+++ b/src/dxvk/dxvk_context.h
@@ -1602,6 +1602,13 @@ namespace dxvk {
             uint32_t              stride,
             bool                  unroll);
 
+    template<bool Indexed>
+    void drawIndirectCountGeneric(
+            VkDeviceSize          offset,
+            VkDeviceSize          countOffset,
+            uint32_t              maxCount,
+            uint32_t              stride);
+
     void resolveImageHw(
       const Rc<DxvkImage>&            dstImage,
       const Rc<DxvkImage>&            srcImage,

--- a/src/dxvk/dxvk_context.h
+++ b/src/dxvk/dxvk_context.h
@@ -1771,17 +1771,20 @@ namespace dxvk {
     template<VkPipelineBindPoint BindPoint>
     bool checkBufferBarrier(
       const DxvkBufferSlice&          bufferSlice,
-            VkAccessFlags             access);
+            VkAccessFlags             access,
+            DxvkAccessOp              accessOp);
 
     template<VkPipelineBindPoint BindPoint>
     bool checkBufferViewBarrier(
       const Rc<DxvkBufferView>&       bufferView,
-            VkAccessFlags             access);
+            VkAccessFlags             access,
+            DxvkAccessOp              accessOp);
 
     template<VkPipelineBindPoint BindPoint>
     bool checkImageViewBarrier(
       const Rc<DxvkImageView>&        imageView,
-            VkAccessFlags             access);
+            VkAccessFlags             access,
+            DxvkAccessOp              accessOp);
 
     template<VkPipelineBindPoint BindPoint>
     DxvkAccessFlags getAllowedStorageHazards() {
@@ -1901,13 +1904,15 @@ namespace dxvk {
       const VkImageSubresourceRange&  subresources,
             VkImageLayout             srcLayout,
             VkPipelineStageFlags2     srcStages,
-            VkAccessFlags2            srcAccess);
+            VkAccessFlags2            srcAccess,
+            DxvkAccessOp              accessOp);
 
     void accessImage(
             DxvkCmdBuffer             cmdBuffer,
       const DxvkImageView&            imageView,
             VkPipelineStageFlags2     srcStages,
-            VkAccessFlags2            srcAccess);
+            VkAccessFlags2            srcAccess,
+            DxvkAccessOp              accessOp);
 
     void accessImage(
             DxvkCmdBuffer             cmdBuffer,
@@ -1918,7 +1923,8 @@ namespace dxvk {
             VkAccessFlags2            srcAccess,
             VkImageLayout             dstLayout,
             VkPipelineStageFlags2     dstStages,
-            VkAccessFlags2            dstAccess);
+            VkAccessFlags2            dstAccess,
+            DxvkAccessOp              accessOp);
 
     void accessBuffer(
             DxvkCmdBuffer             cmdBuffer,
@@ -1926,7 +1932,8 @@ namespace dxvk {
             VkDeviceSize              offset,
             VkDeviceSize              size,
             VkPipelineStageFlags2     srcStages,
-            VkAccessFlags2            srcAccess);
+            VkAccessFlags2            srcAccess,
+            DxvkAccessOp              accessOp);
 
     void accessBuffer(
             DxvkCmdBuffer             cmdBuffer,
@@ -1936,13 +1943,15 @@ namespace dxvk {
             VkPipelineStageFlags2     srcStages,
             VkAccessFlags2            srcAccess,
             VkPipelineStageFlags2     dstStages,
-            VkAccessFlags2            dstAccess);
+            VkAccessFlags2            dstAccess,
+            DxvkAccessOp              accessOp);
 
     void accessBuffer(
             DxvkCmdBuffer             cmdBuffer,
       const DxvkBufferSlice&          bufferSlice,
             VkPipelineStageFlags2     srcStages,
-            VkAccessFlags2            srcAccess);
+            VkAccessFlags2            srcAccess,
+            DxvkAccessOp              accessOp);
 
     void accessBuffer(
             DxvkCmdBuffer             cmdBuffer,
@@ -1950,13 +1959,15 @@ namespace dxvk {
             VkPipelineStageFlags2     srcStages,
             VkAccessFlags2            srcAccess,
             VkPipelineStageFlags2     dstStages,
-            VkAccessFlags2            dstAccess);
+            VkAccessFlags2            dstAccess,
+            DxvkAccessOp              accessOp);
 
     void accessBuffer(
             DxvkCmdBuffer             cmdBuffer,
             DxvkBufferView&           bufferView,
             VkPipelineStageFlags2     srcStages,
-            VkAccessFlags2            srcAccess);
+            VkAccessFlags2            srcAccess,
+            DxvkAccessOp              accessOp);
 
     void accessBuffer(
             DxvkCmdBuffer             cmdBuffer,
@@ -1964,7 +1975,8 @@ namespace dxvk {
             VkPipelineStageFlags2     srcStages,
             VkAccessFlags2            srcAccess,
             VkPipelineStageFlags2     dstStages,
-            VkAccessFlags2            dstAccess);
+            VkAccessFlags2            dstAccess,
+            DxvkAccessOp              accessOp);
 
     void accessDrawBuffer(
             VkDeviceSize              offset,
@@ -2000,20 +2012,24 @@ namespace dxvk {
             DxvkBuffer&               buffer,
             VkDeviceSize              offset,
             VkDeviceSize              size,
-            DxvkAccess                access);
+            DxvkAccess                access,
+            DxvkAccessOp              accessOp);
 
     bool resourceHasAccess(
             DxvkBufferView&           bufferView,
-            DxvkAccess                access);
+            DxvkAccess                access,
+            DxvkAccessOp              accessOp);
 
     bool resourceHasAccess(
             DxvkImage&                image,
       const VkImageSubresourceRange&  subresources,
-            DxvkAccess                access);
+            DxvkAccess                access,
+            DxvkAccessOp              accessOp);
 
     bool resourceHasAccess(
             DxvkImageView&            imageView,
-            DxvkAccess                access);
+            DxvkAccess                access,
+            DxvkAccessOp              accessOp);
 
     DxvkBarrierBatch& getBarrierBatch(
             DxvkCmdBuffer             cmdBuffer);

--- a/src/dxvk/dxvk_context.h
+++ b/src/dxvk/dxvk_context.h
@@ -1434,9 +1434,9 @@ namespace dxvk {
     DxvkBarrierControlFlags m_barrierControl;
 
     DxvkGpuQueryManager     m_queryManager;
-    
-    DxvkGlobalPipelineBarrier m_globalRoGraphicsBarrier;
-    DxvkGlobalPipelineBarrier m_globalRwGraphicsBarrier;
+
+    DxvkGlobalPipelineBarrier m_renderPassBarrierSrc = { };
+    DxvkGlobalPipelineBarrier m_renderPassBarrierDst = { };
 
     DxvkRenderTargetLayouts m_rtLayouts = { };
 
@@ -1690,7 +1690,7 @@ namespace dxvk {
     
     void unbindGraphicsPipeline();
     bool updateGraphicsPipeline();
-    bool updateGraphicsPipelineState(DxvkGlobalPipelineBarrier srcBarrier);
+    bool updateGraphicsPipelineState();
 
     uint32_t getGraphicsPipelineDebugColor() const;
 

--- a/src/dxvk/dxvk_context.h
+++ b/src/dxvk/dxvk_context.h
@@ -763,11 +763,14 @@ namespace dxvk {
      * \param [in] offset Draw buffer offset
      * \param [in] count Number of draws
      * \param [in] stride Stride between dispatch calls
+     * \param [in] unroll Whether to unroll multiple draws if
+     *    there are any potential data dependencies between them.
      */
     void drawIndirect(
             VkDeviceSize      offset,
             uint32_t          count,
-            uint32_t          stride);
+            uint32_t          stride,
+            bool              unroll);
     
     /**
      * \brief Indirect draw call
@@ -809,12 +812,15 @@ namespace dxvk {
      * \param [in] offset Draw buffer offset
      * \param [in] count Number of draws
      * \param [in] stride Stride between dispatch calls
+     * \param [in] unroll Whether to unroll multiple draws if
+     *    there are any potential data dependencies between them.
      */
     void drawIndexedIndirect(
             VkDeviceSize      offset,
             uint32_t          count,
-            uint32_t          stride);
-    
+            uint32_t          stride,
+            bool              unroll);
+
     /**
      * \brief Indirect indexed draw call
      * 
@@ -1588,6 +1594,13 @@ namespace dxvk {
       const uint32_t*             pages,
       const Rc<DxvkBuffer>&       buffer,
             VkDeviceSize          offset);
+
+    template<bool Indexed>
+    void drawIndirectGeneric(
+            VkDeviceSize          offset,
+            uint32_t              count,
+            uint32_t              stride,
+            bool                  unroll);
 
     void resolveImageHw(
       const Rc<DxvkImage>&            dstImage,

--- a/src/dxvk/dxvk_graphics.cpp
+++ b/src/dxvk/dxvk_graphics.cpp
@@ -965,8 +965,12 @@ namespace dxvk {
         m_flags.set(DxvkGraphicsPipelineFlag::HasRasterizerDiscard);
     }
     
-    if (m_barrier.access & VK_ACCESS_SHADER_WRITE_BIT)
+    if (m_barrier.access & VK_ACCESS_SHADER_WRITE_BIT) {
       m_flags.set(DxvkGraphicsPipelineFlag::HasStorageDescriptors);
+
+      if (layout->layout().getHazardousSetMask())
+        m_flags.set(DxvkGraphicsPipelineFlag::UnrollMergedDraws);
+    }
 
     if (m_shaders.fs != nullptr) {
       if (m_shaders.fs->flags().test(DxvkShaderFlag::HasSampleRateShading))

--- a/src/dxvk/dxvk_graphics.cpp
+++ b/src/dxvk/dxvk_graphics.cpp
@@ -955,8 +955,7 @@ namespace dxvk {
       if (m_shaders.gs->flags().test(DxvkShaderFlag::HasTransformFeedback)) {
         m_flags.set(DxvkGraphicsPipelineFlag::HasTransformFeedback);
 
-        m_barrier.stages |= VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT
-                         |  VK_PIPELINE_STAGE_TRANSFORM_FEEDBACK_BIT_EXT;
+        m_barrier.stages |= VK_PIPELINE_STAGE_TRANSFORM_FEEDBACK_BIT_EXT;
         m_barrier.access |= VK_ACCESS_TRANSFORM_FEEDBACK_COUNTER_READ_BIT_EXT
                          |  VK_ACCESS_TRANSFORM_FEEDBACK_COUNTER_WRITE_BIT_EXT
                          |  VK_ACCESS_TRANSFORM_FEEDBACK_WRITE_BIT_EXT;

--- a/src/dxvk/dxvk_graphics.h
+++ b/src/dxvk/dxvk_graphics.h
@@ -31,6 +31,7 @@ namespace dxvk {
     HasStorageDescriptors,
     HasSampleRateShading,
     HasSampleMaskExport,
+    UnrollMergedDraws,
   };
 
   using DxvkGraphicsPipelineFlags = Flags<DxvkGraphicsPipelineFlag>;

--- a/src/dxvk/dxvk_pipelayout.cpp
+++ b/src/dxvk/dxvk_pipelayout.cpp
@@ -205,7 +205,7 @@ namespace dxvk {
 
 
   DxvkBindingLayout::DxvkBindingLayout(VkShaderStageFlags stages)
-  : m_pushConst { 0, 0, 0 }, m_pushConstStages(0), m_stages(stages) {
+  : m_pushConst { 0, 0, 0 }, m_pushConstStages(0), m_stages(stages), m_hazards(0u) {
 
   }
 
@@ -236,6 +236,9 @@ namespace dxvk {
   void DxvkBindingLayout::addBinding(const DxvkBindingInfo& binding) {
     uint32_t set = binding.computeSetIndex();
     m_bindings[set].addBinding(binding);
+
+    if ((binding.access & VK_ACCESS_2_SHADER_WRITE_BIT) && binding.accessOp == DxvkAccessOp::None)
+      m_hazards |= 1u << set;
   }
 
 
@@ -260,6 +263,8 @@ namespace dxvk {
 
     addPushConstantRange(layout.m_pushConst);
     m_pushConstStages |= layout.m_pushConstStages;
+
+    m_hazards |= layout.m_hazards;
   }
 
 

--- a/src/dxvk/dxvk_pipelayout.h
+++ b/src/dxvk/dxvk_pipelayout.h
@@ -12,6 +12,24 @@ namespace dxvk {
   class DxvkDevice;
 
   /**
+   * \brief Order-invariant atomic access operation
+   *
+   * Information used to optimize barriers when a resource
+   * is accessed exlusively via order-invariant stores.
+   */
+  enum class DxvkAccessOp : uint32_t {
+    None  = 0,
+    Or    = 1,
+    And   = 2,
+    Xor   = 3,
+    Add   = 4,
+    IMin  = 5,
+    IMax  = 6,
+    UMin  = 7,
+    UMax  = 8,
+  };
+
+  /**
    * \brief Descriptor set indices
    */
   struct DxvkDescriptorSets {
@@ -37,6 +55,7 @@ namespace dxvk {
     VkShaderStageFlagBits stage;            ///< Shader stage
     VkAccessFlags         access;           ///< Access mask for the resource
     VkBool32              uboSet;           ///< Whether to include this in the UBO set
+    DxvkAccessOp          accessOp;         ///< Order-invariant store type, if any
 
     /**
      * \brief Computes descriptor set index for the given binding

--- a/src/dxvk/dxvk_pipelayout.h
+++ b/src/dxvk/dxvk_pipelayout.h
@@ -29,6 +29,9 @@ namespace dxvk {
     UMax  = 8,
   };
 
+  using DxvkAccessOps = Flags<DxvkAccessOp>;
+
+
   /**
    * \brief Descriptor set indices
    */

--- a/src/dxvk/dxvk_pipelayout.h
+++ b/src/dxvk/dxvk_pipelayout.h
@@ -338,6 +338,16 @@ namespace dxvk {
     }
 
     /**
+     * \brief Queries hazardous sets
+     *
+     * \returns Mask of sets with storage descriptors
+     *    that are not accessed in an order-invariant way.
+     */
+    uint32_t getHazardousSetMask() const {
+      return m_hazards;
+    }
+
+    /**
      * \brief Queries defined descriptor set layouts
      *
      * Any set layout not included in this must be null.
@@ -394,6 +404,7 @@ namespace dxvk {
     VkPushConstantRange                                       m_pushConst;
     VkShaderStageFlags                                        m_pushConstStages;
     VkShaderStageFlags                                        m_stages;
+    uint32_t                                                  m_hazards;
 
   };
 

--- a/src/util/com/com_private_data.h
+++ b/src/util/com/com_private_data.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstddef>
+#include <cstdint>
 #include <vector>
 
 #include "com_include.h"
@@ -9,7 +11,7 @@ namespace dxvk {
   /**
    * \brief COM private data entry type
    */
-  enum ComPrivateDataType {
+  enum class ComPrivateDataType : uint32_t {
     None,
     Data,
     Iface,


### PR DESCRIPTION
Based on #4691, which needs to land first.

TL;DR if a shader accesses a UAV only via one atomic operation (`add`, `and`, `or`, etc) and does not use the result, and if all prior accesses to the same UAV have used only the same operation, the result will be the same regardless of execution order, and we do not need to insert a barrier.

A small number of games hit this case in graphics shaders (Trine 4/5, Days Gone), some in compute (e.g. RE2 remake in D3D11 mode).

Also fixes a (more theoretical) bug with merged multidraw where we would incorrectly skip inserting barriers.