### PR TITLE
[util] Limit vram reported for Prototype and minor cleanup

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -646,7 +646,7 @@ namespace dxvk {
     }} },
     /* Dragon Nest                               */
     { R"(\\DragonNest_x64\.exe$)", {{
-      { "d3d9.memoryTrackTest ",            "True" },
+      { "d3d9.memoryTrackTest",             "True" },
     }} },
     /* Dal Segno                                 */
     { R"(\\DST\.exe$)", {{
@@ -932,8 +932,7 @@ namespace dxvk {
     { R"(\\ninthdawnii\.exe$)", {{
       { "d3d9.deferSurfaceCreation",        "True" },
     }} },
-    /* Delta Force: Xtreme 1 & 2                 *
-     * Black screen on Alt-Tab and performance   */
+    /* Delta Force: Xtreme 1 & 2 - Performance   */
     { R"(\\(DFX|dfx2)\.exe$)", {{
       { "d3d9.cachedDynamicBuffers",        "True" },
     }} },
@@ -969,8 +968,8 @@ namespace dxvk {
     { R"(\\WRC4\.exe$)", {{
       { "d3d9.maxFrameRate",                "60" },
     }} },
-    /* Splinter Cell Conviction - Alt-tab black  *
-     * screen and unsupported GPU complaint      */
+    /* Splinter Cell Conviction                  *
+     * Unsupported GPU complaint                 */
     { R"(\\conviction_game\.exe$)", {{
       { "dxgi.customVendorId",              "10de" },
       { "dxgi.customDeviceId",              "05e0" },

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -938,9 +938,11 @@ namespace dxvk {
       { "d3d9.cachedDynamicBuffers",        "True" },
     }} },
     /* Prototype                                 *
-     * Incorrect shadows on AMD & Intel          */
+     * Incorrect shadows on AMD & Intel.         *
+     * AA 4x can not be selected above 2GB vram  */
     { R"(\\prototypef\.exe$)", {{ 
       { "d3d9.supportDFFormats",            "False" },
+      { "dxgi.maxDeviceMemory",             "2047" },
     }} },
     /* STAR WARS: The Force Unleashed            *
      * Prevents black screen on each alt-tab     */


### PR DESCRIPTION
See comment here <https://github.com/ValveSoftware/Proton/issues/164#issuecomment-2800918030>

Verified that Prototype 1 does not allow setting AA to 4x when i sees a high amount of vram. Even though the game is d3d9 it queries it through dxgi.
I could not reproduce the same for the second game which list AA values NONE, LOW and HIGH the same with and without a limit.

Also a minor cleanup for some stuff missed prior.