### PR TITLE
Improve swapchain scaling

### DIFF
--- a/src/dxvk/shaders/dxvk_present_frag_blit.frag
+++ b/src/dxvk/shaders/dxvk_present_frag_blit.frag
@@ -9,7 +9,29 @@ layout(location = 0) out vec4 o_color;
 
 void main() {
   vec2 coord = vec2(src_offset) + vec2(src_extent) * i_coord;
-  o_color = input_to_sc_rgb(textureLod(s_image, coord, 0.0f));
+  vec2 delta = vec2(dFdx(coord.x), dFdy(coord.y));
+
+  ivec2 i_coord = ivec2(coord);
+  vec2  f_coord = fract(coord);
+
+  if (all(lessThan(delta, vec2(1.0f)))) {
+    // Map pixel rectangle to source image. If it is entirely contained within one
+    // source pixel, just sample that pixel, otherwise do a linear interpolation.
+    // For even scaling factors, this is essentially integer scaling.
+    vec2 lo = max(coord - 0.5f * delta, vec2(src_offset));
+    vec2 hi = min(coord + 0.5f * delta, vec2(src_offset + src_extent - 1));
+
+    i_coord = ivec2(lo);
+    f_coord = mix((hi - floor(hi)) / delta, vec2(0.0), equal(floor(lo), floor(hi)));
+  }
+
+  // Manually interpolate in the correct color space
+  o_color = mix(mix(input_to_sc_rgb(texelFetch(s_image, i_coord + ivec2(0, 0), 0)),
+                    input_to_sc_rgb(texelFetch(s_image, i_coord + ivec2(1, 0), 0)), f_coord.x),
+                mix(input_to_sc_rgb(texelFetch(s_image, i_coord + ivec2(0, 1), 0)),
+                    input_to_sc_rgb(texelFetch(s_image, i_coord + ivec2(1, 1), 0)), f_coord.x),
+                f_coord.y);
+
   o_color = composite_image(o_color);
   o_color = sc_rgb_to_output(o_color);
 }


### PR DESCRIPTION
DXVK *generally* does not scale anything up or down because the app will use a swapchain that matches the display resolution, and in any sort of Proton environment we'll have fshack or gamescope dealing with non-native resolutions, however there are situations where the responsibility falls on us.

We already do the following:
- If the game's swapchain resolution matches the Vulkan swapchain, we just copy the source pixel, do whatever color space transforms are necessary (usually none) and move on.
- If the game's swapchain is multisampled, we do a manual resolve in linear space.
- If the game's swapchain is multisampled with `n` samples *and* requires scaling, we do some simple math on the coordinates to sample the closest `n` samples from a 2x2 pixel grid for each output pixel. This is cheaper and better quality than resolve + blit.
- If the game's swapchain is not multisampled but requires scaling anyway, we just sample the source texture with a linear filter.

The latter kind of sticks out like a sore thumb, and this PR brings it more in line with the multisampled blit case and also practically does integer scaling for even scaling factors.