### PR TITLE
[build] Add options for the various DXVK Native WSIs

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -147,9 +147,9 @@ else
     './include/native/directx'
   ]
 
-  lib_sdl3 = dependency('sdl3', required: false)
-  lib_sdl2 = dependency('sdl2', required: false)
-  lib_glfw = dependency('glfw', required: false)
+  lib_sdl3 = dependency('sdl3', required: get_option('native_sdl3'))
+  lib_sdl2 = dependency('sdl2', required: get_option('native_sdl2'))
+  lib_glfw = dependency('glfw', required: get_option('native_glfw'))
   if lib_sdl3.found()
     compiler_args += ['-DDXVK_WSI_SDL3']
   endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -4,3 +4,6 @@ option('enable_d3d9',  type : 'boolean', value : true, description: 'Build D3D9'
 option('enable_d3d10', type : 'boolean', value : true, description: 'Build D3D10')
 option('enable_d3d11', type : 'boolean', value : true, description: 'Build D3D11')
 option('build_id',     type : 'boolean', value : false)
+option('native_glfw',  type : 'feature', value : 'auto', description: 'Enable GLFW WSI for DXVK Native')
+option('native_sdl2',  type : 'feature', value : 'auto', description: 'Enable SDL2 WSI for DXVK Native')
+option('native_sdl3',  type : 'feature', value : 'auto', description: 'Enable SDL3 WSI for DXVK Native')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -4,5 +4,3 @@ option('enable_d3d9',  type : 'boolean', value : true, description: 'Build D3D9'
 option('enable_d3d10', type : 'boolean', value : true, description: 'Build D3D10')
 option('enable_d3d11', type : 'boolean', value : true, description: 'Build D3D11')
 option('build_id',     type : 'boolean', value : false)
-
-option('dxvk_native_wsi',   type : 'string',  value : 'sdl2', description: 'WSI system to use if building natively.')


### PR DESCRIPTION
* [build] Remove unused option dxvk_native_wsi
    
    Before support for dynamic WSI selection was added, this option selected
    the single supported WSI. Now it no longer does anything.
    
    Fixes: d5d236a1 "[wsi] Refactor platform system to support multiple WSI implementations"

* [build] Add options for the various DXVK Native WSIs
    
    Previously, each of these was enabled automatically if its corresponding
    development files was installed, or disabled if they were not (an
    "automagic dependency"). For example, when building in the Steam Runtime
    SDK, which always includes SDL, there would be no way to turn off the
    SDL2 WSI if it is not desired.
    
    For predictable, reproducible builds, OS distributions generally prefer
    to be able to explicitly enable or disable features. Using build options
    of type `feature` gives each one three possible states:
    
    * `-Dnative_sdl2=auto` (default): automatically enable or disable SDL2
      according to whether its development files were found, as was
      previously done
    * `-Dnative_sdl2=enabled`: force SDL2 to be enabled, and fail the build
      early if its development files could not be found, ensuring that it is
      not mis-built without a feature that was intended to be present
    * `-Dnative_sdl2=disabled`: force SDL2 to be disabled, even if its
      development files happen to be present (Meson behaves as though they
      were missing)
    
    and similar choices for SDL3 and GLFW.