### PR TITLE
[util] Remove allowDirectBufferMapping config from Halo Online

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -843,7 +843,6 @@ namespace dxvk {
      * Black textures                          */
     { R"(\\eldorado\.exe$)", {{
       { "d3d9.floatEmulation",              "Strict"   },
-      { "d3d9.allowDirectBufferMapping",    "False" },
     }} },
     /* Injustice: Gods Among Us                *
      * Locks a buffer that's still in use      */


### PR DESCRIPTION
Causes a black foliage issue on specific maps

See https://github.com/doitsujin/dxvk/issues/4758