### PR TITLE
Rework depth-stencil resolves

### DIFF
--- a/src/d3d11/d3d11_context.cpp
+++ b/src/d3d11/d3d11_context.cpp
@@ -909,7 +909,7 @@ namespace dxvk {
           cDstImage->mipLevelExtent(cDstLayers.mipLevel));
       });
     } else {
-      const VkFormat format = m_parent->LookupFormat(
+      VkFormat format = m_parent->LookupFormat(
         Format, DXGI_VK_FORMAT_MODE_ANY).Format;
 
       EmitCs([
@@ -919,6 +919,8 @@ namespace dxvk {
         cSrcSubres = srcSubresourceLayers,
         cFormat    = format
       ] (DxvkContext* ctx) {
+        VkFormat format = cFormat ? cFormat : cSrcImage->info().format;
+
         VkImageResolve region;
         region.srcSubresource = cSrcSubres;
         region.srcOffset      = VkOffset3D { 0, 0, 0 };
@@ -926,7 +928,8 @@ namespace dxvk {
         region.dstOffset      = VkOffset3D { 0, 0, 0 };
         region.extent         = cDstImage->mipLevelExtent(cDstSubres.mipLevel);
 
-        ctx->resolveImage(cDstImage, cSrcImage, region, cFormat);
+        ctx->resolveImage(cDstImage, cSrcImage, region, format,
+          getDefaultResolveMode(format), VK_RESOLVE_MODE_NONE);
       });
 
       if constexpr (!IsDeferred)

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -1353,9 +1353,8 @@ namespace dxvk {
         cRegion      = region
       ] (DxvkContext* ctx) {
         if (cRegion.srcSubresource.aspectMask != (VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT)) {
-          ctx->resolveImage(
-            cDstImage, cSrcImage, cRegion,
-            VK_FORMAT_UNDEFINED);
+          ctx->resolveImage(cDstImage, cSrcImage, cRegion, cSrcImage->info().format,
+            VK_RESOLVE_MODE_AVERAGE_BIT, VK_RESOLVE_MODE_SAMPLE_ZERO_BIT);
         }
         else {
           ctx->resolveDepthStencilImage(
@@ -4935,6 +4934,8 @@ namespace dxvk {
             cResolveImage = mappedImage,
             cSubresource  = subresourceLayers
           ] (DxvkContext* ctx) {
+            VkFormat format = cMainImage->info().format;
+
             VkImageResolve region;
             region.srcSubresource = cSubresource;
             region.srcOffset      = VkOffset3D { 0, 0, 0 };
@@ -4943,9 +4944,8 @@ namespace dxvk {
             region.extent         = cMainImage->mipLevelExtent(cSubresource.mipLevel);
 
             if (cSubresource.aspectMask != (VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT)) {
-              ctx->resolveImage(
-                cResolveImage, cMainImage, region,
-                cMainImage->info().format);
+              ctx->resolveImage(cResolveImage, cMainImage, region, format,
+                getDefaultResolveMode(format), VK_RESOLVE_MODE_NONE);
             }
             else {
               ctx->resolveDepthStencilImage(

--- a/src/d3d9/d3d9_swapchain.cpp
+++ b/src/d3d9/d3d9_swapchain.cpp
@@ -327,9 +327,8 @@ namespace dxvk {
         resolveRegion.dstOffset      = VkOffset3D { 0, 0, 0 };
         resolveRegion.extent         = cSrcImage->info().extent;
 
-        ctx->resolveImage(
-          cDstImage, cSrcImage,
-          resolveRegion, VK_FORMAT_UNDEFINED);
+        ctx->resolveImage(cDstImage, cSrcImage, resolveRegion,
+          cSrcImage->info().format, VK_RESOLVE_MODE_AVERAGE_BIT, VK_RESOLVE_MODE_NONE);
       });
 
       srcImage = std::move(resolvedSrc);

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -2471,6 +2471,9 @@ namespace dxvk {
       auto srcSubresource = attachment.view->imageSubresources();
       auto dstSubresource = resolve.imageView->imageSubresources();
 
+      prepareImage(attachment.view->image(), srcSubresource);
+      prepareImage(resolve.imageView->image(), dstSubresource);
+
       while (resolve.layerMask) {
         uint32_t layerIndex = bit::tzcnt(resolve.layerMask);
         uint32_t layerCount = bit::tzcnt(~(resolve.layerMask >> layerIndex));
@@ -2486,7 +2489,7 @@ namespace dxvk {
         region.srcSubresource.layerCount = layerCount;
         region.extent = resolve.imageView->mipLevelExtent(0u);
 
-        resolveImage(resolve.imageView->image(), attachment.view->image(),
+        resolveImageRp(resolve.imageView->image(), attachment.view->image(),
           region, attachment.view->info().format, resolve.depthMode, resolve.stencilMode);
 
         resolve.layerMask &= ~0u << (layerIndex + layerCount);

--- a/src/dxvk/dxvk_context.h
+++ b/src/dxvk/dxvk_context.h
@@ -1046,13 +1046,17 @@ namespace dxvk {
      * \param [in] srcImage Source image
      * \param [in] region Region to resolve
      * \param [in] format Format for the resolve operation
+     * \param [in] mode Image resolve mode
+     * \param [in] stencilMode Stencil resolve mode
      */
     void resolveImage(
       const Rc<DxvkImage>&            dstImage,
       const Rc<DxvkImage>&            srcImage,
       const VkImageResolve&           region,
-            VkFormat                  format);
-    
+            VkFormat                  format,
+            VkResolveModeFlagBits     mode,
+            VkResolveModeFlagBits     stencilMode);
+
     /**
      * \brief Resolves a multisampled depth-stencil resource
      * 

--- a/src/dxvk/dxvk_context.h
+++ b/src/dxvk/dxvk_context.h
@@ -1058,22 +1058,6 @@ namespace dxvk {
             VkResolveModeFlagBits     stencilMode);
 
     /**
-     * \brief Resolves a multisampled depth-stencil resource
-     * 
-     * \param [in] dstImage Destination image
-     * \param [in] srcImage Source image
-     * \param [in] region Region to resolve
-     * \param [in] depthMode Resolve mode for depth aspect
-     * \param [in] stencilMode Resolve mode for stencil aspect
-     */
-    void resolveDepthStencilImage(
-      const Rc<DxvkImage>&            dstImage,
-      const Rc<DxvkImage>&            srcImage,
-      const VkImageResolve&           region,
-            VkResolveModeFlagBits     depthMode,
-            VkResolveModeFlagBits     stencilMode);
-
-    /**
      * \brief Transforms image subresource layouts
      * 
      * \param [in] dstImage Image to transform

--- a/src/dxvk/dxvk_format.h
+++ b/src/dxvk/dxvk_format.h
@@ -114,4 +114,23 @@ namespace dxvk {
       return lookupFormatInfoSlow(format);
   }
 
+  /**
+   * \brief Queries default resolve mode for format
+   *
+   * For depth-stencil formats, this will return SAMPLE_ZERO.
+   * \param [in] format Format to look up
+   * \returns Default resolve mode
+   */
+  inline VkResolveModeFlagBits getDefaultResolveMode(const DxvkFormatInfo* format) {
+    if ((format->aspectMask & (VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT))
+     || (format->flags.any(DxvkFormatFlag::SampledSInt, DxvkFormatFlag::SampledUInt)))
+      return VK_RESOLVE_MODE_SAMPLE_ZERO_BIT;
+
+    return VK_RESOLVE_MODE_AVERAGE_BIT;
+  }
+
+  inline VkResolveModeFlagBits getDefaultResolveMode(VkFormat format) {
+    return getDefaultResolveMode(lookupFormatInfo(format));
+  }
+
 }


### PR DESCRIPTION
Small cleanup, hence the negative delta. Also fixes an oversight where we accidentally broke partial resolves for certain D3D9 StretchRect cases.

Need to verify that this doesn't break anything else.