### PR TITLE
Don't error out for otherwise unknown CPU architectures

### DIFF
--- a/src/util/sync/sync_spinlock.h
+++ b/src/util/sync/sync_spinlock.h
@@ -26,7 +26,8 @@ namespace dxvk::sync {
         #elif defined(DXVK_ARCH_ARM64)
         __asm__ __volatile__ ("yield");
         #else
-        #error "Pause/Yield not implemented for this architecture."
+        /* Do nothing (busy-loop). Please add more #elif above here if
+         * your CPU architecture has a suitable pause/yield instruction */
         #endif
         if (fn())
           return;

--- a/src/util/util_bit.h
+++ b/src/util/util_bit.h
@@ -8,8 +8,6 @@
   #endif
 #elif defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
   #define DXVK_ARCH_ARM64
-#else
-#error "Unknown CPU Architecture"
 #endif
 
 #ifdef DXVK_ARCH_X86


### PR DESCRIPTION
* [util] Fall back to busy-loop on spinlock for unknown CPU architectures
    
    If there's no known equivalent of _mm_pause() on an architecture,
    it seems to be most typical to fall back to not doing anything,
    resulting in busy-looping for a short time. Porters who don't like this
    behaviour can add an `#elif` here with their architecture's closest
    equivalent, if it has one.

* [util] Don't error out for otherwise unknown CPU architectures
    
    All of the conditionally-compiled parts seem to have a `#else` that is
    ordinary non-architecture-specific C++, except for the spinlock that
    was made generic in the previous commit, so there's no particular reason
    to forbid compiling for other CPUs.

---

The bug report that I believe this resolves:

Debian unstable currently has builds of DXVK as PE DLLs (only) for use with Wine, on the amd64, arm64, i386 and armhf architectures (so, 64- and 32-bit x86 and ARM, which matches the architectures for which Debian compiles Wine 10).

After upgrading to 2.6.1 and starting to build DXVK Native (currently only in experimental as a result of the Debian 13 freeze), I noticed that it no longer builds successfully on armhf: we get the `#error`. In principle it ought to be possible to compile DXVK Native for any CPU architecture, as far as I can see. I will admit that I haven't actually tested this on anything non-x86, hence the draft status (if necessary I can get an armhf environment going on a Raspberry Pi at some point).

While investigating this I noticed that the CPU detection is also pretending that Elbrus E2K is a kind of x86, which seems odd and quite possibly wrong, but for the moment I've assumed that #3795 was (sufficiently close to) correct, rather than sending it into the "generic/unknown CPU" code path.