### PR TITLE
Consider constant stores as invariant

### DIFF
--- a/src/dxbc/dxbc_analysis.cpp
+++ b/src/dxbc/dxbc_analysis.cpp
@@ -37,26 +37,21 @@ namespace dxvk {
           m_analysis->uavInfos[registerId].accessFlags |= VK_ACCESS_SHADER_READ_BIT | VK_ACCESS_SHADER_WRITE_BIT;
 
           // Check whether the atomic operation is order-invariant
-          DxvkAccessOp store = DxvkAccessOp::None;
+          DxvkAccessOp op = DxvkAccessOp::None;
 
           switch (ins.op) {
-            case DxbcOpcode::AtomicAnd:  store = DxvkAccessOp::And;  break;
-            case DxbcOpcode::AtomicOr:   store = DxvkAccessOp::Or;   break;
-            case DxbcOpcode::AtomicXor:  store = DxvkAccessOp::Xor;  break;
-            case DxbcOpcode::AtomicIAdd: store = DxvkAccessOp::Add;  break;
-            case DxbcOpcode::AtomicIMax: store = DxvkAccessOp::IMax; break;
-            case DxbcOpcode::AtomicIMin: store = DxvkAccessOp::IMin; break;
-            case DxbcOpcode::AtomicUMax: store = DxvkAccessOp::UMax; break;
-            case DxbcOpcode::AtomicUMin: store = DxvkAccessOp::UMin; break;
+            case DxbcOpcode::AtomicAnd:  op = DxvkAccessOp::And;  break;
+            case DxbcOpcode::AtomicOr:   op = DxvkAccessOp::Or;   break;
+            case DxbcOpcode::AtomicXor:  op = DxvkAccessOp::Xor;  break;
+            case DxbcOpcode::AtomicIAdd: op = DxvkAccessOp::Add;  break;
+            case DxbcOpcode::AtomicIMax: op = DxvkAccessOp::IMax; break;
+            case DxbcOpcode::AtomicIMin: op = DxvkAccessOp::IMin; break;
+            case DxbcOpcode::AtomicUMax: op = DxvkAccessOp::UMax; break;
+            case DxbcOpcode::AtomicUMin: op = DxvkAccessOp::UMin; break;
             default: break;
           }
 
-          if (m_analysis->uavInfos[registerId].atomicStore == DxvkAccessOp::None)
-            m_analysis->uavInfos[registerId].atomicStore = store;
-
-          // Maintain ordering if the UAV is accessed via other operations as well
-          if (store == DxvkAccessOp::None || m_analysis->uavInfos[registerId].atomicStore != store)
-            m_analysis->uavInfos[registerId].nonInvariantAccess = true;
+          setUavAccessOp(registerId, op);
         }
       } break;
 
@@ -80,7 +75,8 @@ namespace dxvk {
           const uint32_t registerId = ins.src[operandId].idx[0].offset;
           m_analysis->uavInfos[registerId].accessFlags |= VK_ACCESS_SHADER_READ_BIT;
           m_analysis->uavInfos[registerId].sparseFeedback |= sparseFeedback;
-          m_analysis->uavInfos[registerId].nonInvariantAccess = true;
+
+          setUavAccessOp(registerId, DxvkAccessOp::None);
         } else if (ins.src[operandId].type == DxbcOperandType::Resource) {
           const uint32_t registerId = ins.src[operandId].idx[0].offset;
           m_analysis->srvInfos[registerId].sparseFeedback |= sparseFeedback;
@@ -91,7 +87,8 @@ namespace dxvk {
         if (ins.dst[0].type == DxbcOperandType::UnorderedAccessView) {
           const uint32_t registerId = ins.dst[0].idx[0].offset;
           m_analysis->uavInfos[registerId].accessFlags |= VK_ACCESS_SHADER_WRITE_BIT;
-          m_analysis->uavInfos[registerId].nonInvariantAccess = true;
+
+          setUavAccessOp(registerId, getStoreAccessOp(ins.dst[0].mask, ins.src[ins.srcCount - 1u]));
         }
       } break;
 
@@ -99,13 +96,22 @@ namespace dxvk {
         const uint32_t registerId = ins.src[1].idx[0].offset;
         m_analysis->uavInfos[registerId].accessTypedLoad = true;
         m_analysis->uavInfos[registerId].accessFlags |= VK_ACCESS_SHADER_READ_BIT;
-        m_analysis->uavInfos[registerId].nonInvariantAccess = true;
+
+        setUavAccessOp(registerId, DxvkAccessOp::None);
       } break;
-      
+
       case DxbcInstClass::TypedUavStore: {
         const uint32_t registerId = ins.dst[0].idx[0].offset;
         m_analysis->uavInfos[registerId].accessFlags |= VK_ACCESS_SHADER_WRITE_BIT;
-        m_analysis->uavInfos[registerId].nonInvariantAccess = true;
+
+        // The UAV format may change between dispatches, so be conservative here
+        // and only allow this optimization when the app is writing zeroes.
+        DxvkAccessOp storeOp = getStoreAccessOp(DxbcRegMask(0xf), ins.src[1u]);
+
+        if (storeOp != DxvkAccessOp(DxvkAccessOp::OpType::StoreUi, 0u))
+          storeOp = DxvkAccessOp::None;
+
+        setUavAccessOp(registerId, storeOp);
       } break;
 
       case DxbcInstClass::Declaration: {
@@ -178,5 +184,71 @@ namespace dxvk {
     
     return result;
   }
-  
+
+
+  void DxbcAnalyzer::setUavAccessOp(uint32_t uav, DxvkAccessOp op) {
+    if (m_analysis->uavInfos[uav].accessOp == DxvkAccessOp::None)
+      m_analysis->uavInfos[uav].accessOp = op;
+
+    // Maintain ordering if the UAV is accessed via other operations as well
+    if (op == DxvkAccessOp::None || m_analysis->uavInfos[uav].accessOp != op)
+      m_analysis->uavInfos[uav].nonInvariantAccess = true;
+  }
+
+
+  DxvkAccessOp DxbcAnalyzer::getStoreAccessOp(DxbcRegMask writeMask, const DxbcRegister& src) {
+    if (src.type != DxbcOperandType::Imm32)
+      return DxvkAccessOp::None;
+
+    // Trivial case, same value is written to all components
+    if (src.componentCount == DxbcComponentCount::Component1)
+      return getConstantStoreOp(src.imm.u32_1);
+
+    if (src.componentCount != DxbcComponentCount::Component4)
+      return DxvkAccessOp::None;
+
+    // Otherwise, make sure that all written components are equal
+    DxvkAccessOp op = DxvkAccessOp::None;
+
+    for (uint32_t i = 0u; i < 4u; i++) {
+      if (!writeMask[i])
+        continue;
+
+      // If the written value can't be represented, skip
+      DxvkAccessOp scalarOp = getConstantStoreOp(src.imm.u32_4[i]);
+
+      if (scalarOp == DxvkAccessOp::None)
+        return DxvkAccessOp::None;
+
+      // First component written
+      if (op == DxvkAccessOp::None)
+        op = scalarOp;
+
+      // Conflicting store ops
+      if (op != scalarOp)
+        return DxvkAccessOp::None;
+    }
+
+    return op;
+  }
+
+
+  DxvkAccessOp DxbcAnalyzer::getConstantStoreOp(uint32_t value) {
+    constexpr uint32_t mask = 0xfffu;
+
+    uint32_t ubits = value & mask;
+    uint32_t fbits = (value >> 20u);
+
+    if (value == ubits)
+      return DxvkAccessOp(DxvkAccessOp::OpType::StoreUi, ubits);
+
+    if (value == (ubits | ~mask))
+      return DxvkAccessOp(DxvkAccessOp::OpType::StoreSi, ubits);
+
+    if (value == (fbits << 20u))
+      return DxvkAccessOp(DxvkAccessOp::OpType::StoreF, fbits);
+
+    return DxvkAccessOp::None;
+  }
+
 }

--- a/src/dxbc/dxbc_analysis.h
+++ b/src/dxbc/dxbc_analysis.h
@@ -21,7 +21,7 @@ namespace dxvk {
     bool accessAtomicOp     = false;
     bool sparseFeedback     = false;
     bool nonInvariantAccess = false;
-    DxvkAccessOp atomicStore = DxvkAccessOp::None;
+    DxvkAccessOp accessOp   = DxvkAccessOp::None;
     VkAccessFlags accessFlags = 0;
   };
   
@@ -98,7 +98,13 @@ namespace dxvk {
     
     DxbcClipCullInfo getClipCullInfo(
       const Rc<DxbcIsgn>& sgn) const;
-    
+
+    void setUavAccessOp(uint32_t uav, DxvkAccessOp op);
+
+    static DxvkAccessOp getStoreAccessOp(DxbcRegMask writeMask, const DxbcRegister& src);
+
+    static DxvkAccessOp getConstantStoreOp(uint32_t value);
+
   };
   
 }

--- a/src/dxbc/dxbc_compiler.cpp
+++ b/src/dxbc/dxbc_compiler.cpp
@@ -1088,7 +1088,7 @@ namespace dxvk {
       binding.access = m_analysis->uavInfos[registerId].accessFlags;
 
       if (!m_analysis->uavInfos[registerId].nonInvariantAccess)
-        binding.accessOp = m_analysis->uavInfos[registerId].atomicStore;
+        binding.accessOp = m_analysis->uavInfos[registerId].accessOp;
 
       if (!(binding.access & VK_ACCESS_SHADER_WRITE_BIT))
         m_module.decorate(varId, spv::DecorationNonWritable);
@@ -1232,7 +1232,7 @@ namespace dxvk {
       binding.access = m_analysis->uavInfos[registerId].accessFlags;
 
       if (!m_analysis->uavInfos[registerId].nonInvariantAccess)
-        binding.accessOp = m_analysis->uavInfos[registerId].atomicStore;
+        binding.accessOp = m_analysis->uavInfos[registerId].accessOp;
     }
 
     if (useRawSsbo || isUav) {

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -6856,7 +6856,9 @@ namespace dxvk {
         this->spillRenderPass(true);
     }
 
-    if (m_flags.test(DxvkContextFlag::GpRenderPassSideEffects)) {
+    if (m_flags.test(DxvkContextFlag::GpRenderPassSideEffects)
+     || m_state.gp.flags.any(DxvkGraphicsPipelineFlag::HasStorageDescriptors,
+                             DxvkGraphicsPipelineFlag::HasTransformFeedback)) {
       // If either the current pipeline has side effects or if there are pending
       // writes from previous draws, check for hazards. This also tracks any
       // resources written for the first time, but does not emit any barriers
@@ -6864,6 +6866,9 @@ namespace dxvk {
       // implicitly dirties all state for which we need to track resource access.
       if (this->checkGraphicsHazards<Indexed, Indirect>())
         this->spillRenderPass(true);
+
+      // The render pass flag gets reset when the render pass ends, so set it late
+      m_flags.set(DxvkContextFlag::GpRenderPassSideEffects);
     }
 
     // Start the render pass. This must happen before any render state

--- a/src/dxvk/dxvk_pipelayout.h
+++ b/src/dxvk/dxvk_pipelayout.h
@@ -17,17 +17,33 @@ namespace dxvk {
    * Information used to optimize barriers when a resource
    * is accessed exlusively via order-invariant stores.
    */
-  enum class DxvkAccessOp : uint16_t {
-    None  = 0,
-    Or    = 1,
-    And   = 2,
-    Xor   = 3,
-    Add   = 4,
-    IMin  = 5,
-    IMax  = 6,
-    UMin  = 7,
-    UMax  = 8,
+  struct DxvkAccessOp {
+    enum OpType : uint16_t {
+      None      = 0x0u,
+      Or        = 0x1u,
+      And       = 0x2u,
+      Xor       = 0x3u,
+      Add       = 0x4u,
+      IMin      = 0x5u,
+      IMax      = 0x6u,
+      UMin      = 0x7u,
+      UMax      = 0x8u,
+    };
+
+    DxvkAccessOp() = default;
+    DxvkAccessOp(OpType t)
+    : op(uint16_t(t)) { }
+
+    uint16_t op = 0u;
+
+    bool operator == (const DxvkAccessOp& t) const { return op == t.op; }
+    bool operator != (const DxvkAccessOp& t) const { return op != t.op; }
+
+    template<typename T, std::enable_if_t<std::is_integral_v<T>, bool> = true>
+    explicit operator T() const { return op; }
   };
+
+  static_assert(sizeof(DxvkAccessOp) == sizeof(uint16_t));
 
 
   /**

--- a/src/dxvk/dxvk_pipelayout.h
+++ b/src/dxvk/dxvk_pipelayout.h
@@ -28,11 +28,18 @@ namespace dxvk {
       IMax      = 0x6u,
       UMin      = 0x7u,
       UMax      = 0x8u,
+
+      StoreF    = 0xdu,
+      StoreUi   = 0xeu,
+      StoreSi   = 0xfu,
     };
 
     DxvkAccessOp() = default;
     DxvkAccessOp(OpType t)
     : op(uint16_t(t)) { }
+
+    DxvkAccessOp(OpType t, uint16_t constant)
+    : op(uint16_t(t) | (constant << 4u)) { }
 
     uint16_t op = 0u;
 


### PR DESCRIPTION
TL;DR RE2 has a pixel shader that simply writes `1` to a buffer for culling purposes and then does a bunch of back-to-back draws *without* enabling UAV overlap. This adds constant stores to the order-invariant access optimization to avoid over-synchronizing the GPU.