### PR TITLE
Add workaround for ReShade misinterpreting swapchain contents

### DIFF
--- a/src/dxvk/dxvk_presenter.h
+++ b/src/dxvk/dxvk_presenter.h
@@ -381,6 +381,8 @@ namespace dxvk {
 
     void runFrameThread();
 
+    static bool isReshadeEnabled();
+
     static VkResult softError(
             VkResult                  vr);
 


### PR DESCRIPTION
Sigh, it would be real nice if we could actually use Vulkan features without everything blowing up.