### PR TITLE
[util] Enable cachedDynamicBuffers for Lego Batman: The Videogame

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -1048,6 +1048,11 @@ namespace dxvk {
     { R"(\\LEGOIndy\.exe$)", {{
       { "d3d9.cachedDynamicBuffers",        "True" },
     }} },
+    /* Lego Batman: The Videogame                 *
+     * Fix UI performance                         */
+    { R"((\\LEGOBatman|LegoBatman\\Game)\.exe$)", {{
+      { "d3d9.cachedDynamicBuffers",        "True" },
+    }} },
 
     /**********************************************/
     /* D3D8 GAMES                                 */


### PR DESCRIPTION
Exactly the same thing as #4798. Tested EGS version.

Screenshots on the controller remapping menu.

Before
![image](https://github.com/user-attachments/assets/a9a45833-d473-4de1-9de5-1d2a7f1a698f)

After
![image](https://github.com/user-attachments/assets/2cb18712-cbcd-437d-99c7-56afa2a77bb8)


The regex is more complicated because, for some reason, the EGS's `LEGOBatman.exe` only launches a `Game.exe` executable (with the default install folder being `LegoBatman`), while on [Steam](https://steamdb.info/depot/21001/) and [GOG](https://www.gogdb.org/manifest/d3eee01d8a8d35be6eab1bc5dbd2a7b6) it's the actual executable.

This should be the last game using the engine that has the issue, since the next game, Lego Star Wars: The Complete Saga, [does not have the issue](https://github.com/doitsujin/dxvk/pull/4798#issuecomment-2749667601).[^1] I also tested that Lego Lord of the Rings (which is 8 games later) doesn't have the issue.

[^1]: Though these older games have not been tested: `Lego Star Wars: The Video Game`, `The Chronicles of Narnia: The Lion, the Witch and the Wardrobe`, `Lego Star Wars II: The Original Trilogy`, `Bionicle Heroes`, `Transformers: The Game`, `The Chronicles of Narnia: Prince Caspian`.