### PR TITLE
[dxso] Fix uninitialized m_maxDefinedConstant variable

### DIFF
--- a/src/dxso/dxso_compiler.h
+++ b/src/dxso/dxso_compiler.h
@@ -259,7 +259,7 @@ namespace dxvk {
 
     DxsoShaderMetaInfo         m_meta;
     DxsoDefinedConstants       m_constants;
-    uint32_t                   m_maxDefinedConstant;
+    uint32_t                   m_maxDefinedConstant = 0u;
 
     SpirvModule                m_module;
 


### PR DESCRIPTION
Derp that thankfully seems to be harmless.