### PR TITLE
[d3d8/9] Validate D3DDEVTYPE on device creation and cap queries

### DIFF
--- a/src/d3d9/d3d9_adapter.cpp
+++ b/src/d3d9/d3d9_adapter.cpp
@@ -292,8 +292,15 @@ namespace dxvk {
           D3DCAPS9*  pCaps) {
     using namespace dxvk::caps;
 
-    if (pCaps == nullptr)
+    if (unlikely(pCaps == nullptr))
       return D3DERR_INVALIDCALL;
+
+    if (unlikely(DeviceType == D3DDEVTYPE_SW)) {
+      if (m_parent->IsD3D8Compatible())
+        return D3DERR_INVALIDCALL;
+      else
+        return D3DERR_NOTAVAILABLE;
+    }
 
     auto& options = m_parent->GetOptions();
 

--- a/src/d3d9/d3d9_interface.cpp
+++ b/src/d3d9/d3d9_interface.cpp
@@ -358,6 +358,15 @@ namespace dxvk {
               || pPresentationParameters    == nullptr))
       return D3DERR_INVALIDCALL;
 
+    if (unlikely(DeviceType == D3DDEVTYPE_SW))
+      return D3DERR_INVALIDCALL;
+
+    // D3DDEVTYPE_REF devices can be created with D3D8, but not
+    // with D3D9, unless the Windows SDK 8.0 or later is installed.
+    // Report it unavailable, as it would be on most end-user systems.
+    if (unlikely(DeviceType == D3DDEVTYPE_REF && !m_isD3D8Compatible))
+      return D3DERR_NOTAVAILABLE;
+
     // Creating a device with D3DCREATE_PUREDEVICE only works in conjunction
     // with D3DCREATE_HARDWARE_VERTEXPROCESSING on native drivers.
     if (unlikely(BehaviorFlags & D3DCREATE_PUREDEVICE &&


### PR DESCRIPTION
Fixes some device type madness observed in #4766 , but probably not the main cause of concern in that issue.

Drafted until @Blisto91 helps validate the behavior/return codes against modern Windows, current implemented behavior is "the Windows XP way".

~P.S.: Also noticed Windows consistently reports 5 MB shy of 4096 MB when it comes to available texture memory by default, so let's do the same.~