### PR TITLE
D3D11 Direct draw batching

### DIFF
--- a/src/d3d11/d3d11_cmd.h
+++ b/src/d3d11/d3d11_cmd.h
@@ -14,6 +14,8 @@ namespace dxvk {
     None,
     DrawIndirect,
     DrawIndirectIndexed,
+    Draw,
+    DrawIndexed,
   };
 
 

--- a/src/d3d11/d3d11_cmd.h
+++ b/src/d3d11/d3d11_cmd.h
@@ -10,20 +10,10 @@ namespace dxvk {
    * Used to identify the type of command
    * data most recently added to a CS chunk.
    */
-  enum class D3D11CmdType {
+  enum class D3D11CmdType : uint32_t {
+    None,
     DrawIndirect,
     DrawIndirectIndexed,
-  };
-
-
-  /**
-   * \brief Command data header
-   * 
-   * Stores the command type. All command
-   * data structs must inherit this struct.
-   */
-  struct D3D11CmdData {
-    D3D11CmdType        type;
   };
 
 
@@ -34,7 +24,7 @@ namespace dxvk {
    * the first draw, as well as the number of
    * draws to execute.
    */
-  struct D3D11CmdDrawIndirectData : public D3D11CmdData {
+  struct D3D11CmdDrawIndirectData {
     uint32_t            offset;
     uint32_t            count;
     uint32_t            stride;

--- a/src/d3d11/d3d11_context.cpp
+++ b/src/d3d11/d3d11_context.cpp
@@ -3578,12 +3578,7 @@ namespace dxvk {
 
     EmitCsCmd<VkDrawIndirectCommand>(D3D11CmdType::Draw, 1u,
       [] (DxvkContext* ctx, const VkDrawIndirectCommand* draws, size_t count) {
-        for (size_t i = 0; i < count; i++) {
-          ctx->draw(draws[i].vertexCount,
-                    draws[i].instanceCount,
-                    draws[i].firstVertex,
-                    draws[i].firstInstance);
-        }
+        ctx->draw(count, draws);
       });
 
     new (m_csData->first()) VkDrawIndirectCommand(draw);
@@ -3608,13 +3603,7 @@ namespace dxvk {
 
     EmitCsCmd<VkDrawIndexedIndirectCommand>(D3D11CmdType::DrawIndexed, 1u,
       [] (DxvkContext* ctx, const VkDrawIndexedIndirectCommand* draws, size_t count) {
-        for (size_t i = 0; i < count; i++) {
-          ctx->drawIndexed(draws[i].indexCount,
-                           draws[i].instanceCount,
-                           draws[i].firstIndex,
-                           draws[i].vertexOffset,
-                           draws[i].firstInstance);
-        }
+        ctx->drawIndexed(count, draws);
       });
 
     new (m_csData->first()) VkDrawIndexedIndirectCommand(draw);

--- a/src/d3d11/d3d11_context.h
+++ b/src/d3d11/d3d11_context.h
@@ -848,6 +848,12 @@ namespace dxvk {
 
     void ApplyViewportState();
 
+    void BatchDraw(
+      const VkDrawIndirectCommand&            draw);
+
+    void BatchDrawIndexed(
+      const VkDrawIndexedIndirectCommand&     draw);
+
     template<DxbcProgramType ShaderStage>
     void BindShader(
       const D3D11CommonShader*                pShaderModule);

--- a/src/d3d11/d3d11_video.cpp
+++ b/src/d3d11/d3d11_video.cpp
@@ -1312,7 +1312,11 @@ namespace dxvk {
       for (uint32_t i = 0; i < cViews.size(); i++)
         ctx->bindResourceImageView(VK_SHADER_STAGE_FRAGMENT_BIT, 1 + i, Rc<DxvkImageView>(cViews[i]));
 
-      ctx->draw(3, 1, 0, 0);
+      VkDrawIndirectCommand draw = { };
+      draw.vertexCount   = 3u;
+      draw.instanceCount = 1u;
+
+      ctx->draw(1, &draw);
 
       for (uint32_t i = 0; i < cViews.size(); i++)
         ctx->bindResourceImageView(VK_SHADER_STAGE_FRAGMENT_BIT, 1 + i, nullptr);

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -2890,9 +2890,12 @@ namespace dxvk {
 
       // Tests on Windows show that D3D9 does not do non-indexed instanced draws.
 
-      ctx->draw(
-        vertexCount, 1,
-        cStartVertex, 0);
+      VkDrawIndirectCommand draw = { };
+      draw.vertexCount   = vertexCount;
+      draw.instanceCount = 1u;
+      draw.firstVertex   = cStartVertex;
+
+      ctx->draw(1u, &draw);
     });
 
     return D3D_OK;
@@ -2939,10 +2942,13 @@ namespace dxvk {
 
       ApplyPrimitiveType(ctx, cPrimType);
 
-      ctx->drawIndexed(
-        drawInfo.vertexCount, drawInfo.instanceCount,
-        cStartIndex,
-        cBaseVertexIndex, 0);
+      VkDrawIndexedIndirectCommand draw = { };
+      draw.indexCount    = drawInfo.vertexCount;
+      draw.instanceCount = drawInfo.instanceCount;
+      draw.firstIndex    = cStartIndex;
+      draw.vertexOffset  = cBaseVertexIndex;
+
+      ctx->drawIndexed(1u, &draw);
     });
 
     return D3D_OK;
@@ -2981,11 +2987,12 @@ namespace dxvk {
       ApplyPrimitiveType(ctx, cPrimType);
 
       // Tests on Windows show that D3D9 does not do non-indexed instanced draws.
+      VkDrawIndirectCommand draw = { };
+      draw.vertexCount = cVertexCount;
+      draw.instanceCount = 1u;
 
       ctx->bindVertexBuffer(0, std::move(cBufferSlice), cStride);
-      ctx->draw(
-        cVertexCount, 1,
-        0, 0);
+      ctx->draw(1u, &draw);
       ctx->bindVertexBuffer(0, DxvkBufferSlice(), 0);
     });
 
@@ -3045,12 +3052,13 @@ namespace dxvk {
 
       ApplyPrimitiveType(ctx, cPrimType);
 
+      VkDrawIndexedIndirectCommand draw = { };
+      draw.indexCount    = drawInfo.vertexCount;
+      draw.instanceCount = drawInfo.instanceCount;
+
       ctx->bindVertexBuffer(0, cBufferSlice.subSlice(0, cVertexSize), cStride);
       ctx->bindIndexBuffer(cBufferSlice.subSlice(cVertexSize, cBufferSlice.length() - cVertexSize), cIndexType);
-      ctx->drawIndexed(
-        drawInfo.vertexCount, drawInfo.instanceCount,
-        0,
-        0, 0);
+      ctx->drawIndexed(1u, &draw);
       ctx->bindVertexBuffer(0, DxvkBufferSlice(), 0);
       ctx->bindIndexBuffer(DxvkBufferSlice(), VK_INDEX_TYPE_UINT32);
     });
@@ -3162,11 +3170,14 @@ namespace dxvk {
       // to avoid val errors / UB.
       ctx->bindShader<VK_SHADER_STAGE_FRAGMENT_BIT>(nullptr);
 
+      VkDrawIndirectCommand draw = { };
+      draw.vertexCount   = drawInfo.vertexCount;
+      draw.instanceCount = drawInfo.instanceCount;
+      draw.firstVertex   = cStartIndex;
+
       ctx->bindShader<VK_SHADER_STAGE_GEOMETRY_BIT>(std::move(shader));
       ctx->bindUniformBuffer(VK_SHADER_STAGE_GEOMETRY_BIT, getSWVPBufferSlot(), std::move(cBufferSlice));
-      ctx->draw(
-        drawInfo.vertexCount, drawInfo.instanceCount,
-        cStartIndex, 0);
+      ctx->draw(1u, &draw);
       ctx->bindUniformBuffer(VK_SHADER_STAGE_GEOMETRY_BIT, getSWVPBufferSlot(), DxvkBufferSlice());
       ctx->bindShader<VK_SHADER_STAGE_GEOMETRY_BIT>(nullptr);
     });

--- a/src/dxvk/dxvk_adapter.cpp
+++ b/src/dxvk/dxvk_adapter.cpp
@@ -400,6 +400,10 @@ namespace dxvk {
         m_deviceFeatures.extLineRasterization.smoothLines;
     }
 
+    // Enable multi-draw for draw batching
+    enabledFeatures.extMultiDraw.multiDraw =
+      m_deviceFeatures.extMultiDraw.multiDraw;
+
     // Enable memory priority and pageable memory if supported
     // to improve driver-side memory management
     enabledFeatures.extMemoryPriority.memoryPriority =
@@ -600,6 +604,10 @@ namespace dxvk {
           enabledFeatures.extMemoryPriority = *reinterpret_cast<const VkPhysicalDeviceMemoryPriorityFeaturesEXT*>(f);
           break;
 
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTI_DRAW_FEATURES_EXT:
+          enabledFeatures.extMultiDraw = *reinterpret_cast<const VkPhysicalDeviceMultiDrawFeaturesEXT*>(f);
+          break;
+
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_NON_SEAMLESS_CUBE_MAP_FEATURES_EXT:
           enabledFeatures.extNonSeamlessCubeMap = *reinterpret_cast<const VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT*>(f);
           break;
@@ -791,6 +799,11 @@ namespace dxvk {
       m_deviceInfo.extLineRasterization.pNext = std::exchange(m_deviceInfo.core.pNext, &m_deviceInfo.extLineRasterization);
     }
 
+    if (m_deviceExtensions.supports(VK_EXT_MULTI_DRAW_EXTENSION_NAME)) {
+      m_deviceInfo.extMultiDraw.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTI_DRAW_PROPERTIES_EXT;
+      m_deviceInfo.extMultiDraw.pNext = std::exchange(m_deviceInfo.core.pNext, &m_deviceInfo.extMultiDraw);
+    }
+
     if (m_deviceExtensions.supports(VK_EXT_ROBUSTNESS_2_EXTENSION_NAME)) {
       m_deviceInfo.extRobustness2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ROBUSTNESS_2_PROPERTIES_EXT;
       m_deviceInfo.extRobustness2.pNext = std::exchange(m_deviceInfo.core.pNext, &m_deviceInfo.extRobustness2);
@@ -889,6 +902,11 @@ namespace dxvk {
     if (m_deviceExtensions.supports(VK_EXT_MEMORY_PRIORITY_EXTENSION_NAME)) {
       m_deviceFeatures.extMemoryPriority.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_PRIORITY_FEATURES_EXT;
       m_deviceFeatures.extMemoryPriority.pNext = std::exchange(m_deviceFeatures.core.pNext, &m_deviceFeatures.extMemoryPriority);
+    }
+
+    if (m_deviceExtensions.supports(VK_EXT_MULTI_DRAW_EXTENSION_NAME)) {
+      m_deviceFeatures.extMultiDraw.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTI_DRAW_FEATURES_EXT;
+      m_deviceFeatures.extMultiDraw.pNext = std::exchange(m_deviceFeatures.core.pNext, &m_deviceFeatures.extMultiDraw);
     }
 
     if (m_deviceExtensions.supports(VK_EXT_NON_SEAMLESS_CUBE_MAP_EXTENSION_NAME)) {
@@ -1017,6 +1035,7 @@ namespace dxvk {
       &devExtensions.extLineRasterization,
       &devExtensions.extMemoryBudget,
       &devExtensions.extMemoryPriority,
+      &devExtensions.extMultiDraw,
       &devExtensions.extNonSeamlessCubeMap,
       &devExtensions.extPageableDeviceLocalMemory,
       &devExtensions.extRobustness2,
@@ -1114,6 +1133,11 @@ namespace dxvk {
     if (devExtensions.extMemoryPriority) {
       enabledFeatures.extMemoryPriority.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_PRIORITY_FEATURES_EXT;
       enabledFeatures.extMemoryPriority.pNext = std::exchange(enabledFeatures.core.pNext, &enabledFeatures.extMemoryPriority);
+    }
+
+    if (devExtensions.extMultiDraw) {
+      enabledFeatures.extMultiDraw.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTI_DRAW_FEATURES_EXT;
+      enabledFeatures.extMultiDraw.pNext = std::exchange(enabledFeatures.core.pNext, &enabledFeatures.extMultiDraw);
     }
 
     if (devExtensions.extNonSeamlessCubeMap) {
@@ -1308,6 +1332,8 @@ namespace dxvk {
       "\n  extension supported                    : ", features.extMemoryBudget ? "1" : "0",
       "\n", VK_EXT_MEMORY_PRIORITY_EXTENSION_NAME,
       "\n  memoryPriority                         : ", features.extMemoryPriority.memoryPriority ? "1" : "0",
+      "\n", VK_EXT_MULTI_DRAW_EXTENSION_NAME,
+      "\n  multiDraw                              : ", features.extMultiDraw.multiDraw ? "1" : "0",
       "\n", VK_EXT_NON_SEAMLESS_CUBE_MAP_EXTENSION_NAME,
       "\n  nonSeamlessCubeMap                     : ", features.extNonSeamlessCubeMap.nonSeamlessCubeMap ? "1" : "0",
       "\n", VK_EXT_PAGEABLE_DEVICE_LOCAL_MEMORY_EXTENSION_NAME,

--- a/src/dxvk/dxvk_cmdlist.h
+++ b/src/dxvk/dxvk_cmdlist.h
@@ -729,7 +729,8 @@ namespace dxvk {
       const VkMultiDrawInfoEXT*     drawInfos,
             uint32_t                instanceCount,
             uint32_t                firstInstance) {
-      m_statCounters.addCtr(DxvkStatCounter::CmdDrawCalls, 1);
+      m_statCounters.addCtr(DxvkStatCounter::CmdDrawCalls, 1u);
+      m_statCounters.addCtr(DxvkStatCounter::CmdDrawsMerged, drawCount - 1u);
 
       m_vkd->vkCmdDrawMultiEXT(getCmdBuffer(),
         drawCount, drawInfos, instanceCount, firstInstance, sizeof(*drawInfos));
@@ -742,6 +743,7 @@ namespace dxvk {
             uint32_t                drawCount,
             uint32_t                stride) {
       m_statCounters.addCtr(DxvkStatCounter::CmdDrawCalls, 1);
+      m_statCounters.addCtr(DxvkStatCounter::CmdDrawsMerged, drawCount - 1u);
 
       m_vkd->vkCmdDrawIndirect(getCmdBuffer(),
         buffer, offset, drawCount, stride);
@@ -783,6 +785,7 @@ namespace dxvk {
             uint32_t                instanceCount,
             uint32_t                firstInstance) {
       m_statCounters.addCtr(DxvkStatCounter::CmdDrawCalls, 1);
+      m_statCounters.addCtr(DxvkStatCounter::CmdDrawsMerged, drawCount - 1u);
 
       m_vkd->vkCmdDrawMultiIndexedEXT(getCmdBuffer(), drawCount,
         drawInfos, instanceCount, firstInstance, sizeof(*drawInfos), nullptr);
@@ -795,6 +798,7 @@ namespace dxvk {
             uint32_t                drawCount,
             uint32_t                stride) {
       m_statCounters.addCtr(DxvkStatCounter::CmdDrawCalls, 1);
+      m_statCounters.addCtr(DxvkStatCounter::CmdDrawsMerged, drawCount - 1u);
 
       m_vkd->vkCmdDrawIndexedIndirect(getCmdBuffer(),
         buffer, offset, drawCount, stride);

--- a/src/dxvk/dxvk_cmdlist.h
+++ b/src/dxvk/dxvk_cmdlist.h
@@ -722,6 +722,18 @@ namespace dxvk {
         vertexCount, instanceCount,
         firstVertex, firstInstance);
     }
+
+
+    void cmdDrawMulti(
+            uint32_t                drawCount,
+      const VkMultiDrawInfoEXT*     drawInfos,
+            uint32_t                instanceCount,
+            uint32_t                firstInstance) {
+      m_statCounters.addCtr(DxvkStatCounter::CmdDrawCalls, 1);
+
+      m_vkd->vkCmdDrawMultiEXT(getCmdBuffer(),
+        drawCount, drawInfos, instanceCount, firstInstance, sizeof(*drawInfos));
+    }
     
     
     void cmdDrawIndirect(
@@ -745,8 +757,8 @@ namespace dxvk {
             uint32_t                stride) {
       m_statCounters.addCtr(DxvkStatCounter::CmdDrawCalls, 1);
 
-      m_vkd->vkCmdDrawIndirectCount(getCmdBuffer(),
-        buffer, offset, countBuffer, countOffset, maxDrawCount, stride);
+      m_vkd->vkCmdDrawIndirectCount(getCmdBuffer(), buffer,
+        offset, countBuffer, countOffset, maxDrawCount, stride);
     }
     
     
@@ -765,6 +777,18 @@ namespace dxvk {
     }
     
     
+    void cmdDrawMultiIndexed(
+            uint32_t                drawCount,
+      const VkMultiDrawIndexedInfoEXT* drawInfos,
+            uint32_t                instanceCount,
+            uint32_t                firstInstance) {
+      m_statCounters.addCtr(DxvkStatCounter::CmdDrawCalls, 1);
+
+      m_vkd->vkCmdDrawMultiIndexedEXT(getCmdBuffer(), drawCount,
+        drawInfos, instanceCount, firstInstance, sizeof(*drawInfos), nullptr);
+    }
+
+
     void cmdDrawIndexedIndirect(
             VkBuffer                buffer,
             VkDeviceSize            offset,

--- a/src/dxvk/dxvk_cmdlist.h
+++ b/src/dxvk/dxvk_cmdlist.h
@@ -485,7 +485,6 @@ namespace dxvk {
     void cmdBeginRendering(
       const VkRenderingInfo*        pRenderingInfo) {
       m_cmd.execCommands = true;
-      m_statCounters.addCtr(DxvkStatCounter::CmdRenderPassCount, 1);
 
       m_vkd->vkCmdBeginRendering(getCmdBuffer(), pRenderingInfo);
     }
@@ -694,7 +693,6 @@ namespace dxvk {
             uint32_t                y,
             uint32_t                z) {
       m_cmd.execCommands |= cmdBuffer == DxvkCmdBuffer::ExecBuffer;
-      m_statCounters.addCtr(DxvkStatCounter::CmdDispatchCalls, 1);
 
       m_vkd->vkCmdDispatch(getCmdBuffer(cmdBuffer), x, y, z);
     }
@@ -705,7 +703,6 @@ namespace dxvk {
             VkBuffer                buffer,
             VkDeviceSize            offset) {
       m_cmd.execCommands |= cmdBuffer == DxvkCmdBuffer::ExecBuffer;
-      m_statCounters.addCtr(DxvkStatCounter::CmdDispatchCalls, 1);
 
       m_vkd->vkCmdDispatchIndirect(getCmdBuffer(cmdBuffer), buffer, offset);
     }
@@ -716,8 +713,6 @@ namespace dxvk {
             uint32_t                instanceCount,
             uint32_t                firstVertex,
             uint32_t                firstInstance) {
-      m_statCounters.addCtr(DxvkStatCounter::CmdDrawCalls, 1);
-
       m_vkd->vkCmdDraw(getCmdBuffer(),
         vertexCount, instanceCount,
         firstVertex, firstInstance);
@@ -729,9 +724,6 @@ namespace dxvk {
       const VkMultiDrawInfoEXT*     drawInfos,
             uint32_t                instanceCount,
             uint32_t                firstInstance) {
-      m_statCounters.addCtr(DxvkStatCounter::CmdDrawCalls, 1u);
-      m_statCounters.addCtr(DxvkStatCounter::CmdDrawsMerged, drawCount - 1u);
-
       m_vkd->vkCmdDrawMultiEXT(getCmdBuffer(),
         drawCount, drawInfos, instanceCount, firstInstance, sizeof(*drawInfos));
     }
@@ -742,9 +734,6 @@ namespace dxvk {
             VkDeviceSize            offset,
             uint32_t                drawCount,
             uint32_t                stride) {
-      m_statCounters.addCtr(DxvkStatCounter::CmdDrawCalls, 1);
-      m_statCounters.addCtr(DxvkStatCounter::CmdDrawsMerged, drawCount - 1u);
-
       m_vkd->vkCmdDrawIndirect(getCmdBuffer(),
         buffer, offset, drawCount, stride);
     }
@@ -757,8 +746,6 @@ namespace dxvk {
             VkDeviceSize            countOffset,
             uint32_t                maxDrawCount,
             uint32_t                stride) {
-      m_statCounters.addCtr(DxvkStatCounter::CmdDrawCalls, 1);
-
       m_vkd->vkCmdDrawIndirectCount(getCmdBuffer(), buffer,
         offset, countBuffer, countOffset, maxDrawCount, stride);
     }
@@ -770,8 +757,6 @@ namespace dxvk {
             uint32_t                firstIndex,
             int32_t                 vertexOffset,
             uint32_t                firstInstance) {
-      m_statCounters.addCtr(DxvkStatCounter::CmdDrawCalls, 1);
-
       m_vkd->vkCmdDrawIndexed(getCmdBuffer(),
         indexCount, instanceCount,
         firstIndex, vertexOffset,
@@ -784,9 +769,6 @@ namespace dxvk {
       const VkMultiDrawIndexedInfoEXT* drawInfos,
             uint32_t                instanceCount,
             uint32_t                firstInstance) {
-      m_statCounters.addCtr(DxvkStatCounter::CmdDrawCalls, 1);
-      m_statCounters.addCtr(DxvkStatCounter::CmdDrawsMerged, drawCount - 1u);
-
       m_vkd->vkCmdDrawMultiIndexedEXT(getCmdBuffer(), drawCount,
         drawInfos, instanceCount, firstInstance, sizeof(*drawInfos), nullptr);
     }
@@ -797,9 +779,6 @@ namespace dxvk {
             VkDeviceSize            offset,
             uint32_t                drawCount,
             uint32_t                stride) {
-      m_statCounters.addCtr(DxvkStatCounter::CmdDrawCalls, 1);
-      m_statCounters.addCtr(DxvkStatCounter::CmdDrawsMerged, drawCount - 1u);
-
       m_vkd->vkCmdDrawIndexedIndirect(getCmdBuffer(),
         buffer, offset, drawCount, stride);
     }
@@ -812,8 +791,6 @@ namespace dxvk {
             VkDeviceSize            countOffset,
             uint32_t                maxDrawCount,
             uint32_t                stride) {
-      m_statCounters.addCtr(DxvkStatCounter::CmdDrawCalls, 1);
-
       m_vkd->vkCmdDrawIndexedIndirectCount(getCmdBuffer(),
         buffer, offset, countBuffer, countOffset, maxDrawCount, stride);
     }
@@ -826,8 +803,6 @@ namespace dxvk {
             VkDeviceSize            counterBufferOffset,
             uint32_t                counterOffset,
             uint32_t                vertexStride) {
-      m_statCounters.addCtr(DxvkStatCounter::CmdDrawCalls, 1);
-
       m_vkd->vkCmdDrawIndirectByteCountEXT(getCmdBuffer(),
         instanceCount, firstInstance, counterBuffer,
         counterBufferOffset, counterOffset, vertexStride);

--- a/src/dxvk/dxvk_context.h
+++ b/src/dxvk/dxvk_context.h
@@ -32,6 +32,8 @@ namespace dxvk {
   class DxvkContext : public RcObject {
     constexpr static VkDeviceSize MaxDiscardSizeInRp = 256u << 10u;
     constexpr static VkDeviceSize MaxDiscardSize     =  16u << 10u;
+
+    constexpr static uint32_t DirectMultiDrawBatchSize = 256u;
   public:
     
     DxvkContext(const Rc<DxvkDevice>& device);
@@ -744,17 +746,13 @@ namespace dxvk {
     /**
      * \brief Draws primitive without using an index buffer
      * 
-     * \param [in] vertexCount Number of vertices to draw
-     * \param [in] instanceCount Number of instances to render
-     * \param [in] firstVertex First vertex in vertex buffer
-     * \param [in] firstInstance First instance ID
+     * \param [in] count Number of draws
+     * \param [in] draws Draw parameters
      */
     void draw(
-            uint32_t          vertexCount,
-            uint32_t          instanceCount,
-            uint32_t          firstVertex,
-            uint32_t          firstInstance);
-    
+            uint32_t          count,
+      const VkDrawIndirectCommand* draws);
+
     /**
      * \brief Indirect draw call
      * 
@@ -791,19 +789,13 @@ namespace dxvk {
     /**
      * \brief Draws primitives using an index buffer
      * 
-     * \param [in] indexCount Number of indices to draw
-     * \param [in] instanceCount Number of instances to render
-     * \param [in] firstIndex First index within the index buffer
-     * \param [in] vertexOffset Vertex ID that corresponds to index 0
-     * \param [in] firstInstance First instance ID
+     * \param [in] count Number of draws
+     * \param [in] draws Draw parameters
      */
     void drawIndexed(
-            uint32_t indexCount,
-            uint32_t instanceCount,
-            uint32_t firstIndex,
-            int32_t  vertexOffset,
-            uint32_t firstInstance);
-    
+            uint32_t          count,
+      const VkDrawIndexedIndirectCommand* draws);
+
     /**
      * \brief Indirect indexed draw call
      * 
@@ -1595,6 +1587,11 @@ namespace dxvk {
       const Rc<DxvkBuffer>&       buffer,
             VkDeviceSize          offset);
 
+    template<bool Indexed, typename T>
+    void drawGeneric(
+            uint32_t              count,
+      const T*                    draws);
+
     template<bool Indexed>
     void drawIndirectGeneric(
             VkDeviceSize          offset,
@@ -2103,7 +2100,7 @@ namespace dxvk {
       return pred(DxvkAccess::Read);
     }
 
-    void invalidateWriteAfterWriteTracking();
+    bool needsDrawBarriers();
 
     void beginRenderPassDebugRegion();
 

--- a/src/dxvk/dxvk_context_state.h
+++ b/src/dxvk/dxvk_context_state.h
@@ -75,6 +75,7 @@ namespace dxvk {
     VariableMultisampleRate,
     IndexBufferRobustness,
     DebugUtils,
+    DirectMultiDraw,
     FeatureCount
   };
 

--- a/src/dxvk/dxvk_cs.h
+++ b/src/dxvk/dxvk_cs.h
@@ -11,7 +11,9 @@
 #include "dxvk_context.h"
 
 namespace dxvk {
-  
+
+  constexpr static size_t DxvkCsChunkSize = 16384;
+
   /**
    * \brief Command stream operation
    * 
@@ -87,6 +89,41 @@ namespace dxvk {
 
 
   /**
+   * \brief Command data block
+   *
+   * Provides functionality to allocate a potentially growing
+   * array of structures for a command to traverse.
+   */
+  class DxvkCsDataBlock {
+    friend class DxvkCsChunk;
+  public:
+
+    /**
+     * \brief Number of structures allocated
+     * \returns Number of structures allocated
+     */
+    size_t count() const {
+      return m_structCount;
+    }
+
+    /**
+     * \brief Retrieves pointer to first structure
+     * \returns Untyped pointer to first structure
+     */
+    void* first() {
+      return reinterpret_cast<char*>(this) + m_dataOffset;
+    }
+
+  private:
+
+    uint32_t m_dataOffset  = 0u;
+    uint16_t m_structSize  = 0u;
+    uint16_t m_structCount = 0u;
+
+  };
+
+
+  /**
    * \brief Typed command with metadata
    * 
    * Stores a function object and an arbitrary
@@ -98,26 +135,33 @@ namespace dxvk {
 
   public:
 
-    template<typename... Args>
-    DxvkCsDataCmd(T&& cmd, Args&&... args)
-    : m_command (std::move(cmd)),
-      m_data    (std::forward<Args>(args)...) { }
-    
+    DxvkCsDataCmd(T&& cmd)
+    : m_command(std::move(cmd)) { }
+
+    ~DxvkCsDataCmd() {
+      auto data = reinterpret_cast<M*>(m_data.first());
+
+      for (size_t i = 0; i < m_data.count(); i++)
+        data[i].~M();
+    }
+
     DxvkCsDataCmd             (DxvkCsDataCmd&&) = delete;
     DxvkCsDataCmd& operator = (DxvkCsDataCmd&&) = delete;
 
     void exec(DxvkContext* ctx) {
-      m_command(ctx, &m_data);
+      // No const here so that the function can move objects efficiently
+      m_command(ctx, reinterpret_cast<M*>(m_data.first()), m_data.count());
     }
 
-    M* data() {
+    DxvkCsDataBlock* data() {
       return &m_data;
     }
 
   private:
 
-    T m_command;
-    M m_data;
+    alignas(M)
+    T               m_command;
+    DxvkCsDataBlock m_data;
 
   };
   
@@ -140,12 +184,12 @@ namespace dxvk {
    * Stores a list of commands.
    */
   class DxvkCsChunk : public RcObject {
-    constexpr static size_t MaxBlockSize = 16384;
+
   public:
-    
+
     DxvkCsChunk();
     ~DxvkCsChunk();
-    
+
     /**
      * \brief Checks whether the chunk is empty
      * \returns \c true if the chunk is empty
@@ -167,7 +211,7 @@ namespace dxvk {
     template<typename T>
     bool push(T& command) {
       using FuncType = DxvkCsTypedCmd<T>;
-      void* ptr = alloc<FuncType>();
+      void* ptr = alloc<FuncType>(0u);
 
       if (unlikely(!ptr))
         return false;
@@ -186,23 +230,60 @@ namespace dxvk {
      * \brief Adds a command with data to the chunk 
      * 
      * \param [in] command The command to add
-     * \param [in] args Constructor args for the data object
+     * \param [in] count Number of items to allocate. Should be at least
+     *    1 in order to avoid the possibility of an empty command. Note
+     *    that all allocated structures \e must be initialized before
+     *    handing off the command to the worker thread.
      * \returns Pointer to the data object, or \c nullptr
      */
-    template<typename M, typename T, typename... Args>
-    M* pushCmd(T& command, Args&&... args) {
+    template<typename M, typename T>
+    DxvkCsDataBlock* pushCmd(T& command, size_t count) {
+      size_t dataSize = count * sizeof(M);
+
+      // DxvkCsDataCmd is aligned to M
       using FuncType = DxvkCsDataCmd<T, M>;
-      void* ptr = alloc<FuncType>();
+      void* ptr = alloc<FuncType>(dataSize);
 
       if (unlikely(!ptr))
         return nullptr;
 
-      auto next = new (ptr) FuncType(std::move(command), std::forward<Args>(args)...);
+      // Command data is always packed tightly after the function object
+      auto next = new (ptr) FuncType(std::move(command));
       append(next);
 
-      return next->data();
+      // Do some cursed pointer math here so that the block can figure out
+      // where its data is stored based on its own address. This saves a
+      // decent amount of CS chunk memory compared to storing a pointer.
+      auto block = next->data();
+      block->m_dataOffset = reinterpret_cast<uintptr_t>(&m_data[m_commandOffset - dataSize])
+                          - reinterpret_cast<uintptr_t>(block);
+      block->m_structSize = sizeof(M);
+      block->m_structCount = count;
+      return block;
     }
-    
+
+    /**
+     * \brief Allocates more storage for a data block
+     *
+     * The data bock \e must be owned by the last command added to
+     * the CS chunk, or this may override subsequent command data.
+     * \param [in] block Data block
+     * \param [in] count Number of structures to allocate
+     * \returns Pointer to first allocated structure, or \c nullptr
+     */
+    void* pushData(DxvkCsDataBlock* block, uint32_t count) {
+      uint32_t dataSize = block->m_structSize * count;
+
+      if (unlikely(m_commandOffset + dataSize > DxvkCsChunkSize))
+        return nullptr;
+
+      void* ptr = &m_data[m_commandOffset];
+      m_commandOffset += dataSize;
+
+      block->m_structCount += count;
+      return ptr;
+    }
+
     /**
      * \brief Initializes chunk for recording
      * \param [in] flags Chunk flags
@@ -237,18 +318,18 @@ namespace dxvk {
     DxvkCsChunkFlags m_flags;
     
     alignas(64)
-    char m_data[MaxBlockSize];
+    char m_data[DxvkCsChunkSize];
 
     template<typename T>
-    void* alloc() {
+    void* alloc(size_t extra) {
       if (alignof(T) > alignof(DxvkCsCmd))
         m_commandOffset = dxvk::align(m_commandOffset, alignof(T));
 
-      if (unlikely(m_commandOffset + sizeof(T) > MaxBlockSize))
+      if (unlikely(m_commandOffset + sizeof(T) + extra > DxvkCsChunkSize))
         return nullptr;
 
       void* result = &m_data[m_commandOffset];
-      m_commandOffset += sizeof(T);
+      m_commandOffset += sizeof(T) + extra;
       return result;
     }
 
@@ -420,7 +501,7 @@ namespace dxvk {
    * commands on a DXVK context. 
    */
   class DxvkCsThread {
-    
+
   public:
 
     constexpr static uint64_t SynchronizeAll = ~0ull;
@@ -515,5 +596,5 @@ namespace dxvk {
     void threadFunc();
     
   };
-  
+
 }

--- a/src/dxvk/dxvk_device_info.h
+++ b/src/dxvk/dxvk_device_info.h
@@ -25,6 +25,7 @@ namespace dxvk {
     VkPhysicalDeviceExtendedDynamicState3PropertiesEXT        extExtendedDynamicState3;
     VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT      extGraphicsPipelineLibrary;
     VkPhysicalDeviceLineRasterizationPropertiesEXT            extLineRasterization;
+    VkPhysicalDeviceMultiDrawPropertiesEXT                    extMultiDraw;
     VkPhysicalDeviceRobustness2PropertiesEXT                  extRobustness2;
     VkPhysicalDeviceTransformFeedbackPropertiesEXT            extTransformFeedback;
     VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT       extVertexAttributeDivisor;
@@ -58,6 +59,7 @@ namespace dxvk {
     VkPhysicalDeviceLineRasterizationFeaturesEXT              extLineRasterization;
     VkBool32                                                  extMemoryBudget;
     VkPhysicalDeviceMemoryPriorityFeaturesEXT                 extMemoryPriority;
+    VkPhysicalDeviceMultiDrawFeaturesEXT                      extMultiDraw;
     VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT             extNonSeamlessCubeMap;
     VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT      extPageableDeviceLocalMemory;
     VkPhysicalDeviceRobustness2FeaturesEXT                    extRobustness2;

--- a/src/dxvk/dxvk_extensions.h
+++ b/src/dxvk/dxvk_extensions.h
@@ -308,6 +308,7 @@ namespace dxvk {
     DxvkExt extLineRasterization              = { VK_EXT_LINE_RASTERIZATION_EXTENSION_NAME,                 DxvkExtMode::Optional };
     DxvkExt extMemoryBudget                   = { VK_EXT_MEMORY_BUDGET_EXTENSION_NAME,                      DxvkExtMode::Passive  };
     DxvkExt extMemoryPriority                 = { VK_EXT_MEMORY_PRIORITY_EXTENSION_NAME,                    DxvkExtMode::Optional };
+    DxvkExt extMultiDraw                      = { VK_EXT_MULTI_DRAW_EXTENSION_NAME,                         DxvkExtMode::Optional };
     DxvkExt extNonSeamlessCubeMap             = { VK_EXT_NON_SEAMLESS_CUBE_MAP_EXTENSION_NAME,              DxvkExtMode::Optional };
     DxvkExt extPageableDeviceLocalMemory      = { VK_EXT_PAGEABLE_DEVICE_LOCAL_MEMORY_EXTENSION_NAME,       DxvkExtMode::Optional };
     DxvkExt extRobustness2                    = { VK_EXT_ROBUSTNESS_2_EXTENSION_NAME,                       DxvkExtMode::Required };

--- a/src/dxvk/dxvk_stats.h
+++ b/src/dxvk/dxvk_stats.h
@@ -12,6 +12,7 @@ namespace dxvk {
    */
   enum class DxvkStatCounter : uint32_t {
     CmdDrawCalls,             ///< Number of draw calls
+    CmdDrawsMerged,           ///< Number of unique draws, minus draw calls
     CmdDispatchCalls,         ///< Number of compute calls
     CmdRenderPassCount,       ///< Number of render passes
     CmdBarrierCount,          ///< Number of pipeline barriers
@@ -30,7 +31,8 @@ namespace dxvk {
     CsChunkCount,             ///< Submitted CS chunks
     DescriptorPoolCount,      ///< Descriptor pool count
     DescriptorSetCount,       ///< Descriptor sets allocated
-    NumCounters,              ///< Number of counters available
+
+    NumCounters               ///< Number of counters available
   };
   
   

--- a/src/dxvk/hud/dxvk_hud_item.cpp
+++ b/src/dxvk/hud/dxvk_hud_item.cpp
@@ -800,10 +800,11 @@ namespace dxvk::hud {
     auto diffCounters = counters.diff(m_prevCounters);
 
     if (elapsed.count() >= UpdateInterval) {
-      m_gpCount = diffCounters.getCtr(DxvkStatCounter::CmdDrawCalls);
-      m_cpCount = diffCounters.getCtr(DxvkStatCounter::CmdDispatchCalls);
-      m_rpCount = diffCounters.getCtr(DxvkStatCounter::CmdRenderPassCount);
-      m_pbCount = diffCounters.getCtr(DxvkStatCounter::CmdBarrierCount);
+      m_drawCallCount   = diffCounters.getCtr(DxvkStatCounter::CmdDrawCalls);
+      m_drawCount       = diffCounters.getCtr(DxvkStatCounter::CmdDrawsMerged) + m_drawCallCount;
+      m_dispatchCount   = diffCounters.getCtr(DxvkStatCounter::CmdDispatchCalls);
+      m_renderPassCount = diffCounters.getCtr(DxvkStatCounter::CmdRenderPassCount);
+      m_barrierCount    = diffCounters.getCtr(DxvkStatCounter::CmdBarrierCount);
 
       m_lastUpdate = time;
     }
@@ -818,21 +819,25 @@ namespace dxvk::hud {
     const HudOptions&         options,
           HudRenderer&        renderer,
           HudPos              position) {
+    std::string drawCount = m_drawCount > m_drawCallCount
+      ? str::format(m_drawCallCount, " (", m_drawCount, ")")
+      : str::format(m_drawCallCount);
+
     position.y += 16;
     renderer.drawText(16, position, 0xffff8040, "Draw calls:");
-    renderer.drawText(16, { position.x + 192, position.y }, 0xffffffffu, str::format(m_gpCount));
+    renderer.drawText(16, { position.x + 192, position.y }, 0xffffffffu, drawCount);
     
     position.y += 20;
     renderer.drawText(16, position, 0xffff8040, "Dispatch calls:");
-    renderer.drawText(16, { position.x + 192, position.y }, 0xffffffffu, str::format(m_cpCount));
+    renderer.drawText(16, { position.x + 192, position.y }, 0xffffffffu, str::format(m_dispatchCount));
     
     position.y += 20;
     renderer.drawText(16, position, 0xffff8040, "Render passes:");
-    renderer.drawText(16, { position.x + 192, position.y }, 0xffffffffu, str::format(m_rpCount));
+    renderer.drawText(16, { position.x + 192, position.y }, 0xffffffffu, str::format(m_renderPassCount));
     
     position.y += 20;
     renderer.drawText(16, position, 0xffff8040, "Barriers:");
-    renderer.drawText(16, { position.x + 192, position.y }, 0xffffffffu, str::format(m_pbCount));
+    renderer.drawText(16, { position.x + 192, position.y }, 0xffffffffu, str::format(m_barrierCount));
     
     position.y += 8;
     return position;

--- a/src/dxvk/hud/dxvk_hud_item.h
+++ b/src/dxvk/hud/dxvk_hud_item.h
@@ -422,10 +422,11 @@ namespace dxvk::hud {
 
     DxvkStatCounters  m_prevCounters;
 
-    uint64_t          m_gpCount = 0;
-    uint64_t          m_cpCount = 0;
-    uint64_t          m_rpCount = 0;
-    uint64_t          m_pbCount = 0;
+    uint64_t          m_drawCallCount   = 0;
+    uint64_t          m_drawCount       = 0;
+    uint64_t          m_dispatchCount   = 0;
+    uint64_t          m_renderPassCount = 0;
+    uint64_t          m_barrierCount    = 0;
 
     dxvk::high_resolution_clock::time_point m_lastUpdate
       = dxvk::high_resolution_clock::now();

--- a/src/vulkan/vulkan_loader.h
+++ b/src/vulkan/vulkan_loader.h
@@ -405,6 +405,11 @@ namespace dxvk::vk {
     VULKAN_FN(vkSetDeviceMemoryPriorityEXT);
     #endif
 
+    #ifdef VK_EXT_multi_draw
+    VULKAN_FN(vkCmdDrawMultiEXT);
+    VULKAN_FN(vkCmdDrawMultiIndexedEXT);
+    #endif
+
     #ifdef VK_EXT_shader_module_identifier
     VULKAN_FN(vkGetShaderModuleCreateInfoIdentifierEXT);
     VULKAN_FN(vkGetShaderModuleIdentifierEXT);

--- a/src/vulkan/vulkan_util.h
+++ b/src/vulkan/vulkan_util.h
@@ -244,7 +244,7 @@ namespace dxvk::vk {
     label.color[0] = ((color >> 16u) & 0xffu) / 255.0f;
     label.color[1] = ((color >> 8u)  & 0xffu) / 255.0f;
     label.color[2] = ((color >> 0u)  & 0xffu) / 255.0f;
-    label.color[3] = 1.0f;
+    label.color[3] = color ? 1.0f : 0.0f;
     label.pLabelName = text;
     return label;
   }


### PR DESCRIPTION
Because @DadSchoorse bullied me into it.

This uses `VK_EXT_multi_draw` to batch consecutive draws with no state changes, in much the same way we already batch consecutive *indirect* draws into a single indirect multidraw. Even if the extension *isn't* supported, this may slightly reduce CPU overhead because we're no longer redundantly checking dirty states all the time.

Games that see a notable reduction in draw calls include the Atelier series, Yakuza 0 / Kiwami, Nier Automata, Watch Dogs 2.

Based on #4699 to avoid rebase hell.