### PR TITLE
[d3d9] Add an option to allow biased correctness factor to fix some buggy games

### DIFF
--- a/dxvk.conf
+++ b/dxvk.conf
@@ -773,6 +773,16 @@
 
 # d3d9.extraFrontbuffer = False
 
+# Bias correctness factor a bit
+#
+# Some buggy games may have horizontal scan lines on specified resolutions.
+# Enable this will bias correctness factor a bit to fix these scan lines.
+# This is only a workaround for some buggy games.
+#
+# Supported values: True, False
+
+# d3d9.correctnessBias = False
+
 # Dref scaling for DXS0/FVF
 #
 # Some early D3D8 games expect Dref (depth texcoord Z) to be on the range of

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -6741,8 +6741,10 @@ namespace dxvk {
     // corner so we can get away with flipping the viewport.
     const D3DVIEWPORT9& vp = m_state.viewport;
 
+    
     // Correctness Factor for 1/2 texel offset
-    constexpr float cf = 0.5f;
+    // Unless for buggy games that need a bit bias
+    float cf = m_d3d9Options.correctnessBias? 0.5f - (1.0f / 128.0f) : 0.5f;
 
     // How much to bias MinZ by to avoid a depth
     // degenerate viewport.

--- a/src/d3d9/d3d9_options.cpp
+++ b/src/d3d9/d3d9_options.cpp
@@ -74,6 +74,7 @@ namespace dxvk {
     this->samplerLodBias                = config.getOption<float>       ("d3d9.samplerLodBias",                0.0f);
     this->clampNegativeLodBias          = config.getOption<bool>        ("d3d9.clampNegativeLodBias",          false);
     this->countLosableResources         = config.getOption<bool>        ("d3d9.countLosableResources",         true);
+    this->correctnessBias               = config.getOption<bool>        ("d3d9.correctnessBias",               false);
     this->reproducibleCommandStream     = config.getOption<bool>        ("d3d9.reproducibleCommandStream",     false);
     this->extraFrontbuffer              = config.getOption<bool>        ("d3d9.extraFrontbuffer",              false);
 

--- a/src/d3d9/d3d9_options.h
+++ b/src/d3d9/d3d9_options.h
@@ -144,6 +144,9 @@ namespace dxvk {
     /// Disable counting losable resources and rejecting calls to Reset() if any are still alive
     bool countLosableResources;
 
+    /// Bias correctness factor a bit to fix some game bugs
+    bool correctnessBias;
+
     /// Ensure that for the same D3D commands the output VK commands
     /// don't change between runs. Useful for comparative benchmarking,
     /// can negatively affect performance.

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -492,12 +492,14 @@ namespace dxvk {
      * without Strict floats                       */
     { R"(\\Borderlands2\.exe$)", {{
       { "d3d9.lenientClear",                "True" },
+      { "d3d9.correctnessBias",             "True" },
       { "d3d9.supportDFFormats",            "False" },
       { "d3d9.floatEmulation",              "Strict" },
     }} },
     /* Borderlands: The Pre-Sequel                  */
     { R"(\\BorderlandsPreSequel\.exe$)", {{
       { "d3d9.lenientClear",                "True" },
+      { "d3d9.correctnessBias",             "True" },
       { "d3d9.supportDFFormats",            "False" },
     }} },
     /* Gothic 3                                   */


### PR DESCRIPTION
Fix #4618 
But should we add such an option just for a few buggy games? (Currently only Borderlands 2&TPS and FFXIII known to be buggy)
And I'm not sure whether remove the constexpr to make it configurable will result observable performance issue. (I could not see any performance issue during my own test since I didn't reach CPU bottleneck)

Put in draft here first. Needs some more discussion.