### PR TITLE
Implement custom sin/cos approximation

### DIFF
--- a/dxvk.conf
+++ b/dxvk.conf
@@ -587,6 +587,19 @@
 # d3d9.floatEmulation = Auto
 
 
+# Force enable/disable custom sine/cosine approximation
+#
+# On some hardware, this may be more accurate than native sin/cos,
+# but will come at a performance cost.
+#
+# Supported values:
+# - True: Always enable emulation path
+# - Auto: Only enable emulation on drivers with poor sin/cos precision
+# - False: Always enable native path
+
+# d3d9.sincosEmulation = Auto
+
+
 # Overrides the application's MSAA level on the swapchain
 # 
 # Supported values: -1 (application) and 0 to 16 (user override)

--- a/dxvk.conf
+++ b/dxvk.conf
@@ -598,6 +598,7 @@
 # - False: Always enable native path
 
 # d3d9.sincosEmulation = Auto
+# d3d11.sincosEmulation = Auto
 
 
 # Overrides the application's MSAA level on the swapchain

--- a/src/d3d11/d3d11_options.cpp
+++ b/src/d3d11/d3d11_options.cpp
@@ -32,6 +32,7 @@ namespace dxvk {
     this->exposeDriverCommandLists = config.getOption<bool>("d3d11.exposeDriverCommandLists", true);
     this->reproducibleCommandStream = config.getOption<bool>("d3d11.reproducibleCommandStream", false);
     this->disableDirectImageMapping = config.getOption<bool>("d3d11.disableDirectImageMapping", false);
+    this->sincosEmulation       = config.getOption<Tristate>("d3d11.sincosEmulation", Tristate::Auto);
 
     // Clamp LOD bias so that people don't abuse this in unintended ways
     this->samplerLodBias = dxvk::fclamp(this->samplerLodBias, -2.0f, 1.0f);

--- a/src/d3d11/d3d11_options.h
+++ b/src/d3d11/d3d11_options.h
@@ -114,6 +114,9 @@ namespace dxvk {
     /// Some games are broken and ignore row pitch.
     bool disableDirectImageMapping = false;
 
+    /// Whether to use sincos emulation
+    Tristate sincosEmulation = Tristate::Auto;
+
     /// Shader dump path
     std::string shaderDumpPath;
   };

--- a/src/d3d9/d3d9_options.cpp
+++ b/src/d3d9/d3d9_options.cpp
@@ -101,6 +101,11 @@ namespace dxvk {
       d3d9FloatEmulation = hasMulz ? D3D9FloatEmulation::Strict : D3D9FloatEmulation::Enabled;
     }
 
+    // Intel's hardware sin/cos is so inaccurate that it causes rendering issues in some games
+    this->sincosEmulation = adapter && (adapter->matchesDriver(VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA)
+                                     || adapter->matchesDriver(VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS));
+    applyTristate(this->sincosEmulation, config.getOption<Tristate>("d3d9.sincosEmulation", Tristate::Auto));
+
     this->shaderDumpPath = env::getEnvVar("DXVK_SHADER_DUMP_PATH");
   }
 

--- a/src/d3d9/d3d9_options.h
+++ b/src/d3d9/d3d9_options.h
@@ -152,6 +152,9 @@ namespace dxvk {
     /// Enable depth texcoord Z (Dref) scaling (D3D8 quirk)
     int32_t drefScaling;
 
+    /// Enable slow sincos emulation
+    bool sincosEmulation;
+
     /// Add an extra front buffer to make GetFrontBufferData() work correctly when the swapchain only has a single buffer
     bool extraFrontbuffer;
   };

--- a/src/dxbc/dxbc_compiler.cpp
+++ b/src/dxbc/dxbc_compiler.cpp
@@ -2328,33 +2328,48 @@ namespace dxvk {
     // Load source operand as 32-bit float vector.
     const DxbcRegisterValue srcValue = emitRegisterLoad(
       ins.src[0], DxbcRegMask(true, true, true, true));
-    
-    // Either output may be DxbcOperandType::Null, in
-    // which case we don't have to generate any code.
-    if (ins.dst[0].type != DxbcOperandType::Null) {
-      const DxbcRegisterValue sinInput =
-        emitRegisterExtract(srcValue, ins.dst[0].mask);
-      
-      DxbcRegisterValue sin;
-      sin.type = sinInput.type;
-      sin.id = m_module.opSin(
-        getVectorTypeId(sin.type),
-        sinInput.id);
-      
-      emitRegisterStore(ins.dst[0], sin);
+
+    uint32_t typeId = getScalarTypeId(srcValue.type.ctype);
+
+    DxbcRegisterValue sinVector = { };
+    sinVector.type.ctype = DxbcScalarType::Float32;
+
+    DxbcRegisterValue cosVector = { };
+    cosVector.type.ctype = DxbcScalarType::Float32;
+
+    // Only compute sincos for enabled components
+    std::array<uint32_t, 4> sinIds = { };
+    std::array<uint32_t, 4> cosIds = { };
+
+    for (uint32_t i = 0; i < 4; i++) {
+      const uint32_t sinIndex = 0u;
+      const uint32_t cosIndex = 1u;
+
+      if (ins.dst[0].mask[i] || ins.dst[1].mask[i]) {
+        uint32_t sincosId = m_module.opSinCos(m_module.opCompositeExtract(typeId, srcValue.id, 1u, &i), !m_moduleInfo.options.sincosEmulation);
+
+        if (ins.dst[0].type != DxbcOperandType::Null && ins.dst[0].mask[i])
+          sinIds[sinVector.type.ccount++] = m_module.opCompositeExtract(typeId, sincosId, 1u, &sinIndex);
+
+        if (ins.dst[1].type != DxbcOperandType::Null && ins.dst[1].mask[i])
+          cosIds[cosVector.type.ccount++] = m_module.opCompositeExtract(typeId, sincosId, 1u, &cosIndex);
+      }
     }
-    
-    if (ins.dst[1].type != DxbcOperandType::Null) {
-      const DxbcRegisterValue cosInput =
-        emitRegisterExtract(srcValue, ins.dst[1].mask);
-      
-      DxbcRegisterValue cos;
-      cos.type = cosInput.type;
-      cos.id = m_module.opCos(
-        getVectorTypeId(cos.type),
-        cosInput.id);
-      
-      emitRegisterStore(ins.dst[1], cos);
+
+    if (sinVector.type.ccount) {
+      sinVector.id = sinVector.type.ccount > 1u
+        ? m_module.opCompositeConstruct(getVectorTypeId(sinVector.type), sinVector.type.ccount, sinIds.data())
+        : sinIds[0];
+
+      emitRegisterStore(ins.dst[0], sinVector);
+    }
+
+    if (cosVector.type.ccount) {
+      cosVector.id = cosVector.type.ccount > 1u
+        ? m_module.opCompositeConstruct(getVectorTypeId(cosVector.type), cosVector.type.ccount, cosIds.data())
+        : cosIds[0];
+
+      emitRegisterStore(ins.dst[1], cosVector);
     }
   }
   

--- a/src/dxbc/dxbc_options.cpp
+++ b/src/dxbc/dxbc_options.cpp
@@ -44,6 +44,11 @@ namespace dxvk {
     // ANV up to mesa 25.0.2 breaks when we *don't* explicitly write point size
     needsPointSizeExport = device->adapter()->matchesDriver(VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA, Version(), Version(25, 0, 3));
 
+    // Intel's hardware sin/cos is so inaccurate that it causes rendering issues in some games
+    sincosEmulation = device->adapter()->matchesDriver(VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA)
+                   || device->adapter()->matchesDriver(VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS);
+    applyTristate(sincosEmulation, options.sincosEmulation);
+
     // Figure out float control flags to match D3D11 rules
     if (options.floatControls) {
       if (devInfo.vk12.shaderSignedZeroInfNanPreserveFloat32)

--- a/src/dxbc/dxbc_options.h
+++ b/src/dxbc/dxbc_options.h
@@ -60,6 +60,9 @@ namespace dxvk {
     /// Whether exporting point size is required
     bool needsPointSizeExport = false;
 
+    /// Whether to enable sincos emulation
+    bool sincosEmulation = false;
+
     /// Float control flags
     DxbcFloatControlFlags floatControl;
 

--- a/src/dxso/dxso_compiler.cpp
+++ b/src/dxso/dxso_compiler.cpp
@@ -2114,11 +2114,17 @@ namespace dxvk {
         std::array<uint32_t, 4> sincosVectorIndices = { 0, 0, 0, 0 };
 
         uint32_t index = 0;
+        uint32_t type = m_module.defFloatType(32);
+        uint32_t sincos = m_module.opSinCos(src0, !m_moduleInfo.options.sincosEmulation);
+
+        uint32_t sinIndex = 0u;
+        uint32_t cosIndex = 1u;
+
         if (mask[0])
-          sincosVectorIndices[index++] = m_module.opCos(scalarTypeId, src0);
+          sincosVectorIndices[index++] = m_module.opCompositeExtract(type, sincos, 1u, &cosIndex);
 
         if (mask[1])
-          sincosVectorIndices[index++] = m_module.opSin(scalarTypeId, src0);
+          sincosVectorIndices[index++] = m_module.opCompositeExtract(type, sincos, 1u, &sinIndex);
 
         for (; index < result.type.ccount; index++) {
           if (sincosVectorIndices[index] == 0)

--- a/src/dxso/dxso_options.cpp
+++ b/src/dxso/dxso_options.cpp
@@ -29,6 +29,7 @@ namespace dxvk {
 
     robustness2Supported = devFeatures.extRobustness2.robustBufferAccess2;
 
+    sincosEmulation     = options.sincosEmulation;
     drefScaling         = options.drefScaling;
   }
 

--- a/src/dxso/dxso_options.h
+++ b/src/dxso/dxso_options.h
@@ -42,6 +42,9 @@ namespace dxvk {
     /// Whether or not we can rely on robustness2 to handle oob constant access
     bool robustness2Supported;
 
+    /// Whether or not we need to use custom sincos
+    bool sincosEmulation = false;
+
     /// Whether runtime to apply Dref scaling for depth textures of specified bit depth
     /// (24: D24S8, 16: D16, 0: Disabled). This allows compatability with games
     /// that expect a different depth test range, which was typically a D3D8 quirk on

--- a/src/spirv/spirv_module.h
+++ b/src/spirv/spirv_module.h
@@ -1277,6 +1277,10 @@ namespace dxvk {
 
     void opEndInvocationInterlock();
 
+    uint32_t opSinCos(
+            uint32_t                x,
+            bool                    useBuiltIn);
+
   private:
     
     uint32_t m_version;
@@ -1331,6 +1335,15 @@ namespace dxvk {
     void classifyBlocks(
             std::unordered_set<uint32_t>& reachableBlocks,
             std::unordered_set<uint32_t>& mergeBlocks);
+
+    static constexpr double sincosTaylorFactor(uint32_t power) {
+      double result = 1.0;
+
+      for (uint32_t i = 1; i <= power; i++)
+        result *= pi * 0.25f / double(i);
+
+      return result;
+    }
 
   };
   

--- a/src/util/util_math.h
+++ b/src/util/util_math.h
@@ -5,7 +5,8 @@
 namespace dxvk {
   
   constexpr size_t CACHE_LINE_SIZE = 64;
-  
+  constexpr double pi = 3.14159265359;
+
   template<typename T>
   constexpr T clamp(T n, T lo, T hi) {
     if (n < lo) return lo;


### PR DESCRIPTION
Intel's `sin(x)` is **very** inaccurate for `|x| ≈ π/2`, which leads to issues such as #4861.

This is an attempt to work around the problem by implementing a custom sin/cos implementation using a Taylor approximation within a range of `[-π/4,π/4]`, and doing some magic to map the rest of the curve to that interval. Precision is good enough to meet D3D11 requirements and should fix Thumper, but this is expected to be quite slow.

On systems with good sin/cos, keep using the corresponding SPIR-V instructions.

Needs testing across a reasonably wide range of games including D3D11, this changes code gen in *all* shaders that use `sincos` instructions even if the workaround is not used.