### PR TITLE
Remove d3d11.dcSingleUseMode option

### DIFF
--- a/dxvk.conf
+++ b/dxvk.conf
@@ -228,17 +228,6 @@
 # dxvk.tilerMode = Auto
 
 
-# Assume that command lists created from deferred contexts are only used
-# once. This is extremely common and may improve performance while reducing
-# the amount of memory wasted if games keep their command list objects alive
-# for too long, but may also lead to rendering issues if command lists are
-# submitted multiple times.
-#
-# Supported values: True, False
-
-# d3d11.dcSingleUseMode = True
-
-
 # Override the maximum feature level that a D3D11 device can be created
 # with. Setting this to a higher value may allow some applications to run
 # that would otherwise fail to create a D3D11 device.

--- a/src/d3d11/d3d11_cmdlist.cpp
+++ b/src/d3d11/d3d11_cmdlist.cpp
@@ -74,8 +74,6 @@ namespace dxvk {
       m_resources.push_back(std::move(entry));
     }
 
-    pCommandList->MarkSubmitted();
-
     // Return ID of the last chunk added. The command list
     // added can never be empty, so do not handle zero.
     return m_chunks.size() - 1;
@@ -102,8 +100,6 @@ namespace dxvk {
       while (j < m_resources.size() && m_resources[j].chunkId == i)
         TrackResourceSequenceNumber(m_resources[j++].ref, seq);
     }
-
-    MarkSubmitted();
   }
   
   
@@ -148,16 +144,6 @@ namespace dxvk {
         auto impl = static_cast<D3D11Texture3D*>(iface)->GetCommonTexture();
         impl->TrackSequenceNumber(Resource.GetSubresource(), Seq);
       } break;
-    }
-  }
-
-
-  void D3D11CommandList::MarkSubmitted() {
-    if (m_submitted.exchange(true) && !m_warned.exchange(true)
-     && m_parent->GetOptions()->dcSingleUseMode) {
-      Logger::warn(
-        "D3D11: Command list submitted multiple times,\n"
-        "       but d3d11.dcSingleUseMode is enabled");
     }
   }
   

--- a/src/d3d11/d3d11_cmdlist.h
+++ b/src/d3d11/d3d11_cmdlist.h
@@ -55,14 +55,9 @@ namespace dxvk {
     std::vector<Com<D3D11Query, false>> m_queries;
     std::vector<TrackedResource>        m_resources;
 
-    std::atomic<bool> m_submitted = { false };
-    std::atomic<bool> m_warned    = { false };
-
     void TrackResourceSequenceNumber(
       const D3D11ResourceRef&   Resource,
             uint64_t            Seq);
-
-    void MarkSubmitted();
     
   };
   

--- a/src/d3d11/d3d11_context_def.cpp
+++ b/src/d3d11/d3d11_context_def.cpp
@@ -7,7 +7,7 @@ namespace dxvk {
           D3D11Device*    pParent,
     const Rc<DxvkDevice>& Device,
           UINT            ContextFlags)
-  : D3D11CommonContext<D3D11DeferredContext>(pParent, Device, ContextFlags, GetCsChunkFlags(pParent)),
+  : D3D11CommonContext<D3D11DeferredContext>(pParent, Device, ContextFlags, 0u),
     m_commandList (CreateCommandList()) {
     ResetContextState();
   }
@@ -434,14 +434,6 @@ namespace dxvk {
           uint64_t                      Cookie,
     const D3D11_MAPPED_SUBRESOURCE&     MapInfo) {
     m_mappedResources.push_back({ Cookie, MapInfo });
-  }
-
-
-  DxvkCsChunkFlags D3D11DeferredContext::GetCsChunkFlags(
-          D3D11Device*                  pDevice) {
-    return pDevice->GetOptions()->dcSingleUseMode
-      ? DxvkCsChunkFlags(DxvkCsChunkFlag::SingleUse)
-      : DxvkCsChunkFlags();
   }
 
 }

--- a/src/d3d11/d3d11_options.cpp
+++ b/src/d3d11/d3d11_options.cpp
@@ -13,7 +13,6 @@ namespace dxvk {
   }
 
   D3D11Options::D3D11Options(const Config& config) {
-    this->dcSingleUseMode       = config.getOption<bool>("d3d11.dcSingleUseMode", true);
     this->zeroInitWorkgroupMemory  = config.getOption<bool>("d3d11.zeroInitWorkgroupMemory", false);
     this->forceVolatileTgsmAccess = config.getOption<bool>("d3d11.forceVolatileTgsmAccess", false);
     this->relaxedBarriers       = config.getOption<bool>("d3d11.relaxedBarriers", false);

--- a/src/d3d11/d3d11_options.h
+++ b/src/d3d11/d3d11_options.h
@@ -13,13 +13,6 @@ namespace dxvk {
   struct D3D11Options {
     D3D11Options(const Config& config);
 
-    /// Enables speed hack for mapping on deferred contexts
-    ///
-    /// This can substantially speed up some games, but may
-    /// cause issues if the game submits command lists more
-    /// than once.
-    bool dcSingleUseMode = false;
-
     /// Zero-initialize workgroup memory
     ///
     /// Workargound for games that don't initialize

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -82,7 +82,6 @@ namespace dxvk {
     /* The Evil Within: Submits command lists     *
      * multiple times                             */
     { R"(\\EvilWithin(Demo)?\.exe$)", {{
-      { "d3d11.dcSingleUseMode",            "False" },
       { "d3d11.cachedDynamicResources",     "vi"   },
     }} },
     /* Far Cry 3: Assumes clear(0.5) on an UNORM  *
@@ -160,10 +159,6 @@ namespace dxvk {
     /* NieR Replicant                             */
     { R"(\\NieR Replicant ver\.1\.22474487139\.exe)", {{
       { "d3d11.cachedDynamicResources",     "vi"   },
-    }} },
-    /* SteamVR performance test                   */
-    { R"(\\vr\.exe$)", {{
-      { "d3d11.dcSingleUseMode",            "False" },
     }} },
     /* Hitman 2 - requires AGS library      */
     { R"(\\HITMAN2\.exe$)", {{
@@ -350,11 +345,6 @@ namespace dxvk {
     { R"(\\MSFC\.exe$)", {{
       { "dxgi.maxFrameRate",                "60" },
     }} },
-    /* Cardfight!! Vanguard Dear Days:            *
-     * Submits command lists multiple times       */
-    { R"(\\VG2\.exe$)", {{
-      { "d3d11.dcSingleUseMode",            "False" },
-    }} },
     /* Battlefield: Bad Company 2                 *
      * Gets rid of black flickering               */
     { R"(\\BFBC2Game\.exe$)", {{
@@ -383,10 +373,6 @@ namespace dxvk {
     { R"(\\CrashBandicootNSaneTrilogy\.exe$)", {{
       { "dxgi.syncInterval",                "1"   },
     }} },
-    /* SnowRunner                                 */
-    { R"(\\SnowRunner\.exe$)", {{
-      { "d3d11.dcSingleUseMode",            "False" },
-    }} },
     /* Fallout 76
      * Game tries to be too "smart" and changes sync
      * interval based on performance (in fullscreen)
@@ -407,10 +393,6 @@ namespace dxvk {
      * the tavern area                            */
     { R"(\\BLADESTORM Nightmare\\Launch_(EA|JP)\.exe$)", {{
       { "dxgi.maxFrameRate",                "60"  },
-    }} },
-    /* Ghost Recon Wildlands                      */
-    { R"(\\GRW\.exe$)", {{
-      { "d3d11.dcSingleUseMode",            "False" },
     }} },
     /* Vindictus d3d11 CPU bound perf, and work   *
      * around the game not properly initializing  *
@@ -475,11 +457,6 @@ namespace dxvk {
      * Invisible terrain on Intel                  */
     { R"(\\FarCry(5|NewDawn)\.exe$)", {{
       { "d3d11.zeroInitWorkgroupMemory",    "True" },
-    }} },
-    /* Cardfight!! Vanguard Dear Days 2 - Broken   *
-     * effects and Invisible cards in battles      */
-    { R"(\\VGDD2\.exe$)", {{
-      { "d3d11.dcSingleUseMode",            "False" },
     }} },
 
     /**********************************************/


### PR DESCRIPTION
Did some testing and it looks like a combination of lazy binding and the resource upload changes that we did after deciding to keep the option in the first place largely fixed the most catastrophic cases of extra memory usage (mostly Sekiro).

Increased memory use in games that use Deferred Contexts and don't actually free their command lists is still a thing, but since we're no longer talking about almost an entire gigabyte of wasted system memory we should probably just do the correct thing by default.

Doesn't seem to affect perf at all either, which is unsurprising.