### PR TITLE
[dxvk] Don't skip CPU devices when a device filter is set

### DIFF
--- a/src/dxvk/dxvk_device_filter.cpp
+++ b/src/dxvk/dxvk_device_filter.cpp
@@ -33,9 +33,7 @@ namespace dxvk {
     if (m_flags.test(DxvkDeviceFilterFlag::MatchDeviceName)) {
       if (std::string(properties.deviceName).find(m_matchDeviceName) == std::string::npos)
         return false;
-    }
-
-    if (m_flags.test(DxvkDeviceFilterFlag::SkipCpuDevices)) {
+    } else if (m_flags.test(DxvkDeviceFilterFlag::SkipCpuDevices)) {
       if (properties.deviceType == VK_PHYSICAL_DEVICE_TYPE_CPU) {
         Logger::warn(str::format("Skipping CPU adapter: ", properties.deviceName));
         return false;


### PR DESCRIPTION
Closes #4121 and enables quick testing with `DXVK_FILTER_DEVICE_NAME="llvmpipe"`.