### PR TITLE
Don't use sRGB swapchain formats

### DIFF
--- a/VP_DXVK_requirements.json
+++ b/VP_DXVK_requirements.json
@@ -78,6 +78,7 @@
                 "VK_KHR_maintenance5": 1,
                 "VK_KHR_present_id": 1,
                 "VK_KHR_present_wait": 1,
+                "VK_KHR_swapchain_mutable_format": 1,
                 "VK_EXT_line_rasterization": 1,
                 "VK_EXT_pageable_device_local_memory": 1,
                 "VK_EXT_swapchain_maintenance1": 1

--- a/src/dxvk/dxvk_adapter.cpp
+++ b/src/dxvk/dxvk_adapter.cpp
@@ -1069,6 +1069,7 @@ namespace dxvk {
       &devExtensions.khrPresentId,
       &devExtensions.khrPresentWait,
       &devExtensions.khrSwapchain,
+      &devExtensions.khrSwapchainMutableFormat,
       &devExtensions.khrWin32KeyedMutex,
       &devExtensions.nvDescriptorPoolOverallocation,
       &devExtensions.nvLowLatency2,
@@ -1221,6 +1222,9 @@ namespace dxvk {
       enabledFeatures.khrPresentWait.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRESENT_WAIT_FEATURES_KHR;
       enabledFeatures.khrPresentWait.pNext = std::exchange(enabledFeatures.core.pNext, &enabledFeatures.khrPresentWait);
     }
+
+    if (devExtensions.khrSwapchainMutableFormat)
+      enabledFeatures.khrSwapchainMutableFormat = VK_TRUE;
 
     if (devExtensions.nvDescriptorPoolOverallocation) {
       enabledFeatures.nvDescriptorPoolOverallocation.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_POOL_OVERALLOCATION_FEATURES_NV;

--- a/src/dxvk/dxvk_device_info.h
+++ b/src/dxvk/dxvk_device_info.h
@@ -74,6 +74,7 @@ namespace dxvk {
     VkPhysicalDeviceMaintenance5FeaturesKHR                   khrMaintenance5;
     VkPhysicalDevicePresentIdFeaturesKHR                      khrPresentId;
     VkPhysicalDevicePresentWaitFeaturesKHR                    khrPresentWait;
+    VkBool32                                                  khrSwapchainMutableFormat;
     VkPhysicalDeviceDescriptorPoolOverallocationFeaturesNV    nvDescriptorPoolOverallocation;
     VkBool32                                                  nvLowLatency2;
     VkPhysicalDeviceRawAccessChainsFeaturesNV                 nvRawAccessChains;

--- a/src/dxvk/dxvk_extensions.h
+++ b/src/dxvk/dxvk_extensions.h
@@ -326,6 +326,7 @@ namespace dxvk {
     DxvkExt khrPresentId                      = { VK_KHR_PRESENT_ID_EXTENSION_NAME,                         DxvkExtMode::Optional };
     DxvkExt khrPresentWait                    = { VK_KHR_PRESENT_WAIT_EXTENSION_NAME,                       DxvkExtMode::Optional };
     DxvkExt khrSwapchain                      = { VK_KHR_SWAPCHAIN_EXTENSION_NAME,                          DxvkExtMode::Required };
+    DxvkExt khrSwapchainMutableFormat         = { VK_KHR_SWAPCHAIN_MUTABLE_FORMAT_EXTENSION_NAME,           DxvkExtMode::Optional };
     DxvkExt khrWin32KeyedMutex                = { VK_KHR_WIN32_KEYED_MUTEX_EXTENSION_NAME,                  DxvkExtMode::Optional };
     DxvkExt nvDescriptorPoolOverallocation    = { VK_NV_DESCRIPTOR_POOL_OVERALLOCATION_EXTENSION_NAME,      DxvkExtMode::Optional };
     DxvkExt nvLowLatency2                     = { VK_NV_LOW_LATENCY_2_EXTENSION_NAME,                       DxvkExtMode::Optional };

--- a/src/dxvk/dxvk_presenter.cpp
+++ b/src/dxvk/dxvk_presenter.cpp
@@ -587,6 +587,16 @@ namespace dxvk {
 
     VkSurfaceFormatKHR surfaceFormat = pickSurfaceFormat(formats.size(), formats.data(), m_preferredFormat);
 
+    // Set up image format list for mutable swap chain if necessary
+    small_vector<VkFormat, 2> viewFormats = { };
+
+    auto formatPair = vk::getSrgbFormatPair(surfaceFormat.format);
+
+    if (formatPair.second) {
+      viewFormats.push_back(formatPair.first);
+      viewFormats.push_back(formatPair.second);
+    }
+
     // Select a present mode for the current sync interval
     if ((status = getSupportedPresentModes(modes)))
       return status;
@@ -684,6 +694,10 @@ namespace dxvk {
     VkSwapchainLatencyCreateInfoNV latencyInfo = { VK_STRUCTURE_TYPE_SWAPCHAIN_LATENCY_CREATE_INFO_NV };
     latencyInfo.latencyModeEnable   = m_latencySleepMode.has_value();
 
+    VkImageFormatListCreateInfo formatList = { VK_STRUCTURE_TYPE_IMAGE_FORMAT_LIST_CREATE_INFO };
+    formatList.viewFormatCount      = viewFormats.size();
+    formatList.pViewFormats         = viewFormats.data();
+
     VkSwapchainCreateInfoKHR swapInfo = { VK_STRUCTURE_TYPE_SWAPCHAIN_CREATE_INFO_KHR };
     swapInfo.surface                = m_surface;
     swapInfo.minImageCount          = pickImageCount(minImageCount, maxImageCount);
@@ -698,6 +712,11 @@ namespace dxvk {
     swapInfo.compositeAlpha         = VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR;
     swapInfo.presentMode            = m_presentMode;
     swapInfo.clipped                = VK_TRUE;
+
+    if (m_device->features().khrSwapchainMutableFormat && formatList.viewFormatCount) {
+      swapInfo.flags |= VK_SWAPCHAIN_CREATE_MUTABLE_FORMAT_BIT_KHR;
+      formatList.pNext = std::exchange(swapInfo.pNext, &formatList);
+    }
 
     if (m_device->features().extFullScreenExclusive)
       fullScreenInfo.pNext = const_cast<void*>(std::exchange(swapInfo.pNext, &fullScreenInfo));
@@ -743,6 +762,17 @@ namespace dxvk {
       imageInfo.colorSpace  = swapInfo.imageColorSpace;
       imageInfo.shared      = VK_TRUE;
       imageInfo.debugName   = debugName.c_str();
+
+      // If possible, expose the image with an sRGB format internally so
+      // that it will be used as the default format for composition.
+      if (swapInfo.flags & VK_SWAPCHAIN_CREATE_MUTABLE_FORMAT_BIT_KHR) {
+        imageInfo.flags |= VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT | VK_IMAGE_CREATE_EXTENDED_USAGE_BIT;
+        imageInfo.viewFormatCount = formatList.viewFormatCount;
+        imageInfo.viewFormats = formatList.pViewFormats;
+
+        if (formatPair.second)
+          imageInfo.format = formatPair.second;
+      }
 
       m_images.push_back(m_device->importImage(imageInfo, images[i],
         VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT));
@@ -952,21 +982,15 @@ namespace dxvk {
     const VkSurfaceFormatKHR*       pSupported,
           VkColorSpaceKHR           colorSpace,
           VkFormat                  format) {
-    static const std::array<std::pair<VkFormat, VkFormat>, 3> srgbFormatMap = {{
-      { VK_FORMAT_R8G8B8A8_UNORM, VK_FORMAT_R8G8B8A8_SRGB },
-      { VK_FORMAT_B8G8R8A8_UNORM, VK_FORMAT_B8G8R8A8_SRGB },
-      { VK_FORMAT_A8B8G8R8_UNORM_PACK32, VK_FORMAT_A8B8G8R8_SRGB_PACK32 },
-    }};
-
     static const std::array<VkFormat, 13> srgbFormatList = {
       VK_FORMAT_B5G5R5A1_UNORM_PACK16,
       VK_FORMAT_R5G5B5A1_UNORM_PACK16,
       VK_FORMAT_A1B5G5R5_UNORM_PACK16_KHR,
       VK_FORMAT_R5G6B5_UNORM_PACK16,
       VK_FORMAT_B5G6R5_UNORM_PACK16,
-      VK_FORMAT_R8G8B8A8_SRGB,
-      VK_FORMAT_B8G8R8A8_SRGB,
-      VK_FORMAT_A8B8G8R8_SRGB_PACK32,
+      VK_FORMAT_R8G8B8A8_UNORM,
+      VK_FORMAT_B8G8R8A8_UNORM,
+      VK_FORMAT_A8B8G8R8_UNORM_PACK32,
       VK_FORMAT_A2R10G10B10_UNORM_PACK32,
       VK_FORMAT_A2B10G10R10_UNORM_PACK32,
       VK_FORMAT_E5B9G9R9_UFLOAT_PACK32,
@@ -995,14 +1019,12 @@ namespace dxvk {
         scRGBFormatList.size(), scRGBFormatList.data() },
     }};
 
-    // For the sRGB color space, always prefer an actual sRGB
-    // format so that the blitter can use alpha blending.
-    if (colorSpace == VK_COLOR_SPACE_SRGB_NONLINEAR_KHR) {
-      for (const auto& e : srgbFormatMap) {
-        if (format == e.first)
-          format = e.second;
-      }
-    }
+    // Third-party overlays don't handle sRGB image formats correctly,
+    // so use the corresponding linear format instead.
+    auto formatPair = vk::getSrgbFormatPair(format);
+
+    if (formatPair.first)
+      format = formatPair.first;
 
     // If the desired format is supported natively, use it
     VkFormat fallback = VK_FORMAT_UNDEFINED;

--- a/src/vulkan/vulkan_util.h
+++ b/src/vulkan/vulkan_util.h
@@ -234,6 +234,30 @@ namespace dxvk::vk {
 
 
   /**
+   * \brief Queries sRGB and non-sSRGB format pair
+   *
+   * \param [in] format Format to look up
+   * \returns Pair of the corresponding non-SRGB and sRGB formats.
+   *    If the format in quesion has no sRGB equivalent, this
+   *    function returns \c VK_FORMAT_UNDEFINED.
+   */
+  inline std::pair<VkFormat, VkFormat> getSrgbFormatPair(VkFormat format) {
+    static const std::array<std::pair<VkFormat, VkFormat>, 3> srgbFormatMap = {{
+      { VK_FORMAT_R8G8B8A8_UNORM, VK_FORMAT_R8G8B8A8_SRGB },
+      { VK_FORMAT_B8G8R8A8_UNORM, VK_FORMAT_B8G8R8A8_SRGB },
+      { VK_FORMAT_A8B8G8R8_UNORM_PACK32, VK_FORMAT_A8B8G8R8_SRGB_PACK32 },
+    }};
+
+    for (const auto& f : srgbFormatMap) {
+      if (f.first == format || f.second == format)
+        return f;
+    }
+
+    return std::make_pair(VK_FORMAT_UNDEFINED, VK_FORMAT_UNDEFINED);
+  }
+
+
+  /**
    * \brief Makes debug label
    *
    * \param [in] color Color, as BGR with implied opaque alpha


### PR DESCRIPTION
Third-party software like RTSS doesn't handle `_SRGB` formats properly, so always create swapchains with a plain `_UNORM` format and use `VK_KHR_swapchain_mutable_format` in order to keep the `_SRGB` format internally, which is necessary for the HUD and software cursor to be rendered correctly.

On the other hand, this change may regress SDR games on some HDR setups on Windows as well for the same reason.

This may also regress third-party software that isn't aware of swapchain create flags or `pNext` chains.