### PR TITLE
build: Locate SDL by its case-sensitive name

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -147,8 +147,8 @@ else
     './include/native/directx'
   ]
 
-  lib_sdl3 = dependency('SDL3', required: false)
-  lib_sdl2 = dependency('SDL2', required: false)
+  lib_sdl3 = dependency('sdl3', required: false)
+  lib_sdl2 = dependency('sdl2', required: false)
   lib_glfw = dependency('glfw', required: false)
   if lib_sdl3.found()
     compiler_args += ['-DDXVK_WSI_SDL3']


### PR DESCRIPTION
The pkg-config file describing SDL's API is `sdl2.pc` or `sdl3.pc`, so the name to look for is `sdl2` or `sdl3`. Looking for it with a different case combination will not necessarily work.

With the versions of `pkg-config` and `meson` in Steam Runtime 3 'sniper', it seems that SDL 2 can be found via either case combination, but SDL 3 requires the canonical case combination, `sdl3`.