### PR TITLE
Don't use sparse zero buffer

### DIFF
--- a/src/d3d11/d3d11_context_def.cpp
+++ b/src/d3d11/d3d11_context_def.cpp
@@ -316,7 +316,7 @@ namespace dxvk {
         cStorage = std::move(storage)
       ] (DxvkContext* ctx) {
         ctx->invalidateImage(cImage, Rc<DxvkResourceAllocation>(cStorage));
-        ctx->initImage(cImage, cImage->getAvailableSubresources(), VK_IMAGE_LAYOUT_PREINITIALIZED);
+        ctx->initImage(cImage, VK_IMAGE_LAYOUT_PREINITIALIZED);
       });
 
       pMappedResource->RowPitch   = layout.RowPitch;

--- a/src/d3d11/d3d11_context_imm.cpp
+++ b/src/d3d11/d3d11_context_imm.cpp
@@ -505,7 +505,7 @@ namespace dxvk {
           cStorage = pResource->DiscardStorage()
         ] (DxvkContext* ctx) {
           ctx->invalidateImage(cImage, Rc<DxvkResourceAllocation>(cStorage));
-          ctx->initImage(cImage, cImage->getAvailableSubresources(), VK_IMAGE_LAYOUT_PREINITIALIZED);
+          ctx->initImage(cImage, VK_IMAGE_LAYOUT_PREINITIALIZED);
         });
 
         ThrottleDiscard(layout.Size);

--- a/src/d3d11/d3d11_initializer.cpp
+++ b/src/d3d11/d3d11_initializer.cpp
@@ -232,9 +232,7 @@ namespace dxvk {
         EmitCs([
           cImage = std::move(image)
         ] (DxvkContext* ctx) {
-          ctx->initImage(cImage,
-            cImage->getAvailableSubresources(),
-            VK_IMAGE_LAYOUT_UNDEFINED);
+          ctx->initImage(cImage, VK_IMAGE_LAYOUT_UNDEFINED);
         });
       }
 
@@ -305,9 +303,7 @@ namespace dxvk {
     EmitCs([
       cImage = std::move(image)
     ] (DxvkContext* ctx) {
-      ctx->initImage(cImage,
-        cImage->getAvailableSubresources(),
-        VK_IMAGE_LAYOUT_PREINITIALIZED);
+      ctx->initImage(cImage, VK_IMAGE_LAYOUT_PREINITIALIZED);
     });
 
     m_transferCommands += 1;

--- a/src/d3d11/d3d11_swapchain.cpp
+++ b/src/d3d11/d3d11_swapchain.cpp
@@ -584,10 +584,7 @@ namespace dxvk {
     ] (DxvkContext* ctx) {
       for (size_t i = 0; i < cImages.size(); i++) {
         ctx->setDebugName(cImages[i], str::format("Back buffer ", i).c_str());
-
-        ctx->initImage(cImages[i],
-          cImages[i]->getAvailableSubresources(),
-          VK_IMAGE_LAYOUT_UNDEFINED);
+        ctx->initImage(cImages[i], VK_IMAGE_LAYOUT_UNDEFINED);
       }
     });
   }

--- a/src/d3d9/d3d9_initializer.cpp
+++ b/src/d3d9/d3d9_initializer.cpp
@@ -101,9 +101,7 @@ namespace dxvk {
     EmitCs([
       cImage = std::move(image)
     ] (DxvkContext* ctx) {
-      ctx->initImage(cImage,
-        cImage->getAvailableSubresources(),
-        VK_IMAGE_LAYOUT_UNDEFINED);
+      ctx->initImage(cImage, VK_IMAGE_LAYOUT_UNDEFINED);
     });
 
     ThrottleAllocationLocked();

--- a/src/d3d9/d3d9_swapchain.cpp
+++ b/src/d3d9/d3d9_swapchain.cpp
@@ -1053,9 +1053,7 @@ namespace dxvk {
       cImages = std::move(images)
     ] (DxvkContext* ctx) {
       for (size_t i = 0; i < cImages.size(); i++) {
-        ctx->initImage(cImages[i],
-          cImages[i]->getAvailableSubresources(),
-          VK_IMAGE_LAYOUT_UNDEFINED);
+        ctx->initImage(cImages[i], VK_IMAGE_LAYOUT_UNDEFINED);
       }
     });
 

--- a/src/dxvk/dxvk_adapter.cpp
+++ b/src/dxvk/dxvk_adapter.cpp
@@ -326,12 +326,6 @@ namespace dxvk {
     // Always enable robust buffer access
     enabledFeatures.core.features.robustBufferAccess = VK_TRUE;
 
-    // Always enable sparse residency if we can use it for efficient zero-initialization
-    if (m_deviceInfo.core.properties.sparseProperties.residencyNonResidentStrict) {
-      enabledFeatures.core.features.sparseBinding = m_deviceFeatures.core.features.sparseBinding;
-      enabledFeatures.core.features.sparseResidencyBuffer = m_deviceFeatures.core.features.sparseResidencyBuffer;
-    }
-
     // Always enable features used by the HUD
     enabledFeatures.core.features.multiDrawIndirect = VK_TRUE;
     enabledFeatures.vk11.shaderDrawParameters = VK_TRUE;

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -7723,55 +7723,24 @@ namespace dxvk {
                     | VK_ACCESS_TRANSFER_READ_BIT;
     bufInfo.debugName = "Zero buffer";
 
-    // If supported by the device, create a large sparse buffer and keep it unmapped
-    // in order to avoid having to allocate and clear any actual memory. Some specific
-    // older AMD hardware seems to have some trouble with this, use the minimum subgroup
-    // size to disable the sparse path on anything that predates RDNA1.
-    bool noSparseWorkaroundAmd = m_device->properties().core.properties.vendorID == uint32_t(DxvkGpuVendor::Amd)
-                              && m_device->properties().vk13.minSubgroupSize == 64u;
-
-    if (m_device->features().core.features.sparseBinding
-     && m_device->features().core.features.sparseResidencyBuffer
-     && m_device->properties().core.properties.sparseProperties.residencyNonResidentStrict
-     && !noSparseWorkaroundAmd) {
-      bufInfo.size = align<VkDeviceSize>(size, DxvkMemoryPool::MaxChunkSize);
-      bufInfo.flags |= VK_BUFFER_CREATE_SPARSE_BINDING_BIT | VK_BUFFER_CREATE_SPARSE_RESIDENCY_BIT;
-    }
-
     m_zeroBuffer = m_device->createBuffer(bufInfo,
       VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
 
     DxvkBufferSliceHandle slice = m_zeroBuffer->getSliceHandle();
 
-    if (bufInfo.flags & VK_BUFFER_CREATE_SPARSE_BINDING_BIT) {
-      DxvkSparseBufferBindKey key = { };
-      key.buffer = slice.handle;
-      key.offset = slice.offset;
-      key.size = slice.length;
+    // FillBuffer is allowed even on transfer queues. Execute it on the barrier
+    // command buffer to ensure that subsequent transfer commands can see it.
+    m_cmd->cmdFillBuffer(DxvkCmdBuffer::SdmaBarriers,
+      slice.handle, slice.offset, slice.length, 0);
 
-      DxvkResourceMemoryInfo memory = { };
-      memory.size = slice.length;
+    accessMemory(DxvkCmdBuffer::SdmaBarriers,
+      VK_PIPELINE_STAGE_2_TRANSFER_BIT, VK_ACCESS_2_TRANSFER_WRITE_BIT,
+      VK_PIPELINE_STAGE_2_TRANSFER_BIT, VK_ACCESS_2_TRANSFER_READ_BIT);
 
-      // We really should have a sparse queue, but if for whatever reason we don't,
-      // just assume that the buffer is mapped to null by default, which seems to
-      // be intended by the spec anyway
-      if (m_device->queues().sparse.queueHandle)
-        m_cmd->bindBufferMemory(key, memory);
-    } else {
-      // FillBuffer is allowed even on transfer queues. Execute it on the barrier
-      // command buffer to ensure that subsequent transfer commands can see it.
-      m_cmd->cmdFillBuffer(DxvkCmdBuffer::SdmaBarriers,
-        slice.handle, slice.offset, slice.length, 0);
-
-      accessMemory(DxvkCmdBuffer::SdmaBarriers,
-        VK_PIPELINE_STAGE_2_TRANSFER_BIT, VK_ACCESS_2_TRANSFER_WRITE_BIT,
+    if (m_device->hasDedicatedTransferQueue()) {
+      accessMemory(DxvkCmdBuffer::InitBarriers,
+        VK_PIPELINE_STAGE_2_TRANSFER_BIT, VK_ACCESS_2_NONE,
         VK_PIPELINE_STAGE_2_TRANSFER_BIT, VK_ACCESS_2_TRANSFER_READ_BIT);
-
-      if (m_device->hasDedicatedTransferQueue()) {
-        accessMemory(DxvkCmdBuffer::InitBarriers,
-          VK_PIPELINE_STAGE_2_TRANSFER_BIT, VK_ACCESS_2_NONE,
-          VK_PIPELINE_STAGE_2_TRANSFER_BIT, VK_ACCESS_2_TRANSFER_READ_BIT);
-      }
     }
 
     m_cmd->track(m_zeroBuffer, DxvkAccess::Write);

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -1088,8 +1088,9 @@ namespace dxvk {
 
   void DxvkContext::initImage(
     const Rc<DxvkImage>&            image,
-    const VkImageSubresourceRange&  subresources,
           VkImageLayout             initialLayout) {
+    VkImageSubresourceRange subresources = image->getAvailableSubresources();
+
     if (initialLayout == VK_IMAGE_LAYOUT_PREINITIALIZED) {
       accessImage(DxvkCmdBuffer::InitBarriers,
         *image, subresources, initialLayout,

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -1034,6 +1034,16 @@ namespace dxvk {
     const Rc<DxvkBuffer>&           buffer) {
     auto dstSlice = buffer->getSliceHandle();
 
+    // If the buffer is suballocated, clear the entire allocated
+    // region, which is guaranteed to have a nicely aligned size
+    if (!buffer->storage()->flags().test(DxvkAllocationFlag::OwnsBuffer)) {
+      auto bufferInfo = buffer->storage()->getBufferInfo();
+
+      dstSlice.handle = bufferInfo.buffer;
+      dstSlice.offset = bufferInfo.offset;
+      dstSlice.length = bufferInfo.size;
+    }
+
     // Buffer size may be misaligned, in which case we have
     // to use a plain buffer copy to fill the last few bytes.
     constexpr VkDeviceSize MinCopyAndFillSize = 1u << 20;

--- a/src/dxvk/dxvk_context.h
+++ b/src/dxvk/dxvk_context.h
@@ -1865,6 +1865,8 @@ namespace dxvk {
     Rc<DxvkBuffer> createZeroBuffer(
             VkDeviceSize              size);
 
+    void freeZeroBuffer();
+
     void resizeDescriptorArrays(
             uint32_t                  bindingCount);
 

--- a/src/dxvk/dxvk_context.h
+++ b/src/dxvk/dxvk_context.h
@@ -934,12 +934,10 @@ namespace dxvk {
      * it to black unless the initial layout is preinitialized.
      * Only safe to call if the image is not in use by the GPU.
      * \param [in] image The image to initialize
-     * \param [in] subresources Image subresources
      * \param [in] initialLayout Initial image layout
      */
     void initImage(
       const Rc<DxvkImage>&            image,
-      const VkImageSubresourceRange&  subresources,
             VkImageLayout             initialLayout);
 
     /**


### PR DESCRIPTION
And instead do some magic to clear backing storage for resources directly as much as humanly possible.

There will still be cases when a zero buffer is required, but that should be extremely rare now and largely be limited to systems without `maintenance5` support.

The sparse thing is just broken on too many drivers.