### PR TITLE
Don't override app-provided barrier control flags

### DIFF
--- a/src/d3d11/d3d11_context_ext.cpp
+++ b/src/d3d11/d3d11_context_ext.cpp
@@ -155,8 +155,7 @@ namespace dxvk {
   void STDMETHODCALLTYPE D3D11DeviceContextExt<ContextType>::SetBarrierControl(
           UINT                    ControlFlags) {
     D3D10DeviceLock lock = m_ctx->LockContext();
-    D3D11Device* parent = static_cast<D3D11Device*>(m_ctx->GetParentInterface());
-    DxvkBarrierControlFlags flags = parent->GetOptionsBarrierControlFlags();
+    DxvkBarrierControlFlags flags = 0u;
 
     if (ControlFlags & D3D11_VK_BARRIER_CONTROL_IGNORE_WRITE_AFTER_WRITE) {
       flags.set(DxvkBarrierControl::ComputeAllowReadWriteOverlap,


### PR DESCRIPTION
Needs a bit of Nvidia perf testing in the handful of games that we enable this for, but TL;DR if app uses UAV Overlap explicitly, don't try to outsmart it. Our implementation should match Windows behaviour now.