### PR TITLE
Refactor and normalize render state

### DIFF
--- a/src/d3d11/d3d11_blend.cpp
+++ b/src/d3d11/d3d11_blend.cpp
@@ -27,8 +27,8 @@ namespace dxvk {
     if (desc.IndependentBlendEnable && desc.RenderTarget[0].LogicOpEnable)
       Logger::warn("D3D11: Per-target logic ops not supported");
     
-    m_loState.enableLogicOp         = desc.RenderTarget[0].LogicOpEnable;
-    m_loState.logicOp               = DecodeLogicOp(desc.RenderTarget[0].LogicOp);
+    m_loState.setLogicOp(desc.RenderTarget[0].LogicOpEnable,
+      DecodeLogicOp(desc.RenderTarget[0].LogicOp));
   }
   
   
@@ -96,9 +96,6 @@ namespace dxvk {
     // blend mode array will be identical
     for (uint32_t i = 0; i < m_blendModes.size(); i++)
       ctx->setBlendMode(i, m_blendModes.at(i));
-    
-    // Set up logic op state as well
-    ctx->setLogicOpState(m_loState);
   }
   
   

--- a/src/d3d11/d3d11_blend.cpp
+++ b/src/d3d11/d3d11_blend.cpp
@@ -12,7 +12,7 @@ namespace dxvk {
     // blend modes for render target 1 to 7. In Vulkan, all
     // blend modes need to be identical in that case.
     for (uint32_t i = 0; i < m_blendModes.size(); i++) {
-      m_blendModes.at(i) = DecodeBlendMode(
+      m_blendModes[i] = DecodeBlendMode(
         desc.IndependentBlendEnable
           ? desc.RenderTarget[i]
           : desc.RenderTarget[0]);
@@ -86,16 +86,6 @@ namespace dxvk {
   
   void STDMETHODCALLTYPE D3D11BlendState::GetDesc1(D3D11_BLEND_DESC1* pDesc) {
     *pDesc = m_desc;
-  }
-  
-  
-  void D3D11BlendState::BindToContext(
-          DxvkContext*      ctx) const {
-    // We handled Independent Blend during object creation
-    // already, so if it is disabled, all elements in the
-    // blend mode array will be identical
-    for (uint32_t i = 0; i < m_blendModes.size(); i++)
-      ctx->setBlendMode(i, m_blendModes.at(i));
   }
   
   
@@ -183,15 +173,15 @@ namespace dxvk {
   
   DxvkBlendMode D3D11BlendState::DecodeBlendMode(
     const D3D11_RENDER_TARGET_BLEND_DESC1& BlendDesc) {
-    DxvkBlendMode mode;
-    mode.enableBlending   = BlendDesc.BlendEnable;
-    mode.colorSrcFactor   = DecodeBlendFactor(BlendDesc.SrcBlend, false);
-    mode.colorDstFactor   = DecodeBlendFactor(BlendDesc.DestBlend, false);
-    mode.colorBlendOp     = DecodeBlendOp(BlendDesc.BlendOp);
-    mode.alphaSrcFactor   = DecodeBlendFactor(BlendDesc.SrcBlendAlpha, true);
-    mode.alphaDstFactor   = DecodeBlendFactor(BlendDesc.DestBlendAlpha, true);
-    mode.alphaBlendOp     = DecodeBlendOp(BlendDesc.BlendOpAlpha);
-    mode.writeMask        = BlendDesc.RenderTargetWriteMask;
+    DxvkBlendMode mode = { };
+    mode.setBlendEnable(BlendDesc.BlendEnable);
+    mode.setColorOp(DecodeBlendFactor(BlendDesc.SrcBlend, false),
+                    DecodeBlendFactor(BlendDesc.DestBlend, false),
+                    DecodeBlendOp(BlendDesc.BlendOp));
+    mode.setAlphaOp(DecodeBlendFactor(BlendDesc.SrcBlendAlpha, true),
+                    DecodeBlendFactor(BlendDesc.DestBlendAlpha, true),
+                    DecodeBlendOp(BlendDesc.BlendOpAlpha));
+    mode.setWriteMask(BlendDesc.RenderTargetWriteMask);
     return mode;
   }
   

--- a/src/d3d11/d3d11_blend.cpp
+++ b/src/d3d11/d3d11_blend.cpp
@@ -182,6 +182,8 @@ namespace dxvk {
                     DecodeBlendFactor(BlendDesc.DestBlendAlpha, true),
                     DecodeBlendOp(BlendDesc.BlendOpAlpha));
     mode.setWriteMask(BlendDesc.RenderTargetWriteMask);
+
+    mode.normalize();
     return mode;
   }
   

--- a/src/d3d11/d3d11_blend.cpp
+++ b/src/d3d11/d3d11_blend.cpp
@@ -19,8 +19,8 @@ namespace dxvk {
     }
     
     // Multisample state is part of the blend state in D3D11
-    m_msState.sampleMask            = 0; // Set during bind
-    m_msState.enableAlphaToCoverage = desc.AlphaToCoverageEnable;
+    m_msState.setSampleMask(0u); // Set during bind
+    m_msState.setAlphaToCoverage(desc.AlphaToCoverageEnable);
     
     // Vulkan only supports a global logic op for the blend
     // state, which might be problematic in some cases.
@@ -90,18 +90,12 @@ namespace dxvk {
   
   
   void D3D11BlendState::BindToContext(
-          DxvkContext*      ctx,
-          uint32_t          sampleMask) const {
+          DxvkContext*      ctx) const {
     // We handled Independent Blend during object creation
     // already, so if it is disabled, all elements in the
     // blend mode array will be identical
     for (uint32_t i = 0; i < m_blendModes.size(); i++)
       ctx->setBlendMode(i, m_blendModes.at(i));
-    
-    // The sample mask is dynamic state in D3D11
-    DxvkMultisampleState msState = m_msState;
-    msState.sampleMask = sampleMask;
-    ctx->setMultisampleState(msState);
     
     // Set up logic op state as well
     ctx->setLogicOpState(m_loState);

--- a/src/d3d11/d3d11_blend.h
+++ b/src/d3d11/d3d11_blend.h
@@ -42,9 +42,10 @@ namespace dxvk {
       return m_loState;
     }
 
-    void BindToContext(
-            DxvkContext*      ctx) const;
-    
+    std::array<DxvkBlendMode, 8> GetBlendState() const {
+      return m_blendModes;
+    }
+
     D3D10BlendState* GetD3D10Iface() {
       return &m_d3d10;
     }
@@ -59,7 +60,7 @@ namespace dxvk {
     
     D3D11_BLEND_DESC1             m_desc;
     
-    std::array<DxvkBlendMode, 8>  m_blendModes;
+    std::array<DxvkBlendMode, 8>  m_blendModes = { };
     DxvkMultisampleState          m_msState = { };
     DxvkLogicOpState              m_loState = { };
 

--- a/src/d3d11/d3d11_blend.h
+++ b/src/d3d11/d3d11_blend.h
@@ -32,9 +32,14 @@ namespace dxvk {
     void STDMETHODCALLTYPE GetDesc1(
             D3D11_BLEND_DESC1* pDesc) final;
     
+    DxvkMultisampleState GetMsState(uint32_t SampleMask) const {
+      DxvkMultisampleState msState = m_msState;
+      msState.setSampleMask(SampleMask);
+      return msState;
+    }
+
     void BindToContext(
-            DxvkContext*      ctx,
-            UINT              sampleMask) const;
+            DxvkContext*      ctx) const;
     
     D3D10BlendState* GetD3D10Iface() {
       return &m_d3d10;
@@ -51,7 +56,7 @@ namespace dxvk {
     D3D11_BLEND_DESC1             m_desc;
     
     std::array<DxvkBlendMode, 8>  m_blendModes;
-    DxvkMultisampleState          m_msState;
+    DxvkMultisampleState          m_msState = { };
     DxvkLogicOpState              m_loState;
 
     D3D10BlendState               m_d3d10;

--- a/src/d3d11/d3d11_blend.h
+++ b/src/d3d11/d3d11_blend.h
@@ -38,6 +38,10 @@ namespace dxvk {
       return msState;
     }
 
+    DxvkLogicOpState GetLoState() const {
+      return m_loState;
+    }
+
     void BindToContext(
             DxvkContext*      ctx) const;
     
@@ -57,10 +61,10 @@ namespace dxvk {
     
     std::array<DxvkBlendMode, 8>  m_blendModes;
     DxvkMultisampleState          m_msState = { };
-    DxvkLogicOpState              m_loState;
+    DxvkLogicOpState              m_loState = { };
 
     D3D10BlendState               m_d3d10;
-    
+
     static DxvkBlendMode DecodeBlendMode(
       const D3D11_RENDER_TARGET_BLEND_DESC1& BlendDesc);
     

--- a/src/d3d11/d3d11_context.cpp
+++ b/src/d3d11/d3d11_context.cpp
@@ -3381,9 +3381,11 @@ namespace dxvk {
     if (m_state.om.cbState != nullptr) {
       EmitCs([
         cBlendState = m_state.om.cbState,
-        cSampleMask = m_state.om.sampleMask
+        cMsState    = m_state.om.cbState->GetMsState(m_state.om.sampleMask)
       ] (DxvkContext* ctx) {
-        cBlendState->BindToContext(ctx, cSampleMask);
+        cBlendState->BindToContext(ctx);
+
+        ctx->setMultisampleState(cMsState);
       });
     } else {
       EmitCs([
@@ -3391,14 +3393,13 @@ namespace dxvk {
       ] (DxvkContext* ctx) {
         DxvkBlendMode cbState;
         DxvkLogicOpState loState;
-        DxvkMultisampleState msState;
-        InitDefaultBlendState(&cbState, &loState, &msState, cSampleMask);
+        InitDefaultBlendState(&cbState, &loState);
 
         for (uint32_t i = 0; i < D3D11_SIMULTANEOUS_RENDER_TARGET_COUNT; i++)
           ctx->setBlendMode(i, cbState);
 
         ctx->setLogicOpState(loState);
-        ctx->setMultisampleState(msState);
+        ctx->setMultisampleState(InitDefaultMultisampleState(cSampleMask));
       });
     }
   }
@@ -4740,14 +4741,13 @@ namespace dxvk {
 
       DxvkBlendMode cbState;
       DxvkLogicOpState loState;
-      DxvkMultisampleState msState;
-      InitDefaultBlendState(&cbState, &loState, &msState, D3D11_DEFAULT_SAMPLE_MASK);
+      InitDefaultBlendState(&cbState, &loState);
 
       ctx->setInputAssemblyState(iaState);
       ctx->setDepthStencilState(InitDefaultDepthStencilState());
       ctx->setRasterizerState(rsState);
       ctx->setLogicOpState(loState);
-      ctx->setMultisampleState(msState);
+      ctx->setMultisampleState(InitDefaultMultisampleState(D3D11_DEFAULT_SAMPLE_MASK));
 
       for (uint32_t i = 0; i < D3D11_SIMULTANEOUS_RENDER_TARGET_COUNT; i++)
         ctx->setBlendMode(i, cbState);
@@ -5823,11 +5823,18 @@ namespace dxvk {
 
 
   template<typename ContextType>
+  DxvkMultisampleState D3D11CommonContext<ContextType>::InitDefaultMultisampleState(
+          UINT                              SampleMask) {
+    DxvkMultisampleState msState = { };
+    msState.setSampleMask(SampleMask);
+    return msState;
+  }
+
+
+  template<typename ContextType>
   void D3D11CommonContext<ContextType>::InitDefaultBlendState(
           DxvkBlendMode*                    pCbState,
-          DxvkLogicOpState*                 pLoState,
-          DxvkMultisampleState*             pMsState,
-          UINT                              SampleMask) {
+          DxvkLogicOpState*                 pLoState) {
     pCbState->enableBlending    = VK_FALSE;
     pCbState->colorSrcFactor    = VK_BLEND_FACTOR_ONE;
     pCbState->colorDstFactor    = VK_BLEND_FACTOR_ZERO;
@@ -5840,9 +5847,6 @@ namespace dxvk {
 
     pLoState->enableLogicOp     = VK_FALSE;
     pLoState->logicOp           = VK_LOGIC_OP_NO_OP;
-
-    pMsState->sampleMask            = SampleMask;
-    pMsState->enableAlphaToCoverage = VK_FALSE;
   }
 
   // Explicitly instantiate here

--- a/src/d3d11/d3d11_context.cpp
+++ b/src/d3d11/d3d11_context.cpp
@@ -3381,25 +3381,26 @@ namespace dxvk {
     if (m_state.om.cbState != nullptr) {
       EmitCs([
         cBlendState = m_state.om.cbState,
-        cMsState    = m_state.om.cbState->GetMsState(m_state.om.sampleMask)
+        cMsState    = m_state.om.cbState->GetMsState(m_state.om.sampleMask),
+        cLoState    = m_state.om.cbState->GetLoState()
       ] (DxvkContext* ctx) {
         cBlendState->BindToContext(ctx);
 
         ctx->setMultisampleState(cMsState);
+        ctx->setLogicOpState(cLoState);
       });
     } else {
       EmitCs([
         cSampleMask = m_state.om.sampleMask
       ] (DxvkContext* ctx) {
         DxvkBlendMode cbState;
-        DxvkLogicOpState loState;
-        InitDefaultBlendState(&cbState, &loState);
+        InitDefaultBlendState(&cbState);
 
         for (uint32_t i = 0; i < D3D11_SIMULTANEOUS_RENDER_TARGET_COUNT; i++)
           ctx->setBlendMode(i, cbState);
 
-        ctx->setLogicOpState(loState);
         ctx->setMultisampleState(InitDefaultMultisampleState(cSampleMask));
+        ctx->setLogicOpState(InitDefaultLogicOpState());
       });
     }
   }
@@ -4740,13 +4741,12 @@ namespace dxvk {
       InitDefaultRasterizerState(&rsState);
 
       DxvkBlendMode cbState;
-      DxvkLogicOpState loState;
-      InitDefaultBlendState(&cbState, &loState);
+      InitDefaultBlendState(&cbState);
 
       ctx->setInputAssemblyState(iaState);
       ctx->setDepthStencilState(InitDefaultDepthStencilState());
       ctx->setRasterizerState(rsState);
-      ctx->setLogicOpState(loState);
+      ctx->setLogicOpState(InitDefaultLogicOpState());
       ctx->setMultisampleState(InitDefaultMultisampleState(D3D11_DEFAULT_SAMPLE_MASK));
 
       for (uint32_t i = 0; i < D3D11_SIMULTANEOUS_RENDER_TARGET_COUNT; i++)
@@ -5832,9 +5832,16 @@ namespace dxvk {
 
 
   template<typename ContextType>
+  DxvkLogicOpState D3D11CommonContext<ContextType>::InitDefaultLogicOpState() {
+    DxvkLogicOpState loState = { };
+    loState.setLogicOp(false, VK_LOGIC_OP_NO_OP);
+    return loState;
+  }
+
+
+  template<typename ContextType>
   void D3D11CommonContext<ContextType>::InitDefaultBlendState(
-          DxvkBlendMode*                    pCbState,
-          DxvkLogicOpState*                 pLoState) {
+          DxvkBlendMode*                    pCbState) {
     pCbState->enableBlending    = VK_FALSE;
     pCbState->colorSrcFactor    = VK_BLEND_FACTOR_ONE;
     pCbState->colorDstFactor    = VK_BLEND_FACTOR_ZERO;
@@ -5844,9 +5851,6 @@ namespace dxvk {
     pCbState->alphaBlendOp      = VK_BLEND_OP_ADD;
     pCbState->writeMask         = VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT
                                 | VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT;
-
-    pLoState->enableLogicOp     = VK_FALSE;
-    pLoState->logicOp           = VK_LOGIC_OP_NO_OP;
   }
 
   // Explicitly instantiate here

--- a/src/d3d11/d3d11_context.cpp
+++ b/src/d3d11/d3d11_context.cpp
@@ -3420,16 +3420,13 @@ namespace dxvk {
   void D3D11CommonContext<ContextType>::ApplyDepthStencilState() {
     if (m_state.om.dsState != nullptr) {
       EmitCs([
-        cDepthStencilState = m_state.om.dsState
+        cState = m_state.om.dsState->GetState()
       ] (DxvkContext* ctx) {
-        cDepthStencilState->BindToContext(ctx);
+        ctx->setDepthStencilState(cState);
       });
     } else {
       EmitCs([] (DxvkContext* ctx) {
-        DxvkDepthStencilState dsState;
-        InitDefaultDepthStencilState(&dsState);
-
-        ctx->setDepthStencilState(dsState);
+        ctx->setDepthStencilState(InitDefaultDepthStencilState());
       });
     }
   }
@@ -4738,9 +4735,6 @@ namespace dxvk {
       DxvkInputAssemblyState iaState;
       InitDefaultPrimitiveTopology(&iaState);
 
-      DxvkDepthStencilState dsState;
-      InitDefaultDepthStencilState(&dsState);
-
       DxvkRasterizerState rsState;
       InitDefaultRasterizerState(&rsState);
 
@@ -4750,7 +4744,7 @@ namespace dxvk {
       InitDefaultBlendState(&cbState, &loState, &msState, D3D11_DEFAULT_SAMPLE_MASK);
 
       ctx->setInputAssemblyState(iaState);
-      ctx->setDepthStencilState(dsState);
+      ctx->setDepthStencilState(InitDefaultDepthStencilState());
       ctx->setRasterizerState(rsState);
       ctx->setLogicOpState(loState);
       ctx->setMultisampleState(msState);
@@ -5819,23 +5813,12 @@ namespace dxvk {
 
 
   template<typename ContextType>
-  void D3D11CommonContext<ContextType>::InitDefaultDepthStencilState(
-          DxvkDepthStencilState*            pDsState) {
-    VkStencilOpState stencilOp;
-    stencilOp.failOp            = VK_STENCIL_OP_KEEP;
-    stencilOp.passOp            = VK_STENCIL_OP_KEEP;
-    stencilOp.depthFailOp       = VK_STENCIL_OP_KEEP;
-    stencilOp.compareOp         = VK_COMPARE_OP_ALWAYS;
-    stencilOp.compareMask       = D3D11_DEFAULT_STENCIL_READ_MASK;
-    stencilOp.writeMask         = D3D11_DEFAULT_STENCIL_WRITE_MASK;
-    stencilOp.reference         = 0;
-
-    pDsState->enableDepthTest   = VK_TRUE;
-    pDsState->enableDepthWrite  = VK_TRUE;
-    pDsState->enableStencilTest = VK_FALSE;
-    pDsState->depthCompareOp    = VK_COMPARE_OP_LESS;
-    pDsState->stencilOpFront    = stencilOp;
-    pDsState->stencilOpBack     = stencilOp;
+  DxvkDepthStencilState D3D11CommonContext<ContextType>::InitDefaultDepthStencilState() {
+    DxvkDepthStencilState dsState = { };
+    dsState.setDepthTest(true);
+    dsState.setDepthWrite(true);
+    dsState.setDepthCompareOp(VK_COMPARE_OP_LESS);
+    return dsState;
   }
 
 

--- a/src/d3d11/d3d11_context.cpp
+++ b/src/d3d11/d3d11_context.cpp
@@ -3448,16 +3448,17 @@ namespace dxvk {
   void D3D11CommonContext<ContextType>::ApplyRasterizerState() {
     if (m_state.rs.state != nullptr) {
       EmitCs([
-        cRasterizerState = m_state.rs.state
+        cState      = m_state.rs.state->GetState(),
+        cDepthBias  = m_state.rs.state->GetDepthBias()
       ] (DxvkContext* ctx) {
-        cRasterizerState->BindToContext(ctx);
+        ctx->setRasterizerState(cState);
+
+        if (cState.depthBias())
+          ctx->setDepthBias(cDepthBias);
       });
     } else {
       EmitCs([] (DxvkContext* ctx) {
-        DxvkRasterizerState rsState;
-        InitDefaultRasterizerState(&rsState);
-
-        ctx->setRasterizerState(rsState);
+        ctx->setRasterizerState(InitDefaultRasterizerState());
       });
     }
   }
@@ -4737,12 +4738,9 @@ namespace dxvk {
       DxvkInputAssemblyState iaState;
       InitDefaultPrimitiveTopology(&iaState);
 
-      DxvkRasterizerState rsState;
-      InitDefaultRasterizerState(&rsState);
-
       ctx->setInputAssemblyState(iaState);
       ctx->setDepthStencilState(InitDefaultDepthStencilState());
-      ctx->setRasterizerState(rsState);
+      ctx->setRasterizerState(InitDefaultRasterizerState());
       ctx->setLogicOpState(InitDefaultLogicOpState());
       ctx->setMultisampleState(InitDefaultMultisampleState(D3D11_DEFAULT_SAMPLE_MASK));
 
@@ -5797,17 +5795,18 @@ namespace dxvk {
 
 
   template<typename ContextType>
-  void D3D11CommonContext<ContextType>::InitDefaultRasterizerState(
-          DxvkRasterizerState*              pRsState) {
-    pRsState->polygonMode     = VK_POLYGON_MODE_FILL;
-    pRsState->cullMode        = VK_CULL_MODE_BACK_BIT;
-    pRsState->frontFace       = VK_FRONT_FACE_CLOCKWISE;
-    pRsState->depthClipEnable = VK_TRUE;
-    pRsState->depthBiasEnable = VK_FALSE;
-    pRsState->conservativeMode = VK_CONSERVATIVE_RASTERIZATION_MODE_DISABLED_EXT;
-    pRsState->sampleCount     = 0;
-    pRsState->flatShading     = VK_FALSE;
-    pRsState->lineMode        = VK_LINE_RASTERIZATION_MODE_DEFAULT_EXT;
+  DxvkRasterizerState D3D11CommonContext<ContextType>::InitDefaultRasterizerState() {
+    DxvkRasterizerState rsState = { };
+    rsState.setPolygonMode(VK_POLYGON_MODE_FILL);
+    rsState.setCullMode(VK_CULL_MODE_BACK_BIT);
+    rsState.setFrontFace(VK_FRONT_FACE_CLOCKWISE);
+    rsState.setDepthClip(true);
+    rsState.setDepthBias(false);
+    rsState.setConservativeMode(VK_CONSERVATIVE_RASTERIZATION_MODE_DISABLED_EXT);
+    rsState.setSampleCount(0);
+    rsState.setFlatShading(false);
+    rsState.setLineMode(VK_LINE_RASTERIZATION_MODE_DEFAULT_EXT);
+    return rsState;
   }
 
 

--- a/src/d3d11/d3d11_context.cpp
+++ b/src/d3d11/d3d11_context.cpp
@@ -3326,14 +3326,20 @@ namespace dxvk {
 
   template<typename ContextType>
   void D3D11CommonContext<ContextType>::ApplyInputLayout() {
-    auto inputLayout = m_state.ia.inputLayout.prvRef();
+    if (likely(m_state.ia.inputLayout != nullptr)) {
+      uint32_t attributeCount = m_state.ia.inputLayout->GetAttributeCount();
+      uint32_t bindingCount = m_state.ia.inputLayout->GetBindingCount();
 
-    if (likely(inputLayout != nullptr)) {
-      EmitCs([
-        cInputLayout = std::move(inputLayout)
-      ] (DxvkContext* ctx) {
-        cInputLayout->BindToContext(ctx);
+      EmitCsCmd<DxvkVertexInput>(D3D11CmdType::None, attributeCount + bindingCount, [
+        cAttributeCount   = attributeCount,
+        cBindingCount     = bindingCount
+      ] (DxvkContext* ctx, const DxvkVertexInput* layout, size_t) {
+        ctx->setInputLayout(cAttributeCount, &layout[0],
+          cBindingCount, &layout[cAttributeCount]);
       });
+
+      for (uint32_t i = 0; i < attributeCount + bindingCount; i++)
+        new (m_csData->at(i)) DxvkVertexInput(m_state.ia.inputLayout->GetInput(i));
     } else {
       EmitCs([] (DxvkContext* ctx) {
         ctx->setInputLayout(0, nullptr, 0, nullptr);

--- a/src/d3d11/d3d11_context.h
+++ b/src/d3d11/d3d11_context.h
@@ -1154,9 +1154,10 @@ namespace dxvk {
     static DxvkMultisampleState InitDefaultMultisampleState(
             UINT                              SampleMask);
 
+    static DxvkLogicOpState InitDefaultLogicOpState();
+
     static void InitDefaultBlendState(
-            DxvkBlendMode*                    pCbState,
-            DxvkLogicOpState*                 pLoState);
+            DxvkBlendMode*                    pCbState);
 
     template<bool AllowFlush = true, typename Cmd>
     void EmitCs(Cmd&& command) {

--- a/src/d3d11/d3d11_context.h
+++ b/src/d3d11/d3d11_context.h
@@ -75,7 +75,6 @@ namespace dxvk {
     // Use a local staging buffer to handle tiny uploads, most
     // of the time we're fine with hitting the global allocator
     constexpr static VkDeviceSize StagingBufferSize = 256ull << 10;
-
   protected:
     // Compile-time debug flag to force lazy binding on (True) or off (False)
     constexpr static Tristate DebugLazyBinding = Tristate::Auto;
@@ -1143,8 +1142,7 @@ namespace dxvk {
             ID3D11RenderTargetView* const*    ppRenderTargetViews,
             ID3D11DepthStencilView*           pDepthStencilView);
 
-    static void InitDefaultPrimitiveTopology(
-            DxvkInputAssemblyState*           pIaState);
+    static DxvkInputAssemblyState InitDefaultPrimitiveTopology();
 
     static DxvkRasterizerState InitDefaultRasterizerState();
 

--- a/src/d3d11/d3d11_context.h
+++ b/src/d3d11/d3d11_context.h
@@ -1149,8 +1149,7 @@ namespace dxvk {
     static void InitDefaultRasterizerState(
             DxvkRasterizerState*              pRsState);
 
-    static void InitDefaultDepthStencilState(
-            DxvkDepthStencilState*            pDsState);
+    static DxvkDepthStencilState InitDefaultDepthStencilState();
 
     static void InitDefaultBlendState(
             DxvkBlendMode*                    pCbState,

--- a/src/d3d11/d3d11_context.h
+++ b/src/d3d11/d3d11_context.h
@@ -1151,11 +1151,12 @@ namespace dxvk {
 
     static DxvkDepthStencilState InitDefaultDepthStencilState();
 
+    static DxvkMultisampleState InitDefaultMultisampleState(
+            UINT                              SampleMask);
+
     static void InitDefaultBlendState(
             DxvkBlendMode*                    pCbState,
-            DxvkLogicOpState*                 pLoState,
-            DxvkMultisampleState*             pMsState,
-            UINT                              SampleMask);
+            DxvkLogicOpState*                 pLoState);
 
     template<bool AllowFlush = true, typename Cmd>
     void EmitCs(Cmd&& command) {

--- a/src/d3d11/d3d11_context.h
+++ b/src/d3d11/d3d11_context.h
@@ -1156,8 +1156,7 @@ namespace dxvk {
 
     static DxvkLogicOpState InitDefaultLogicOpState();
 
-    static void InitDefaultBlendState(
-            DxvkBlendMode*                    pCbState);
+    static DxvkBlendMode InitDefaultBlendState();
 
     template<bool AllowFlush = true, typename Cmd>
     void EmitCs(Cmd&& command) {

--- a/src/d3d11/d3d11_context.h
+++ b/src/d3d11/d3d11_context.h
@@ -1146,8 +1146,7 @@ namespace dxvk {
     static void InitDefaultPrimitiveTopology(
             DxvkInputAssemblyState*           pIaState);
 
-    static void InitDefaultRasterizerState(
-            DxvkRasterizerState*              pRsState);
+    static DxvkRasterizerState InitDefaultRasterizerState();
 
     static DxvkDepthStencilState InitDefaultDepthStencilState();
 

--- a/src/d3d11/d3d11_depth_stencil.cpp
+++ b/src/d3d11/d3d11_depth_stencil.cpp
@@ -14,6 +14,8 @@ namespace dxvk {
     m_state.setDepthCompareOp(DecodeCompareOp(desc.DepthFunc));
     m_state.setStencilOpFront(DecodeStencilOpState(desc.FrontFace, desc));
     m_state.setStencilOpBack(DecodeStencilOpState(desc.BackFace, desc));
+
+    m_state.normalize();
   }
   
   

--- a/src/d3d11/d3d11_depth_stencil.cpp
+++ b/src/d3d11/d3d11_depth_stencil.cpp
@@ -8,12 +8,12 @@ namespace dxvk {
     const D3D11_DEPTH_STENCIL_DESC& desc)
   : D3D11StateObject<ID3D11DepthStencilState>(device),
     m_desc(desc), m_d3d10(this) {
-    m_state.enableDepthTest   = desc.DepthEnable;
-    m_state.enableDepthWrite  = desc.DepthWriteMask == D3D11_DEPTH_WRITE_MASK_ALL;
-    m_state.enableStencilTest = desc.StencilEnable;
-    m_state.depthCompareOp    = DecodeCompareOp(desc.DepthFunc);
-    m_state.stencilOpFront    = DecodeStencilOpState(desc.FrontFace, desc);
-    m_state.stencilOpBack     = DecodeStencilOpState(desc.BackFace,  desc);
+    m_state.setDepthTest(desc.DepthEnable);
+    m_state.setDepthWrite(desc.DepthWriteMask == D3D11_DEPTH_WRITE_MASK_ALL);
+    m_state.setStencilTest(desc.StencilEnable);
+    m_state.setDepthCompareOp(DecodeCompareOp(desc.DepthFunc));
+    m_state.setStencilOpFront(DecodeStencilOpState(desc.FrontFace, desc));
+    m_state.setStencilOpBack(DecodeStencilOpState(desc.BackFace, desc));
   }
   
   
@@ -52,11 +52,6 @@ namespace dxvk {
   
   void STDMETHODCALLTYPE D3D11DepthStencilState::GetDesc(D3D11_DEPTH_STENCIL_DESC* pDesc) {
     *pDesc = m_desc;
-  }
-  
-  
-  void D3D11DepthStencilState::BindToContext(DxvkContext* ctx) {
-    ctx->setDepthStencilState(m_state);
   }
   
   
@@ -105,25 +100,20 @@ namespace dxvk {
   }
   
   
-  VkStencilOpState D3D11DepthStencilState::DecodeStencilOpState(
+  DxvkStencilOp D3D11DepthStencilState::DecodeStencilOpState(
     const D3D11_DEPTH_STENCILOP_DESC& StencilDesc,
     const D3D11_DEPTH_STENCIL_DESC&   Desc) const {
-    VkStencilOpState result;
-    result.failOp      = VK_STENCIL_OP_KEEP;
-    result.passOp      = VK_STENCIL_OP_KEEP;
-    result.depthFailOp = VK_STENCIL_OP_KEEP;
-    result.compareOp   = VK_COMPARE_OP_ALWAYS;
-    result.compareMask = Desc.StencilReadMask;
-    result.writeMask   = Desc.StencilWriteMask;
-    result.reference   = 0;
-    
+    DxvkStencilOp result = { };
+
     if (Desc.StencilEnable) {
-      result.failOp      = DecodeStencilOp(StencilDesc.StencilFailOp);
-      result.passOp      = DecodeStencilOp(StencilDesc.StencilPassOp);
-      result.depthFailOp = DecodeStencilOp(StencilDesc.StencilDepthFailOp);
-      result.compareOp   = DecodeCompareOp(StencilDesc.StencilFunc);
+      result.setFailOp(DecodeStencilOp(StencilDesc.StencilFailOp));
+      result.setPassOp(DecodeStencilOp(StencilDesc.StencilPassOp));
+      result.setDepthFailOp(DecodeStencilOp(StencilDesc.StencilDepthFailOp));
+      result.setCompareOp(DecodeCompareOp(StencilDesc.StencilFunc));
+      result.setCompareMask(Desc.StencilReadMask);
+      result.setWriteMask(Desc.StencilWriteMask);
     }
-    
+
     return result;
   }
   

--- a/src/d3d11/d3d11_depth_stencil.h
+++ b/src/d3d11/d3d11_depth_stencil.h
@@ -28,9 +28,11 @@ namespace dxvk {
     
     void STDMETHODCALLTYPE GetDesc(
             D3D11_DEPTH_STENCIL_DESC* pDesc) final;
-    
-    void BindToContext(DxvkContext* ctx);
-    
+
+    DxvkDepthStencilState GetState() const {
+      return m_state;
+    }
+
     D3D10DepthStencilState* GetD3D10Iface() {
       return &m_d3d10;
     }
@@ -41,10 +43,10 @@ namespace dxvk {
   private:
     
     D3D11_DEPTH_STENCIL_DESC  m_desc;
-    DxvkDepthStencilState     m_state;
+    DxvkDepthStencilState     m_state = { };
     D3D10DepthStencilState    m_d3d10;
     
-    VkStencilOpState DecodeStencilOpState(
+    DxvkStencilOp DecodeStencilOpState(
       const D3D11_DEPTH_STENCILOP_DESC& StencilDesc,
       const D3D11_DEPTH_STENCIL_DESC&   Desc) const;
     

--- a/src/d3d11/d3d11_input_layout.cpp
+++ b/src/d3d11/d3d11_input_layout.cpp
@@ -10,23 +10,22 @@ namespace dxvk {
           uint32_t              numBindings,
     const DxvkVertexBinding*    pBindings)
   : D3D11DeviceChild<ID3D11InputLayout>(pDevice),
-    m_d3d10(this) {
-    m_attributes.resize(numAttributes);
-    m_bindings.resize(numBindings);
-    
+    m_attributeCount  (numAttributes),
+    m_bindingCount    (numBindings),
+    m_d3d10           (this) {
     for (uint32_t i = 0; i < numAttributes; i++)
-      m_attributes.at(i) = pAttributes[i];
-    
+      m_input.inputs[i] = DxvkVertexInput(pAttributes[i]);
+
     for (uint32_t i = 0; i < numBindings; i++)
-      m_bindings.at(i) = pBindings[i];
+      m_input.inputs[i + numAttributes] = DxvkVertexInput(pBindings[i]);
   }
-  
-  
+
+
   D3D11InputLayout::~D3D11InputLayout() {
-    
+
   }
-  
-  
+
+
   HRESULT STDMETHODCALLTYPE D3D11InputLayout::QueryInterface(REFIID riid, void** ppvObject) {
     if (ppvObject == nullptr)
       return E_POINTER;
@@ -55,33 +54,11 @@ namespace dxvk {
   }
   
   
-  void D3D11InputLayout::BindToContext(DxvkContext* ctx) {
-    ctx->setInputLayout(
-      m_attributes.size(),
-      m_attributes.data(),
-      m_bindings.size(),
-      m_bindings.data());
-  }
-  
-  
   bool D3D11InputLayout::Compare(const D3D11InputLayout* pOther) const {
-    bool eq = m_attributes.size() == pOther->m_attributes.size()
-           && m_bindings.size()   == pOther->m_bindings.size();
-    
-    for (uint32_t i = 0; eq && i < m_attributes.size(); i++) {
-      eq &= m_attributes[i].location == pOther->m_attributes[i].location
-         && m_attributes[i].binding  == pOther->m_attributes[i].binding
-         && m_attributes[i].format   == pOther->m_attributes[i].format
-         && m_attributes[i].offset   == pOther->m_attributes[i].offset;
-    }
-    
-    for (uint32_t i = 0; eq && i < m_bindings.size(); i++) {
-      eq &= m_bindings[i].binding    == pOther->m_bindings[i].binding
-         && m_bindings[i].fetchRate  == pOther->m_bindings[i].fetchRate
-         && m_bindings[i].inputRate  == pOther->m_bindings[i].inputRate;
-    }
-    
-    return eq;
+    if (m_attributeCount != pOther->m_attributeCount || m_bindingCount != pOther->m_bindingCount)
+      return false;
+
+    return bit::bcmpeq(&m_input, &pOther->m_input);
   }
   
 }

--- a/src/d3d11/d3d11_input_layout.h
+++ b/src/d3d11/d3d11_input_layout.h
@@ -7,7 +7,12 @@
 namespace dxvk {
   
   class D3D11Device;
-  
+
+  struct alignas(16) D3D11VertexInput {
+    std::array<DxvkVertexInput, MaxNumVertexAttributes + MaxNumVertexBindings> inputs;
+  };
+
+
   class D3D11InputLayout : public D3D11DeviceChild<ID3D11InputLayout> {
     
   public:
@@ -24,9 +29,19 @@ namespace dxvk {
     HRESULT STDMETHODCALLTYPE QueryInterface(
             REFIID                riid,
             void**                ppvObject) final;
-    
-    void BindToContext(DxvkContext* ctx);
-    
+
+    uint32_t GetAttributeCount() const {
+      return m_attributeCount;
+    }
+
+    uint32_t GetBindingCount() const {
+      return m_bindingCount;
+    }
+
+    DxvkVertexInput GetInput(uint32_t Index) const {
+      return m_input.inputs[Index];
+    }
+
     bool Compare(
       const D3D11InputLayout*     pOther) const;
     
@@ -35,9 +50,11 @@ namespace dxvk {
     }
     
   private:
-    
-    std::vector<DxvkVertexAttribute> m_attributes;
-    std::vector<DxvkVertexBinding>   m_bindings;
+
+    D3D11VertexInput m_input = { };
+
+    uint32_t m_attributeCount = 0;
+    uint32_t m_bindingCount = 0;
 
     D3D10InputLayout m_d3d10;
     

--- a/src/d3d11/d3d11_rasterizer.h
+++ b/src/d3d11/d3d11_rasterizer.h
@@ -38,7 +38,13 @@ namespace dxvk {
       return &m_desc;
     }
     
-    void BindToContext(DxvkContext* ctx);
+    DxvkRasterizerState GetState() const {
+      return m_state;
+    }
+
+    DxvkDepthBias GetDepthBias() const {
+      return m_depthBias;
+    }
     
     D3D10RasterizerState* GetD3D10Iface() {
       return &m_d3d10;
@@ -56,8 +62,8 @@ namespace dxvk {
   private:
     
     D3D11_RASTERIZER_DESC2 m_desc;
-    DxvkRasterizerState    m_state;
-    DxvkDepthBias          m_depthBias;
+    DxvkRasterizerState    m_state      = { };
+    DxvkDepthBias          m_depthBias  = { };
     D3D10RasterizerState   m_d3d10;
     
   };

--- a/src/d3d11/d3d11_video.cpp
+++ b/src/d3d11/d3d11_video.cpp
@@ -1196,10 +1196,7 @@ namespace dxvk {
 
       ctx->bindRenderTargets(std::move(rt), 0u);
 
-      DxvkInputAssemblyState iaState;
-      iaState.primitiveTopology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
-      iaState.primitiveRestart = VK_FALSE;
-      iaState.patchVertexCount = 0;
+      DxvkInputAssemblyState iaState(VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST, false);
       ctx->setInputAssemblyState(iaState);
     });
 

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -6806,11 +6806,11 @@ namespace dxvk {
   void D3D9DeviceEx::BindMultiSampleState() {
     m_flags.clr(D3D9DeviceFlag::DirtyMultiSampleState);
 
-    DxvkMultisampleState msState;
-    msState.sampleMask = m_flags.test(D3D9DeviceFlag::ValidSampleMask)
-      ? m_state.renderStates[D3DRS_MULTISAMPLEMASK]
-      : 0xffffffff;
-    msState.enableAlphaToCoverage = IsAlphaToCoverageEnabled();
+    DxvkMultisampleState msState = { };
+    msState.setSampleMask(m_flags.test(D3D9DeviceFlag::ValidSampleMask)
+      ? uint16_t(m_state.renderStates[D3DRS_MULTISAMPLEMASK])
+      : uint16_t(0xffffu));
+    msState.setAlphaToCoverage(IsAlphaToCoverageEnabled());
 
     EmitCs([
       cState = msState

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -6882,6 +6882,8 @@ namespace dxvk {
                           NormalizeFactor(mode.alphaDstFactor()), mode.alphaBlendOp());
         }
 
+        mode.normalize();
+
         ctx->setBlendMode(i, mode);
       }
     });

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -6919,35 +6919,36 @@ namespace dxvk {
     bool stencil            = rs[D3DRS_STENCILENABLE];
     bool twoSidedStencil    = stencil && rs[D3DRS_TWOSIDEDSTENCILMODE];
 
-    DxvkDepthStencilState state;
-    state.enableDepthTest   = rs[D3DRS_ZENABLE]       != FALSE;
-    state.enableDepthWrite  = rs[D3DRS_ZWRITEENABLE]  != FALSE;
-    state.enableStencilTest = stencil;
-    state.depthCompareOp    = DecodeCompareOp(D3DCMPFUNC(rs[D3DRS_ZFUNC]));
+    DxvkDepthStencilState state = { };
+    state.setDepthTest(rs[D3DRS_ZENABLE]);
+    state.setDepthWrite(rs[D3DRS_ZWRITEENABLE]);
+    state.setStencilTest(stencil);
+    state.setDepthCompareOp(DecodeCompareOp(D3DCMPFUNC(rs[D3DRS_ZFUNC])));
+
+    DxvkStencilOp frontOp = { };
 
     if (stencil) {
-      state.stencilOpFront.failOp      = DecodeStencilOp(D3DSTENCILOP(rs[D3DRS_STENCILFAIL]));
-      state.stencilOpFront.passOp      = DecodeStencilOp(D3DSTENCILOP(rs[D3DRS_STENCILPASS]));
-      state.stencilOpFront.depthFailOp = DecodeStencilOp(D3DSTENCILOP(rs[D3DRS_STENCILZFAIL]));
-      state.stencilOpFront.compareOp   = DecodeCompareOp(D3DCMPFUNC  (rs[D3DRS_STENCILFUNC]));
-      state.stencilOpFront.compareMask = uint32_t(rs[D3DRS_STENCILMASK]);
-      state.stencilOpFront.writeMask   = uint32_t(rs[D3DRS_STENCILWRITEMASK]);
-      state.stencilOpFront.reference   = 0;
+      frontOp.setFailOp(DecodeStencilOp(D3DSTENCILOP(rs[D3DRS_STENCILFAIL])));
+      frontOp.setPassOp(DecodeStencilOp(D3DSTENCILOP(rs[D3DRS_STENCILPASS])));
+      frontOp.setDepthFailOp(DecodeStencilOp(D3DSTENCILOP(rs[D3DRS_STENCILZFAIL])));
+      frontOp.setCompareOp(DecodeCompareOp(D3DCMPFUNC(rs[D3DRS_STENCILFUNC])));
+      frontOp.setCompareMask(rs[D3DRS_STENCILMASK]);
+      frontOp.setWriteMask(rs[D3DRS_STENCILWRITEMASK]);
     }
-    else
-      state.stencilOpFront = VkStencilOpState();
+
+    DxvkStencilOp backOp = frontOp;
 
     if (twoSidedStencil) {
-      state.stencilOpBack.failOp      = DecodeStencilOp(D3DSTENCILOP(rs[D3DRS_CCW_STENCILFAIL]));
-      state.stencilOpBack.passOp      = DecodeStencilOp(D3DSTENCILOP(rs[D3DRS_CCW_STENCILPASS]));
-      state.stencilOpBack.depthFailOp = DecodeStencilOp(D3DSTENCILOP(rs[D3DRS_CCW_STENCILZFAIL]));
-      state.stencilOpBack.compareOp   = DecodeCompareOp(D3DCMPFUNC  (rs[D3DRS_CCW_STENCILFUNC]));
-      state.stencilOpBack.compareMask = state.stencilOpFront.compareMask;
-      state.stencilOpBack.writeMask   = state.stencilOpFront.writeMask;
-      state.stencilOpBack.reference   = 0;
+      backOp.setFailOp(DecodeStencilOp(D3DSTENCILOP(rs[D3DRS_CCW_STENCILFAIL])));
+      backOp.setPassOp(DecodeStencilOp(D3DSTENCILOP(rs[D3DRS_CCW_STENCILPASS])));
+      backOp.setDepthFailOp(DecodeStencilOp(D3DSTENCILOP(rs[D3DRS_CCW_STENCILZFAIL])));
+      backOp.setCompareOp(DecodeCompareOp(D3DCMPFUNC(rs[D3DRS_CCW_STENCILFUNC])));
+      backOp.setCompareMask(rs[D3DRS_STENCILMASK]);
+      backOp.setWriteMask(rs[D3DRS_STENCILWRITEMASK]);
     }
-    else
-      state.stencilOpBack = state.stencilOpFront;
+
+    state.setStencilOpFront(frontOp);
+    state.setStencilOpBack(backOp);
 
     EmitCs([
       cState = state

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -6952,7 +6952,9 @@ namespace dxvk {
 
     EmitCs([
       cState = state
-    ](DxvkContext* ctx) {
+    ] (DxvkContext* ctx) mutable {
+      cState.normalize();
+
       ctx->setDepthStencilState(cState);
     });
   }

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -6823,71 +6823,64 @@ namespace dxvk {
 
     auto& state = m_state.renderStates;
 
-    bool separateAlpha = state[D3DRS_SEPARATEALPHABLENDENABLE];
+    DxvkBlendMode mode = { };
+    mode.setBlendEnable(state[D3DRS_ALPHABLENDENABLE]);
 
-    DxvkBlendMode mode;
-    mode.enableBlending = state[D3DRS_ALPHABLENDENABLE] != FALSE;
-
-    D3D9BlendState color, alpha;
+    D3D9BlendState color = { };
 
     color.Src = D3DBLEND(state[D3DRS_SRCBLEND]);
     color.Dst = D3DBLEND(state[D3DRS_DESTBLEND]);
     color.Op  = D3DBLENDOP(state[D3DRS_BLENDOP]);
     FixupBlendState(color);
 
-    if (separateAlpha) {
+    D3D9BlendState alpha = color;
+
+    if (state[D3DRS_SEPARATEALPHABLENDENABLE]) {
       alpha.Src = D3DBLEND(state[D3DRS_SRCBLENDALPHA]);
       alpha.Dst = D3DBLEND(state[D3DRS_DESTBLENDALPHA]);
       alpha.Op  = D3DBLENDOP(state[D3DRS_BLENDOPALPHA]);
       FixupBlendState(alpha);
     }
-    else
-      alpha = color;
 
-    mode.colorSrcFactor = DecodeBlendFactor(color.Src, false);
-    mode.colorDstFactor = DecodeBlendFactor(color.Dst, false);
-    mode.colorBlendOp   = DecodeBlendOp    (color.Op);
+    mode.setColorOp(DecodeBlendFactor(color.Src, false),
+                    DecodeBlendFactor(color.Dst, false),
+                    DecodeBlendOp(color.Op));
 
-    mode.alphaSrcFactor = DecodeBlendFactor(alpha.Src, true);
-    mode.alphaDstFactor = DecodeBlendFactor(alpha.Dst, true);
-    mode.alphaBlendOp   = DecodeBlendOp    (alpha.Op);
+    mode.setAlphaOp(DecodeBlendFactor(alpha.Src, true),
+                    DecodeBlendFactor(alpha.Dst, true),
+                    DecodeBlendOp(alpha.Op));
 
-    mode.writeMask = state[ColorWriteIndex(0)];
+    uint16_t writeMasks = 0;
 
-    std::array<VkColorComponentFlags, 3> extraWriteMasks;
-    for (uint32_t i = 0; i < 3; i++)
-      extraWriteMasks[i] = state[ColorWriteIndex(i + 1)];
+    for (uint32_t i = 0; i < 4; i++)
+      writeMasks |= (state[ColorWriteIndex(i)] & 0xfu) << (4u * i);
 
     EmitCs([
       cMode       = mode,
-      cWriteMasks = extraWriteMasks,
+      cWriteMasks = writeMasks,
       cAlphaMasks = m_alphaSwizzleRTs
     ](DxvkContext* ctx) {
       for (uint32_t i = 0; i < 4; i++) {
         DxvkBlendMode mode = cMode;
-        if (i != 0)
-          mode.writeMask = cWriteMasks[i - 1];
+        mode.setWriteMask(cWriteMasks >> (4u * i));
 
         // Adjust the blend factor based on the render target alpha swizzle bit mask.
         // Specific formats such as the XRGB ones require a ONE swizzle for alpha
         // which cannot be directly applied with the image view of the attachment.
-        const bool alphaSwizzle = cAlphaMasks & (1 << i);
-
-        auto NormalizeFactor = [alphaSwizzle](VkBlendFactor Factor) {
-          if (alphaSwizzle) {
+        if (cAlphaMasks & (1 << i)) {
+          auto NormalizeFactor = [] (VkBlendFactor Factor) {
             if (Factor == VK_BLEND_FACTOR_DST_ALPHA)
               return VK_BLEND_FACTOR_ONE;
             else if (Factor == VK_BLEND_FACTOR_ONE_MINUS_DST_ALPHA)
               return VK_BLEND_FACTOR_ZERO;
-          }
+            return Factor;
+          };
 
-          return Factor;
-        };
-
-        mode.colorSrcFactor = NormalizeFactor(mode.colorSrcFactor);
-        mode.colorDstFactor = NormalizeFactor(mode.colorDstFactor);
-        mode.alphaSrcFactor = NormalizeFactor(mode.alphaSrcFactor);
-        mode.alphaDstFactor = NormalizeFactor(mode.alphaDstFactor);
+          mode.setColorOp(NormalizeFactor(mode.colorSrcFactor()),
+                          NormalizeFactor(mode.colorDstFactor()), mode.colorBlendOp());
+          mode.setAlphaOp(NormalizeFactor(mode.alphaSrcFactor()),
+                          NormalizeFactor(mode.alphaDstFactor()), mode.alphaBlendOp());
+        }
 
         ctx->setBlendMode(i, mode);
       }

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -82,9 +82,7 @@ namespace dxvk {
       ctx->beginRecording(cDevice->createCommandList());
 
       // Disable logic op once and for all.
-      DxvkLogicOpState loState;
-      loState.enableLogicOp = VK_FALSE;
-      loState.logicOp       = VK_LOGIC_OP_CLEAR;
+      DxvkLogicOpState loState = { };
       ctx->setLogicOpState(loState);
     });
 

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -6959,12 +6959,12 @@ namespace dxvk {
     auto& rs = m_state.renderStates;
 
     DxvkRasterizerState state = { };
-    state.cullMode        = DecodeCullMode(D3DCULL(rs[D3DRS_CULLMODE]));
-    state.depthBiasEnable = IsDepthBiasEnabled();
-    state.depthClipEnable = true;
-    state.frontFace       = VK_FRONT_FACE_CLOCKWISE;
-    state.polygonMode     = DecodeFillMode(D3DFILLMODE(rs[D3DRS_FILLMODE]));
-    state.flatShading     = m_state.renderStates[D3DRS_SHADEMODE] == D3DSHADE_FLAT;
+    state.setCullMode(DecodeCullMode(D3DCULL(rs[D3DRS_CULLMODE])));
+    state.setDepthBias(IsDepthBiasEnabled());
+    state.setDepthClip(true);
+    state.setFrontFace(VK_FRONT_FACE_CLOCKWISE);
+    state.setPolygonMode(DecodeFillMode(D3DFILLMODE(rs[D3DRS_FILLMODE])));
+    state.setFlatShading(m_state.renderStates[D3DRS_SHADEMODE] == D3DSHADE_FLAT);
 
     EmitCs([
       cState  = state

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -7521,8 +7521,9 @@ namespace dxvk {
 
         const auto& elements = cVertexDecl->GetElements();
 
-        std::array<DxvkVertexAttribute, 2 * caps::InputRegisterCount> attrList;
-        std::array<DxvkVertexBinding,   2 * caps::InputRegisterCount> bindList;
+        std::array<DxvkVertexInput, 2 * caps::InputRegisterCount> attrList = { };
+        std::array<DxvkVertexInput, 2 * caps::InputRegisterCount> bindList = { };
+        std::array<uint32_t, 2 * caps::InputRegisterCount> vertexSizes = { };
 
         uint32_t attrMask = 0;
         uint32_t bindMask = 0;
@@ -7534,7 +7535,7 @@ namespace dxvk {
         for (uint32_t i = 0; i < isgn.elemCount; i++) {
           const auto& decl = isgn.elems[i];
 
-          DxvkVertexAttribute attrib;
+          DxvkVertexAttribute attrib = { };
           attrib.location = i;
           attrib.binding  = NullStreamIdx;
           attrib.format   = VK_FORMAT_R32G32B32A32_SFLOAT;
@@ -7555,28 +7556,26 @@ namespace dxvk {
             }
           }
 
-          attrList[i] = attrib;
+          attrList[i] = DxvkVertexInput(attrib);
 
-          DxvkVertexBinding binding;
+          vertexSizes[attrib.binding] = std::max(vertexSizes[attrib.binding],
+            uint32_t(attrib.offset + lookupFormatInfo(attrib.format)->elementSize));
+
+          DxvkVertexBinding binding = { };
           binding.binding = attrib.binding;
-          binding.extent = attrib.offset + lookupFormatInfo(attrib.format)->elementSize;
+          binding.extent = vertexSizes[attrib.binding];
 
           uint32_t instanceData = cStreamFreq[binding.binding % caps::MaxStreams];
           if (instanceData & D3DSTREAMSOURCE_INSTANCEDATA) {
-            binding.fetchRate = instanceData & 0x7FFFFF; // Remove instance packed-in flags in the data.
+            binding.divisor = instanceData & 0x7FFFFF; // Remove instance packed-in flags in the data.
             binding.inputRate = VK_VERTEX_INPUT_RATE_INSTANCE;
           }
           else {
-            binding.fetchRate = 0;
+            binding.divisor = 0u;
             binding.inputRate = VK_VERTEX_INPUT_RATE_VERTEX;
           }
 
-          if (bindMask & (1u << binding.binding)) {
-            bindList.at(binding.binding).extent = std::max(
-              bindList.at(binding.binding).extent, binding.extent);
-          } else {
-            bindList.at(binding.binding) = binding;
-          }
+          bindList[binding.binding] = DxvkVertexInput(binding);
 
           attrMask |= 1u << i;
           bindMask |= 1u << binding.binding;

--- a/src/d3d9/d3d9_util.cpp
+++ b/src/d3d9/d3d9_util.cpp
@@ -142,22 +142,22 @@ namespace dxvk {
     switch (type) {
       default:
       case D3DPT_TRIANGLELIST:
-        return { VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST,  VK_FALSE, 0 };
+        return DxvkInputAssemblyState(VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST, false);
 
       case D3DPT_POINTLIST:
-        return { VK_PRIMITIVE_TOPOLOGY_POINT_LIST,     VK_FALSE, 0 };
+        return DxvkInputAssemblyState(VK_PRIMITIVE_TOPOLOGY_POINT_LIST, false);
 
       case D3DPT_LINELIST:
-        return { VK_PRIMITIVE_TOPOLOGY_LINE_LIST,      VK_FALSE, 0 };
+        return DxvkInputAssemblyState(VK_PRIMITIVE_TOPOLOGY_LINE_LIST, false);
 
       case D3DPT_LINESTRIP:
-        return { VK_PRIMITIVE_TOPOLOGY_LINE_STRIP,     VK_FALSE, 0 };
+        return DxvkInputAssemblyState(VK_PRIMITIVE_TOPOLOGY_LINE_STRIP, false);
 
       case D3DPT_TRIANGLESTRIP:
-        return { VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP, VK_FALSE, 0 };
+        return DxvkInputAssemblyState(VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP, false);
 
       case D3DPT_TRIANGLEFAN:
-        return { VK_PRIMITIVE_TOPOLOGY_TRIANGLE_FAN,   VK_FALSE, 0 };
+        return DxvkInputAssemblyState(VK_PRIMITIVE_TOPOLOGY_TRIANGLE_FAN, false);
     }
   }
 

--- a/src/dxvk/dxvk_constant_state.cpp
+++ b/src/dxvk/dxvk_constant_state.cpp
@@ -1,0 +1,68 @@
+#include "dxvk_constant_state.h"
+
+namespace dxvk {
+
+  bool DxvkStencilOp::normalize(VkCompareOp depthOp) {
+    if (writeMask()) {
+      // If the depth test always passes, this is irrelevant
+      if (depthOp == VK_COMPARE_OP_ALWAYS)
+        setDepthFailOp(VK_STENCIL_OP_KEEP);
+
+      // Also mask out unused ops if the stencil test
+      // always pases or always fails
+      if (compareOp() == VK_COMPARE_OP_ALWAYS)
+        setFailOp(VK_STENCIL_OP_KEEP);
+      else if (compareOp() == VK_COMPARE_OP_NEVER)
+        setPassOp(VK_STENCIL_OP_KEEP);
+
+      // If all stencil ops are no-ops, clear write mask
+      if (passOp() == VK_STENCIL_OP_KEEP
+       && failOp() == VK_STENCIL_OP_KEEP
+       && depthFailOp() == VK_STENCIL_OP_KEEP)
+        setWriteMask(0u);
+    } else {
+      // Normalize stencil ops if write mask is 0
+      setPassOp(VK_STENCIL_OP_KEEP);
+      setFailOp(VK_STENCIL_OP_KEEP);
+      setDepthFailOp(VK_STENCIL_OP_KEEP);
+    }
+
+    // Check if the stencil test for this face is a no-op
+    return writeMask() || compareOp() != VK_COMPARE_OP_ALWAYS;
+  }
+
+
+  void DxvkDepthStencilState::normalize() {
+    if (depthTest()) {
+      // If depth func is equal or if the depth test always fails, depth
+      // writes will not have any observable effect so we can skip them.
+      if (depthCompareOp() == VK_COMPARE_OP_EQUAL
+       || depthCompareOp() == VK_COMPARE_OP_NEVER)
+        setDepthWrite(false);
+
+      // If the depth test always passes and no writes are performed, the
+      // depth test as a whole is a no-op and can safely be disabled.
+      if (depthCompareOp() == VK_COMPARE_OP_ALWAYS && !depthWrite())
+        setDepthTest(false);
+    } else {
+      setDepthWrite(false);
+      setDepthCompareOp(VK_COMPARE_OP_ALWAYS);
+    }
+
+    if (stencilTest()) {
+      // Normalize stencil op and disable stencil testing if both are no-ops.
+      bool frontIsNoOp = !m_stencilOpFront.normalize(depthCompareOp());
+      bool backIsNoOp = !m_stencilOpBack.normalize(depthCompareOp());
+
+      if (frontIsNoOp && backIsNoOp)
+        setStencilTest(false);
+    }
+
+    // Normalize stencil ops if stencil test is disabled
+    if (!stencilTest()) {
+      setStencilOpFront(DxvkStencilOp());
+      setStencilOpBack(DxvkStencilOp());
+    }
+  }
+
+}

--- a/src/dxvk/dxvk_constant_state.h
+++ b/src/dxvk/dxvk_constant_state.h
@@ -136,9 +136,32 @@ namespace dxvk {
    * Defines how to handle certain
    * aspects of multisampling.
    */
-  struct DxvkMultisampleState {
-    uint32_t            sampleMask;
-    VkBool32            enableAlphaToCoverage;
+  class DxvkMultisampleState {
+
+  public:
+
+    uint16_t sampleMask() const {
+      return m_sampleMask;
+    }
+
+    bool alphaToCoverage() const {
+      return m_enableAlphaToCoverage;
+    }
+
+    void setSampleMask(uint16_t mask) {
+      m_sampleMask = mask;
+    }
+
+    void setAlphaToCoverage(bool alphaToCoverage) {
+      m_enableAlphaToCoverage = alphaToCoverage;
+    }
+
+  private:
+
+    uint16_t m_sampleMask;
+    uint16_t m_enableAlphaToCoverage : 1;
+    uint16_t m_reserved              : 15;
+
   };
   
 

--- a/src/dxvk/dxvk_constant_state.h
+++ b/src/dxvk/dxvk_constant_state.h
@@ -197,6 +197,8 @@ namespace dxvk {
       m_writeMask = mask;
     }
 
+    bool normalize(VkCompareOp depthOp);
+
   private:
 
     uint16_t m_failOp            : 3;
@@ -267,6 +269,8 @@ namespace dxvk {
     void setStencilOpBack(DxvkStencilOp op) {
       m_stencilOpBack = op;
     }
+
+    void normalize();
 
   private:
 

--- a/src/dxvk/dxvk_constant_state.h
+++ b/src/dxvk/dxvk_constant_state.h
@@ -105,12 +105,53 @@ namespace dxvk {
    * is enabled.
    */
   struct DxvkInputAssemblyState {
-    VkPrimitiveTopology primitiveTopology;
-    VkBool32            primitiveRestart;
-    uint32_t            patchVertexCount;
+
+  public:
+
+    DxvkInputAssemblyState() = default;
+
+    DxvkInputAssemblyState(VkPrimitiveTopology topology, bool restart)
+    : m_primitiveTopology (uint16_t(topology)),
+      m_primitiveRestart  (uint16_t(restart)),
+      m_patchVertexCount  (0u),
+      m_reserved          (0u) { }
+
+    VkPrimitiveTopology primitiveTopology() const {
+      return VkPrimitiveTopology(m_primitiveTopology) <= VK_PRIMITIVE_TOPOLOGY_PATCH_LIST
+        ? VkPrimitiveTopology(m_primitiveTopology)
+        : VK_PRIMITIVE_TOPOLOGY_MAX_ENUM;
+    }
+
+    bool primitiveRestart() const {
+      return m_primitiveRestart;
+    }
+
+    uint32_t patchVertexCount() const {
+      return m_patchVertexCount;
+    }
+
+    void setPrimitiveTopology(VkPrimitiveTopology topology) {
+      m_primitiveTopology = uint16_t(topology);
+    }
+
+    void setPrimitiveRestart(bool enable) {
+      m_primitiveRestart = enable;
+    }
+
+    void setPatchVertexCount(uint32_t count) {
+      m_patchVertexCount = count;
+    }
+
+  private:
+
+    uint16_t m_primitiveTopology  : 4;
+    uint16_t m_primitiveRestart   : 1;
+    uint16_t m_patchVertexCount   : 6;
+    uint16_t m_reserved           : 5;
+
   };
-  
-  
+
+
   /**
    * \brief Rasterizer state
    * 

--- a/src/dxvk/dxvk_constant_state.h
+++ b/src/dxvk/dxvk_constant_state.h
@@ -312,9 +312,29 @@ namespace dxvk {
    * \brief Logic op state
    * Defines a logic op.
    */
-  struct DxvkLogicOpState {
-    VkBool32  enableLogicOp;
-    VkLogicOp logicOp;
+  class DxvkLogicOpState {
+
+  public:
+
+    bool logicOpEnable() const {
+      return m_logicOpEnable;
+    }
+
+    VkLogicOp logicOp() const {
+      return VkLogicOp(m_logicOp);
+    }
+
+    void setLogicOp(bool enable, VkLogicOp op) {
+      m_logicOpEnable = enable;
+      m_logicOp = uint8_t(op);
+    }
+
+  private:
+
+    uint8_t m_logicOpEnable : 1;
+    uint8_t m_logicOp       : 4;
+    uint8_t m_reserved      : 3;
+
   };
   
   

--- a/src/dxvk/dxvk_constant_state.h
+++ b/src/dxvk/dxvk_constant_state.h
@@ -344,15 +344,74 @@ namespace dxvk {
    * Stores the blend state for a single color attachment.
    * Blend modes can be set separately for each attachment.
    */
-  struct DxvkBlendMode {
-    VkBool32              enableBlending;
-    VkBlendFactor         colorSrcFactor;
-    VkBlendFactor         colorDstFactor;
-    VkBlendOp             colorBlendOp;
-    VkBlendFactor         alphaSrcFactor;
-    VkBlendFactor         alphaDstFactor;
-    VkBlendOp             alphaBlendOp;
-    VkColorComponentFlags writeMask;
+  class DxvkBlendMode {
+
+  public:
+
+    bool blendEnable() const {
+      return m_enableBlending;
+    }
+
+    VkBlendFactor colorSrcFactor() const {
+      return VkBlendFactor(m_colorSrcFactor);
+    }
+
+    VkBlendFactor colorDstFactor() const {
+      return VkBlendFactor(m_colorDstFactor);
+    }
+
+    VkBlendOp colorBlendOp() const {
+      return VkBlendOp(m_colorBlendOp);
+    }
+
+    VkBlendFactor alphaSrcFactor() const {
+      return VkBlendFactor(m_alphaSrcFactor);
+    }
+
+    VkBlendFactor alphaDstFactor() const {
+      return VkBlendFactor(m_alphaDstFactor);
+    }
+
+    VkBlendOp alphaBlendOp() const {
+      return VkBlendOp(m_alphaBlendOp);
+    }
+
+    VkColorComponentFlags writeMask() const {
+      return VkColorComponentFlags(m_writeMask);
+    }
+
+    void setBlendEnable(bool enable) {
+      m_enableBlending = enable;
+    }
+
+    void setColorOp(VkBlendFactor srcFactor, VkBlendFactor dstFactor, VkBlendOp op) {
+      m_colorSrcFactor = uint32_t(srcFactor);
+      m_colorDstFactor = uint32_t(dstFactor);
+      m_colorBlendOp = uint32_t(op);
+    }
+
+    void setAlphaOp(VkBlendFactor srcFactor, VkBlendFactor dstFactor, VkBlendOp op) {
+      m_alphaSrcFactor = uint32_t(srcFactor);
+      m_alphaDstFactor = uint32_t(dstFactor);
+      m_alphaBlendOp = uint32_t(op);
+    }
+
+    void setWriteMask(VkColorComponentFlags writeMask) {
+      m_writeMask = writeMask;
+    }
+
+  private:
+
+    uint32_t m_enableBlending : 1;
+    uint32_t m_colorSrcFactor : 5;
+    uint32_t m_colorDstFactor : 5;
+    uint32_t m_colorBlendOp   : 3;
+    uint32_t m_alphaSrcFactor : 5;
+    uint32_t m_alphaDstFactor : 5;
+    uint32_t m_alphaBlendOp   : 3;
+    uint32_t m_writeMask      : 4;
+    uint32_t m_reserved       : 1;
+
   };
   
   

--- a/src/dxvk/dxvk_constant_state.h
+++ b/src/dxvk/dxvk_constant_state.h
@@ -400,6 +400,8 @@ namespace dxvk {
       m_writeMask = writeMask;
     }
 
+    void normalize();
+
   private:
 
     uint32_t m_enableBlending : 1;

--- a/src/dxvk/dxvk_constant_state.h
+++ b/src/dxvk/dxvk_constant_state.h
@@ -141,20 +141,143 @@ namespace dxvk {
     VkBool32            enableAlphaToCoverage;
   };
   
-  
+
+  /**
+   * \brief Stencil operation
+   */
+  class DxvkStencilOp {
+
+  public:
+
+    VkStencilOp failOp() const {
+      return VkStencilOp(m_failOp);
+    }
+
+    VkStencilOp passOp() const {
+      return VkStencilOp(m_passOp);
+    }
+
+    VkStencilOp depthFailOp() const {
+      return VkStencilOp(m_depthFailOp);
+    }
+
+    VkCompareOp compareOp() const {
+      return VkCompareOp(m_compareOp);
+    }
+
+    uint8_t compareMask() const {
+      return m_compareMask;
+    }
+
+    uint8_t writeMask() const {
+      return m_writeMask;
+    }
+
+    void setFailOp(VkStencilOp op) {
+      m_failOp = uint16_t(op);
+    }
+
+    void setPassOp(VkStencilOp op) {
+      m_passOp = uint16_t(op);
+    }
+
+    void setDepthFailOp(VkStencilOp op) {
+      m_depthFailOp = uint16_t(op);
+    }
+
+    void setCompareOp(VkCompareOp op) {
+      m_compareOp = uint16_t(op);
+    }
+
+    void setCompareMask(uint8_t mask) {
+      m_compareMask = mask;
+    }
+
+    void setWriteMask(uint8_t mask) {
+      m_writeMask = mask;
+    }
+
+  private:
+
+    uint16_t m_failOp            : 3;
+    uint16_t m_passOp            : 3;
+    uint16_t m_depthFailOp       : 3;
+    uint16_t m_compareOp         : 3;
+    uint16_t m_reserved          : 4;
+    uint8_t  m_compareMask;
+    uint8_t  m_writeMask;
+
+  };
+
+
   /**
    * \brief Depth-stencil state
    * 
    * Defines the depth test and stencil
    * operations for the graphics pipeline.
    */
-  struct DxvkDepthStencilState {
-    VkBool32            enableDepthTest;
-    VkBool32            enableDepthWrite;
-    VkBool32            enableStencilTest;
-    VkCompareOp         depthCompareOp;
-    VkStencilOpState    stencilOpFront;
-    VkStencilOpState    stencilOpBack;
+  class DxvkDepthStencilState {
+
+  public:
+
+    bool depthTest() const {
+      return m_enableDepthTest;
+    }
+
+    bool depthWrite() const {
+      return m_enableDepthWrite;
+    }
+
+    bool stencilTest() const {
+      return m_enableStencilTest;
+    }
+
+    VkCompareOp depthCompareOp() const {
+      return VkCompareOp(m_depthCompareOp);
+    }
+
+    DxvkStencilOp stencilOpFront() const {
+      return m_stencilOpFront;
+    }
+
+    DxvkStencilOp stencilOpBack() const {
+      return m_stencilOpBack;
+    }
+
+    void setDepthTest(bool depthTest) {
+      m_enableDepthTest = depthTest;
+    }
+
+    void setDepthWrite(bool depthWrite) {
+      m_enableDepthWrite = depthWrite;
+    }
+
+    void setStencilTest(bool stencilTest) {
+      m_enableStencilTest = stencilTest;
+    }
+
+    void setDepthCompareOp(VkCompareOp compareOp) {
+      m_depthCompareOp = uint16_t(compareOp);
+    }
+
+    void setStencilOpFront(DxvkStencilOp op) {
+      m_stencilOpFront = op;
+    }
+
+    void setStencilOpBack(DxvkStencilOp op) {
+      m_stencilOpBack = op;
+    }
+
+  private:
+
+    uint16_t m_enableDepthTest   : 1;
+    uint16_t m_enableDepthWrite  : 1;
+    uint16_t m_enableStencilTest : 1;
+    uint16_t m_depthCompareOp    : 3;
+    uint16_t m_reserved          : 10;
+    DxvkStencilOp m_stencilOpFront;
+    DxvkStencilOp m_stencilOpBack;
+
   };
   
   
@@ -227,5 +350,5 @@ namespace dxvk {
     std::array<DxvkVertexAttribute, DxvkLimits::MaxNumVertexAttributes> attributes;
     std::array<DxvkVertexBinding,   DxvkLimits::MaxNumVertexBindings>   bindings;
   };
-  
+
 }

--- a/src/dxvk/dxvk_constant_state.h
+++ b/src/dxvk/dxvk_constant_state.h
@@ -118,15 +118,94 @@ namespace dxvk {
    * rasterizer, including the depth bias.
    */
   struct DxvkRasterizerState {
-    VkPolygonMode       polygonMode;
-    VkCullModeFlags     cullMode;
-    VkFrontFace         frontFace;
-    VkBool32            depthClipEnable;
-    VkBool32            depthBiasEnable;
-    VkConservativeRasterizationModeEXT conservativeMode;
-    VkSampleCountFlags  sampleCount;
-    VkBool32            flatShading;
-    VkLineRasterizationModeEXT lineMode;
+
+  public:
+
+    VkPolygonMode polygonMode() const {
+      return VkPolygonMode(m_polygonMode);
+    }
+
+    VkCullModeFlags cullMode() const {
+      return VkCullModeFlags(m_cullMode);
+    }
+
+    VkFrontFace frontFace() const {
+      return VkFrontFace(m_frontFace);
+    }
+
+    bool depthClip() const {
+      return m_depthClipEnable;
+    }
+
+    bool depthBias() const {
+      return m_depthBiasEnable;
+    }
+
+    VkConservativeRasterizationModeEXT conservativeMode() const {
+      return VkConservativeRasterizationModeEXT(m_conservativeMode);
+    }
+
+    VkSampleCountFlags sampleCount() const {
+      return VkSampleCountFlags(m_sampleCount);
+    }
+
+    bool flatShading() const {
+      return m_flatShading;
+    }
+
+    VkLineRasterizationModeEXT lineMode() const {
+      return VkLineRasterizationModeEXT(m_lineMode);
+    }
+
+    void setPolygonMode(VkPolygonMode mode) {
+      m_polygonMode = uint32_t(mode);
+    }
+
+    void setCullMode(VkCullModeFlags mode) {
+      m_cullMode = uint32_t(mode);
+    }
+
+    void setFrontFace(VkFrontFace face) {
+      m_frontFace = uint32_t(face);
+    }
+
+    void setDepthClip(bool enable) {
+      m_depthClipEnable = enable;
+    }
+
+    void setDepthBias(bool enable) {
+      m_depthBiasEnable = enable;
+    }
+
+    void setConservativeMode(VkConservativeRasterizationModeEXT mode) {
+      m_conservativeMode = uint32_t(mode);
+    }
+
+    void setSampleCount(VkSampleCountFlags count) {
+      m_sampleCount = uint32_t(count);
+    }
+
+    void setFlatShading(bool enable) {
+      m_flatShading = enable;
+    }
+
+    void setLineMode(VkLineRasterizationModeEXT mode) {
+      m_lineMode = uint32_t(mode);
+    }
+
+  private:
+
+    uint32_t m_polygonMode       : 2;
+    uint32_t m_cullMode          : 2;
+    uint32_t m_frontFace         : 1;
+    uint32_t m_depthClipEnable   : 1;
+    uint32_t m_depthBiasEnable   : 1;
+    uint32_t m_conservativeMode  : 2;
+    uint32_t m_sampleCount       : 5;
+    uint32_t m_flatShading       : 1;
+    uint32_t m_lineMode          : 2;
+    uint32_t m_reserved          : 15;
+
   };
   
   

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -2812,8 +2812,8 @@ namespace dxvk {
   
   void DxvkContext::setLogicOpState(const DxvkLogicOpState& lo) {
     m_state.gp.state.om = DxvkOmInfo(
-      lo.enableLogicOp,
-      lo.logicOp,
+      lo.logicOpEnable(),
+      lo.logicOp(),
       m_state.gp.state.om.feedbackLoop());
     
     m_flags.set(DxvkContextFlag::GpDirtyPipelineState);

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -2684,9 +2684,9 @@ namespace dxvk {
   
   void DxvkContext::setInputAssemblyState(const DxvkInputAssemblyState& ia) {
     m_state.gp.state.ia = DxvkIaInfo(
-      ia.primitiveTopology,
-      ia.primitiveRestart,
-      ia.patchVertexCount);
+      ia.primitiveTopology(),
+      ia.primitiveRestart(),
+      ia.patchVertexCount());
     
     m_flags.set(DxvkContextFlag::GpDirtyPipelineState);
   }

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -2727,14 +2727,17 @@ namespace dxvk {
   
   
   void DxvkContext::setRasterizerState(const DxvkRasterizerState& rs) {
-    if (m_state.dyn.cullMode != rs.cullMode || m_state.dyn.frontFace != rs.frontFace) {
-      m_state.dyn.cullMode = rs.cullMode;
-      m_state.dyn.frontFace = rs.frontFace;
+    VkCullModeFlags cullMode = rs.cullMode();
+    VkFrontFace frontFace = rs.frontFace();
+
+    if (m_state.dyn.cullMode != cullMode || m_state.dyn.frontFace != frontFace) {
+      m_state.dyn.cullMode = cullMode;
+      m_state.dyn.frontFace = frontFace;
 
       m_flags.set(DxvkContextFlag::GpDirtyRasterizerState);
     }
 
-    if (unlikely(rs.sampleCount != m_state.gp.state.rs.sampleCount())) {
+    if (unlikely(rs.sampleCount() != m_state.gp.state.rs.sampleCount())) {
       if (!m_state.gp.state.ms.sampleCount())
         m_flags.set(DxvkContextFlag::GpDirtyMultisampleState);
 
@@ -2743,20 +2746,20 @@ namespace dxvk {
     }
 
     DxvkRsInfo rsInfo(
-      rs.depthClipEnable,
-      rs.depthBiasEnable,
-      rs.polygonMode,
-      rs.sampleCount,
-      rs.conservativeMode,
-      rs.flatShading,
-      rs.lineMode);
+      rs.depthClip(),
+      rs.depthBias(),
+      rs.polygonMode(),
+      rs.sampleCount(),
+      rs.conservativeMode(),
+      rs.flatShading(),
+      rs.lineMode());
 
     if (!m_state.gp.state.rs.eq(rsInfo)) {
       m_flags.set(DxvkContextFlag::GpDirtyPipelineState);
 
       // Since depth bias enable is only dynamic for base pipelines,
       // it is applied as part of the dynamic depth-stencil state
-      if (m_state.gp.state.rs.depthBiasEnable() != rs.depthBiasEnable)
+      if (m_state.gp.state.rs.depthBiasEnable() != rs.depthBias())
         m_flags.set(DxvkContextFlag::GpDirtyDepthStencilState);
 
       m_state.gp.state.rs = rsInfo;

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -2694,38 +2694,45 @@ namespace dxvk {
   
   void DxvkContext::setInputLayout(
           uint32_t             attributeCount,
-    const DxvkVertexAttribute* attributes,
+    const DxvkVertexInput*     attributes,
           uint32_t             bindingCount,
-    const DxvkVertexBinding*   bindings) {
+    const DxvkVertexInput*     bindings) {
     m_flags.set(
       DxvkContextFlag::GpDirtyPipelineState,
       DxvkContextFlag::GpDirtyVertexBuffers);
 
     for (uint32_t i = 0; i < bindingCount; i++) {
+      auto binding = bindings[i].binding();
+
       m_state.gp.state.ilBindings[i] = DxvkIlBinding(
-        bindings[i].binding, 0, bindings[i].inputRate,
-        bindings[i].fetchRate);
-      m_state.vi.vertexExtents[i] = bindings[i].extent;
+        binding.binding, 0,
+        binding.inputRate,
+        binding.divisor);
+      m_state.vi.vertexExtents[i] = binding.extent;
     }
 
     for (uint32_t i = bindingCount; i < m_state.gp.state.il.bindingCount(); i++) {
       m_state.gp.state.ilBindings[i] = DxvkIlBinding();
       m_state.vi.vertexExtents[i] = 0;
     }
-    
+
     for (uint32_t i = 0; i < attributeCount; i++) {
+      auto attribute = attributes[i].attribute();
+
       m_state.gp.state.ilAttributes[i] = DxvkIlAttribute(
-        attributes[i].location, attributes[i].binding,
-        attributes[i].format,   attributes[i].offset);
+        attribute.location,
+        attribute.binding,
+        attribute.format,
+        attribute.offset);
     }
-    
+
     for (uint32_t i = attributeCount; i < m_state.gp.state.il.attributeCount(); i++)
       m_state.gp.state.ilAttributes[i] = DxvkIlAttribute();
-    
+
     m_state.gp.state.il = DxvkIlInfo(attributeCount, bindingCount);
   }
-  
-  
+
+
   void DxvkContext::setRasterizerState(const DxvkRasterizerState& rs) {
     VkCullModeFlags cullMode = rs.cullMode();
     VkFrontFace frontFace = rs.frontFace();

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -2767,9 +2767,9 @@ namespace dxvk {
   void DxvkContext::setMultisampleState(const DxvkMultisampleState& ms) {
     m_state.gp.state.ms = DxvkMsInfo(
       m_state.gp.state.ms.sampleCount(),
-      ms.sampleMask,
-      ms.enableAlphaToCoverage);
-    
+      ms.sampleMask(),
+      ms.alphaToCoverage());
+
     m_flags.set(
       DxvkContextFlag::GpDirtyPipelineState,
       DxvkContextFlag::GpDirtyMultisampleState);

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -2778,15 +2778,32 @@ namespace dxvk {
   
   void DxvkContext::setDepthStencilState(const DxvkDepthStencilState& ds) {
     m_state.gp.state.ds = DxvkDsInfo(
-      ds.enableDepthTest,
-      ds.enableDepthWrite,
+      ds.depthTest(),
+      ds.depthWrite(),
       m_state.gp.state.ds.enableDepthBoundsTest(),
-      ds.enableStencilTest,
-      ds.depthCompareOp);
-    
-    m_state.gp.state.dsFront = DxvkDsStencilOp(ds.stencilOpFront);
-    m_state.gp.state.dsBack  = DxvkDsStencilOp(ds.stencilOpBack);
-    
+      ds.stencilTest(),
+      ds.depthCompareOp());
+
+    DxvkStencilOp front = ds.stencilOpFront();
+
+    m_state.gp.state.dsFront = DxvkDsStencilOp(
+      front.failOp(),
+      front.passOp(),
+      front.depthFailOp(),
+      front.compareOp(),
+      front.compareMask(),
+      front.writeMask());
+
+    DxvkStencilOp back = ds.stencilOpBack();
+
+    m_state.gp.state.dsBack = DxvkDsStencilOp(
+      back.failOp(),
+      back.passOp(),
+      back.depthFailOp(),
+      back.compareOp(),
+      back.compareMask(),
+      back.writeMask());
+
     m_flags.set(
       DxvkContextFlag::GpDirtyPipelineState,
       DxvkContextFlag::GpDirtyDepthStencilState);

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -2824,15 +2824,15 @@ namespace dxvk {
           uint32_t            attachment,
     const DxvkBlendMode&      blendMode) {
     m_state.gp.state.omBlend[attachment] = DxvkOmAttachmentBlend(
-      blendMode.enableBlending,
-      blendMode.colorSrcFactor,
-      blendMode.colorDstFactor,
-      blendMode.colorBlendOp,
-      blendMode.alphaSrcFactor,
-      blendMode.alphaDstFactor,
-      blendMode.alphaBlendOp,
-      blendMode.writeMask);
-    
+      blendMode.blendEnable(),
+      blendMode.colorSrcFactor(),
+      blendMode.colorDstFactor(),
+      blendMode.colorBlendOp(),
+      blendMode.alphaSrcFactor(),
+      blendMode.alphaDstFactor(),
+      blendMode.alphaBlendOp(),
+      blendMode.writeMask());
+
     m_flags.set(DxvkContextFlag::GpDirtyPipelineState);
   }
 

--- a/src/dxvk/dxvk_context.h
+++ b/src/dxvk/dxvk_context.h
@@ -1187,16 +1187,16 @@ namespace dxvk {
      * \brief Sets input layout
      * 
      * \param [in] attributeCount Number of vertex attributes
-     * \param [in] attributes The vertex attributes
+     * \param [in] attributes Array of attribute infos
      * \param [in] bindingCount Number of buffer bindings
-     * \param [in] bindings Vertex buffer bindigs
+     * \param [in] bindings Array of binding infos
      */
     void setInputLayout(
             uint32_t             attributeCount,
-      const DxvkVertexAttribute* attributes,
+      const DxvkVertexInput*     attributes,
             uint32_t             bindingCount,
-      const DxvkVertexBinding*   bindings);
-    
+      const DxvkVertexInput*     bindings);
+
     /**
      * \brief Sets rasterizer state
      * \param [in] rs New state object

--- a/src/dxvk/dxvk_graphics_state.h
+++ b/src/dxvk/dxvk_graphics_state.h
@@ -400,14 +400,20 @@ namespace dxvk {
 
     DxvkDsStencilOp() = default;
 
-    DxvkDsStencilOp(VkStencilOpState state)
-    : m_failOp      (uint32_t(state.failOp)),
-      m_passOp      (uint32_t(state.passOp)),
-      m_depthFailOp (uint32_t(state.depthFailOp)),
-      m_compareOp   (uint32_t(state.compareOp)),
+    DxvkDsStencilOp(
+            VkStencilOp           failOp,
+            VkStencilOp           passOp,
+            VkStencilOp           depthFailOp,
+            VkCompareOp           compareOp,
+            uint8_t               compareMask,
+            uint8_t               writeMask)
+    : m_failOp      (uint32_t(failOp)),
+      m_passOp      (uint32_t(passOp)),
+      m_depthFailOp (uint32_t(depthFailOp)),
+      m_compareOp   (uint32_t(compareOp)),
       m_reserved    (0),
-      m_compareMask (uint32_t(state.compareMask)),
-      m_writeMask   (uint32_t(state.writeMask)) { }
+      m_compareMask (uint32_t(compareMask)),
+      m_writeMask   (uint32_t(writeMask)) { }
     
     VkStencilOpState state(bool write) const {
       VkStencilOpState result;

--- a/src/dxvk/meson.build
+++ b/src/dxvk/meson.build
@@ -75,6 +75,7 @@ dxvk_src = [
   'dxvk_buffer.cpp',
   'dxvk_cmdlist.cpp',
   'dxvk_compute.cpp',
+  'dxvk_constant_state.cpp',
   'dxvk_context.cpp',
   'dxvk_cs.cpp',
   'dxvk_descriptor.cpp',


### PR DESCRIPTION
Compresses some render state structures in a similar way to what the pipeline state thing already does, and changes all the D3D11 state binding methods to pass a copy of the full state rather than ref-counting the D3D11 state object itself. This is now much more feasible when things like depth-stencil state are now 10 bytes rather than 72.

Additionally, this normalizes depth-stencil and blend state to the extent possible in the frontends. The backend already does this to an extent at pipeline compile time, but sanitizing some state can be useful to not create extra pipeline states in the first place. 

This also benefits #4785 since we can now more easily prove that e.g. stencil isn't written, and also changes blend states that essentially disable writing to a given render target to use a write mask of 0.

Needs extensive regression testing for both D3D11 and D3D9.