### PR TITLE
Rework D3D11 Immediate Constant Buffers

### DIFF
--- a/src/d3d11/d3d11_device.h
+++ b/src/d3d11/d3d11_device.h
@@ -429,6 +429,13 @@ namespace dxvk {
       m_initializer->NotifyContextFlush();
     }
     
+    void InitShaderIcb(
+            D3D11CommonShader*          pShader,
+            size_t                      IcbSize,
+      const void*                       pIcbData) {
+      return m_initializer->InitShaderIcb(pShader, IcbSize, pIcbData);
+    }
+
     VkPipelineStageFlags GetEnabledShaderStages() const {
       return m_dxvkDevice->getShaderPipelineStages();
     }

--- a/src/d3d11/d3d11_initializer.cpp
+++ b/src/d3d11/d3d11_initializer.cpp
@@ -77,6 +77,33 @@ namespace dxvk {
   }
 
 
+  void D3D11Initializer::InitShaderIcb(
+          D3D11CommonShader*          pShader,
+          size_t                      IcbSize,
+    const void*                       pIcbData) {
+    std::lock_guard<dxvk::mutex> lock(m_mutex);
+    m_transferCommands += 1;
+
+    auto icbSlice = pShader->GetIcb();
+    auto srcSlice = m_stagingBuffer.alloc(icbSlice.length());
+
+    std::memcpy(srcSlice.mapPtr(0), pIcbData, IcbSize);
+
+    if (IcbSize < icbSlice.length())
+      std::memset(srcSlice.mapPtr(IcbSize), 0, icbSlice.length() - IcbSize);
+
+    EmitCs([
+      cIcbSlice = std::move(icbSlice),
+      cSrcSlice = std::move(srcSlice)
+    ] (DxvkContext* ctx) {
+      ctx->copyBuffer(cIcbSlice.buffer(), cIcbSlice.offset(),
+        cSrcSlice.buffer(), cSrcSlice.offset(), cIcbSlice.length());
+    });
+
+    ThrottleAllocationLocked();
+  }
+
+
   void D3D11Initializer::InitDeviceLocalBuffer(
           D3D11Buffer*                pBuffer,
     const D3D11_SUBRESOURCE_DATA*     pInitialData) {

--- a/src/d3d11/d3d11_initializer.h
+++ b/src/d3d11/d3d11_initializer.h
@@ -3,7 +3,9 @@
 #include "../dxvk/dxvk_staging.h"
 
 #include "d3d11_buffer.h"
+#include "d3d11_shader.h"
 #include "d3d11_texture.h"
+#include "d3d11_view_uav.h"
 
 namespace dxvk {
 
@@ -57,6 +59,11 @@ namespace dxvk {
     void InitUavCounter(
             D3D11UnorderedAccessView*   pUav);
     
+    void InitShaderIcb(
+            D3D11CommonShader*          pShader,
+            size_t                      IcbSize,
+      const void*                       pIcbData);
+
   private:
 
     dxvk::mutex       m_mutex;

--- a/src/d3d11/d3d11_shader.cpp
+++ b/src/d3d11/d3d11_shader.cpp
@@ -64,19 +64,17 @@ namespace dxvk {
     if (icb.size) {
       DxvkBufferCreateInfo info = { };
       info.size   = align(icb.size, 256u);
-      info.usage  = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
+      info.usage  = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT
+                  | VK_BUFFER_USAGE_TRANSFER_DST_BIT;
       info.stages = util::pipelineStages(m_shader->info().stage);
-      info.access = VK_ACCESS_UNIFORM_READ_BIT;
+      info.access = VK_ACCESS_UNIFORM_READ_BIT
+                  | VK_ACCESS_TRANSFER_WRITE_BIT;
       info.debugName = "Icb";
       
-      VkMemoryPropertyFlags memFlags
-        = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT
-        | VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT
-        | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
-      
-      m_buffer = pDevice->GetDXVKDevice()->createBuffer(info, memFlags);
-      std::memcpy(m_buffer->mapPtr(0), icb.data, icb.size);
-      std::memset(m_buffer->mapPtr(icb.size), 0, info.size - icb.size);
+      m_buffer = pDevice->GetDXVKDevice()->createBuffer(info, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+
+      // Upload immediate constant buffer to VRAM
+      pDevice->InitShaderIcb(this, icb.size, icb.data);
     }
 
     pDevice->GetDXVKDevice()->registerShader(m_shader);

--- a/src/dxbc/dxbc_compiler.cpp
+++ b/src/dxbc/dxbc_compiler.cpp
@@ -241,8 +241,8 @@ namespace dxvk {
     info.bindings = m_bindings.data();
     info.inputMask = m_inputMask;
     info.outputMask = m_outputMask;
-    info.uniformSize = m_immConstData.size();
-    info.uniformData = m_immConstData.data();
+    info.uniformSize = m_icbData.size();
+    info.uniformData = m_icbData.data();
     info.pushConstStages = VK_SHADER_STAGE_FRAGMENT_BIT;
     info.pushConstSize = sizeof(DxbcPushConstants);
     info.outputTopology = m_outputTopology;
@@ -1491,77 +1491,108 @@ namespace dxvk {
   
   
   void DxbcCompiler::emitDclImmediateConstantBuffer(const DxbcShaderInstruction& ins) {
-    if (m_immConstBuf != 0)
+    if (m_icbArray)
       throw DxvkError("DxbcCompiler: Immediate constant buffer already declared");
     
     if ((ins.customDataSize & 0x3) != 0)
       throw DxvkError("DxbcCompiler: Immediate constant buffer size not a multiple of four DWORDs");
-    
-    if (ins.customDataSize <= Icb_MaxBakedDwords) {
+
+    // A lot of the time we'll be dealing with a scalar or vec2
+    // array here, there's no reason to emit all those zeroes.
+    uint32_t componentCount = 1u;
+
+    for (uint32_t i = 0; i < ins.customDataSize; i += 4u) {
+      for (uint32_t c = componentCount; c < 4u; c++) {
+        if (ins.customData[i + c])
+          componentCount = c + 1u;
+      }
+
+      if (componentCount == 4u)
+        break;
+    }
+
+    uint32_t vectorCount = (ins.customDataSize / 4u);
+    uint32_t dwordCount = vectorCount * componentCount;
+
+    if (dwordCount <= Icb_MaxBakedDwords) {
       this->emitDclImmediateConstantBufferBaked(
-        ins.customDataSize, ins.customData);
+        ins.customDataSize, ins.customData, componentCount);
     } else {
       this->emitDclImmediateConstantBufferUbo(
-        ins.customDataSize, ins.customData);
+        ins.customDataSize, ins.customData, componentCount);
     }
   }
 
 
   void DxbcCompiler::emitDclImmediateConstantBufferBaked(
           uint32_t                dwordCount,
-    const uint32_t*               dwordArray) {
+    const uint32_t*               dwordArray,
+          uint32_t                componentCount) {
     // Declare individual vector constants as 4x32-bit vectors
-    std::array<uint32_t, 4096> vectorIds;
+    small_vector<uint32_t, Icb_MaxBakedDwords> vectorIds;
     
     DxbcVectorType vecType;
     vecType.ctype  = DxbcScalarType::Uint32;
-    vecType.ccount = 4;
+    vecType.ccount = componentCount;
     
-    const uint32_t vectorTypeId = getVectorTypeId(vecType);
-    const uint32_t vectorCount  = dwordCount / 4;
+    uint32_t vectorTypeId = getVectorTypeId(vecType);
     
-    for (uint32_t i = 0; i < vectorCount; i++) {
-      std::array<uint32_t, 4> scalarIds = {
-        m_module.constu32(dwordArray[4 * i + 0]),
-        m_module.constu32(dwordArray[4 * i + 1]),
-        m_module.constu32(dwordArray[4 * i + 2]),
-        m_module.constu32(dwordArray[4 * i + 3]),
-      };
-      
-      vectorIds.at(i) = m_module.constComposite(
-        vectorTypeId, scalarIds.size(), scalarIds.data());
+    for (uint32_t i = 0; i < dwordCount; i += 4u) {
+      std::array<uint32_t, 4> scalarIds = { };
+
+      for (uint32_t c = 0; c < componentCount; c++)
+        scalarIds[c] = m_module.constu32(dwordArray[i + c]);
+
+      uint32_t id = scalarIds[0];
+
+      if (componentCount > 1u)
+        id = m_module.constComposite(vectorTypeId, componentCount, scalarIds.data());
+
+      vectorIds.push_back(id);
     }
-    
+
+    // Pad array with one entry of zeroes so that we can
+    // handle out-of-bounds accesses more conveniently.
+    vectorIds.push_back(emitBuildZeroVector(vecType).id);
+
     // Declare the array that contains all the vectors
     DxbcArrayType arrInfo;
     arrInfo.ctype   = DxbcScalarType::Uint32;
-    arrInfo.ccount  = 4;
-    arrInfo.alength = vectorCount;
-    
-    const uint32_t arrayTypeId = getArrayTypeId(arrInfo);
-    const uint32_t arrayId = m_module.constComposite(
-      arrayTypeId, vectorCount, vectorIds.data());
-    
+    arrInfo.ccount  = componentCount;
+    arrInfo.alength = vectorIds.size();
+
+    uint32_t arrayTypeId = getArrayTypeId(arrInfo);
+    uint32_t arrayId = m_module.constComposite(
+      arrayTypeId, vectorIds.size(), vectorIds.data());
+
     // Declare the variable that will hold the constant
     // data and initialize it with the constant array.
-    const uint32_t pointerTypeId = m_module.defPointerType(
+    uint32_t pointerTypeId = m_module.defPointerType(
       arrayTypeId, spv::StorageClassPrivate);
-    
-    m_immConstBuf = m_module.newVarInit(
+
+    m_icbArray = m_module.newVarInit(
       pointerTypeId, spv::StorageClassPrivate,
       arrayId);
 
-    m_module.setDebugName(m_immConstBuf, "icb");
-    m_module.decorate(m_immConstBuf, spv::DecorationNonWritable);
+    m_module.setDebugName(m_icbArray, "icb");
+    m_module.decorate(m_icbArray, spv::DecorationNonWritable);
+
+    m_icbComponents = componentCount;
+    m_icbSize = dwordCount / 4u;
   }
   
   
   void DxbcCompiler::emitDclImmediateConstantBufferUbo(
           uint32_t                dwordCount,
-    const uint32_t*               dwordArray) {
+    const uint32_t*               dwordArray,
+          uint32_t                componentCount) {
     this->emitDclConstantBufferVar(Icb_BindingSlotId, dwordCount / 4, "icb");
-    m_immConstData.resize(dwordCount * sizeof(uint32_t));
-    std::memcpy(m_immConstData.data(), dwordArray, m_immConstData.size());
+
+    m_icbData.resize(dwordCount * sizeof(uint32_t));
+    std::memcpy(m_icbData.data(), dwordArray, m_icbData.size());
+
+    m_icbComponents = 4u;
+    m_icbSize = dwordCount / 4u;
   }
 
 
@@ -5282,13 +5313,17 @@ namespace dxvk {
   
   DxbcRegisterPointer DxbcCompiler::emitGetImmConstBufPtr(
     const DxbcRegister&           operand) {
-    const DxbcRegisterValue constId
-      = emitIndexLoad(operand.idx[0]);
-    
-    if (m_immConstBuf != 0) {
+    DxbcRegisterValue constId = emitIndexLoad(operand.idx[0]);
+
+    if (m_icbArray) {
+      // We pad the icb array with an extra zero vector, so we can
+      // clamp the index and get correct robustness behaviour.
+      constId.id = m_module.opUMin(getVectorTypeId(constId.type),
+        constId.id, m_module.constu32(m_icbSize));
+
       DxbcRegisterInfo ptrInfo;
       ptrInfo.type.ctype   = DxbcScalarType::Uint32;
-      ptrInfo.type.ccount  = 4;
+      ptrInfo.type.ccount  = m_icbComponents;
       ptrInfo.type.alength = 0;
       ptrInfo.sclass = spv::StorageClassPrivate;
 
@@ -5297,7 +5332,7 @@ namespace dxvk {
       result.type.ccount = ptrInfo.type.ccount;
       result.id = m_module.opAccessChain(
         getPointerTypeId(ptrInfo),
-        m_immConstBuf, 1, &constId.id);
+        m_icbArray, 1, &constId.id);
       return result;
     } else if (m_constantBuffers.at(Icb_BindingSlotId).varId != 0) {
       const std::array<uint32_t, 2> indices =
@@ -5305,7 +5340,7 @@ namespace dxvk {
       
       DxbcRegisterInfo ptrInfo;
       ptrInfo.type.ctype   = DxbcScalarType::Float32;
-      ptrInfo.type.ccount  = 4;
+      ptrInfo.type.ccount  = m_icbComponents;
       ptrInfo.type.alength = 0;
       ptrInfo.sclass = spv::StorageClassUniform;
 
@@ -5343,7 +5378,7 @@ namespace dxvk {
       
       case DxbcOperandType::ImmediateConstantBuffer:
         return emitGetImmConstBufPtr(operand);
-      
+
       case DxbcOperandType::InputThreadId:
         return DxbcRegisterPointer {
           { DxbcScalarType::Uint32, 3 },
@@ -5812,7 +5847,24 @@ namespace dxvk {
       }
     }
 
-    return emitValueLoad(emitGetOperandPtr(reg));
+    DxbcRegisterValue value = emitValueLoad(emitGetOperandPtr(reg));
+
+    // Pad icb values to a vec4 since the app may access components that are always 0
+    if (reg.type == DxbcOperandType::ImmediateConstantBuffer && value.type.ccount < 4u) {
+      DxbcVectorType zeroType;
+      zeroType.ctype = value.type.ctype;
+      zeroType.ccount = 4u - value.type.ccount;
+
+      uint32_t zeroVector = emitBuildZeroVector(zeroType).id;
+
+      std::array<uint32_t, 2> constituents = { value.id, zeroVector };
+
+      value.type.ccount = 4u;
+      value.id = m_module.opCompositeConstruct(getVectorTypeId(value.type),
+        constituents.size(), constituents.data());
+    }
+
+    return value;
   }
   
   

--- a/src/dxbc/dxbc_compiler.cpp
+++ b/src/dxbc/dxbc_compiler.cpp
@@ -241,8 +241,6 @@ namespace dxvk {
     info.bindings = m_bindings.data();
     info.inputMask = m_inputMask;
     info.outputMask = m_outputMask;
-    info.uniformSize = m_icbData.size() * sizeof(uint32_t);
-    info.uniformData = reinterpret_cast<const char*>(m_icbData.data());
     info.pushConstStages = VK_SHADER_STAGE_FRAGMENT_BIT;
     info.pushConstSize = sizeof(DxbcPushConstants);
     info.outputTopology = m_outputTopology;

--- a/src/dxbc/dxbc_compiler.h
+++ b/src/dxbc/dxbc_compiler.h
@@ -504,7 +504,7 @@ namespace dxvk {
     // Immediate constant buffer. If defined, this is
     // an array of four-component uint32 vectors.
     uint32_t          m_icbArray = 0;
-    std::vector<char> m_icbData;
+    std::vector<uint32_t> m_icbData;
 
     uint32_t          m_icbComponents = 0u;
     uint32_t          m_icbSize = 0u;
@@ -593,6 +593,7 @@ namespace dxvk {
     void emitDclConstantBufferVar(
             uint32_t                regIdx,
             uint32_t                numConstants,
+            uint32_t                numComponents,
       const char*                   name);
     
     void emitDclSampler(

--- a/src/dxbc/dxbc_compiler.h
+++ b/src/dxbc/dxbc_compiler.h
@@ -173,8 +173,8 @@ namespace dxvk {
 
     bool needsOutputSetup = false;
   };
-  
-  
+
+
   /**
    * \brief Pixel shader-specific structure
    */
@@ -404,6 +404,17 @@ namespace dxvk {
      * \returns The final shader object
      */
     Rc<DxvkShader> finalize();
+
+    /**
+     * \brief Extracts immediate constant buffer data
+     *
+     * Only defined if the ICB needs to be backed by a
+     * uniform buffer.
+     * \returns Immediate constant buffer data
+     */
+    std::vector<uint32_t> getIcbData() const {
+      return std::move(m_icbData);
+    }
     
   private:
     

--- a/src/dxbc/dxbc_compiler.h
+++ b/src/dxbc/dxbc_compiler.h
@@ -503,8 +503,11 @@ namespace dxvk {
     //////////////////////////////////////////////////
     // Immediate constant buffer. If defined, this is
     // an array of four-component uint32 vectors.
-    uint32_t m_immConstBuf = 0;
-    std::vector<char> m_immConstData;
+    uint32_t          m_icbArray = 0;
+    std::vector<char> m_icbData;
+
+    uint32_t          m_icbComponents = 0u;
+    uint32_t          m_icbSize = 0u;
     
     ///////////////////////////////////////////////////
     // Sample pos array. If defined, this iis an array
@@ -650,11 +653,13 @@ namespace dxvk {
     
     void emitDclImmediateConstantBufferBaked(
             uint32_t                dwordCount,
-      const uint32_t*               dwordArray);
+      const uint32_t*               dwordArray,
+            uint32_t                componentCount);
     
     void emitDclImmediateConstantBufferUbo(
             uint32_t                dwordCount,
-      const uint32_t*               dwordArray);
+      const uint32_t*               dwordArray,
+            uint32_t                componentCount);
     
     void emitCustomData(
       const DxbcShaderInstruction&  ins);

--- a/src/dxbc/dxbc_module.cpp
+++ b/src/dxbc/dxbc_module.cpp
@@ -65,6 +65,8 @@ namespace dxvk {
     
     this->runCompiler(compiler, m_shexChunk->slice());
 
+    m_icb = compiler.getIcbData();
+
     return compiler.finalize();
   }
   

--- a/src/dxbc/dxbc_module.h
+++ b/src/dxbc/dxbc_module.h
@@ -19,6 +19,15 @@ namespace dxvk {
   class DxbcCompiler;
   
   /**
+   * \brief Immediate constant buffer properties
+   */
+  struct DxbcIcbInfo {
+    size_t      size = 0u;
+    const void* data = nullptr;
+  };
+
+
+  /**
    * \brief DXBC shader module
    * 
    * Reads the DXBC byte code and extracts information
@@ -50,6 +59,19 @@ namespace dxvk {
      */
     std::optional<DxbcBindingMask> bindings() const {
       return m_bindings;
+    }
+
+    /**
+     * \brief Retrieves immediate constant buffer info
+     *
+     * Only valid after successfully compiling the shader.
+     * \returns Immediate constant buffer data
+     */
+    DxbcIcbInfo icbInfo() const {
+      DxbcIcbInfo result = { };
+      result.size = m_icb.size() * sizeof(uint32_t);
+      result.data = m_icb.data();
+      return result;
     }
 
     /**
@@ -86,7 +108,7 @@ namespace dxvk {
     Rc<DxvkShader> compilePassthroughShader(
       const DxbcModuleInfo& moduleInfo,
       const std::string&    fileName) const;
-    
+
   private:
     
     DxbcHeader   m_header;
@@ -95,6 +117,8 @@ namespace dxvk {
     Rc<DxbcIsgn> m_osgnChunk;
     Rc<DxbcIsgn> m_psgnChunk;
     Rc<DxbcShex> m_shexChunk;
+
+    std::vector<uint32_t> m_icb;
 
     std::optional<DxbcBindingMask> m_bindings;
     

--- a/src/dxbc/dxbc_options.cpp
+++ b/src/dxbc/dxbc_options.cpp
@@ -38,6 +38,7 @@ namespace dxvk {
     disableMsaa              = options.disableMsaa;
     forceSampleRateShading   = options.forceSampleRateShading;
     enableSampleShadingInterlock = device->features().extFragmentShaderInterlock.fragmentShaderSampleInterlock;
+    supportsTightIcbPacking  = device->features().vk12.uniformBufferStandardLayout;
 
     // Figure out float control flags to match D3D11 rules
     if (options.floatControls) {

--- a/src/dxbc/dxbc_options.h
+++ b/src/dxbc/dxbc_options.h
@@ -49,6 +49,10 @@ namespace dxvk {
     // Enable per-sample interlock if supported
     bool enableSampleShadingInterlock = false;
 
+    /// Use tightly packed arrays for immediate
+    /// constant buffers if possible
+    bool supportsTightIcbPacking = false;
+
     /// Float control flags
     DxbcFloatControlFlags floatControl;
 

--- a/src/dxvk/dxvk_adapter.cpp
+++ b/src/dxvk/dxvk_adapter.cpp
@@ -353,6 +353,10 @@ namespace dxvk {
     // Required for proper GPU synchronization
     enabledFeatures.vk12.timelineSemaphore = VK_TRUE;
 
+    // Used for better constant array packing in some cases
+    enabledFeatures.vk12.uniformBufferStandardLayout =
+      m_deviceFeatures.vk12.uniformBufferStandardLayout;
+
     // Only enable the base image robustness feature if robustness 2 isn't
     // supported, since this is only a subset of what we actually want.
     enabledFeatures.vk13.robustImageAccess =

--- a/src/dxvk/dxvk_shader.cpp
+++ b/src/dxvk/dxvk_shader.cpp
@@ -47,7 +47,6 @@ namespace dxvk {
     const DxvkShaderCreateInfo&   info,
           SpirvCodeBuffer&&       spirv)
   : m_info(info), m_code(spirv), m_bindings(info.stage) {
-    m_info.uniformData = nullptr;
     m_info.bindings = nullptr;
 
     // Copy resource binding slot infos
@@ -64,13 +63,6 @@ namespace dxvk {
       pushConst.size = info.pushConstSize;
 
       m_bindings.addPushConstantRange(pushConst);
-    }
-
-    // Copy uniform buffer data
-    if (info.uniformSize) {
-      m_uniformData.resize(info.uniformSize);
-      std::memcpy(m_uniformData.data(), info.uniformData, info.uniformSize);
-      m_info.uniformData = m_uniformData.data();
     }
 
     // Run an analysis pass over the SPIR-V code to gather some

--- a/src/dxvk/dxvk_shader.h
+++ b/src/dxvk/dxvk_shader.h
@@ -54,9 +54,6 @@ namespace dxvk {
     /// Push constant range
     VkShaderStageFlags pushConstStages = 0;
     uint32_t pushConstSize = 0;
-    /// Uniform buffer data
-    uint32_t uniformSize = 0;
-    const char* uniformData = nullptr;
     /// Rasterized stream, or -1
     int32_t xfbRasterizedStream = 0;
     /// Tess control patch vertex count
@@ -266,7 +263,6 @@ namespace dxvk {
     uint32_t                      m_specConstantMask = 0;
     std::atomic<bool>             m_needsLibraryCompile = { true };
 
-    std::vector<char>             m_uniformData;
     std::vector<BindingOffsets>   m_bindingOffsets;
 
     DxvkBindingLayout             m_bindings;


### PR DESCRIPTION
Small rework, not overly scary. TL;DR:
- Skip vector components that are always zero to save some space; plenty of shaders only use a scalar or vec2 array.
- If we promote an icb to a uniform buffer, allocate it in non-mapped VRAM rather than HVV. HVV allocations can't be relocated by defragmentation, so having any sort of persistent allocation there is bad.
- If we keep the icb as a local array instead, bound-check any reads from it to avoid UB.