### PR TITLE
[wsi] Check more display mode flags when comparing them.

### DIFF
--- a/src/wsi/win32/wsi_window_win32.cpp
+++ b/src/wsi/win32/wsi_window_win32.cpp
@@ -48,6 +48,12 @@ namespace dxvk::wsi {
 
       if (pMode->dmFields & DM_DISPLAYFREQUENCY)
         eq &= curMode.dmDisplayFrequency == pMode->dmDisplayFrequency;
+      if (pMode->dmFields & DM_DISPLAYFLAGS)
+        eq &= curMode.dmDisplayFlags == pMode->dmDisplayFlags;
+      if (pMode->dmFields & DM_DISPLAYORIENTATION)
+        eq &= curMode.dmDisplayOrientation == pMode->dmDisplayOrientation;
+      if (pMode->dmFields & DM_POSITION)
+        eq &= curMode.dmPosition.x == pMode->dmPosition.x && curMode.dmPosition.y == pMode->dmPosition.y;
 
       if (eq)
         return true;


### PR DESCRIPTION
EnumDisplaySettings(..., ENUM_CURRENT_SETTINGS, ...) is guaranteed to have DM_DISPLAYORIENTATION, DM_BITSPERPEL, DM_PELSWIDTH, DM_PELSHEIGHT, DM_DISPLAYFLAGS, DM_DISPLAYFREQUENCY, and DM_POSITION.

If we don't compare positions, then in Win32WsiDriver::restoreDisplayMode(), the original monitor layout might not be restored. For example, a secondary 1080p monitor at (3840, 0) can be moved to (1280, -1080) after the primary 4K monitor resolution changes to 720p and back to 4K. And due to the secondary monitor having the same resolution, its position won't be restored before this patch.

Fix Rime (493200) fails to switch monitors in borderless mode in some cases for Proton 10 alpha.

Related to #2064.