### PR TITLE
[d3d9] Consolidate shader const related fields

### DIFF
--- a/src/d3d9/d3d9_constant_set.h
+++ b/src/d3d9/d3d9_constant_set.h
@@ -2,12 +2,11 @@
 
 #include "d3d9_caps.h"
 #include "d3d9_constant_buffer.h"
+#include "d3d9_constant_layout.h"
 
-#include "../dxvk/dxvk_buffer.h"
 
 #include "../dxso/dxso_isgn.h"
 
-#include "../util/util_math.h"
 #include "../util/util_vector.h"
 
 #include <cstdint>
@@ -45,10 +44,14 @@ namespace dxvk {
   };
 
   struct D3D9ConstantSets {
+    D3D9ConstantLayout        layout;
     D3D9SwvpConstantBuffers   swvp;
     D3D9ConstantBuffer        buffer;
     DxsoShaderMetaInfo        meta  = {};
     bool                      dirty = true;
+    uint32_t                  maxChangedConstF = 0;
+    uint32_t                  maxChangedConstI = 0;
+    uint32_t                  maxChangedConstB = 0;
   };
 
 }

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -1051,8 +1051,8 @@ namespace dxvk {
             VkImageLayout            OldLayout,
             VkImageLayout            NewLayout);
 
-    const D3D9ConstantLayout& GetVertexConstantLayout() { return m_vsLayout; }
-    const D3D9ConstantLayout& GetPixelConstantLayout()  { return m_psLayout; }
+    const D3D9ConstantLayout& GetVertexConstantLayout() { return m_consts[DxsoProgramType::VertexShader].layout; }
+    const D3D9ConstantLayout& GetPixelConstantLayout()  { return m_consts[DxsoProgramType::PixelShader].layout; }
 
     void ResetState(D3DPRESENT_PARAMETERS* pPresentationParameters);
     HRESULT ResetSwapChain(D3DPRESENT_PARAMETERS* pPresentationParameters, D3DDISPLAYMODEEX* pFullscreenDisplayMode);
@@ -1283,8 +1283,7 @@ namespace dxvk {
     template <DxsoProgramType  ProgramType,
               D3D9ConstantType ConstantType>
     inline uint32_t DetermineHardwareRegCount() const {
-      const auto& layout = ProgramType == DxsoProgramType::VertexShader
-        ? m_vsLayout : m_psLayout;
+      const auto& layout = m_consts[ProgramType].layout;
 
       switch (ConstantType) {
         default:
@@ -1582,15 +1581,6 @@ namespace dxvk {
     uint32_t                        m_robustSSBOAlignment     = 1;
     uint32_t                        m_robustUBOAlignment      = 1;
 
-    uint32_t                        m_vsFloatConstsCount = 0;
-    uint32_t                        m_vsIntConstsCount   = 0;
-    uint32_t                        m_vsBoolConstsCount  = 0;
-    uint32_t                        m_psFloatConstsCount = 0;
-    VkDeviceSize                    m_boundVSConstantsBufferSize = 0;
-    VkDeviceSize                    m_boundPSConstantsBufferSize = 0;
-
-    D3D9ConstantLayout              m_vsLayout;
-    D3D9ConstantLayout              m_psLayout;
     D3D9ConstantSets                m_consts[DxsoProgramTypes::Count];
 	
 	D3D9UserDefinedAnnotation*      m_annotation = nullptr;


### PR DESCRIPTION
Some small leftover from #4745

Basically moves everything we have for shader constants into one place. This is a little cleaner and allows us to get rid of some `VertexShader ? a : b` expressions (although they were always with a template).

The only exception are the actual shader constants because they live in the `D3D9State` struct which is shared between the device and state blocks.