### PR TITLE
[util] Spoof vendor ID for CivCity: Rome

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -1022,6 +1022,11 @@ namespace dxvk {
       { "d3d9.maxAvailableMemory",          "2048" },
       { "d3d9.memoryTrackTest",             "True" },
     }} },
+    /* CivCity: Rome                              *
+     * Enables soft real-time shadows             */
+    { R"(\\CivCity Rome\.exe$)", {{
+      { "d3d9.customVendorId",              "10de" },
+    }} },
 
     /**********************************************/
     /* D3D8 GAMES                                 */


### PR DESCRIPTION
The game checks for either ATi or nVidia vendor ID to enable real-time shadows, unfiltered for ATi and filtered for nVidia. Because of that there are no dynamic shadows on e.g. Intel. This PR fixes that. Maybe there are other effects locked behind a vendor check.

Only tested on Intel HD Graphics 630 (Mesa 24.3.4).
