### PR TITLE
[d3d9] Build shader constant UBOs on CS thread

### DIFF
--- a/src/d3d9/d3d9_constant_buffer.h
+++ b/src/d3d9/d3d9_constant_buffer.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "../dxvk/dxvk_buffer.h"
+#include "../dxvk/dxvk_context.h"
 
 #include "../dxso/dxso_util.h"
 
@@ -77,6 +78,82 @@ namespace dxvk {
     Rc<DxvkResourceAllocation> m_slice = nullptr;
 
     Rc<DxvkResourceAllocation> createBuffer();
+
+    VkDeviceSize getAlignment(const Rc<DxvkDevice>& device) const;
+
+  };
+
+
+
+  /**
+   * \brief Constant buffer living on the CS thread
+   */
+  class D3D9CSConstantBuffer {
+
+  public:
+
+    D3D9CSConstantBuffer();
+
+    D3D9CSConstantBuffer(
+      const Rc<DxvkDevice>&       Device,
+            DxsoProgramType       ShaderStage,
+            DxsoConstantBuffers   BufferType,
+            VkDeviceSize          Size,
+            bool                  UseDeviceLocalBuffer);
+
+    D3D9CSConstantBuffer(
+      const Rc<DxvkDevice>&       Device,
+            VkBufferUsageFlags    Usage,
+            VkShaderStageFlags    Stages,
+            uint32_t              ResourceSlot,
+            VkDeviceSize          Size,
+            bool                  UseDeviceLocalBuffer);
+
+    ~D3D9CSConstantBuffer();
+
+    /**
+     * \brief Queries alignment
+     *
+     * Useful to pad copies with initialized data.
+     * \returns Data alignment
+     */
+    VkDeviceSize GetAlignment() const {
+      return m_align;
+    }
+
+    /**
+     * \brief Allocates a given amount of memory
+     *
+     * \param [in] size Number of bytes to allocate
+     * \returns Map pointer of the allocated region
+     */
+    void* Alloc(DxvkContext* ctx, VkDeviceSize size);
+
+    /**
+     * \brief Allocates a full buffer slice
+     *
+     * This must not be called if \ref Alloc is used.
+     * \returns Map pointer of the allocated region
+     */
+    void* AllocSlice(DxvkContext* ctx);
+
+  private:
+
+    Rc<DxvkDevice>        m_device;
+
+    uint32_t              m_binding = 0u;
+    VkBufferUsageFlags    m_usage   = 0u;
+    VkShaderStageFlags    m_stages  = 0u;
+    VkDeviceSize          m_size    = 0ull;
+    VkDeviceSize          m_align   = 0ull;
+    VkDeviceSize          m_offset  = 0ull;
+
+    bool                  m_useDeviceLocalBuffer = false;
+
+    Rc<DxvkBuffer>        m_buffer  = nullptr;
+    Rc<DxvkResourceAllocation> m_slice = nullptr;
+
+    Rc<DxvkResourceAllocation> createBuffer(DxvkContext* ctx);
 
     VkDeviceSize getAlignment(const Rc<DxvkDevice>& device) const;
 

--- a/src/d3d9/d3d9_constant_set.h
+++ b/src/d3d9/d3d9_constant_set.h
@@ -40,15 +40,30 @@ namespace dxvk {
   };
 
   struct D3D9SwvpConstantBuffers {
-    D3D9ConstantBuffer        intBuffer;
-    D3D9ConstantBuffer        boolBuffer;
+    D3D9CSConstantBuffer intBuffer;
+    D3D9CSConstantBuffer boolBuffer;
   };
 
-  struct D3D9ConstantSets {
-    D3D9SwvpConstantBuffers   swvp;
-    D3D9ConstantBuffer        buffer;
+  template<typename ShaderConstantsStorage>
+  struct D3D9CSShaderConstants {
+    ShaderConstantsStorage constants;
+
+    // Primary buffer (contains HWVP or pixel shaders: Ints + Floats, SWVP: Floats)
+    D3D9CSConstantBuffer    buffer;
+    // Secondary buffers for SWVP (one for Ints, one for Bools)
+    D3D9SwvpConstantBuffers swvp;
+
+    // Shader related
     DxsoShaderMetaInfo        meta  = {};
+    DxsoDefinedConstants      shaderDefinedConsts;
+
+    // Tracking
     bool                      dirty = true;
+    uint32_t                  floatConstsCount = 0;
+    // The highest changed int and bool constants are only tracked for SWVP.
+    // For HWVP or pixel shaders, the maximum amount is only 16 anyway.
+    uint32_t                  intConstsCount   = 0;
+    uint32_t                  boolConstsCount = 0;
   };
 
 }

--- a/src/d3d9/d3d9_shader.cpp
+++ b/src/d3d9/d3d9_shader.cpp
@@ -70,7 +70,6 @@ namespace dxvk {
     m_info      = pModule->info();
     m_meta      = pModule->meta();
     m_constants = pModule->constants();
-    m_maxDefinedConst = pModule->maxDefinedConstant();
 
     m_shader->setShaderKey(Key);
 

--- a/src/d3d9/d3d9_shader.h
+++ b/src/d3d9/d3d9_shader.h
@@ -52,8 +52,6 @@ namespace dxvk {
 
     const DxsoProgramInfo& GetInfo() const { return m_info; }
 
-    uint32_t GetMaxDefinedConstant() const { return m_maxDefinedConst; }
-
     VkImageViewType GetImageViewType(uint32_t samplerSlot) const {
       const uint32_t offset = samplerSlot * 2;
       const uint32_t mask = 0b11;
@@ -70,7 +68,6 @@ namespace dxvk {
     DxsoProgramInfo       m_info;
     DxsoShaderMetaInfo    m_meta;
     DxsoDefinedConstants  m_constants;
-    uint32_t              m_maxDefinedConst;
 
     Rc<DxvkShader>        m_shader;
 

--- a/src/d3d9/d3d9_stateblock.h
+++ b/src/d3d9/d3d9_stateblock.h
@@ -367,15 +367,27 @@ namespace dxvk {
             setCaptures.bConsts.set(reg, true);
         }
 
-        UpdateStateConstants<
-          ProgramType,
-          ConstantType,
-          T>(
-            &m_state,
-            StartRegister,
-            pConstantData,
-            Count,
-            false);
+        if constexpr (ProgramType == DxsoProgramType::VertexShader) {
+          UpdateStateConstants<
+            dynamic_item<D3D9ShaderConstantsVSSoftware>&,
+            ConstantType,
+            T>(
+              m_state.vsConsts,
+              StartRegister,
+              pConstantData,
+              Count,
+              false);
+        } else {
+          UpdateStateConstants<
+            dynamic_item<D3D9ShaderConstantsPS>&,
+            ConstantType,
+            T>(
+              m_state.psConsts,
+              StartRegister,
+              pConstantData,
+              Count,
+              false);
+        }
 
         return D3D_OK;
       };

--- a/src/dxso/dxso_compiler.cpp
+++ b/src/dxso/dxso_compiler.cpp
@@ -1797,7 +1797,7 @@ namespace dxvk {
     for (uint32_t i = 0; i < 4; i++)
       constant.float32[i] = data[i];
     m_constants.push_back(constant);
-    m_maxDefinedConstant = std::max(constant.uboIdx, m_maxDefinedConstant);
+    m_meta.maxShaderDefinedFloatConstant = std::max(constant.uboIdx, m_meta.maxShaderDefinedFloatConstant);
   }
 
   void DxsoCompiler::emitDefI(const DxsoInstructionContext& ctx) {

--- a/src/dxso/dxso_compiler.h
+++ b/src/dxso/dxso_compiler.h
@@ -247,7 +247,6 @@ namespace dxvk {
     const DxsoDefinedConstants& constants() { return m_constants; }
     uint32_t usedSamplers() const { return m_usedSamplers; }
     uint32_t usedRTs() const { return m_usedRTs; }
-    uint32_t maxDefinedConstant() const { return m_maxDefinedConstant; }
     uint32_t textureTypes() const { return m_textureTypes; }
 
   private:

--- a/src/dxso/dxso_isgn.h
+++ b/src/dxso/dxso_isgn.h
@@ -31,6 +31,7 @@ namespace dxvk {
 
   struct DxsoShaderMetaInfo {
     bool needsConstantCopies = false;
+    uint32_t maxShaderDefinedFloatConstant = 0;
     uint32_t maxConstIndexF = 0;
     uint32_t maxConstIndexI = 0;
     uint32_t maxConstIndexB = 0;

--- a/src/dxso/dxso_module.cpp
+++ b/src/dxso/dxso_module.cpp
@@ -36,7 +36,6 @@ namespace dxvk {
 
     m_meta            = compiler->meta();
     m_constants       = compiler->constants();
-    m_maxDefinedConst = compiler->maxDefinedConstant();
     m_usedSamplers    = compiler->usedSamplers();
     m_textureTypes    = compiler->textureTypes();
 

--- a/src/dxso/dxso_module.h
+++ b/src/dxso/dxso_module.h
@@ -59,8 +59,6 @@ namespace dxvk {
 
     uint32_t usedRTs() { return m_usedRTs; }
 
-    uint32_t maxDefinedConstant() { return m_maxDefinedConst; }
-
     uint32_t textureTypes() { return m_textureTypes; }
 
   private:
@@ -82,7 +80,6 @@ namespace dxvk {
     uint32_t        m_textureTypes;
 
     DxsoShaderMetaInfo   m_meta;
-    uint32_t             m_maxDefinedConst;
     DxsoDefinedConstants m_constants;
 
   };


### PR DESCRIPTION
As discussed on Discord, this moves the task of copying the constants into a bump allocated UBO for each draw onto the CS thread. Hopefully this will reduce the work on the game thread as the CS thread is usually the less busy one. Not a lot of games manage to saturate it.

So far I'm skeptical whether it provides any actual performance gains. Either way, this needs to be tested.