### PR TITLE
Improve image hazard tracking granularity

### DIFF
--- a/src/dxvk/dxvk_buffer.h
+++ b/src/dxvk/dxvk_buffer.h
@@ -364,9 +364,9 @@ namespace dxvk {
      * \brief Retrieves resource ID for barrier tracking
      * \returns Unique resource ID
      */
-    uint64_t getResourceId() const {
+    bit::uint48_t getResourceId() const {
       constexpr static size_t Align = alignof(DxvkResourceAllocation);
-      return reinterpret_cast<uintptr_t>(m_storage.ptr()) / (Align & -Align);
+      return bit::uint48_t(reinterpret_cast<uintptr_t>(m_storage.ptr()) / (Align & -Align));
     }
 
     /**

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -3787,7 +3787,8 @@ namespace dxvk {
 
     ensureImageCompatibility(image, imageUsage);
 
-    flushPendingAccesses(*image, vk::makeSubresourceRange(imageSubresource), DxvkAccess::Read);
+    flushPendingAccesses(*image, imageSubresource,
+      imageOffset, imageExtent, DxvkAccess::Read);
 
     if (unlikely(m_features.test(DxvkContextFeature::DebugUtils))) {
       const char* dstName = buffer->info().debugName;
@@ -3932,7 +3933,7 @@ namespace dxvk {
     accessBuffer(DxvkCmdBuffer::ExecBuffer, *bufferView,
       VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT, VK_ACCESS_2_SHADER_WRITE_BIT, DxvkAccessOp::None);
 
-    accessImage(DxvkCmdBuffer::ExecBuffer, *image, vk::makeSubresourceRange(imageSubresource), imageLayout,
+    accessImageRegion(DxvkCmdBuffer::ExecBuffer, *image, imageSubresource, imageOffset, imageExtent, imageLayout,
       VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT, VK_ACCESS_2_SHADER_READ_BIT, DxvkAccessOp::None);
 
     m_flags.set(DxvkContextFlag::ForceWriteAfterWriteSync);

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -4171,8 +4171,8 @@ namespace dxvk {
 
     auto dstFormatInfo = dstImage->formatInfo();
 
-    flushPendingAccesses(*dstImage, dstSubresourceRange, DxvkAccess::Write);
-    flushPendingAccesses(*srcImage, srcSubresourceRange, DxvkAccess::Read);
+    flushPendingAccesses(*dstImage, dstSubresource, dstOffset, extent, DxvkAccess::Write);
+    flushPendingAccesses(*srcImage, srcSubresource, srcOffset, extent, DxvkAccess::Read);
 
     VkImageLayout dstImageLayout = dstImage->pickLayout(VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
     VkImageLayout srcImageLayout = srcImage->pickLayout(VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL);
@@ -4217,10 +4217,10 @@ namespace dxvk {
       m_cmd->cmdCopyImage(DxvkCmdBuffer::ExecBuffer, &copyInfo);
     }
 
-    accessImage(DxvkCmdBuffer::ExecBuffer, *dstImage, dstSubresourceRange, dstImageLayout,
+    accessImageRegion(DxvkCmdBuffer::ExecBuffer, *dstImage, dstSubresource, dstOffset, extent, dstImageLayout,
       VK_PIPELINE_STAGE_2_TRANSFER_BIT, VK_ACCESS_2_TRANSFER_WRITE_BIT, DxvkAccessOp::None);
 
-    accessImage(DxvkCmdBuffer::ExecBuffer, *srcImage, srcSubresourceRange, srcImageLayout,
+    accessImageRegion(DxvkCmdBuffer::ExecBuffer, *srcImage, srcSubresource, srcOffset, extent, srcImageLayout,
       VK_PIPELINE_STAGE_2_TRANSFER_BIT, VK_ACCESS_2_TRANSFER_READ_BIT, DxvkAccessOp::None);
 
     m_cmd->track(dstImage, DxvkAccess::Write);

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -3738,16 +3738,16 @@ namespace dxvk {
     // but pipeline barriers need to have all aspect bits set
     auto srcFormatInfo = image->formatInfo();
 
-    auto srcSubresourceRange = vk::makeSubresourceRange(imageSubresource);
-    srcSubresourceRange.aspectMask = srcFormatInfo->aspectMask;
+    auto srcSubresource = imageSubresource;
+    srcSubresource.aspectMask = srcFormatInfo->aspectMask;
 
-    flushPendingAccesses(*image, srcSubresourceRange, DxvkAccess::Read);
+    flushPendingAccesses(*image, srcSubresource, imageOffset, imageExtent, DxvkAccess::Read);
     flushPendingAccesses(*buffer, bufferOffset, dataSize, DxvkAccess::Write);
 
     // Select a suitable image layout for the transfer op
     VkImageLayout srcImageLayoutTransfer = image->pickLayout(VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL);
 
-    addImageLayoutTransition(*image, srcSubresourceRange, srcImageLayoutTransfer, 
+    addImageLayoutTransition(*image, vk::makeSubresourceRange(srcSubresource), srcImageLayoutTransfer,
       VK_PIPELINE_STAGE_2_TRANSFER_BIT, VK_ACCESS_2_TRANSFER_READ_BIT, false);
     flushImageLayoutTransitions(DxvkCmdBuffer::ExecBuffer);
 
@@ -3755,7 +3755,7 @@ namespace dxvk {
       image, imageSubresource, imageOffset, imageExtent, srcImageLayoutTransfer,
       bufferSlice, bufferRowAlignment, bufferSliceAlignment);
 
-    accessImage(DxvkCmdBuffer::ExecBuffer, *image, srcSubresourceRange, srcImageLayoutTransfer,
+    accessImageRegion(DxvkCmdBuffer::ExecBuffer, *image, srcSubresource, imageOffset, imageExtent, srcImageLayoutTransfer,
       VK_PIPELINE_STAGE_2_TRANSFER_BIT, VK_ACCESS_2_TRANSFER_READ_BIT, DxvkAccessOp::None);
 
     accessBuffer(DxvkCmdBuffer::ExecBuffer, *buffer, bufferOffset, dataSize,

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -7945,26 +7945,28 @@ namespace dxvk {
       if (subresources.levelCount == 1u || subresources.layerCount == layerCount) {
         DxvkAddressRange range;
         range.resource = image.getResourceId();
+        range.accessOp = accessOp;
         range.rangeStart = subresources.baseMipLevel * layerCount + subresources.baseArrayLayer;
         range.rangeEnd = (subresources.baseMipLevel + subresources.levelCount - 1u) * layerCount
                        + (subresources.baseArrayLayer + subresources.layerCount - 1u);
 
         if (hasWrite)
-          m_barrierTracker.insertRange(range, DxvkAccess::Write, accessOp);
+          m_barrierTracker.insertRange(range, DxvkAccess::Write);
         if (hasRead)
-          m_barrierTracker.insertRange(range, DxvkAccess::Read, accessOp);
+          m_barrierTracker.insertRange(range, DxvkAccess::Read);
       } else {
         DxvkAddressRange range;
         range.resource = image.getResourceId();
+        range.accessOp = accessOp;
 
         for (uint32_t i = subresources.baseMipLevel; i < subresources.baseMipLevel + subresources.levelCount; i++) {
           range.rangeStart = i * layerCount + subresources.baseArrayLayer;
           range.rangeEnd = range.rangeStart + subresources.layerCount - 1u;
 
           if (hasWrite)
-            m_barrierTracker.insertRange(range, DxvkAccess::Write, accessOp);
+            m_barrierTracker.insertRange(range, DxvkAccess::Write);
           if (hasRead)
-            m_barrierTracker.insertRange(range, DxvkAccess::Read, accessOp);
+            m_barrierTracker.insertRange(range, DxvkAccess::Read);
         }
       }
     }
@@ -8013,13 +8015,14 @@ namespace dxvk {
     if (cmdBuffer == DxvkCmdBuffer::ExecBuffer) {
       DxvkAddressRange range;
       range.resource = buffer.getResourceId();
+      range.accessOp = accessOp;
       range.rangeStart = offset;
       range.rangeEnd = offset + size - 1;
 
       if (srcAccess & vk::AccessWriteMask)
-        m_barrierTracker.insertRange(range, DxvkAccess::Write, accessOp);
+        m_barrierTracker.insertRange(range, DxvkAccess::Write);
       if (srcAccess & vk::AccessReadMask)
-        m_barrierTracker.insertRange(range, DxvkAccess::Read, accessOp);
+        m_barrierTracker.insertRange(range, DxvkAccess::Read);
     }
   }
 
@@ -8188,10 +8191,11 @@ namespace dxvk {
 
     DxvkAddressRange range;
     range.resource = buffer.getResourceId();
+    range.accessOp = accessOp;
     range.rangeStart = offset;
     range.rangeEnd = offset + size - 1;
 
-    return m_barrierTracker.findRange(range, access, accessOp);
+    return m_barrierTracker.findRange(range, access);
   }
 
 
@@ -8218,6 +8222,7 @@ namespace dxvk {
     // rendering and compute can only access one mip level.
     DxvkAddressRange range;
     range.resource = image.getResourceId();
+    range.accessOp = accessOp;
     range.rangeStart = subresources.baseMipLevel * layerCount + subresources.baseArrayLayer;
     range.rangeEnd = (subresources.baseMipLevel + subresources.levelCount - 1u) * layerCount
                    + (subresources.baseArrayLayer + subresources.layerCount - 1u);
@@ -8225,7 +8230,7 @@ namespace dxvk {
     // Probe all subresources first, only check individual mip levels
     // if there are overlaps and if we are checking a subset of array
     // layers of multiple mips.
-    bool dirty = m_barrierTracker.findRange(range, access, accessOp);
+    bool dirty = m_barrierTracker.findRange(range, access);
 
     if (!dirty || subresources.levelCount == 1u || subresources.layerCount == layerCount)
       return dirty;
@@ -8234,7 +8239,7 @@ namespace dxvk {
       range.rangeStart = i * layerCount + subresources.baseArrayLayer;
       range.rangeEnd = range.rangeStart + subresources.layerCount - 1u;
 
-      dirty = m_barrierTracker.findRange(range, access, accessOp);
+      dirty = m_barrierTracker.findRange(range, access);
     }
 
     return dirty;

--- a/src/dxvk/dxvk_context.h
+++ b/src/dxvk/dxvk_context.h
@@ -1948,6 +1948,31 @@ namespace dxvk {
             VkAccessFlags2            dstAccess,
             DxvkAccessOp              accessOp);
 
+    void accessImageRegion(
+            DxvkCmdBuffer             cmdBuffer,
+            DxvkImage&                image,
+      const VkImageSubresourceLayers& subresources,
+            VkOffset3D                offset,
+            VkExtent3D                extent,
+            VkImageLayout             srcLayout,
+            VkPipelineStageFlags2     srcStages,
+            VkAccessFlags2            srcAccess,
+            DxvkAccessOp              accessOp);
+
+    void accessImageRegion(
+            DxvkCmdBuffer             cmdBuffer,
+            DxvkImage&                image,
+      const VkImageSubresourceLayers& subresources,
+            VkOffset3D                offset,
+            VkExtent3D                extent,
+            VkImageLayout             srcLayout,
+            VkPipelineStageFlags2     srcStages,
+            VkAccessFlags2            srcAccess,
+            VkImageLayout             dstLayout,
+            VkPipelineStageFlags2     dstStages,
+            VkAccessFlags2            dstAccess,
+            DxvkAccessOp              accessOp);
+
     void accessBuffer(
             DxvkCmdBuffer             cmdBuffer,
             DxvkBuffer&               buffer,
@@ -2025,6 +2050,13 @@ namespace dxvk {
             DxvkAccess                access);
 
     void flushPendingAccesses(
+            DxvkImage&                image,
+      const VkImageSubresourceLayers& subresources,
+            VkOffset3D                offset,
+            VkExtent3D                extent,
+            DxvkAccess                access);
+
+    void flushPendingAccesses(
             DxvkImageView&            imageView,
             DxvkAccess                access);
 
@@ -2045,6 +2077,14 @@ namespace dxvk {
     bool resourceHasAccess(
             DxvkImage&                image,
       const VkImageSubresourceRange&  subresources,
+            DxvkAccess                access,
+            DxvkAccessOp              accessOp);
+
+    bool resourceHasAccess(
+            DxvkImage&                image,
+      const VkImageSubresourceLayers& subresources,
+            VkOffset3D                offset,
+            VkExtent3D                extent,
             DxvkAccess                access,
             DxvkAccessOp              accessOp);
 

--- a/src/dxvk/dxvk_image.h
+++ b/src/dxvk/dxvk_image.h
@@ -583,6 +583,31 @@ namespace dxvk {
     }
 
     /**
+     * \brief Computes virtual offset of a subresource
+     *
+     * Used for hazard tracking. Ignores the aspect mask and
+     * only takes the mip level and array layer into account.
+     * \param [in] mip Mip level index
+     * \param [in] layer Array layer index
+     */
+    uint64_t getTrackingAddress(uint32_t mip, uint32_t layer) const {
+      // Put layers within the same mip into a contiguous range. This works well
+      // for not only transfer operations but also most image view use cases.
+      return uint64_t((m_info.numLayers * mip) + layer) << 48u;
+    }
+
+    /**
+     * \brief Computes virtual offset of a specific image region
+     *
+     * Used for more granular hazard tracking. This interleaves coordinate
+     * bits in order to compute a unique address for each pixel.
+     * \param [in] mip Mip level index
+     * \param [in] layer Array layer index
+     * \param [in] coord Pixel coordinate within the subresource
+     */
+    uint64_t getTrackingAddress(uint32_t mip, uint32_t layer, VkOffset3D coord) const;
+
+    /**
      * \brief Creates or retrieves an image view
      *
      * \param [in] info Image view create info

--- a/src/dxvk/dxvk_image.h
+++ b/src/dxvk/dxvk_image.h
@@ -577,9 +577,9 @@ namespace dxvk {
      * \brief Retrieves resource ID for barrier tracking
      * \returns Unique resource ID
      */
-    uint64_t getResourceId() const {
+    bit::uint48_t getResourceId() const {
       constexpr static size_t Align = alignof(DxvkResourceAllocation);
-      return reinterpret_cast<uintptr_t>(m_storage.ptr()) / (Align & -Align);
+      return bit::uint48_t(reinterpret_cast<uintptr_t>(m_storage.ptr()) / (Align & -Align));
     }
 
     /**

--- a/src/dxvk/dxvk_pipelayout.h
+++ b/src/dxvk/dxvk_pipelayout.h
@@ -17,7 +17,7 @@ namespace dxvk {
    * Information used to optimize barriers when a resource
    * is accessed exlusively via order-invariant stores.
    */
-  enum class DxvkAccessOp : uint32_t {
+  enum class DxvkAccessOp : uint16_t {
     None  = 0,
     Or    = 1,
     And   = 2,
@@ -28,8 +28,6 @@ namespace dxvk {
     UMin  = 7,
     UMax  = 8,
   };
-
-  using DxvkAccessOps = Flags<DxvkAccessOp>;
 
 
   /**

--- a/src/util/util_bit.h
+++ b/src/util/util_bit.h
@@ -632,4 +632,25 @@ namespace dxvk::bit {
     return float(n) / float(1u << F);
   }
 
+
+  /**
+   * \brief 48-bit integer storage type
+   */
+  struct uint48_t {
+    uint48_t() = default;
+
+    explicit uint48_t(uint64_t n)
+    : a(uint16_t(n)), b(uint16_t(n >> 16)), c(uint16_t(n >> 32)) { }
+
+    uint16_t a;
+    uint16_t b;
+    uint16_t c;
+
+    explicit operator uint64_t () const {
+      // GCC generates worse code if we promote to uint64 directly
+      uint32_t lo = uint32_t(a) | (uint32_t(b) << 16);
+      return uint64_t(lo) | (uint64_t(c) << 32);
+    }
+  };
+
 }

--- a/src/util/util_bit.h
+++ b/src/util/util_bit.h
@@ -634,6 +634,54 @@ namespace dxvk::bit {
 
 
   /**
+   * \brief Inserts one null bit after each bit
+   */
+  inline uint32_t split2(uint32_t c) {
+    c = (c ^ (c << 8u)) & 0x00ff00ffu;
+    c = (c ^ (c << 4u)) & 0x0f0f0f0fu;
+    c = (c ^ (c << 2u)) & 0x33333333u;
+    c = (c ^ (c << 1u)) & 0x55555555u;
+    return c;
+  }
+
+
+  /**
+   * \brief Inserts two null bits after each bit
+   */
+  inline uint64_t split3(uint64_t c) {
+    c = (c | c << 32u) & 0x001f00000000ffffull;
+    c = (c | c << 16u) & 0x001f0000ff0000ffull;
+    c = (c | c <<  8u) & 0x100f00f00f00f00full;
+    c = (c | c <<  4u) & 0x10c30c30c30c30c3ull;
+    c = (c | c <<  2u) & 0x1249249249249249ull;
+    return c;
+  }
+
+
+  /**
+   * \brief Interleaves bits from two integers
+   *
+   * Both numbers must fit into 16 bits.
+   * \param [in] x X coordinate
+   * \param [in] y Y coordinate
+   * \returns Morton code of x and y
+   */
+  inline uint32_t interleave(uint16_t x, uint16_t y) {
+    return split2(x) | (split2(y) << 1u);
+  }
+
+
+  /**
+   * \brief Interleaves bits from three integers
+   *
+   * All three numbers must fit into 16 bits.
+   */
+  inline uint64_t interleave(uint16_t x, uint16_t y, uint16_t z) {
+    return split3(x) | (split3(y) << 1u) | (split3(z) << 2u);
+  }
+
+
+  /**
    * \brief 48-bit integer storage type
    */
   struct uint48_t {


### PR DESCRIPTION
Optimizes a bunch of barriers away when the app is doing back-to-back image copies/updates to the same subresource of an image. Since this uses morton codes to linearize texture coordinates, there **will** be false positives when copying unaligned image blocks around, but it improves a few common use cases.

This is a relatively common occurence when games stream in textures, either if virtual texturing is used (e.g. The Evil Within, this is one of the few games that constantly hit this case even during gameplay), or if a texture atlas is being created (seen that in Trine 5).

Also catches a few cases of 3D image updates in various Cryengine games, and some image->image copies in AC:Origins.

This probably won't drastically change performance anywhere, but it's a fairly trivial optmization and **may** reduce some GPU-bound frametime spikes here and there.