### PR TITLE
[d3d8] Various D3D8 Wine device test fixes and other nits

### DIFF
--- a/dxvk.conf
+++ b/dxvk.conf
@@ -764,3 +764,83 @@
 # - True/False
 
 # d3d9.countLosableResources = True
+
+# Dref scaling for DXS0/FVF
+#
+# Some early D3D8 games expect Dref (depth texcoord Z) to be on the range of
+# [0..2^bitDepth - 1]. This option allows DXSO and fixed vertex function to
+# scale it back down to [0..1].
+#
+# Supported values: Any number representing bitDepth (typically 24).
+
+# d3d8.drefScaling = 0
+
+# Shadow perspective divide
+#
+# Older applications designed for Nvidia hardware (or ported from XBox)
+# expect shadow map texture coordinates to be perspective divided, even
+# though D3DTTFF_PROJECTED is never set for any texture coordinates.
+# Older Nvidia cards (GeForce 3, GeForce 4 series) performed this
+# projection directly in hardware.
+#
+# This option forces the D3DTTFF_PROJECTED flag for the necessary stages
+# when a depth texture is bound to slot 0, in order to emulate older
+# Nvidia hardware behavior.
+#
+# Supported values:
+# - True/False
+
+# d3d8.shadowPerspectiveDivide = False
+
+# Force vertex shader declaration
+#
+# Some games rely on undefined behavior by using undeclared vertex shader inputs.
+# The simplest way to fix them is to modify their vertex shader decl.
+#
+# This option takes a comma-separated list of colon-separated number pairs, where
+# the first number is a D3DVSDE_REGISTER value, the second is a D3DVSDT_TYPE value.
+#
+# Supported values:
+# - e.g. "0:2,3:2,7:1" for float3 position : v0, float3 normal : v3, float2 uv : v7.
+
+# d3d8.forceVsDecl = ""
+
+# Draw call batching
+#
+# Specialized drawcall batcher, typically for games that draw a lot of similar
+# geometry in separate drawcalls (sometimes even one triangle at a time).
+#
+# May hurt performance or introduce graphical artifacts outside of
+# specific games that are known to benefit from it.
+#
+# Supported values:
+# - True/False
+
+# d3d8.batching = False
+
+# P8 texture support workaround
+#
+# Early Nvidia GPUs, such as the GeForce 4 generation cards, included and exposed
+# P8 texture support. However, it was no longer advertised with cards in the FX series
+# and above. ATI/AMD drivers and hardware were most likely in a similar situation.
+#
+# This option will ensure all P8 textures are placed in D3DPOOL_SCRATCH, so that
+# their creation is guaranteed to succeed even if the format is unsupported.
+# Can help older titles that don't properly handle the lack of P8 support.
+#
+# Supported values:
+# - True/False
+
+# d3d8.placeP8InScratch = False
+
+# Legacy discard buffer behavior
+#
+# Older applications may rely on D3DLOCK_DISCARD being ignored for everything
+# except D3DUSAGE_DYNAMIC + D3DUSAGE_WRITEONLY buffers, however this approach
+# incurs a performance penalty.
+#
+# Supported values:
+# - True/False
+
+# d3d8.forceLegacyDiscard = False
+

--- a/dxvk.conf
+++ b/dxvk.conf
@@ -493,7 +493,8 @@
 # Reported shader model
 #
 # The shader model to state that we support in the device
-# capabilities that the applicatation queries.
+# capabilities that the application queries. Note that
+# the value will be limited to 1 for D3D8 applications.
 # 
 # Supported values:
 # - 0: Fixed-function only

--- a/src/d3d8/d3d8_device.cpp
+++ b/src/d3d8/d3d8_device.cpp
@@ -1815,17 +1815,6 @@ namespace dxvk {
     if (unlikely(pDeclaration == nullptr || pHandle == nullptr))
       return D3DERR_INVALIDCALL;
 
-    // Validate VS version for non-FF shaders
-    if (pFunction != nullptr) {
-      const uint32_t majorVersion = D3DSHADER_VERSION_MAJOR(pFunction[0]);
-      const uint32_t minorVersion = D3DSHADER_VERSION_MINOR(pFunction[0]);
-
-      if (unlikely(majorVersion != 1 || minorVersion > 1)) {
-        Logger::err(str::format("D3D8Device::CreateVertexShader: Unsupported VS version ", majorVersion, ".", minorVersion));
-        return D3DERR_INVALIDCALL;
-      }
-    }
-
     D3D9VertexShaderCode translatedVS;
     HRESULT res = TranslateVertexShader8(pDeclaration, pFunction, m_d3d8Options, translatedVS);
     if (unlikely(FAILED(res)))
@@ -2063,14 +2052,6 @@ namespace dxvk {
 
     if (unlikely(pFunction == nullptr || pHandle == nullptr))
       return D3DERR_INVALIDCALL;
-
-    const uint32_t majorVersion = D3DSHADER_VERSION_MAJOR(pFunction[0]);
-    const uint32_t minorVersion = D3DSHADER_VERSION_MINOR(pFunction[0]);
-
-    if (unlikely(m_isFixedFunctionOnly || majorVersion != 1 || minorVersion > 4)) {
-      Logger::err(str::format("D3D8Device::CreatePixelShader: Unsupported PS version ", majorVersion, ".", minorVersion));
-      return D3DERR_INVALIDCALL;
-    }
 
     Com<d3d9::IDirect3DPixelShader9> pPixelShader;
     HRESULT res = GetD3D9()->CreatePixelShader(pFunction, &pPixelShader);

--- a/src/d3d8/d3d8_interface.cpp
+++ b/src/d3d8/d3d8_interface.cpp
@@ -15,7 +15,7 @@ namespace dxvk {
       throw DxvkError("D3D8Interface: ERROR! Failed to get D3D9 Bridge. d3d9.dll might not be DXVK!");
     }
 
-    m_bridge->SetD3D8CompatibilityMode(true);
+    m_bridge->EnableD3D8CompatibilityMode();
 
     m_d3d8Options = D3D8Options(*m_bridge->GetConfig());
 

--- a/src/d3d8/d3d8_options.h
+++ b/src/d3d8/d3d8_options.h
@@ -8,53 +8,29 @@ namespace dxvk {
 
   struct D3D8Options {
 
-    /// Some games rely on undefined behavior by using undeclared vertex shader inputs.
-    /// The simplest way to fix them is to simply modify their vertex shader decl.
-    ///
-    /// This option takes a comma-separated list of colon-separated number pairs, where
-    /// the first number is a D3DVSDE_REGISTER value, the second is a D3DVSDT_TYPE value.
-    ///   e.g. "0:2,3:2,7:1" for float3 position : v0, float3 normal : v3, float2 uv : v7
+    /// Override application vertex shader declarations.
     std::vector<std::pair<D3DVSDE_REGISTER, D3DVSDT_TYPE>> forceVsDecl;
 
-    /// Specialized drawcall batcher, typically for games that draw a lot of similar
-    /// geometry in separate drawcalls (sometimes even one triangle at a time).
-    ///
-    /// May hurt performance outside of specifc games that benefit from it.
-    bool batching = false;
+    /// Enable/disable the drawcall batcher.
+    bool batching;
 
-    /// The Lord of the Rings: The Fellowship of the Ring tries to create a P8 texture
-    /// in D3DPOOL_MANAGED on Nvidia and Intel, which fails, but has a separate code
-    /// path for ATI/AMD that creates it in D3DPOOL_SCRATCH instead, which works.
-    ///
-    /// The internal logic determining this path doesn't seem to be d3d-related, but
-    /// the game works universally if we mimic its own ATI/AMD workaround during P8
-    /// texture creation.
-    ///
-    /// Early Nvidia GPUs, such as the GeForce 4 generation cards, included and exposed
-    /// P8 texture support. However, it was no longer advertised with cards in the FX series
-    /// and above. Most likely ATI/AMD drivers never supported P8 in the first place.
-    bool placeP8InScratch = false;
+    /// Place all P8 textures in D3DPOOL_SCRATCH.
+    bool placeP8InScratch;
 
-    /// Rayman 3 relies on D3DLOCK_DISCARD being ignored for everything except D3DUSAGE_DYNAMIC +
-    /// D3DUSAGE_WRITEONLY buffers, however this approach incurs a performance penalty.
-    ///
-    /// Some titles might abuse this early D3D8 quirk, however at some point in its history
-    /// it was brought in line with standard D3D9 behavior.
-    bool forceLegacyDiscard = false;
+    /// Ignore D3DLOCK_DISCARD for everything except D3DUSAGE_DYNAMIC + D3DUSAGE_WRITEONLY buffers.
+    bool forceLegacyDiscard;
 
-    /// Splinter Cell expects shadow map texture coordinates to be perspective divided
-    /// even though D3DTTFF_PROJECTED is never set for any texture coordinates. This flag
-    /// forces that flag for the necessary stages when a depth texture is bound to slot 0
-    bool shadowPerspectiveDivide = false;
+    /// Force D3DTTFF_PROJECTED for the necessary stages when a depth texture is bound to slot 0.
+    bool shadowPerspectiveDivide;
 
     D3D8Options() {}
 
     D3D8Options(const Config& config) {
       auto forceVsDeclStr     = config.getOption<std::string>("d3d8.forceVsDecl",             "");
-      batching                = config.getOption<bool>       ("d3d8.batching",                batching);
-      placeP8InScratch        = config.getOption<bool>       ("d3d8.placeP8InScratch",        placeP8InScratch);
-      forceLegacyDiscard      = config.getOption<bool>       ("d3d8.forceLegacyDiscard",      forceLegacyDiscard);
-      shadowPerspectiveDivide = config.getOption<bool>       ("d3d8.shadowPerspectiveDivide", shadowPerspectiveDivide);
+      batching                = config.getOption<bool>       ("d3d8.batching",                false);
+      placeP8InScratch        = config.getOption<bool>       ("d3d8.placeP8InScratch",        false);
+      forceLegacyDiscard      = config.getOption<bool>       ("d3d8.forceLegacyDiscard",      false);
+      shadowPerspectiveDivide = config.getOption<bool>       ("d3d8.shadowPerspectiveDivide", false);
 
       parseVsDecl(forceVsDeclStr);
     }

--- a/src/d3d8/d3d8_shader.h
+++ b/src/d3d8/d3d8_shader.h
@@ -10,9 +10,10 @@ namespace dxvk {
       std::vector<DWORD> function;
     };
 
-    D3D9VertexShaderCode TranslateVertexShader8(
-      const DWORD*        pDeclaration,
-      const DWORD*        pFunction,
-      const D3D8Options&  overrides);
+    HRESULT TranslateVertexShader8(
+      const DWORD*          pDeclaration,
+      const DWORD*          pFunction,
+      const D3D8Options&    overrides,
+      D3D9VertexShaderCode& pTranslatedVS);
 
 }

--- a/src/d3d9/d3d9_adapter.cpp
+++ b/src/d3d9/d3d9_adapter.cpp
@@ -114,7 +114,10 @@ namespace dxvk {
           DWORD           Usage,
           D3DRESOURCETYPE RType,
           D3D9Format      CheckFormat) {
-    if(unlikely(AdapterFormat == D3D9Format::Unknown))
+    if (unlikely(AdapterFormat == D3D9Format::Unknown))
+      return D3DERR_INVALIDCALL;
+
+    if (unlikely(RType == D3DRTYPE_VERTEXBUFFER || RType == D3DRTYPE_INDEXBUFFER))
       return D3DERR_INVALIDCALL;
 
     if (!IsSupportedAdapterFormat(AdapterFormat))
@@ -167,9 +170,6 @@ namespace dxvk {
 
     if (RType == D3DRTYPE_CUBETEXTURE && mapping.Aspect != VK_IMAGE_ASPECT_COLOR_BIT)
       return D3DERR_NOTAVAILABLE;
-
-    if (RType == D3DRTYPE_VERTEXBUFFER || RType == D3DRTYPE_INDEXBUFFER)
-      return D3D_OK;
 
     // Let's actually ask Vulkan now that we got some quirks out the way!
     VkFormat format = mapping.FormatColor;

--- a/src/d3d9/d3d9_adapter.cpp
+++ b/src/d3d9/d3d9_adapter.cpp
@@ -297,6 +297,7 @@ namespace dxvk {
 
     auto& options = m_parent->GetOptions();
 
+    const uint32_t maxShaderModel = m_parent->IsD3D8Compatible() ? std::min(1u, options.shaderModel) : options.shaderModel;
     const VkPhysicalDeviceLimits& limits = m_adapter->deviceProperties().limits;
 
     // TODO: Actually care about what the adapter supports here.
@@ -575,8 +576,8 @@ namespace dxvk {
 
     // Late fixed-function capable cards, such as the GeForce 4 MX series,
     // expose support for VS 1.1, while not advertising any PS support
-    const uint32_t majorVersionVS = options.shaderModel == 0 ? 1 : options.shaderModel;
-    const uint32_t majorVersionPS = options.shaderModel;
+    const uint32_t majorVersionVS = maxShaderModel == 0 ? 1 : maxShaderModel;
+    const uint32_t majorVersionPS = maxShaderModel;
     // Max supported SM1 is VS 1.1 and PS 1.4
     const uint32_t minorVersionVS = majorVersionVS != 1 ? 0 : 1;
     const uint32_t minorVersionPS = majorVersionPS != 1 ? 0 : 4;
@@ -588,7 +589,7 @@ namespace dxvk {
     // Max Vertex Shader Const
     pCaps->MaxVertexShaderConst       = MaxFloatConstantsVS;
     // Max PS1 Value
-    pCaps->PixelShader1xMaxValue      = options.shaderModel > 0 ? std::numeric_limits<float>::max() : 0.0f;
+    pCaps->PixelShader1xMaxValue      = maxShaderModel > 0 ? std::numeric_limits<float>::max() : 0.0f;
     // Dev Caps 2
     pCaps->DevCaps2                   = D3DDEVCAPS2_STREAMOFFSET
                                    /* | D3DDEVCAPS2_DMAPNPATCH */
@@ -635,41 +636,41 @@ namespace dxvk {
                                    /* | D3DPTFILTERCAPS_MAGFPYRAMIDALQUAD */
                                    /* | D3DPTFILTERCAPS_MAGFGAUSSIANQUAD */;
 
-    pCaps->VS20Caps.Caps                     = options.shaderModel >= 2 ? D3DVS20CAPS_PREDICATION : 0;
-    pCaps->VS20Caps.DynamicFlowControlDepth  = options.shaderModel >= 2 ? D3DVS20_MAX_DYNAMICFLOWCONTROLDEPTH : 0;
-    pCaps->VS20Caps.NumTemps                 = options.shaderModel >= 2 ? D3DVS20_MAX_NUMTEMPS : 0;
-    pCaps->VS20Caps.StaticFlowControlDepth   = options.shaderModel >= 2 ? D3DVS20_MAX_STATICFLOWCONTROLDEPTH : 0;
+    pCaps->VS20Caps.Caps                     = maxShaderModel >= 2 ? D3DVS20CAPS_PREDICATION : 0;
+    pCaps->VS20Caps.DynamicFlowControlDepth  = maxShaderModel >= 2 ? D3DVS20_MAX_DYNAMICFLOWCONTROLDEPTH : 0;
+    pCaps->VS20Caps.NumTemps                 = maxShaderModel >= 2 ? D3DVS20_MAX_NUMTEMPS : 0;
+    pCaps->VS20Caps.StaticFlowControlDepth   = maxShaderModel >= 2 ? D3DVS20_MAX_STATICFLOWCONTROLDEPTH : 0;
 
-    pCaps->PS20Caps.Caps                     = options.shaderModel >= 2 ? D3DPS20CAPS_ARBITRARYSWIZZLE
-                                                                        | D3DPS20CAPS_GRADIENTINSTRUCTIONS
-                                                                        | D3DPS20CAPS_PREDICATION
-                                                                        | D3DPS20CAPS_NODEPENDENTREADLIMIT
-                                                                        | D3DPS20CAPS_NOTEXINSTRUCTIONLIMIT : 0;
-    pCaps->PS20Caps.DynamicFlowControlDepth  = options.shaderModel >= 2 ? D3DPS20_MAX_DYNAMICFLOWCONTROLDEPTH : 0;
-    pCaps->PS20Caps.NumTemps                 = options.shaderModel >= 2 ? D3DPS20_MAX_NUMTEMPS : 0;
-    pCaps->PS20Caps.StaticFlowControlDepth   = options.shaderModel >= 2 ? D3DPS20_MAX_STATICFLOWCONTROLDEPTH : 0;
-    pCaps->PS20Caps.NumInstructionSlots      = options.shaderModel >= 2 ? D3DPS20_MAX_NUMINSTRUCTIONSLOTS : 0;
+    pCaps->PS20Caps.Caps                     = maxShaderModel >= 2 ? D3DPS20CAPS_ARBITRARYSWIZZLE
+                                                                   | D3DPS20CAPS_GRADIENTINSTRUCTIONS
+                                                                   | D3DPS20CAPS_PREDICATION
+                                                                   | D3DPS20CAPS_NODEPENDENTREADLIMIT
+                                                                   | D3DPS20CAPS_NOTEXINSTRUCTIONLIMIT : 0;
+    pCaps->PS20Caps.DynamicFlowControlDepth  = maxShaderModel >= 2 ? D3DPS20_MAX_DYNAMICFLOWCONTROLDEPTH : 0;
+    pCaps->PS20Caps.NumTemps                 = maxShaderModel >= 2 ? D3DPS20_MAX_NUMTEMPS : 0;
+    pCaps->PS20Caps.StaticFlowControlDepth   = maxShaderModel >= 2 ? D3DPS20_MAX_STATICFLOWCONTROLDEPTH : 0;
+    pCaps->PS20Caps.NumInstructionSlots      = maxShaderModel >= 2 ? D3DPS20_MAX_NUMINSTRUCTIONSLOTS : 0;
 
     // Vertex texture samplers are only available as part of SM3, the caps are 0 otherwise.
-    pCaps->VertexTextureFilterCaps           = options.shaderModel == 3 ? D3DPTFILTERCAPS_MINFPOINT
-                                                                        | D3DPTFILTERCAPS_MINFLINEAR
-                                                                     /* | D3DPTFILTERCAPS_MINFANISOTROPIC */
-                                                                     /* | D3DPTFILTERCAPS_MINFPYRAMIDALQUAD */
-                                                                     /* | D3DPTFILTERCAPS_MINFGAUSSIANQUAD */
-                                                                     /* | D3DPTFILTERCAPS_MIPFPOINT */
-                                                                     /* | D3DPTFILTERCAPS_MIPFLINEAR */
-                                                                     /* | D3DPTFILTERCAPS_CONVOLUTIONMONO */
-                                                                        | D3DPTFILTERCAPS_MAGFPOINT
-                                                                        | D3DPTFILTERCAPS_MAGFLINEAR
-                                                                     /* | D3DPTFILTERCAPS_MAGFANISOTROPIC */
-                                                                     /* | D3DPTFILTERCAPS_MAGFPYRAMIDALQUAD */
-                                                                     /* | D3DPTFILTERCAPS_MAGFGAUSSIANQUAD */ : 0;
+    pCaps->VertexTextureFilterCaps           = maxShaderModel == 3 ? D3DPTFILTERCAPS_MINFPOINT
+                                                                   | D3DPTFILTERCAPS_MINFLINEAR
+                                                                /* | D3DPTFILTERCAPS_MINFANISOTROPIC */
+                                                                /* | D3DPTFILTERCAPS_MINFPYRAMIDALQUAD */
+                                                                /* | D3DPTFILTERCAPS_MINFGAUSSIANQUAD */
+                                                                /* | D3DPTFILTERCAPS_MIPFPOINT */
+                                                                /* | D3DPTFILTERCAPS_MIPFLINEAR */
+                                                                /* | D3DPTFILTERCAPS_CONVOLUTIONMONO */
+                                                                   | D3DPTFILTERCAPS_MAGFPOINT
+                                                                   | D3DPTFILTERCAPS_MAGFLINEAR
+                                                                /* | D3DPTFILTERCAPS_MAGFANISOTROPIC */
+                                                                /* | D3DPTFILTERCAPS_MAGFPYRAMIDALQUAD */
+                                                                /* | D3DPTFILTERCAPS_MAGFGAUSSIANQUAD */ : 0;
 
-    pCaps->MaxVShaderInstructionsExecuted    = options.shaderModel >= 2 ? 4294967295 : 0;
-    pCaps->MaxPShaderInstructionsExecuted    = options.shaderModel >= 2 ? 4294967295 : 0;
+    pCaps->MaxVShaderInstructionsExecuted    = maxShaderModel >= 2 ? 4294967295 : 0;
+    pCaps->MaxPShaderInstructionsExecuted    = maxShaderModel >= 2 ? 4294967295 : 0;
 
-    pCaps->MaxVertexShader30InstructionSlots = options.shaderModel == 3 ? 32768 : 0;
-    pCaps->MaxPixelShader30InstructionSlots  = options.shaderModel == 3 ? 32768 : 0;
+    pCaps->MaxVertexShader30InstructionSlots = maxShaderModel == 3 ? 32768 : 0;
+    pCaps->MaxPixelShader30InstructionSlots  = maxShaderModel == 3 ? 32768 : 0;
 
     return D3D_OK;
   }

--- a/src/d3d9/d3d9_bridge.cpp
+++ b/src/d3d9/d3d9_bridge.cpp
@@ -114,8 +114,8 @@ namespace dxvk {
     return m_interface->QueryInterface(riid, ppvObject);
   }
 
-  void DxvkD3D8InterfaceBridge::SetD3D8CompatibilityMode(const bool compatMode) {
-    m_interface->SetD3D8CompatibilityMode(compatMode);
+  void DxvkD3D8InterfaceBridge::EnableD3D8CompatibilityMode() {
+    m_interface->EnableD3D8CompatibilityMode();
   }
 
   const Config* DxvkD3D8InterfaceBridge::GetConfig() const {

--- a/src/d3d9/d3d9_bridge.h
+++ b/src/d3d9/d3d9_bridge.h
@@ -42,11 +42,9 @@ IDxvkD3D8Bridge : public IUnknown {
 MIDL_INTERFACE("D3D9D3D8-A407-773E-18E9-CAFEBEEF3000")
 IDxvkD3D8InterfaceBridge : public IUnknown {
   /**
-   * \brief Enables or disables D3D9-specific features and validations
-   *
-   * \param [in] compatMode Compatibility state
+   * \brief Enforces D3D8-specific features and validations
    */
-  virtual void SetD3D8CompatibilityMode(const bool compatMode) = 0;
+  virtual void EnableD3D8CompatibilityMode() = 0;
 
   /**
    * \brief Retrieves the DXVK configuration
@@ -106,7 +104,7 @@ namespace dxvk {
             REFIID  riid,
             void** ppvObject);
 
-    void SetD3D8CompatibilityMode(const bool compatMode);
+    void EnableD3D8CompatibilityMode();
 
     const Config* GetConfig() const;
 

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -3352,6 +3352,16 @@ namespace dxvk {
       &moduleInfo)))
       return D3DERR_INVALIDCALL;
 
+
+    if (m_isD3D8Compatible && !m_isSWVP) {
+      const uint32_t maxVSConstantIndex = module.GetMaxDefinedConstant();
+      // D3D8 enforces the value advertised in pCaps->MaxVertexShaderConst for HWVP
+      if (unlikely(maxVSConstantIndex > caps::MaxFloatConstantsVS - 1)) {
+        Logger::err(str::format("D3D9DeviceEx::CreateVertexShader: Invalid constant index ", maxVSConstantIndex));
+        return D3DERR_INVALIDCALL;
+      }
+    }
+
     *ppShader = ref(new D3D9VertexShader(this,
       &m_shaderAllocator,
       module,

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -3329,7 +3329,7 @@ namespace dxvk {
     const uint32_t minorVersion = D3DSHADER_VERSION_MINOR(pFunction[0]);
 
     // Late fixed-function capable hardware exposed support for VS 1.1
-    const uint32_t shaderModelVS = m_d3d9Options.shaderModel == 0 ? 1 : m_d3d9Options.shaderModel;
+    const uint32_t shaderModelVS = m_isD3D8Compatible ? 1u : std::max(1u, m_d3d9Options.shaderModel);
 
     if (unlikely(majorVersion > shaderModelVS
              || (majorVersion == 1 && minorVersion > 1)
@@ -3706,7 +3706,9 @@ namespace dxvk {
     const uint32_t majorVersion = D3DSHADER_VERSION_MAJOR(pFunction[0]);
     const uint32_t minorVersion = D3DSHADER_VERSION_MINOR(pFunction[0]);
 
-    if (unlikely(majorVersion > m_d3d9Options.shaderModel
+    const uint32_t shaderModelPS = m_isD3D8Compatible ? std::min(1u, m_d3d9Options.shaderModel) : m_d3d9Options.shaderModel;
+
+    if (unlikely(majorVersion > shaderModelPS
              || (majorVersion == 1 && minorVersion > 4)
              // Skip checking the SM2 minor version, as it has a 2_x mode apparently
              || (majorVersion == 3 && minorVersion != 0))) {

--- a/src/d3d9/d3d9_fixed_function.cpp
+++ b/src/d3d9/d3d9_fixed_function.cpp
@@ -1160,7 +1160,6 @@ namespace dxvk {
         case (DXVK_TSS_TCI_CAMERASPACEPOSITION >> TCIOffset):
           transformed = vtx;
           if (!applyTransform) {
-            Logger::warn(str::format("!applyTransform flags: ", flags, " projidx: ", projIndex));
             count = 3;
             projIndex = 4;
           }

--- a/src/d3d9/d3d9_interface.h
+++ b/src/d3d9/d3d9_interface.h
@@ -137,11 +137,9 @@ namespace dxvk {
       return m_isD3D8Compatible;
     }
 
-    void SetD3D8CompatibilityMode(bool compatMode) {
-      if (compatMode)
-        Logger::info("The D3D9 interface is now operating in D3D8 compatibility mode.");
-
-      m_isD3D8Compatible = compatMode;
+    void EnableD3D8CompatibilityMode() {
+      m_isD3D8Compatible = true;
+      Logger::info("The D3D9 interface is now operating in D3D8 compatibility mode.");
     }
 
     Rc<DxvkInstance> GetInstance() { return m_instance; }

--- a/src/d3d9/d3d9_options.cpp
+++ b/src/d3d9/d3d9_options.cpp
@@ -44,7 +44,7 @@ namespace dxvk {
     this->maxFrameLatency               = config.getOption<int32_t>     ("d3d9.maxFrameLatency",               0);
     this->maxFrameRate                  = config.getOption<int32_t>     ("d3d9.maxFrameRate",                  0);
     this->presentInterval               = config.getOption<int32_t>     ("d3d9.presentInterval",               -1);
-    this->shaderModel                   = config.getOption<int32_t>     ("d3d9.shaderModel",                   3);
+    this->shaderModel                   = config.getOption<int32_t>     ("d3d9.shaderModel",                   3u);
     this->dpiAware                      = config.getOption<bool>        ("d3d9.dpiAware",                      true);
     this->strictConstantCopies          = config.getOption<bool>        ("d3d9.strictConstantCopies",          false);
     this->strictPow                     = config.getOption<bool>        ("d3d9.strictPow",                     true);

--- a/src/d3d9/d3d9_surface.cpp
+++ b/src/d3d9/d3d9_surface.cpp
@@ -119,7 +119,7 @@ namespace dxvk {
     
     pDesc->MultiSampleType    = desc.MultiSample;
     pDesc->MultiSampleQuality = desc.MultisampleQuality;
-    pDesc->Width              = std::max(1u, desc.Width >> m_mipLevel);
+    pDesc->Width              = std::max(1u, desc.Width  >> m_mipLevel);
     pDesc->Height             = std::max(1u, desc.Height >> m_mipLevel);
 
     return D3D_OK;
@@ -148,9 +148,9 @@ namespace dxvk {
       bool isBlockAlignedFormat = blockSize.Width > 0 && blockSize.Height > 0;
 
       // The boundaries of pRect are validated for D3DPOOL_DEFAULT surfaces
-      // with formats which need to be block aligned (mip 0), surfaces created via
+      // with formats which need to be block aligned, surfaces created via
       // CreateImageSurface and D3D8 cube textures outside of D3DPOOL_DEFAULT
-      if ((m_mipLevel == 0 && isBlockAlignedFormat && desc.Pool == D3DPOOL_DEFAULT)
+      if ((isBlockAlignedFormat && desc.Pool == D3DPOOL_DEFAULT)
        || (desc.Pool == D3DPOOL_SYSTEMMEM && type == D3DRTYPE_SURFACE)
        || (m_texture->Device()->IsD3D8Compatible() &&
            desc.Pool != D3DPOOL_DEFAULT   && type == D3DRTYPE_CUBETEXTURE)) {
@@ -161,8 +161,8 @@ namespace dxvk {
          || pRect->right  - pRect->left <= 0
          || pRect->bottom - pRect->top  <= 0
         // Exceeding surface dimensions
-         || static_cast<UINT>(pRect->right)  > desc.Width
-         || static_cast<UINT>(pRect->bottom) > desc.Height)
+         || static_cast<UINT>(pRect->right)  > std::max(1u, desc.Width  >> m_mipLevel)
+         || static_cast<UINT>(pRect->bottom) > std::max(1u, desc.Height >> m_mipLevel))
           return D3DERR_INVALIDCALL;
       }
 

--- a/src/d3d9/d3d9_volume.cpp
+++ b/src/d3d9/d3d9_volume.cpp
@@ -119,9 +119,9 @@ namespace dxvk {
         || static_cast<LONG>(pBox->Bottom) - static_cast<LONG>(pBox->Top)   <= 0
         || static_cast<LONG>(pBox->Back)   - static_cast<LONG>(pBox->Front) <= 0
       // Exceeding surface dimensions
-        || pBox->Right  > desc.Width
-        || pBox->Bottom > desc.Height
-        || pBox->Back   > desc.Depth)
+        || pBox->Right  > std::max(1u, desc.Width  >> m_mipLevel)
+        || pBox->Bottom > std::max(1u, desc.Height >> m_mipLevel)
+        || pBox->Back   > std::max(1u, desc.Depth  >> m_mipLevel))
         return D3DERR_INVALIDCALL;
     }
 

--- a/src/dxvk/dxvk_state_cache.cpp
+++ b/src/dxvk/dxvk_state_cache.cpp
@@ -481,7 +481,7 @@ namespace dxvk {
     std::ifstream ifile = openCacheFileForRead();
 
     if (!ifile) {
-      Logger::warn("DXVK: No state cache file found");
+      Logger::debug("DXVK: No state cache file found");
       return true;
     }
 
@@ -504,7 +504,7 @@ namespace dxvk {
 
     // Notify user about format conversion
     if (curHeader.version != newHeader.version)
-      Logger::warn(str::format("DXVK: Updating state cache version to v", newHeader.version));
+      Logger::info(str::format("DXVK: Updating state cache version to v", newHeader.version));
 
     // Read actual cache entries from the file.
     // If we encounter invalid entries, we should
@@ -880,7 +880,7 @@ namespace dxvk {
       return file;
 
     if (recreate) {
-      Logger::warn("DXVK: Creating new state cache file");
+      Logger::info("DXVK: Creating new state cache file");
 
       // Write header with the current version number
       DxvkStateCacheHeader header;

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -703,7 +703,7 @@ namespace dxvk {
       { "d3d9.maxFrameRate",                "60" },
     }} },
     /* Escape from Tarkov launcher
-       Same issue as Warhammer: RoR above       */
+       Work around partial presentation issues  */
     { R"(\\BsgLauncher\.exe$)", {{
       { "d3d9.shaderModel",                 "1" },
     }} },


### PR DESCRIPTION
This adds validation capabilities to our d3d8->d3d9 shader translation logic and fixes a FVF normals component Wine test specific to d3d8. The test in question seems to suggest the validation is needed by 3DMark2001, but at least 3DMark2001 SE does not appear to hit it, so perhaps it was ultimately fixed? Regardless, the validation *is* in line with native behavior.

While I was at it, I also changed the shader creation logic a bit to not needlessly store partially created vertex shader objects if something should fail along the way.

Might look into a few more of the remaining tests, after which I'll test a bit and undraft.