### PR TITLE
[util] Fix broken LZCNT&TZCNT on non-BMI platforms

### DIFF
--- a/src/util/util_bit.h
+++ b/src/util/util_bit.h
@@ -160,7 +160,7 @@ namespace dxvk::bit {
   }
 
   inline uint32_t lzcnt(uint32_t n) {
-    #if ((defined(_MSC_VER) && !defined(__clang__))) && !defined(__LZCNT__)
+    #if defined(_MSC_VER) && !defined(__clang__) && !defined(__LZCNT__)
     unsigned long bsr;
     if(n == 0)
       return 32;
@@ -186,7 +186,7 @@ namespace dxvk::bit {
   }
 
   inline uint32_t lzcnt(uint64_t n) {
-    #if ((defined(_MSC_VER) && !defined(__clang__))) && !defined(__LZCNT__) && defined(DXVK_ARCH_X86_64)
+    #if defined(_MSC_VER) && !defined(__clang__) && !defined(__LZCNT__) && defined(DXVK_ARCH_X86_64)
     unsigned long bsr;
     if(n == 0)
       return 64;

--- a/src/util/util_bit.h
+++ b/src/util/util_bit.h
@@ -178,8 +178,15 @@ namespace dxvk::bit {
   inline uint32_t lzcnt(uint64_t n) {
     #if defined(_MSC_VER) && !defined(__AVX2__)
     unsigned long bsr;
-    _BitScanReverse(&bsr, n);
-    return 31-bsr;
+    #if defined(DXVK_ARCH_X86_64)
+    _BitScanReverse64(&bsr, n);
+    #else
+    if  (_BitScanReverse(&bsr, n >> 32))
+        bsr += 32;
+    else
+        _BitScanReverse(&bsr, n & 0xffffffff);
+    #endif
+    return 63-bsr;
     #elif defined(DXVK_ARCH_X86_64) && ((defined(_MSC_VER) && !defined(__clang__)) || defined(__LZCNT__))
     return _lzcnt_u64(n);
     #elif defined(DXVK_ARCH_X86_64) && (defined(__GNUC__) || defined(__clang__))

--- a/src/util/util_bit.h
+++ b/src/util/util_bit.h
@@ -156,13 +156,13 @@ namespace dxvk::bit {
   }
 
   inline uint32_t lzcnt(uint32_t n) {
-    #if defined(_MSC_VER) && !defined(__AVX2__)
+    #if ((defined(_MSC_VER) && !defined(__clang__))) && !defined(__AVX2__)
     unsigned long bsr;
     if(n == 0)
       return 32;
     _BitScanReverse(&bsr, n);
     return 31-bsr;
-    #elif (defined(_MSC_VER) && !defined(__clang__)) || defined(__LZCNT__)
+    #elif (defined(_MSC_VER) && !defined(__clang__)) || defined(__AVX2__)
     return _lzcnt_u32(n);
     #elif defined(__GNUC__) || defined(__clang__)
     return n != 0 ? __builtin_clz(n) : 32;
@@ -182,13 +182,13 @@ namespace dxvk::bit {
   }
 
   inline uint32_t lzcnt(uint64_t n) {
-    #if defined(_MSC_VER) && !defined(__AVX2__) && defined(DXVK_ARCH_X86_64)
+    #if ((defined(_MSC_VER) && !defined(__clang__))) && !defined(__AVX2__) && defined(DXVK_ARCH_X86_64)
     unsigned long bsr;
     if(n == 0)
       return 64;
     _BitScanReverse64(&bsr, n);
     return 63-bsr;
-    #elif defined(DXVK_ARCH_X86_64) && ((defined(_MSC_VER) && !defined(__clang__)) || defined(__LZCNT__))
+    #elif defined(DXVK_ARCH_X86_64) && ((defined(_MSC_VER) && !defined(__clang__)) || defined(__AVX2__))
     return _lzcnt_u64(n);
     #elif defined(DXVK_ARCH_X86_64) && (defined(__GNUC__) || defined(__clang__))
     return n != 0 ? __builtin_clzll(n) : 64;

--- a/src/util/util_bit.h
+++ b/src/util/util_bit.h
@@ -65,6 +65,8 @@ namespace dxvk::bit {
 
   inline uint32_t tzcnt(uint32_t n) {
     #if defined(_MSC_VER) && !defined(__clang__)
+    if(n == 0)
+      return 32;
     return _tzcnt_u32(n);
     #elif defined(__BMI__)
     return __tzcnt_u32(n);
@@ -101,6 +103,8 @@ namespace dxvk::bit {
 
   inline uint32_t tzcnt(uint64_t n) {
     #if defined(DXVK_ARCH_X86_64) && defined(_MSC_VER) && !defined(__clang__)
+    if(n == 0)
+      return 64;
     return (uint32_t)_tzcnt_u64(n);
     #elif defined(DXVK_ARCH_X86_64) && defined(__BMI__)
     return __tzcnt_u64(n);

--- a/src/util/util_bit.h
+++ b/src/util/util_bit.h
@@ -176,7 +176,11 @@ namespace dxvk::bit {
   }
 
   inline uint32_t lzcnt(uint64_t n) {
-    #if defined(DXVK_ARCH_X86_64) && ((defined(_MSC_VER) && !defined(__clang__)) || defined(__LZCNT__))
+    #if defined(_MSC_VER) && !defined(__AVX2__)
+    unsigned long bsr;
+    _BitScanReverse(&bsr, n);
+    return 31-bsr;
+    #elif defined(DXVK_ARCH_X86_64) && ((defined(_MSC_VER) && !defined(__clang__)) || defined(__LZCNT__))
     return _lzcnt_u64(n);
     #elif defined(DXVK_ARCH_X86_64) && (defined(__GNUC__) || defined(__clang__))
     return n != 0 ? __builtin_clzll(n) : 64;

--- a/src/util/util_bit.h
+++ b/src/util/util_bit.h
@@ -156,13 +156,13 @@ namespace dxvk::bit {
   }
 
   inline uint32_t lzcnt(uint32_t n) {
-    #if ((defined(_MSC_VER) && !defined(__clang__))) && !defined(__AVX2__)
+    #if ((defined(_MSC_VER) && !defined(__clang__))) && !defined(__LZCNT__)
     unsigned long bsr;
     if(n == 0)
       return 32;
     _BitScanReverse(&bsr, n);
     return 31-bsr;
-    #elif (defined(_MSC_VER) && !defined(__clang__)) || defined(__AVX2__)
+    #elif (defined(_MSC_VER) && !defined(__clang__)) || defined(__LZCNT__)
     return _lzcnt_u32(n);
     #elif defined(__GNUC__) || defined(__clang__)
     return n != 0 ? __builtin_clz(n) : 32;
@@ -182,13 +182,13 @@ namespace dxvk::bit {
   }
 
   inline uint32_t lzcnt(uint64_t n) {
-    #if ((defined(_MSC_VER) && !defined(__clang__))) && !defined(__AVX2__) && defined(DXVK_ARCH_X86_64)
+    #if ((defined(_MSC_VER) && !defined(__clang__))) && !defined(__LZCNT__) && defined(DXVK_ARCH_X86_64)
     unsigned long bsr;
     if(n == 0)
       return 64;
     _BitScanReverse64(&bsr, n);
     return 63-bsr;
-    #elif defined(DXVK_ARCH_X86_64) && ((defined(_MSC_VER) && !defined(__clang__)) || defined(__AVX2__))
+    #elif defined(DXVK_ARCH_X86_64) && ((defined(_MSC_VER) && !defined(__clang__)) && defined(__LZCNT__))
     return _lzcnt_u64(n);
     #elif defined(DXVK_ARCH_X86_64) && (defined(__GNUC__) || defined(__clang__))
     return n != 0 ? __builtin_clzll(n) : 64;


### PR DESCRIPTION
Now MSVC will always use BSR for LZCNT.
Also correct 0 input behavior for TZCNT when fallback to BSF.
Should fix #4808 .
Need test before merge.

 