### PR TITLE
Don't use secondary command buffers on desktop drivers in general

### DIFF
--- a/src/dxvk/dxvk_device.cpp
+++ b/src/dxvk/dxvk_device.cpp
@@ -451,7 +451,7 @@ namespace dxvk {
 
     // Be less aggressive on secondary command buffer usage on
     // drivers that do not natively support them
-    hints.preferPrimaryCmdBufs = m_adapter->matchesDriver(VK_DRIVER_ID_MESA_HONEYKRISP);
+    hints.preferPrimaryCmdBufs = m_adapter->matchesDriver(VK_DRIVER_ID_MESA_HONEYKRISP) || !tilerMode;
     return hints;
   }
 


### PR DESCRIPTION
Clearly I am once again the proud owner of the **only** PC in the entire universe that doesn't run into any sort of GPU hang, rendering issue or whatever, so shipping this path doesn't seem viable and debugging it is kind of impossible right now until I find a way to actually reproduce anything on either RDNA2 or Nvidia.

Unfortunately this is going to turn the tiler optimizations into untested bitrot, but it's clearly broken anyway.