### PR TITLE
ICB matrix optimization

### DIFF
--- a/src/dxbc/dxbc_compiler.h
+++ b/src/dxbc/dxbc_compiler.h
@@ -519,6 +519,9 @@ namespace dxvk {
 
     uint32_t          m_icbComponents = 0u;
     uint32_t          m_icbSize = 0u;
+
+    uint32_t          m_icbMatrixMap = 0u;
+    uint32_t          m_icbMatrixData = 0u;
     
     ///////////////////////////////////////////////////
     // Sample pos array. If defined, this iis an array
@@ -673,7 +676,12 @@ namespace dxvk {
             uint32_t                dwordCount,
       const uint32_t*               dwordArray,
             uint32_t                componentCount);
-    
+
+    bool emitDclImmediateConstantBufferMatrix(
+            uint32_t                dwordCount,
+      const uint32_t*               dwordArray,
+            uint32_t                componentCount);
+
     void emitCustomData(
       const DxbcShaderInstruction&  ins);
     

--- a/src/dxbc/dxbc_compiler.h
+++ b/src/dxbc/dxbc_compiler.h
@@ -968,9 +968,6 @@ namespace dxvk {
     DxbcRegisterPointer emitGetConstBufPtr(
       const DxbcRegister&           operand);
     
-    DxbcRegisterPointer emitGetImmConstBufPtr(
-      const DxbcRegister&           operand);
-    
     DxbcRegisterPointer emitGetOperandPtr(
       const DxbcRegister&           operand);
     
@@ -1027,13 +1024,16 @@ namespace dxvk {
             DxbcRegisterValue       value,
             DxbcRegMask             writeMask);
     
+    DxbcRegisterValue emitImmediateConstantBufferLoadRaw(
+      const DxbcRegister&           reg);
+
     DxbcRegisterValue emitRegisterLoadRaw(
       const DxbcRegister&           reg);
     
     DxbcRegisterValue emitConstantBufferLoad(
       const DxbcRegister&           reg,
             DxbcRegMask             writeMask);
-    
+
     DxbcRegisterValue emitRegisterLoad(
       const DxbcRegister&           reg,
             DxbcRegMask             writeMask);


### PR DESCRIPTION
tl;dr FXC often emits immediate a 4x4 identity or scaling matrix as an immediate constant buffer, this experimentally transforms that to a vec4 constant and implements indexing by doing a component-wise `index == n ? value : 0`.

The theory here is that this *should* be more efficient because we replace a memory load with a few ALU ops, in practice however this seems to be worse (at least on RADV) because we're replacing *one* memory load that the driver will try its best to optimize with a whole bunch of VALU ops that are redundantly spammed everywhere because CSE apparently doesn't want to help us out.

Leaving this open for perf test / discussion for now, but unfortunately this appears to be a bit of a dud.