### PR TITLE
Lazy binding for D3D11

### DIFF
--- a/src/d3d11/d3d11_context.cpp
+++ b/src/d3d11/d3d11_context.cpp
@@ -5275,10 +5275,14 @@ namespace dxvk {
 
     if (unlikely(NumUAVs || m_state.om.maxUav)) {
       if (likely(NumUAVs != D3D11_KEEP_UNORDERED_ACCESS_VIEWS)) {
-        uint32_t newMaxUav = NumUAVs ? UAVStartSlot + NumUAVs : 0;
+        uint32_t newMinUav = NumUAVs ? UAVStartSlot : D3D11_1_UAV_SLOT_COUNT;
+        uint32_t newMaxUav = NumUAVs ? UAVStartSlot + NumUAVs : 0u;
+
+        uint32_t oldMinUav = std::exchange(m_state.om.minUav, newMinUav);
         uint32_t oldMaxUav = std::exchange(m_state.om.maxUav, newMaxUav);
 
-        for (uint32_t i = 0; i < std::max(oldMaxUav, newMaxUav); i++) {
+        for (uint32_t i = std::min(oldMinUav, newMinUav);
+                      i < std::max(oldMaxUav, newMaxUav); i++) {
           D3D11UnorderedAccessView* uav = nullptr;
           uint32_t                  ctr = ~0u;
 

--- a/src/d3d11/d3d11_context.cpp
+++ b/src/d3d11/d3d11_context.cpp
@@ -3186,6 +3186,7 @@ namespace dxvk {
     if (!bindMask)
       return;
 
+    // Need to clear dirty bits before binding
     const auto& state = m_state.cbv[Stage];
     DirtyMask.cbvMask -= bindMask;
 
@@ -3208,6 +3209,7 @@ namespace dxvk {
     if (!bindMask)
       return;
 
+    // Need to clear dirty bits before binding
     const auto& state = m_state.samplers[Stage];
     DirtyMask.samplerMask -= bindMask;
 
@@ -3230,6 +3232,7 @@ namespace dxvk {
       if (!bindMask)
         continue;
 
+    // Need to clear dirty bits before binding
       DirtyMask.srvMask[maskIndex] -= bindMask;
 
       for (uint32_t slot : bit::BitMask(bindMask))
@@ -4889,6 +4892,8 @@ namespace dxvk {
     for (uint32_t i = 0; i < m_state.so.targets.size(); i++)
       BindXfbBuffer(i, m_state.so.targets[i].buffer.ptr(), ~0u);
 
+    // Reset dirty binding and shader masks before applying
+    // bindings to avoid implicit null binding overrids.
     ResetDirtyTracking();
 
     for (uint32_t i = 0; i < uint32_t(DxbcProgramType::Count); i++) {

--- a/src/d3d11/d3d11_context.cpp
+++ b/src/d3d11/d3d11_context.cpp
@@ -4880,29 +4880,16 @@ namespace dxvk {
     for (uint32_t i = 0; i < m_state.so.targets.size(); i++)
       BindXfbBuffer(i, m_state.so.targets[i].buffer.ptr(), ~0u);
 
-    RestoreConstantBuffers<DxbcProgramType::VertexShader>();
-    RestoreConstantBuffers<DxbcProgramType::HullShader>();
-    RestoreConstantBuffers<DxbcProgramType::DomainShader>();
-    RestoreConstantBuffers<DxbcProgramType::GeometryShader>();
-    RestoreConstantBuffers<DxbcProgramType::PixelShader>();
-    RestoreConstantBuffers<DxbcProgramType::ComputeShader>();
+    for (uint32_t i = 0; i < uint32_t(DxbcProgramType::Count); i++) {
+      auto stage = DxbcProgramType(i);
 
-    RestoreShaderResources<DxbcProgramType::VertexShader>();
-    RestoreShaderResources<DxbcProgramType::HullShader>();
-    RestoreShaderResources<DxbcProgramType::DomainShader>();
-    RestoreShaderResources<DxbcProgramType::GeometryShader>();
-    RestoreShaderResources<DxbcProgramType::PixelShader>();
-    RestoreShaderResources<DxbcProgramType::ComputeShader>();
+      RestoreConstantBuffers(stage);
+      RestoreShaderResources(stage);
+      RestoreSamplers(stage);
+    }
 
-    RestoreUnorderedAccessViews<DxbcProgramType::PixelShader>();
-    RestoreUnorderedAccessViews<DxbcProgramType::ComputeShader>();
-
-    RestoreSamplers<DxbcProgramType::VertexShader>();
-    RestoreSamplers<DxbcProgramType::HullShader>();
-    RestoreSamplers<DxbcProgramType::DomainShader>();
-    RestoreSamplers<DxbcProgramType::GeometryShader>();
-    RestoreSamplers<DxbcProgramType::PixelShader>();
-    RestoreSamplers<DxbcProgramType::ComputeShader>();
+    RestoreUnorderedAccessViews(DxbcProgramType::PixelShader);
+    RestoreUnorderedAccessViews(DxbcProgramType::ComputeShader);
 
     // Draw buffer bindings aren't persistent at the API level, and
     // we can't meaningfully track them. Just reset this state here
@@ -4912,9 +4899,10 @@ namespace dxvk {
 
 
   template<typename ContextType>
-  template<DxbcProgramType Stage>
-  void D3D11CommonContext<ContextType>::RestoreConstantBuffers() {
+  void D3D11CommonContext<ContextType>::RestoreConstantBuffers(
+          DxbcProgramType                   Stage) {
     const auto& bindings = m_state.cbv[Stage];
+
     for (uint32_t i = 0; i < bindings.maxCount; i++) {
       BindConstantBuffer(Stage, i, bindings.buffers[i].buffer.ptr(),
         bindings.buffers[i].constantOffset, bindings.buffers[i].constantBound);
@@ -4923,26 +4911,28 @@ namespace dxvk {
 
 
   template<typename ContextType>
-  template<DxbcProgramType Stage>
-  void D3D11CommonContext<ContextType>::RestoreSamplers() {
+  void D3D11CommonContext<ContextType>::RestoreSamplers(
+          DxbcProgramType                   Stage) {
     const auto& bindings = m_state.samplers[Stage];
+
     for (uint32_t i = 0; i < bindings.maxCount; i++)
       BindSampler(Stage, i, bindings.samplers[i]);
   }
 
 
   template<typename ContextType>
-  template<DxbcProgramType Stage>
-  void D3D11CommonContext<ContextType>::RestoreShaderResources() {
+  void D3D11CommonContext<ContextType>::RestoreShaderResources(
+          DxbcProgramType                   Stage) {
     const auto& bindings = m_state.srv[Stage];
+
     for (uint32_t i = 0; i < bindings.maxCount; i++)
       BindShaderResource(Stage, i, bindings.views[i].ptr());
   }
 
 
   template<typename ContextType>
-  template<DxbcProgramType Stage>
-  void D3D11CommonContext<ContextType>::RestoreUnorderedAccessViews() {
+  void D3D11CommonContext<ContextType>::RestoreUnorderedAccessViews(
+          DxbcProgramType                   Stage) {
     const auto& views = Stage == DxbcProgramType::ComputeShader
       ? m_state.uav.views
       : m_state.om.uavs;

--- a/src/d3d11/d3d11_context.cpp
+++ b/src/d3d11/d3d11_context.cpp
@@ -4747,6 +4747,15 @@ namespace dxvk {
 
 
   template<typename ContextType>
+  void D3D11CommonContext<ContextType>::ResetDirtyTracking() {
+    // Must only be called when all bindings are guaranteed to get applied
+    // to the DXVK context before the next draw or dispatch command.
+    m_state.lazy.bindingsDirty.reset();
+    m_state.lazy.shadersDirty = 0u;
+  }
+
+
+  template<typename ContextType>
   void D3D11CommonContext<ContextType>::ResetStagingBuffer() {
     m_staging.reset();
   }
@@ -4879,6 +4888,8 @@ namespace dxvk {
 
     for (uint32_t i = 0; i < m_state.so.targets.size(); i++)
       BindXfbBuffer(i, m_state.so.targets[i].buffer.ptr(), ~0u);
+
+    ResetDirtyTracking();
 
     for (uint32_t i = 0; i < uint32_t(DxbcProgramType::Count); i++) {
       auto stage = DxbcProgramType(i);

--- a/src/d3d11/d3d11_context.h
+++ b/src/d3d11/d3d11_context.h
@@ -819,6 +819,11 @@ namespace dxvk {
       const DxbcBindingMask&                  BoundMask,
             DxbcBindingMask&                  DirtyMask);
 
+    void ApplyDirtyUnorderedAccessViews(
+            DxbcProgramType                   Stage,
+      const DxbcBindingMask&                  BoundMask,
+            DxbcBindingMask&                  DirtyMask);
+
     void ApplyDirtyGraphicsBindings();
 
     void ApplyDirtyComputeBindings();
@@ -904,8 +909,7 @@ namespace dxvk {
     void BindUnorderedAccessView(
             DxbcProgramType                   ShaderStage,
             UINT                              Slot,
-            D3D11UnorderedAccessView*         pUav,
-            UINT                              Counter);
+            D3D11UnorderedAccessView*         pUav);
 
     VkClearValue ConvertColorValue(
       const FLOAT                             Color[4],
@@ -954,6 +958,10 @@ namespace dxvk {
 
     bool DirtyShaderResource(
             DxbcProgramType                   ShaderStage,
+            uint32_t                          Slot,
+            bool                              IsNull);
+
+    bool DirtyComputeUnorderedAccessView(
             uint32_t                          Slot,
             bool                              IsNull);
 
@@ -1114,6 +1122,10 @@ namespace dxvk {
             UINT                              SrcRowPitch,
             UINT                              SrcDepthPitch,
             UINT                              CopyFlags);
+
+    void UpdateUnorderedAccessViewCounter(
+            D3D11UnorderedAccessView*         pUav,
+            uint32_t                          CounterValue);
 
     bool ValidateRenderTargets(
             UINT                              NumViews,

--- a/src/d3d11/d3d11_context.h
+++ b/src/d3d11/d3d11_context.h
@@ -967,6 +967,8 @@ namespace dxvk {
     void ResolveOmUavHazards(
             D3D11RenderTargetView*            pView);
 
+    void RestoreUsedBindings();
+
     void RestoreCommandListState();
     
     template<DxbcProgramType Stage>

--- a/src/d3d11/d3d11_context.h
+++ b/src/d3d11/d3d11_context.h
@@ -965,6 +965,9 @@ namespace dxvk {
             uint32_t                          Slot,
             bool                              IsNull);
 
+    bool DirtyGraphicsUnorderedAccessView(
+            uint32_t                          Slot);
+
     void DiscardBuffer(
             ID3D11Resource*                   pResource);
 

--- a/src/d3d11/d3d11_context.h
+++ b/src/d3d11/d3d11_context.h
@@ -1085,7 +1085,7 @@ namespace dxvk {
             DxvkMultisampleState*             pMsState,
             UINT                              SampleMask);
 
-    template<bool AllowFlush = !IsDeferred, typename Cmd>
+    template<bool AllowFlush = true, typename Cmd>
     void EmitCs(Cmd&& command) {
       m_cmdData = nullptr;
 
@@ -1093,14 +1093,14 @@ namespace dxvk {
         GetTypedContext()->EmitCsChunk(std::move(m_csChunk));
         m_csChunk = AllocCsChunk();
 
-        if constexpr (AllowFlush)
+        if constexpr (!IsDeferred && AllowFlush)
           GetTypedContext()->ConsiderFlush(GpuFlushType::ImplicitWeakHint);
 
         m_csChunk->push(command);
       }
     }
 
-    template<typename M, bool AllowFlush = !IsDeferred, typename Cmd, typename... Args>
+    template<typename M, bool AllowFlush = true, typename Cmd, typename... Args>
     M* EmitCsCmd(Cmd&& command, Args&&... args) {
       M* data = m_csChunk->pushCmd<M, Cmd, Args...>(
         command, std::forward<Args>(args)...);
@@ -1109,7 +1109,7 @@ namespace dxvk {
         GetTypedContext()->EmitCsChunk(std::move(m_csChunk));
         m_csChunk = AllocCsChunk();
 
-        if constexpr (AllowFlush)
+        if constexpr (!IsDeferred && AllowFlush)
           GetTypedContext()->ConsiderFlush(GpuFlushType::ImplicitWeakHint);
 
         // We must record this command after the potential

--- a/src/d3d11/d3d11_context.h
+++ b/src/d3d11/d3d11_context.h
@@ -1014,18 +1014,18 @@ namespace dxvk {
 
     void RestoreCommandListState();
     
-    template<DxbcProgramType Stage>
-    void RestoreConstantBuffers();
+    void RestoreConstantBuffers(
+            DxbcProgramType                   Stage);
     
-    template<DxbcProgramType Stage>
-    void RestoreSamplers();
-    
-    template<DxbcProgramType Stage>
-    void RestoreShaderResources();
-    
-    template<DxbcProgramType Stage>
-    void RestoreUnorderedAccessViews();
-    
+    void RestoreSamplers(
+            DxbcProgramType                   Stage);
+
+    void RestoreShaderResources(
+            DxbcProgramType                   Stage);
+
+    void RestoreUnorderedAccessViews(
+            DxbcProgramType                   Stage);
+
     template<DxbcProgramType ShaderStage>
     void SetConstantBuffers(
             UINT                              StartSlot,

--- a/src/d3d11/d3d11_context.h
+++ b/src/d3d11/d3d11_context.h
@@ -896,11 +896,10 @@ namespace dxvk {
             UINT                              Slot,
             D3D11ShaderResourceView*          pResource);
 
-    template<DxbcProgramType ShaderStage>
     void BindUnorderedAccessView(
-            UINT                              UavSlot,
+            DxbcProgramType                   ShaderStage,
+            UINT                              Slot,
             D3D11UnorderedAccessView*         pUav,
-            UINT                              CtrSlot,
             UINT                              Counter);
 
     VkClearValue ConvertColorValue(

--- a/src/d3d11/d3d11_context.h
+++ b/src/d3d11/d3d11_context.h
@@ -804,6 +804,11 @@ namespace dxvk {
       const DxbcBindingMask&                  BoundMask,
             DxbcBindingMask&                  DirtyMask);
 
+    void ApplyDirtyShaderResources(
+            DxbcProgramType                   Stage,
+      const DxbcBindingMask&                  BoundMask,
+            DxbcBindingMask&                  DirtyMask);
+
     void ApplyDirtyGraphicsBindings();
 
     void ApplyDirtyComputeBindings();
@@ -881,8 +886,8 @@ namespace dxvk {
             UINT                              Slot,
             D3D11SamplerState*                pSampler);
 
-    template<DxbcProgramType ShaderStage>
     void BindShaderResource(
+            DxbcProgramType                   ShaderStage,
             UINT                              Slot,
             D3D11ShaderResourceView*          pResource);
 
@@ -929,6 +934,11 @@ namespace dxvk {
             bool                              IsNull);
 
     bool DirtyConstantBuffer(
+            DxbcProgramType                   ShaderStage,
+            uint32_t                          Slot,
+            bool                              IsNull);
+
+    bool DirtyShaderResource(
             DxbcProgramType                   ShaderStage,
             uint32_t                          Slot,
             bool                              IsNull);

--- a/src/d3d11/d3d11_context.h
+++ b/src/d3d11/d3d11_context.h
@@ -799,6 +799,15 @@ namespace dxvk {
     DxvkBufferSlice AllocStagingBuffer(
             VkDeviceSize                      Size);
 
+    void ApplyDirtyConstantBuffers(
+            DxbcProgramType                   Stage,
+      const DxbcBindingMask&                  BoundMask,
+            DxbcBindingMask&                  DirtyMask);
+
+    void ApplyDirtyGraphicsBindings();
+
+    void ApplyDirtyComputeBindings();
+
     void ApplyInputLayout();
     
     void ApplyPrimitiveTopology();
@@ -854,15 +863,15 @@ namespace dxvk {
             D3D11Buffer*                      pBuffer,
             UINT                              Offset);
 
-    template<DxbcProgramType ShaderStage>
     void BindConstantBuffer(
+            DxbcProgramType                   ShaderStage,
             UINT                              Slot,
             D3D11Buffer*                      pBuffer,
             UINT                              Offset,
             UINT                              Length);
 
-    template<DxbcProgramType ShaderStage>
     void BindConstantBufferRange(
+            DxbcProgramType                   ShaderStage,
             UINT                              Slot,
             UINT                              Offset,
             UINT                              Length);
@@ -911,6 +920,19 @@ namespace dxvk {
             DxvkBufferSlice                   BufferSlice,
             UINT                              Flags);
 
+    template<typename T>
+    bool DirtyBindingGeneric(
+            DxbcProgramType                   ShaderStage,
+            T                                 BoundMask,
+            T&                                DirtyMask,
+            T                                 DirtyBit,
+            bool                              IsNull);
+
+    bool DirtyConstantBuffer(
+            DxbcProgramType                   ShaderStage,
+            uint32_t                          Slot,
+            bool                              IsNull);
+
     void DiscardBuffer(
             ID3D11Resource*                   pResource);
 
@@ -943,6 +965,10 @@ namespace dxvk {
 
     D3D11MaxUsedBindings GetMaxUsedBindings();
 
+    bool HasDirtyComputeBindings();
+
+    bool HasDirtyGraphicsBindings();
+
     void ResetCommandListState();
 
     void ResetContextState();
@@ -966,8 +992,6 @@ namespace dxvk {
 
     void ResolveOmUavHazards(
             D3D11RenderTargetView*            pView);
-
-    void RestoreUsedBindings();
 
     void RestoreCommandListState();
     

--- a/src/d3d11/d3d11_context.h
+++ b/src/d3d11/d3d11_context.h
@@ -992,6 +992,8 @@ namespace dxvk {
 
     void ResetContextState();
 
+    void ResetDirtyTracking();
+
     void ResetStagingBuffer();
 
     template<DxbcProgramType ShaderStage, typename T>

--- a/src/d3d11/d3d11_context.h
+++ b/src/d3d11/d3d11_context.h
@@ -75,6 +75,11 @@ namespace dxvk {
     // Use a local staging buffer to handle tiny uploads, most
     // of the time we're fine with hitting the global allocator
     constexpr static VkDeviceSize StagingBufferSize = 256ull << 10;
+
+  protected:
+    // Compile-time debug flag to force lazy binding on (True) or off (False)
+    constexpr static Tristate DebugLazyBinding = Tristate::Auto;
+
   public:
     
     D3D11CommonContext(

--- a/src/d3d11/d3d11_context.h
+++ b/src/d3d11/d3d11_context.h
@@ -804,6 +804,11 @@ namespace dxvk {
       const DxbcBindingMask&                  BoundMask,
             DxbcBindingMask&                  DirtyMask);
 
+    void ApplyDirtySamplers(
+            DxbcProgramType                   Stage,
+      const DxbcBindingMask&                  BoundMask,
+            DxbcBindingMask&                  DirtyMask);
+
     void ApplyDirtyShaderResources(
             DxbcProgramType                   Stage,
       const DxbcBindingMask&                  BoundMask,
@@ -881,8 +886,8 @@ namespace dxvk {
             UINT                              Offset,
             UINT                              Length);
 
-    template<DxbcProgramType ShaderStage>
     void BindSampler(
+            DxbcProgramType                   ShaderStage,
             UINT                              Slot,
             D3D11SamplerState*                pSampler);
 
@@ -934,6 +939,11 @@ namespace dxvk {
             bool                              IsNull);
 
     bool DirtyConstantBuffer(
+            DxbcProgramType                   ShaderStage,
+            uint32_t                          Slot,
+            bool                              IsNull);
+
+    bool DirtySampler(
             DxbcProgramType                   ShaderStage,
             uint32_t                          Slot,
             bool                              IsNull);

--- a/src/d3d11/d3d11_context_ext.cpp
+++ b/src/d3d11/d3d11_context_ext.cpp
@@ -48,6 +48,9 @@ namespace dxvk {
     D3D10DeviceLock lock = m_ctx->LockContext();
     m_ctx->SetDrawBuffers(pBufferForArgs, nullptr);
     
+    if (unlikely(m_ctx->HasDirtyGraphicsBindings()))
+      m_ctx->ApplyDirtyGraphicsBindings();
+
     m_ctx->EmitCs([
       cCount  = DrawCount,
       cOffset = ByteOffsetForArgs,
@@ -67,6 +70,9 @@ namespace dxvk {
     D3D10DeviceLock lock = m_ctx->LockContext();
     m_ctx->SetDrawBuffers(pBufferForArgs, nullptr);
     
+    if (unlikely(m_ctx->HasDirtyGraphicsBindings()))
+      m_ctx->ApplyDirtyGraphicsBindings();
+
     m_ctx->EmitCs([
       cCount  = DrawCount,
       cOffset = ByteOffsetForArgs,
@@ -87,6 +93,9 @@ namespace dxvk {
           UINT                    ByteStrideForArgs) {
     D3D10DeviceLock lock = m_ctx->LockContext();
     m_ctx->SetDrawBuffers(pBufferForArgs, pBufferForCount);
+
+    if (unlikely(m_ctx->HasDirtyGraphicsBindings()))
+      m_ctx->ApplyDirtyGraphicsBindings();
 
     m_ctx->EmitCs([
       cMaxCount  = MaxDrawCount,
@@ -109,6 +118,9 @@ namespace dxvk {
           UINT                    ByteStrideForArgs) {
     D3D10DeviceLock lock = m_ctx->LockContext();
     m_ctx->SetDrawBuffers(pBufferForArgs, pBufferForCount);
+
+    if (unlikely(m_ctx->HasDirtyGraphicsBindings()))
+      m_ctx->ApplyDirtyGraphicsBindings();
 
     m_ctx->EmitCs([
       cMaxCount  = MaxDrawCount,

--- a/src/d3d11/d3d11_context_imm.cpp
+++ b/src/d3d11/d3d11_context_imm.cpp
@@ -754,7 +754,11 @@ namespace dxvk {
     if (!pState)
       return;
 
-    // Reset all state affected by the current context state
+    // Clear dirty tracking here since all context state will be
+    // re-applied anyway when the context state is swapped in again.
+    ResetDirtyTracking();
+
+    // Reset all state affected by the current context state.
     ResetCommandListState();
 
     Com<D3D11DeviceContextState, false> oldState = std::move(m_stateObject);

--- a/src/d3d11/d3d11_context_imm.cpp
+++ b/src/d3d11/d3d11_context_imm.cpp
@@ -1053,6 +1053,10 @@ namespace dxvk {
 
   void D3D11ImmediateContext::ConsiderFlush(
           GpuFlushType                FlushType) {
+    // In stress test mode, behave as if this would always flush
+    if (DebugLazyBinding == Tristate::True)
+      ApplyDirtyNullBindings();
+
     uint64_t chunkId = GetCurrentSequenceNumber();
     uint64_t submissionId = m_submissionFence->value();
 

--- a/src/d3d11/d3d11_context_imm.h
+++ b/src/d3d11/d3d11_context_imm.h
@@ -195,6 +195,8 @@ namespace dxvk {
 
     uint64_t GetPendingCsChunks();
 
+    void ApplyDirtyNullBindings();
+
     void ConsiderFlush(
             GpuFlushType                FlushType);
 

--- a/src/d3d11/d3d11_context_state.h
+++ b/src/d3d11/d3d11_context_state.h
@@ -313,6 +313,7 @@ namespace dxvk {
   struct D3D11LazyBindings {
     DxbcProgramTypeFlags shadersUsed = 0u;
     DxbcProgramTypeFlags shadersDirty = 0u;
+    DxbcProgramTypeFlags graphicsUavShaders = 0u;
 
     D3D11ShaderStageState<DxbcBindingMask> bindingsUsed;
     D3D11ShaderStageState<DxbcBindingMask> bindingsDirty;
@@ -320,6 +321,7 @@ namespace dxvk {
     void reset() {
       shadersUsed = 0u;
       shadersDirty = 0u;
+      graphicsUavShaders = 0u;
 
       bindingsUsed.reset();
       bindingsDirty.reset();

--- a/src/d3d11/d3d11_context_state.h
+++ b/src/d3d11/d3d11_context_state.h
@@ -199,6 +199,7 @@ namespace dxvk {
     UINT  stencilRef     = D3D11_DEFAULT_STENCIL_REFERENCE;
 
     UINT  maxRtv         = 0u;
+    UINT  minUav         = 0u;
     UINT  maxUav         = 0u;
 
     void reset() {

--- a/src/d3d11/d3d11_context_state.h
+++ b/src/d3d11/d3d11_context_state.h
@@ -302,6 +302,30 @@ namespace dxvk {
       predicateValue = false;
     }
   };
+
+
+  /**
+   * \brief Lazy binding state
+   *
+   * Keeps track of what state needs to be
+   * re-applied to the context.
+   */
+  struct D3D11LazyBindings {
+    DxbcProgramTypeFlags shadersUsed = 0u;
+    DxbcProgramTypeFlags shadersDirty = 0u;
+
+    D3D11ShaderStageState<DxbcBindingMask> bindingsUsed;
+    D3D11ShaderStageState<DxbcBindingMask> bindingsDirty;
+
+    void reset() {
+      shadersUsed = 0u;
+      shadersDirty = 0u;
+
+      bindingsUsed.reset();
+      bindingsDirty.reset();
+    }
+  };
+
   
   /**
    * \brief Context state
@@ -325,6 +349,8 @@ namespace dxvk {
     D3D11SrvBindings    srv;
     D3D11UavBindings    uav;
     D3D11SamplerBindings samplers;
+
+    D3D11LazyBindings   lazy;
   };
 
   /**
@@ -342,7 +368,7 @@ namespace dxvk {
    * \brief Maximum used binding numbers for all context state
    */
   struct D3D11MaxUsedBindings {
-    std::array<D3D11MaxUsedStageBindings, 6> stages;
+    std::array<D3D11MaxUsedStageBindings, uint32_t(DxbcProgramType::Count)> stages;
     uint32_t  vbCount;
     uint32_t  soCount;
   };

--- a/src/d3d11/d3d11_shader.cpp
+++ b/src/d3d11/d3d11_shader.cpp
@@ -79,6 +79,12 @@ namespace dxvk {
     }
 
     pDevice->GetDXVKDevice()->registerShader(m_shader);
+
+    // Write back binding mask
+    auto bindings = module.bindings();
+
+    if (bindings)
+      m_bindings = *bindings;
   }
 
   

--- a/src/d3d11/d3d11_shader.h
+++ b/src/d3d11/d3d11_shader.h
@@ -18,7 +18,7 @@
 namespace dxvk {
   
   class D3D11Device;
-  
+
   /**
    * \brief Common shader object
    * 
@@ -52,12 +52,18 @@ namespace dxvk {
     std::string GetName() const {
       return m_shader->debugName();
     }
-    
+
+    DxbcBindingMask GetBindingMask() const {
+      return m_bindings;
+    }
+
   private:
-    
+
     Rc<DxvkShader> m_shader;
     Rc<DxvkBuffer> m_buffer;
-    
+
+    DxbcBindingMask m_bindings = { };
+
   };
 
 

--- a/src/d3d11/d3d11_util.h
+++ b/src/d3d11/d3d11_util.h
@@ -52,15 +52,15 @@ namespace dxvk {
    * \returns Corresponding Vulkan shader stage
    */
   constexpr VkShaderStageFlagBits GetShaderStage(DxbcProgramType ProgramType) {
-    switch (ProgramType) {
-      case DxbcProgramType::VertexShader:   return VK_SHADER_STAGE_VERTEX_BIT;
-      case DxbcProgramType::HullShader:     return VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT;
-      case DxbcProgramType::DomainShader:   return VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT;
-      case DxbcProgramType::GeometryShader: return VK_SHADER_STAGE_GEOMETRY_BIT;
-      case DxbcProgramType::PixelShader:    return VK_SHADER_STAGE_FRAGMENT_BIT;
-      case DxbcProgramType::ComputeShader:  return VK_SHADER_STAGE_COMPUTE_BIT;
-      default:                              return VkShaderStageFlagBits(0);
-    }
+    constexpr uint64_t lut
+      = (uint64_t(VK_SHADER_STAGE_VERTEX_BIT)                   << (8u * uint32_t(DxbcProgramType::VertexShader)))
+      | (uint64_t(VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT)     << (8u * uint32_t(DxbcProgramType::HullShader)))
+      | (uint64_t(VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT)  << (8u * uint32_t(DxbcProgramType::DomainShader)))
+      | (uint64_t(VK_SHADER_STAGE_GEOMETRY_BIT)                 << (8u * uint32_t(DxbcProgramType::GeometryShader)))
+      | (uint64_t(VK_SHADER_STAGE_FRAGMENT_BIT)                 << (8u * uint32_t(DxbcProgramType::PixelShader)))
+      | (uint64_t(VK_SHADER_STAGE_COMPUTE_BIT)                  << (8u * uint32_t(DxbcProgramType::ComputeShader)));
+
+    return VkShaderStageFlagBits((lut >> (8u * uint32_t(ProgramType))) & 0xff);
   }
 
 }

--- a/src/d3d11/d3d11_video.cpp
+++ b/src/d3d11/d3d11_video.cpp
@@ -1037,7 +1037,9 @@ namespace dxvk {
         continue;
 
       if (!hasStreamsEnabled) {
+        m_ctx->ResetDirtyTracking();
         m_ctx->ResetCommandListState();
+
         BindOutputView(pOutputView);
         hasStreamsEnabled = true;
       }
@@ -1047,6 +1049,7 @@ namespace dxvk {
 
     if (hasStreamsEnabled) {
       UnbindResources();
+
       m_ctx->RestoreCommandListState();
     }
 

--- a/src/d3d11/d3d11_view_uav.h
+++ b/src/d3d11/d3d11_view_uav.h
@@ -43,6 +43,10 @@ namespace dxvk {
       return m_info.BindFlags & Flags;
     }
 
+    BOOL HasCounter() const {
+      return m_counterView != nullptr;
+    }
+
     D3D11_RESOURCE_DIMENSION GetResourceType() const {
       D3D11_RESOURCE_DIMENSION type;
       m_resource->GetType(&type);

--- a/src/dxbc/dxbc_analysis.cpp
+++ b/src/dxbc/dxbc_analysis.cpp
@@ -108,6 +108,47 @@ namespace dxvk {
         m_analysis->uavInfos[registerId].nonInvariantAccess = true;
       } break;
 
+      case DxbcInstClass::Declaration: {
+        switch (ins.op) {
+          case DxbcOpcode::DclConstantBuffer: {
+            uint32_t registerId = ins.dst[0].idx[0].offset;
+
+            if (registerId < DxbcConstBufBindingCount)
+              m_analysis->bindings.cbvMask |= 1u << registerId;
+          } break;
+
+          case DxbcOpcode::DclSampler: {
+            uint32_t registerId = ins.dst[0].idx[0].offset;
+
+            if (registerId < DxbcSamplerBindingCount)
+              m_analysis->bindings.samplerMask |= 1u << registerId;
+          } break;
+
+          case DxbcOpcode::DclResource:
+          case DxbcOpcode::DclResourceRaw:
+          case DxbcOpcode::DclResourceStructured: {
+            uint32_t registerId = ins.dst[0].idx[0].offset;
+
+            uint32_t idx = registerId / 64u;
+            uint32_t bit = registerId % 64u;
+
+            if (registerId < DxbcResourceBindingCount)
+              m_analysis->bindings.srvMask[idx] |= uint64_t(1u) << bit;
+          } break;
+
+          case DxbcOpcode::DclUavTyped:
+          case DxbcOpcode::DclUavRaw:
+          case DxbcOpcode::DclUavStructured: {
+            uint32_t registerId = ins.dst[0].idx[0].offset;
+
+            if (registerId < DxbcUavBindingCount)
+              m_analysis->bindings.uavMask |= uint64_t(1u) << registerId;
+          } break;
+
+          default: ;
+        }
+      } break;
+
       default:
         break;
     }

--- a/src/dxbc/dxbc_analysis.h
+++ b/src/dxbc/dxbc_analysis.h
@@ -53,6 +53,8 @@ namespace dxvk {
     
     DxbcClipCullInfo clipCullIn;
     DxbcClipCullInfo clipCullOut;
+
+    DxbcBindingMask bindings = { };
     
     bool usesDerivatives  = false;
     bool usesKill         = false;

--- a/src/dxbc/dxbc_common.cpp
+++ b/src/dxbc/dxbc_common.cpp
@@ -10,9 +10,8 @@ namespace dxvk {
       case DxbcProgramType::HullShader     : return VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT;
       case DxbcProgramType::DomainShader   : return VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT;
       case DxbcProgramType::ComputeShader  : return VK_SHADER_STAGE_COMPUTE_BIT;
+      default: throw DxvkError("DxbcProgramInfo::shaderStage: Unsupported program type");
     }
-    
-    throw DxvkError("DxbcProgramInfo::shaderStage: Unsupported program type");
   }
   
   
@@ -24,9 +23,8 @@ namespace dxvk {
       case DxbcProgramType::HullShader     : return spv::ExecutionModelTessellationControl;
       case DxbcProgramType::DomainShader   : return spv::ExecutionModelTessellationEvaluation;
       case DxbcProgramType::ComputeShader  : return spv::ExecutionModelGLCompute;
+      default: throw DxvkError("DxbcProgramInfo::executionModel: Unsupported program type");
     }
-    
-    throw DxvkError("DxbcProgramInfo::executionModel: Unsupported program type");
   }
   
 }

--- a/src/dxbc/dxbc_common.h
+++ b/src/dxbc/dxbc_common.h
@@ -17,7 +17,11 @@ namespace dxvk {
     HullShader      = 3,
     DomainShader    = 4,
     ComputeShader   = 5,
+
+    Count
   };
+
+  using DxbcProgramTypeFlags = Flags<DxbcProgramType>;
   
   
   /**

--- a/src/dxbc/dxbc_compiler.cpp
+++ b/src/dxbc/dxbc_compiler.cpp
@@ -237,6 +237,7 @@ namespace dxvk {
       case DxbcProgramType::GeometryShader: this->emitGsFinalize(); break;
       case DxbcProgramType::PixelShader:    this->emitPsFinalize(); break;
       case DxbcProgramType::ComputeShader:  this->emitCsFinalize(); break;
+      default: throw DxvkError("Invalid shader stage");
     }
 
     // Emit float control mode if the extension is supported
@@ -6138,7 +6139,7 @@ namespace dxvk {
         case DxbcProgramType::HullShader:     emitHsSystemValueStore(sv, mask, value); break;
         case DxbcProgramType::DomainShader:   emitDsSystemValueStore(sv, mask, value); break;
         case DxbcProgramType::PixelShader:    emitPsSystemValueStore(sv, mask, value); break;
-        case DxbcProgramType::ComputeShader:  break;
+        default: break;
       }
     }
   }
@@ -6822,6 +6823,7 @@ namespace dxvk {
       case DxbcProgramType::GeometryShader: emitGsInit(); break;
       case DxbcProgramType::PixelShader:    emitPsInit(); break;
       case DxbcProgramType::ComputeShader:  emitCsInit(); break;
+      default: throw DxvkError("Invalid shader stage");
     }
   }
   

--- a/src/dxbc/dxbc_module.cpp
+++ b/src/dxbc/dxbc_module.cpp
@@ -42,7 +42,7 @@ namespace dxvk {
   
   Rc<DxvkShader> DxbcModule::compile(
     const DxbcModuleInfo& moduleInfo,
-    const std::string&    fileName) const {
+    const std::string&    fileName) {
     if (m_shexChunk == nullptr)
       throw DxvkError("DxbcModule::compile: No SHDR/SHEX chunk");
     
@@ -54,6 +54,8 @@ namespace dxvk {
       m_psgnChunk, analysisInfo);
     
     this->runAnalyzer(analyzer, m_shexChunk->slice());
+
+    m_bindings = std::make_optional(analysisInfo.bindings);
     
     DxbcCompiler compiler(
       fileName, moduleInfo,
@@ -62,7 +64,7 @@ namespace dxvk {
       m_psgnChunk, analysisInfo);
     
     this->runCompiler(compiler, m_shexChunk->slice());
-    
+
     return compiler.finalize();
   }
   

--- a/src/dxbc/dxbc_module.h
+++ b/src/dxbc/dxbc_module.h
@@ -7,6 +7,7 @@
 #include "dxbc_header.h"
 #include "dxbc_modinfo.h"
 #include "dxbc_reader.h"
+#include "dxbc_util.h"
 
 // References used for figuring out DXBC:
 // - https://github.com/tgjones/slimshader-cpp
@@ -41,7 +42,16 @@ namespace dxvk {
 
       return m_shexChunk->programInfo();
     }
-    
+
+    /**
+     * \brief Queries shader binding mask
+     *
+     * Only valid after successfully compiling the shader.
+     */
+    std::optional<DxbcBindingMask> bindings() const {
+      return m_bindings;
+    }
+
     /**
      * \brief Input and output signature chunks
      * 
@@ -50,7 +60,7 @@ namespace dxvk {
      */
     Rc<DxbcIsgn> isgn() const { return m_isgnChunk; }
     Rc<DxbcIsgn> osgn() const { return m_osgnChunk; }
-    
+
     /**
      * \brief Compiles DXBC shader to SPIR-V module
      * 
@@ -61,7 +71,7 @@ namespace dxvk {
      */
     Rc<DxvkShader> compile(
       const DxbcModuleInfo& moduleInfo,
-      const std::string&    fileName) const;
+      const std::string&    fileName);
     
     /**
      * \brief Compiles a pass-through geometry shader
@@ -85,6 +95,8 @@ namespace dxvk {
     Rc<DxbcIsgn> m_osgnChunk;
     Rc<DxbcIsgn> m_psgnChunk;
     Rc<DxbcShex> m_shexChunk;
+
+    std::optional<DxbcBindingMask> m_bindings;
     
     void runAnalyzer(
             DxbcAnalyzer&       analyzer,

--- a/src/dxbc/dxbc_util.h
+++ b/src/dxbc/dxbc_util.h
@@ -34,6 +34,43 @@ namespace dxvk {
 
   
   /**
+   * \brief Shader binding mask
+   *
+   * Stores a bit masks of resource bindings
+   * that are accessed by any given shader.
+   */
+  struct DxbcBindingMask {
+    uint32_t cbvMask      = 0u;
+    uint32_t samplerMask  = 0u;
+    uint64_t uavMask      = 0u;
+    std::array<uint64_t, 2> srvMask = { };
+
+    void reset() {
+      cbvMask = 0u;
+      samplerMask = 0u;
+      uavMask = 0u;
+      srvMask = { };
+    }
+
+    bool empty() const {
+      uint64_t mask = (uint64_t(cbvMask) | uint64_t(samplerMask) << 32u)
+                    | (uavMask | srvMask[0] | srvMask[1]);
+      return !mask;
+    }
+
+    DxbcBindingMask operator & (const DxbcBindingMask& other) const {
+      DxbcBindingMask result = *this;
+      result.cbvMask      &= other.cbvMask;
+      result.samplerMask  &= other.samplerMask;
+      result.uavMask      &= other.uavMask;
+      result.srvMask[0]   &= other.srvMask[0];
+      result.srvMask[1]   &= other.srvMask[1];
+      return result;
+    }
+  };
+
+
+  /**
    * \brief Computes first binding index for a given stage
    *
    * \param [in] stage The shader stage


### PR DESCRIPTION
~~Based on #4693 because the DXBC bits would otherwise turn into rebase hell, so that needs to land first.~~ Merged.

TL;DR is that we defer forwarding resource bindings (`SetShaderResourceViews` and friends) to the backend if:
- None of the active shaders use the binding, or
- The app sets a null buffer/view/sampler.

These will instead be applied on the next draw or dispatch that are actually known to use the given binding.

The rationale here is that forwarding unused bindings can confuse the backend a little and lead to descriptor set invalidations even if none of the *actually used* bindings have changed. As for null bindings, these are very rarely actually used in shaders, and instead we can assume that the app will either bind a non-null resource right after or binds a shader which doesn't use the given binding slot.

At the same time, immediately forwarding currently *active* binding avoids the extra overhead from tracking everything in well-behaved applications, even if this means that *some* bindings might be redundant (e.g. app binds a shader that doesn't use it right after, or binds two different resources to the same slot back-to-back).

In practice, this improves CPU-bound performance in God of War somewhat, and in Trine 5 this reduces the number of draw calls by ~50% in the menu because our indirect draw batching can now kick in properly. Almost all games run into this in *some* capacity, so it should be a nice overall improvement.