### PR TITLE
Use STORE_OP_DONT_CARE/NONE whenever possible

### DIFF
--- a/VP_DXVK_requirements.json
+++ b/VP_DXVK_requirements.json
@@ -76,6 +76,7 @@
         "dxvk_common_optional": {
             "extensions": {
                 "VK_KHR_maintenance5": 1,
+                "VK_KHR_maintenance7": 1,
                 "VK_KHR_present_id": 1,
                 "VK_KHR_present_wait": 1,
                 "VK_KHR_swapchain_mutable_format": 1,
@@ -89,6 +90,9 @@
                 },
                 "VkPhysicalDeviceMaintenance5FeaturesKHR": {
                     "maintenance5": true
+                },
+                "VkPhysicalDeviceMaintenance7FeaturesKHR": {
+                    "maintenance7": true
                 },
                 "VkPhysicalDevicePresentIdFeaturesKHR": {
                     "presentId": true

--- a/VP_DXVK_requirements.json
+++ b/VP_DXVK_requirements.json
@@ -75,6 +75,7 @@
         },
         "dxvk_common_optional": {
             "extensions": {
+                "VK_KHR_load_store_op_none": 1,
                 "VK_KHR_maintenance5": 1,
                 "VK_KHR_maintenance7": 1,
                 "VK_KHR_present_id": 1,

--- a/src/d3d11/d3d11_context.cpp
+++ b/src/d3d11/d3d11_context.cpp
@@ -203,11 +203,11 @@ namespace dxvk {
       }
     }
 
-    // Since we don't handle SRVs here, we can assume that the
-    // view covers all aspects of the underlying resource.
-    EmitCs([cView = view] (DxvkContext* ctx) {
-      ctx->discardImageView(cView, cView->formatInfo()->aspectMask);
-    });
+    if (rtv || dsv) {
+      EmitCs([cView = view] (DxvkContext* ctx) {
+        ctx->clearRenderTarget(cView, 0, VkClearValue(), cView->info().aspects);
+      });
+    }
   }
 
 
@@ -430,10 +430,9 @@ namespace dxvk {
       cClearValue = color,
       cImageView  = std::move(view)
     ] (DxvkContext* ctx) {
-      ctx->clearRenderTarget(
-        cImageView,
+      ctx->clearRenderTarget(cImageView,
         VK_IMAGE_ASPECT_COLOR_BIT,
-        cClearValue);
+        cClearValue, 0u);
     });
   }
 
@@ -667,10 +666,8 @@ namespace dxvk {
       cAspectMask = aspectMask,
       cImageView  = dsv->GetImageView()
     ] (DxvkContext* ctx) {
-      ctx->clearRenderTarget(
-        cImageView,
-        cAspectMask,
-        cClearValue);
+      ctx->clearRenderTarget(cImageView,
+        cAspectMask, cClearValue, 0u);
     });
   }
 
@@ -795,17 +792,10 @@ namespace dxvk {
           bool isFullSize = cImageView->mipLevelExtent(0) == cAreaExtent;
 
           if ((cImageView->info().usage & rtUsage) && isFullSize) {
-            ctx->clearRenderTarget(
-              cImageView,
-              cClearAspect,
-              cClearValue);
+            ctx->clearRenderTarget(cImageView, cClearAspect, cClearValue, 0u);
           } else {
-            ctx->clearImageView(
-              cImageView,
-              cAreaOffset,
-              cAreaExtent,
-              cClearAspect,
-              cClearValue);
+            ctx->clearImageView(cImageView, cAreaOffset, cAreaExtent,
+              cClearAspect, cClearValue);
           }
         });
       }

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -1553,7 +1553,7 @@ namespace dxvk {
         Rc<DxvkImageView> view = cImage->createView(viewKey);
 
         if (cOffset == VkOffset3D() && cExtent == cImage->mipLevelExtent(viewKey.mipIndex)) {
-          ctx->clearRenderTarget(view, cSubresource.aspectMask, cClearValue);
+          ctx->clearRenderTarget(view, cSubresource.aspectMask, cClearValue, 0u);
         } else {
           ctx->clearImageView(view, cOffset, cExtent,
             cSubresource.aspectMask, cClearValue);
@@ -1914,10 +1914,8 @@ namespace dxvk {
           cAspectMask = aspectMask,
           cImageView  = imageView
         ] (DxvkContext* ctx) {
-          ctx->clearRenderTarget(
-            cImageView,
-            cAspectMask,
-            cClearValue);
+          ctx->clearRenderTarget(cImageView,
+            cAspectMask, cClearValue, 0u);
         });
       }
       else {

--- a/src/dxvk/dxvk_adapter.cpp
+++ b/src/dxvk/dxvk_adapter.cpp
@@ -981,6 +981,9 @@ namespace dxvk {
     if (m_deviceExtensions.supports(VK_KHR_EXTERNAL_SEMAPHORE_WIN32_EXTENSION_NAME))
       m_deviceFeatures.khrExternalSemaphoreWin32 = VK_TRUE;
 
+    if (m_deviceExtensions.supports(VK_KHR_LOAD_STORE_OP_NONE_EXTENSION_NAME))
+      m_deviceFeatures.khrLoadStoreOpNone = VK_TRUE;
+
     if (m_deviceExtensions.supports(VK_KHR_MAINTENANCE_5_EXTENSION_NAME)) {
       m_deviceFeatures.khrMaintenance5.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_5_FEATURES_KHR;
       m_deviceFeatures.khrMaintenance5.pNext = std::exchange(m_deviceFeatures.core.pNext, &m_deviceFeatures.khrMaintenance5);
@@ -1074,6 +1077,7 @@ namespace dxvk {
       &devExtensions.extVertexAttributeDivisor,
       &devExtensions.khrExternalMemoryWin32,
       &devExtensions.khrExternalSemaphoreWin32,
+      &devExtensions.khrLoadStoreOpNone,
       &devExtensions.khrMaintenance5,
       &devExtensions.khrMaintenance7,
       &devExtensions.khrPipelineLibrary,
@@ -1218,6 +1222,9 @@ namespace dxvk {
 
     if (devExtensions.khrExternalSemaphoreWin32)
       enabledFeatures.khrExternalSemaphoreWin32 = VK_TRUE;
+
+    if (devExtensions.khrLoadStoreOpNone)
+      enabledFeatures.khrLoadStoreOpNone = VK_TRUE;
 
     if (devExtensions.khrMaintenance5) {
       enabledFeatures.khrMaintenance5.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_5_FEATURES_KHR;
@@ -1400,6 +1407,8 @@ namespace dxvk {
       "\n  extension supported                    : " << (features.khrExternalMemoryWin32 ? "1" : "0") <<
       "\n" << VK_KHR_EXTERNAL_SEMAPHORE_WIN32_EXTENSION_NAME <<
       "\n  extension supported                    : " << (features.khrExternalSemaphoreWin32 ? "1" : "0") <<
+      "\n" << VK_KHR_LOAD_STORE_OP_NONE_EXTENSION_NAME <<
+      "\n  extension supported                    : " << (features.khrLoadStoreOpNone ? "1" : "0") <<
       "\n" << VK_KHR_MAINTENANCE_5_EXTENSION_NAME <<
       "\n  maintenance5                           : " << (features.khrMaintenance5.maintenance5 ? "1" : "0") <<
       "\n" << VK_KHR_MAINTENANCE_7_EXTENSION_NAME <<

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -402,7 +402,7 @@ namespace dxvk {
       //    will indirectly emit barriers for the given render target.
       // If there is overlap, we need to explicitly transition affected attachments.
       this->spillRenderPass(true);
-      this->prepareImage(imageView->image(), imageView->subresources(), false);
+      this->prepareImage(imageView->image(), imageView->imageSubresources(), false);
     } else if (!m_state.om.framebufferInfo.isWritable(attachmentIndex, clearAspects)) {
       // We cannot inline clears if the clear aspects are not writable. End the
       // render pass on the next draw to ensure that the image gets cleared.
@@ -4168,7 +4168,7 @@ namespace dxvk {
     if (attachmentIndex < 0) {
       this->spillRenderPass(false);
 
-      this->prepareImage(imageView->image(), imageView->subresources());
+      this->prepareImage(imageView->image(), imageView->imageSubresources());
       this->flushPendingAccesses(*imageView->image(), imageView->imageSubresources(), DxvkAccess::Write);
 
       if (unlikely(m_features.test(DxvkContextFeature::DebugUtils))) {
@@ -4273,7 +4273,7 @@ namespace dxvk {
       spillRenderPass(false);
       invalidateState();
 
-      prepareImage(imageView->image(), imageView->subresources());
+      prepareImage(imageView->image(), imageView->imageSubresources());
       flushPendingAccesses(*imageView->image(), imageView->imageSubresources(), DxvkAccess::Write);
 
       cmdBuffer = DxvkCmdBuffer::ExecBuffer;
@@ -6748,7 +6748,7 @@ namespace dxvk {
         const DxvkAttachment& attachment = m_state.om.framebufferInfo.getColorTarget(i);
 
         if (attachment.view != nullptr && attachment.view->image() == image
-         && (is3D || vk::checkSubresourceRangeOverlap(attachment.view->subresources(), subresources))) {
+         && (is3D || vk::checkSubresourceRangeOverlap(attachment.view->imageSubresources(), subresources))) {
           this->transitionColorAttachment(attachment, m_rtLayouts.color[i]);
           m_rtLayouts.color[i] = image->info().layout;
         }
@@ -6757,7 +6757,7 @@ namespace dxvk {
       const DxvkAttachment& attachment = m_state.om.framebufferInfo.getDepthTarget();
 
       if (attachment.view != nullptr && attachment.view->image() == image
-       && (is3D || vk::checkSubresourceRangeOverlap(attachment.view->subresources(), subresources))) {
+       && (is3D || vk::checkSubresourceRangeOverlap(attachment.view->imageSubresources(), subresources))) {
         this->transitionDepthAttachment(attachment, m_rtLayouts.depth);
         m_rtLayouts.depth = image->info().layout;
       }

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -6075,15 +6075,15 @@ namespace dxvk {
     // Retrieve and bind actual Vulkan pipeline handle
     auto pipelineInfo = m_state.gp.pipeline->getPipelineHandle(m_state.gp.state);
 
-    if (unlikely(!pipelineInfo.first))
+    if (unlikely(!pipelineInfo.handle))
       return false;
 
     m_cmd->cmdBindPipeline(DxvkCmdBuffer::ExecBuffer,
-      VK_PIPELINE_BIND_POINT_GRAPHICS, pipelineInfo.first);
+      VK_PIPELINE_BIND_POINT_GRAPHICS, pipelineInfo.handle);
 
     // For pipelines created from graphics pipeline libraries, we need to
     // apply a bunch of dynamic state that is otherwise static or unused
-    if (pipelineInfo.second == DxvkGraphicsPipelineType::BasePipeline) {
+    if (pipelineInfo.type == DxvkGraphicsPipelineType::BasePipeline) {
       m_flags.set(
         DxvkContextFlag::GpDynamicDepthStencilState,
         DxvkContextFlag::GpDynamicDepthBias,

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -5851,15 +5851,18 @@ namespace dxvk {
       renderingInheritance.stencilAttachmentFormat = depthStencilFormat;
     }
 
-    // On drivers that don't natively support secondary command buffers, only
-    // use them to enable MSAA resolve attachments. Also ignore color-only
-    // render passes here since we almost certainly need the output anyway.
+    // On drivers that don't natively support secondary command buffers, only use
+    // them to enable MSAA resolve attachments. Also ignore render passes with only
+    // one color attachment here since those tend to only have a small number of
+    // draws and we are almost certainly going to use the output anyway.
     bool useSecondaryCmdBuffer = !m_device->perfHints().preferPrimaryCmdBufs
       && renderingInheritance.rasterizationSamples > VK_SAMPLE_COUNT_1_BIT;
 
     if (m_device->perfHints().preferRenderPassOps) {
-      useSecondaryCmdBuffer = renderingInheritance.rasterizationSamples > VK_SAMPLE_COUNT_1_BIT
-        || (!m_device->perfHints().preferPrimaryCmdBufs && depthStencilAspects);
+      useSecondaryCmdBuffer = renderingInheritance.rasterizationSamples > VK_SAMPLE_COUNT_1_BIT;
+
+      if (!m_device->perfHints().preferPrimaryCmdBufs)
+        useSecondaryCmdBuffer |= depthStencilAspects || colorInfoCount > 1u;
     }
 
     if (useSecondaryCmdBuffer) {

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -2502,8 +2502,10 @@ namespace dxvk {
       auto srcSubresource = attachment.view->imageSubresources();
       auto dstSubresource = resolve.imageView->imageSubresources();
 
-      prepareImage(attachment.view->image(), srcSubresource);
-      prepareImage(resolve.imageView->image(), dstSubresource);
+      // We're within a render pass, any pending clears will have happened
+      // after the resolve, so ignore them here.
+      prepareImage(attachment.view->image(), srcSubresource, false);
+      prepareImage(resolve.imageView->image(), dstSubresource, false);
 
       while (resolve.layerMask) {
         uint32_t layerIndex = bit::tzcnt(resolve.layerMask);
@@ -5111,10 +5113,6 @@ namespace dxvk {
     const Rc<DxvkImage>&            srcImage,
     const VkImageResolve&           region,
           VkFormat                  format) {
-    // Can't have pending clears if we're already inside a render pass
-    if (m_flags.test(DxvkContextFlag::GpRenderPassBound))
-      return false;
-
     // If the destination image is only partially written, ignore
     if (dstImage->mipLevelExtent(region.dstSubresource.mipLevel, region.dstSubresource.aspectMask) != region.extent)
       return false;
@@ -5145,6 +5143,10 @@ namespace dxvk {
     if (!ensureImageCompatibility(dstImage, usage))
       return false;
 
+    // End current render pass and prepare the destination image
+    spillRenderPass(true);
+    prepareImage(dstImage, vk::makeSubresourceRange(region.dstSubresource));
+
     // Create an image view that we can use to perform the clear
     DxvkImageViewKey key = { };
     key.viewType = VK_IMAGE_VIEW_TYPE_2D;
@@ -5159,7 +5161,6 @@ namespace dxvk {
     if (isDepthStencil)
       key.aspects = dstImage->formatInfo()->aspectMask;
 
-    prepareImage(dstImage, vk::makeSubresourceRange(region.dstSubresource));
     deferClear(dstImage->createView(key), region.dstSubresource.aspectMask, clear->clearValue);
     return true;
   }
@@ -7935,6 +7936,10 @@ namespace dxvk {
     const DxvkImage&                image,
     const VkImageSubresourceRange&  subresources) {
     if (!m_flags.test(DxvkContextFlag::GpRenderPassSecondaryCmd))
+      return;
+
+    // Handling 3D is possible, but annoying, so skip it
+    if (image.info().type == VK_IMAGE_TYPE_3D)
       return;
 
     for (uint32_t i = 0; i < m_state.om.framebufferInfo.numAttachments(); i++) {

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -1292,8 +1292,10 @@ namespace dxvk {
     if (imageView->info().mipCount <= 1)
       return;
     
-    this->spillRenderPass(false);
+    this->spillRenderPass(true);
     this->invalidateState();
+
+    this->prepareImage(imageView->image(), imageView->imageSubresources());
 
     // Make sure we can both render to and read from the image
     VkFormat viewFormat = imageView->info().format;
@@ -4166,7 +4168,7 @@ namespace dxvk {
       attachmentIndex = -1;
 
     if (attachmentIndex < 0) {
-      this->spillRenderPass(false);
+      this->spillRenderPass(true);
 
       this->prepareImage(imageView->image(), imageView->imageSubresources());
       this->flushPendingAccesses(*imageView->image(), imageView->imageSubresources(), DxvkAccess::Write);
@@ -4270,7 +4272,7 @@ namespace dxvk {
     DxvkCmdBuffer cmdBuffer = DxvkCmdBuffer::InitBuffer;
 
     if (!prepareOutOfOrderTransfer(imageView->image(), DxvkAccess::Write)) {
-      spillRenderPass(false);
+      spillRenderPass(true);
       invalidateState();
 
       prepareImage(imageView->image(), imageView->imageSubresources());

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -2596,6 +2596,53 @@ namespace dxvk {
   }
 
 
+  void DxvkContext::finalizeLoadStoreOps() {
+    auto& renderingInfo = m_state.om.renderingInfo;
+
+    if (!m_device->properties().khrMaintenance7.separateDepthStencilAttachmentAccess)
+      m_state.om.attachmentMask.unifyDepthStencilAccess();
+
+    for (uint32_t i = 0; i < renderingInfo.rendering.colorAttachmentCount; i++) {
+      adjustAttachmentLoadStoreOps(renderingInfo.color[i],
+        m_state.om.attachmentMask.getColorAccess(i));
+    }
+
+    if (renderingInfo.rendering.pDepthAttachment) {
+      adjustAttachmentLoadStoreOps(renderingInfo.depth,
+        m_state.om.attachmentMask.getDepthAccess());
+    }
+
+    if (renderingInfo.rendering.pStencilAttachment) {
+      adjustAttachmentLoadStoreOps(renderingInfo.stencil,
+        m_state.om.attachmentMask.getStencilAccess());
+    }
+  }
+
+
+  void DxvkContext::adjustAttachmentLoadStoreOps(
+          VkRenderingAttachmentInfo&  attachment,
+          DxvkAccess                  access) const {
+    if (access == DxvkAccess::None) {
+      // If the attachment is not accessed at all, we can set both the
+      // load and store op to NONE if supported by the implementation.
+      bool hasLoadOpNone = m_device->features().khrLoadStoreOpNone;
+
+      attachment.loadOp = hasLoadOpNone
+        ? VK_ATTACHMENT_LOAD_OP_NONE
+        : VK_ATTACHMENT_LOAD_OP_LOAD;
+      attachment.storeOp = VK_ATTACHMENT_STORE_OP_NONE;
+    } else if (access == DxvkAccess::Read) {
+      // Unlike clears, we don't treat DONT_CARE as a write. If the
+      // attachment isn't written in this pass but is read anyway,
+      // demote the store op to DONT_CARE as well.
+      if (attachment.loadOp == VK_ATTACHMENT_LOAD_OP_DONT_CARE)
+        attachment.storeOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+      else
+        attachment.storeOp = VK_ATTACHMENT_STORE_OP_NONE;
+    }
+  }
+
+
   void DxvkContext::updateBuffer(
     const Rc<DxvkBuffer>&           buffer,
           VkDeviceSize              offset,
@@ -5864,6 +5911,10 @@ namespace dxvk {
       // modified store or resolve ops here
       flushRenderPassResolves();
       flushRenderPassDiscards();
+
+      // Need information about clears, discards and resolve
+      // to set up the final load and store ops for the pass
+      finalizeLoadStoreOps();
 
       auto& renderingInfo = m_state.om.renderingInfo.rendering;
       m_cmd->cmdBeginRendering(&renderingInfo);

--- a/src/dxvk/dxvk_context.h
+++ b/src/dxvk/dxvk_context.h
@@ -1662,10 +1662,16 @@ namespace dxvk {
       const Rc<DxvkImageView>&        imageView,
             VkImageAspectFlags        discardAspects);
 
+    void preparePostRenderPassClears();
+
+    void flushClearsInline();
+
     void flushClears(
             bool                      useRenderPass);
 
     void flushSharedImages();
+
+    void flushRenderPassDiscards();
 
     void flushRenderPassResolves();
 

--- a/src/dxvk/dxvk_context.h
+++ b/src/dxvk/dxvk_context.h
@@ -1666,6 +1666,12 @@ namespace dxvk {
 
     void flushResolves();
 
+    void finalizeLoadStoreOps();
+
+    void adjustAttachmentLoadStoreOps(
+            VkRenderingAttachmentInfo&  attachment,
+            DxvkAccess                  access) const;
+
     void startRenderPass();
     void spillRenderPass(bool suspend);
     

--- a/src/dxvk/dxvk_context.h
+++ b/src/dxvk/dxvk_context.h
@@ -500,12 +500,14 @@ namespace dxvk {
      * \param [in] imageView Render target view to clear
      * \param [in] clearAspects Image aspects to clear
      * \param [in] clearValue The clear value
+     * \param [in] discardAspects Image aspects to discard
      */
     void clearRenderTarget(
       const Rc<DxvkImageView>&    imageView,
             VkImageAspectFlags    clearAspects,
-            VkClearValue          clearValue);
-    
+            VkClearValue          clearValue,
+            VkImageAspectFlags    discardAspects);
+
     /**
      * \brief Clears an image view
      * 
@@ -705,19 +707,6 @@ namespace dxvk {
       const uint32_t*             pages,
       const Rc<DxvkBuffer>&       srcBuffer,
             VkDeviceSize          srcOffset);
-    
-    /**
-     * \brief Discards contents of an image view
-     *
-     * Discards the current contents of the image
-     * and performs a fast layout transition. This
-     * may improve performance in some cases.
-     * \param [in] imageView View to discard
-     * \param [in] discardAspects Image aspects to discard
-     */
-    void discardImageView(
-      const Rc<DxvkImageView>&      imageView,
-            VkImageAspectFlags      discardAspects);
 
     /**
      * \brief Discards contents of an image

--- a/src/dxvk/dxvk_context_state.h
+++ b/src/dxvk/dxvk_context_state.h
@@ -134,6 +134,7 @@ namespace dxvk {
     DxvkRenderTargets   renderTargets;
     DxvkRenderPassOps   renderPassOps;
     DxvkFramebufferInfo framebufferInfo;
+    DxvkAttachmentMask  attachmentMask;
   };
 
 

--- a/src/dxvk/dxvk_device_info.h
+++ b/src/dxvk/dxvk_device_info.h
@@ -72,6 +72,7 @@ namespace dxvk {
     VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT         extVertexAttributeDivisor;
     VkBool32                                                  khrExternalMemoryWin32;
     VkBool32                                                  khrExternalSemaphoreWin32;
+    VkBool32                                                  khrLoadStoreOpNone;
     VkPhysicalDeviceMaintenance5FeaturesKHR                   khrMaintenance5;
     VkPhysicalDeviceMaintenance7FeaturesKHR                   khrMaintenance7;
     VkPhysicalDevicePresentIdFeaturesKHR                      khrPresentId;

--- a/src/dxvk/dxvk_extensions.h
+++ b/src/dxvk/dxvk_extensions.h
@@ -321,6 +321,7 @@ namespace dxvk {
     DxvkExt extVertexAttributeDivisor         = { VK_EXT_VERTEX_ATTRIBUTE_DIVISOR_EXTENSION_NAME,           DxvkExtMode::Optional };
     DxvkExt khrExternalMemoryWin32            = { VK_KHR_EXTERNAL_MEMORY_WIN32_EXTENSION_NAME,              DxvkExtMode::Optional };
     DxvkExt khrExternalSemaphoreWin32         = { VK_KHR_EXTERNAL_SEMAPHORE_WIN32_EXTENSION_NAME,           DxvkExtMode::Optional };
+    DxvkExt khrLoadStoreOpNone                = { VK_KHR_LOAD_STORE_OP_NONE_EXTENSION_NAME,                 DxvkExtMode::Optional };
     DxvkExt khrMaintenance5                   = { VK_KHR_MAINTENANCE_5_EXTENSION_NAME,                      DxvkExtMode::Optional };
     DxvkExt khrMaintenance7                   = { VK_KHR_MAINTENANCE_7_EXTENSION_NAME,                      DxvkExtMode::Optional };
     DxvkExt khrPipelineLibrary                = { VK_KHR_PIPELINE_LIBRARY_EXTENSION_NAME,                   DxvkExtMode::Optional };

--- a/src/dxvk/dxvk_graphics.cpp
+++ b/src/dxvk/dxvk_graphics.cpp
@@ -1057,14 +1057,14 @@ namespace dxvk {
   }
 
 
-  std::pair<VkPipeline, DxvkGraphicsPipelineType> DxvkGraphicsPipeline::getPipelineHandle(
+  DxvkGraphicsPipelineHandle DxvkGraphicsPipeline::getPipelineHandle(
     const DxvkGraphicsPipelineStateInfo& state) {
     DxvkGraphicsPipelineInstance* instance = this->findInstance(state);
 
     if (unlikely(!instance)) {
       // Exit early if the state vector is invalid
       if (!this->validatePipelineState(state, true))
-        return std::make_pair(VK_NULL_HANDLE, DxvkGraphicsPipelineType::FastPipeline);
+        return DxvkGraphicsPipelineHandle();
 
       // Prevent other threads from adding new instances and check again
       std::unique_lock<dxvk::mutex> lock(m_mutex);
@@ -1091,14 +1091,7 @@ namespace dxvk {
       }
     }
 
-    // Find a pipeline handle to use. If no optimized pipeline has
-    // been compiled yet, use the slower base pipeline instead.
-    VkPipeline fastHandle = instance->fastHandle.load();
-
-    if (likely(fastHandle != VK_NULL_HANDLE))
-      return std::make_pair(fastHandle, DxvkGraphicsPipelineType::FastPipeline);
-
-    return std::make_pair(instance->baseHandle.load(), DxvkGraphicsPipelineType::BasePipeline);
+    return instance->getHandle();
   }
 
 


### PR DESCRIPTION
Another small tiler optimization: If a render target or depth buffer is used in two back-to-back render passes and gets cleared before the second pass, we can set `STORE_OP_DONT_CARE` for that render target in the first pass, provided that that pass is rendered using secondary command buffers.

This is actually quite common in D3D9 land since many games reuse the default depth buffer for all sorts of things.

Additionally, we can use `LOAD_OP_NONE` for unused attachments, and `STORE_OP_NONE` for unused or read-only attachments.