### PR TITLE
Do not export PointSize on maintenance5-enabled drivers

### DIFF
--- a/src/dxbc/dxbc_compiler.cpp
+++ b/src/dxbc/dxbc_compiler.cpp
@@ -6899,15 +6899,15 @@ namespace dxvk {
   
   
   void DxbcCompiler::emitPointSizeStore() {
-    if (!m_pointSizeOut) {
-      m_pointSizeOut = emitNewBuiltinVariable(DxbcRegisterInfo {
+    if (m_moduleInfo.options.needsPointSizeExport) {
+      uint32_t pointSizeId = emitNewBuiltinVariable(DxbcRegisterInfo {
         { DxbcScalarType::Float32, 1, 0 },
         spv::StorageClassOutput },
         spv::BuiltInPointSize,
         "point_size");
-    }
 
-    m_module.opStore(m_pointSizeOut, m_module.constf32(1.0f));
+      m_module.opStore(pointSizeId, m_module.constf32(1.0f));
+    }
   }
 
 

--- a/src/dxbc/dxbc_compiler.h
+++ b/src/dxbc/dxbc_compiler.h
@@ -514,8 +514,6 @@ namespace dxvk {
     uint32_t m_primitiveIdIn  = 0;
     uint32_t m_primitiveIdOut = 0;
 
-    uint32_t m_pointSizeOut   = 0;
-
     //////////////////////////////////////////////////
     // Immediate constant buffer. If defined, this is
     // an array of four-component uint32 vectors.

--- a/src/dxbc/dxbc_options.cpp
+++ b/src/dxbc/dxbc_options.cpp
@@ -41,6 +41,11 @@ namespace dxvk {
     enableSampleShadingInterlock = device->features().extFragmentShaderInterlock.fragmentShaderSampleInterlock;
     supportsTightIcbPacking  = device->features().vk12.uniformBufferStandardLayout;
 
+    // Qcom just breaks for no reason if we export point size,
+    // even in an environment where doing so is required.
+    needsPointSizeExport = !device->features().khrMaintenance5.maintenance5
+                        && !device->adapter()->matchesDriver(VK_DRIVER_ID_QUALCOMM_PROPRIETARY);
+
     // Figure out float control flags to match D3D11 rules
     if (options.floatControls) {
       if (devInfo.vk12.shaderSignedZeroInfNanPreserveFloat32)

--- a/src/dxbc/dxbc_options.h
+++ b/src/dxbc/dxbc_options.h
@@ -57,6 +57,9 @@ namespace dxvk {
     /// constant buffers if possible
     bool supportsTightIcbPacking = false;
 
+    /// Whether exporting point size is required
+    bool needsPointSizeExport = true;
+
     /// Float control flags
     DxbcFloatControlFlags floatControl;
 


### PR DESCRIPTION
... or on broken drivers that just explode for no reason at all.