### PR TITLE
Clear unused attachments early

### DIFF
--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -4227,6 +4227,17 @@ namespace dxvk {
       // Make sure the render pass is active so
       // that we can actually perform the clear
       this->startRenderPass();
+
+      if (aspect & VK_IMAGE_ASPECT_COLOR_BIT) {
+        uint32_t colorIndex = m_state.om.framebufferInfo.getColorAttachmentIndex(attachmentIndex);
+        m_state.om.attachmentMask.trackColorWrite(colorIndex);
+      }
+
+      if (aspect & VK_IMAGE_ASPECT_DEPTH_BIT)
+        m_state.om.attachmentMask.trackDepthWrite();
+
+      if (aspect & VK_IMAGE_ASPECT_STENCIL_BIT)
+        m_state.om.attachmentMask.trackStencilWrite();
     }
 
     // Perform the actual clear operation

--- a/src/dxvk/dxvk_context.h
+++ b/src/dxvk/dxvk_context.h
@@ -1653,6 +1653,11 @@ namespace dxvk {
 
     void preparePostRenderPassClears();
 
+    void hoistInlineClear(
+            DxvkDeferredClear&        clear,
+            VkRenderingAttachmentInfo& attachment,
+            VkImageAspectFlagBits     aspect);
+
     void flushClearsInline();
 
     void flushClears(


### PR DESCRIPTION
Lego Movie 2 has a number of render passes where it draws a fullscreen triangle without any sort of depth or stencil test and *then* clears stencil. We can make this pattern more tiler-friendly by hoisting that clear into the render pass itself and avoid a useless `LOAD_OP_LOAD`.

I also expect this to be common in D3D9 land.