### PR TITLE
[util] Enable cached constant buffers for Hitman 2

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -168,6 +168,7 @@ namespace dxvk {
     /* Hitman 2 - requires AGS library      */
     { R"(\\HITMAN2\.exe$)", {{
       { "dxgi.customVendorId",              "10de" },
+      { "d3d11.cachedDynamicResources",     "c"    },
     }} },
     /* Modern Warfare Remastered                  */
     { R"(\\h1(_[ms]p64_ship|-mod)\.exe$)", {{


### PR DESCRIPTION
Regresses GPU-bound performance, but considerably reduces FPS drops in areas where draw call counts are high.

Not sure which one is worse tbh, I hate when games make it literally impossible to get good perf all the time.