### PR TITLE
[util] Enable cachedDynamicBuffers for Lego Indiana Jones: The Original Adventures

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -1043,6 +1043,11 @@ namespace dxvk {
     { R"(\\sh2pc\.exe$)", {{
       { "d3d9.extraFrontbuffer",            "True" },
     }} },
+    /* Lego Indiana Jones: The Original Adventures *
+     * Fix UI performance                          */
+    { R"(\\LEGOIndy\.exe$)", {{
+      { "d3d9.cachedDynamicBuffers",        "True" },
+    }} },
 
     /**********************************************/
     /* D3D8 GAMES                                 */


### PR DESCRIPTION
I didn't make an API trace to investigate the game, I just randomly tried the option and saw the improvements. The Extras menu in particular has a 10000% performance improvement.
The game is downloaded from Amazon/Twitch Prime (Heroic).

## Before
Gameplay
![Screenshot_20250324_180036](https://github.com/user-attachments/assets/e8f7abe3-169c-4332-892a-c678bb5e411d)
Pause menu > Extras
![Screenshot_20250324_180050](https://github.com/user-attachments/assets/2cd02895-2212-43cb-9b6a-b7297dc9ef89)

## After
Gameplay
![Screenshot_20250324_175803](https://github.com/user-attachments/assets/dab82b10-e990-47b1-a606-2e3b5440185b)
Pause menu > Extras
![Screenshot_20250324_175820](https://github.com/user-attachments/assets/94e1c05e-8517-4d2c-82d3-4529921db208)

I kinda wonder if this is the only game that has this problem, since there are *many* games using the same engine: https://www.pcgamingwiki.com/wiki/Engine:Nu2 [^1]
I do have other LEGO games that I can test later, though.

[^1]: Ordering by release date, the first game supporting D3D11 is Lego Batman 3 (2014!), while the first to drop D3D9 support was Lego City Undercover (2017!?).