### PR TITLE
[d3d9] Implement hideVendorGPU logic for d3d9

### DIFF
--- a/dxvk.conf
+++ b/dxvk.conf
@@ -147,14 +147,17 @@
 # d3d9.customDeviceDesc = ""
 
 
-# Report Nvidia GPUs as AMD GPUs. Unless NVAPI support is explicitly
-# enabled through Proton, this is done by default in order to work
-# around crashes or low performance with Nvidia-speciic code paths
-# in games, especially Unreal Engine.
+# Report Nvidia GPUs as AMD GPUs. For DXGI, unless NVAPI support
+# is explicitly enabled through Proton, this is done by default in
+# order to work around crashes or low performance with Nvidia-specific
+# code paths in games, especially Unreal Engine. On the D3D8/9 side,
+# it is generally only done for games known to take issue with NVAPI,
+# or otherwise behave poorly on Nvidia.
 #
 # Supported values: Auto, True, False
 
 # dxgi.hideNvidiaGpu = Auto
+# d3d9.hideNvidiaGpu = Auto
 
 
 # Report Nvidia GPUs running on NVK as AMD GPUs.
@@ -162,6 +165,7 @@
 # Supported values: Auto, True, False
 
 # dxgi.hideNvkGpu = Auto
+# d3d9.hideNvkGpu = Auto
 
 
 # Report AMD GPUs as Nvidia GPUs. This is only done for games that are
@@ -170,14 +174,18 @@
 # Supported values: Auto, True, False
 
 # dxgi.hideAmdGpu = Auto
+# d3d9.hideAmdGpu = Auto
 
 
 # Report Intel GPUs as AMD GPUs. This is only done for games that are
 # known to have issues with Intel-specific libraries such as XESS.
+# Hiding Intel GPUs defaults to True for D3D8/9 in order to circumvent
+# iGPU specific restrictions affecting early Intel hardware.
 #
 # Supported values: Auto, True, False
 
 # dxgi.hideIntelGpu = Auto
+# d3d9.hideIntelGpu = True
 
 
 # Override maximum amount of device memory and shared system memory
@@ -635,17 +643,6 @@
 
 # d3d9.supportX4R4G4B4 = True
 
-# Support D16_LOCKABLE
-#
-# Support the D16_LOCKABLE format.
-# Always enabled on AMD, or when spoofing an AMD GPU
-# via customVendorId, disabled by default on Nvidia and Intel.
-#
-# Supported values:
-# - True/False
-
-# d3d9.supportD16Lockable = False
-
 # Disable A8 as a Render Target
 #
 # Disable support for A8 format render targets
@@ -655,18 +652,6 @@
 # - True/False
 
 # d3d9.disableA8RT = False
-
-# Support for VCache Query
-#
-# Support for the vcache query
-# Not very important as a user config.
-# Used internally.
-#
-# Supported values:
-# - True/False
-
-# Defaults to True if vendorId == 0x10de
-# d3d9.supportVCache = True
 
 # Force Sampler Type Spec Constants
 #

--- a/src/d3d9/d3d9_adapter.h
+++ b/src/d3d9/d3d9_adapter.h
@@ -107,6 +107,9 @@ namespace dxvk {
 
     const D3D9VkFormatTable       m_d3d9Formats;
 
+    // Ensure GPU hiding only gets logged once per adapter
+    bool                          m_notifyHidingGpu = true;
+
   };
 
 }

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -193,6 +193,12 @@ namespace dxvk {
     m_activeRTsWhichAreTextures = 0;
     m_alphaSwizzleRTs = 0;
     m_lastHazardsRT = 0;
+
+    // Determine VCache query support
+    D3DADAPTER_IDENTIFIER9 adapterId9;
+    HRESULT res = m_adapter->GetAdapterIdentifier(0, &adapterId9);
+    const uint32_t vendorId = SUCCEEDED(res) ? adapterId9.VendorId : 0;
+    m_isVCacheQuerySupported = vendorId == uint32_t(DxvkGpuVendor::Nvidia);
   }
 
 
@@ -4507,6 +4513,11 @@ namespace dxvk {
 
   bool D3D9DeviceEx::SupportsSWVP() {
     return m_dxvkDevice->features().core.features.vertexPipelineStoresAndAtomics && m_dxvkDevice->features().vk12.shaderInt8;
+  }
+
+
+  bool D3D9DeviceEx::SupportsVCacheQuery() const {
+    return m_isVCacheQuerySupported;
   }
 
 

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -704,6 +704,8 @@ namespace dxvk {
      */
     bool SupportsSWVP();
 
+    bool SupportsVCacheQuery() const;
+
     bool IsExtended();
 
     HWND GetWindow();
@@ -1566,6 +1568,7 @@ namespace dxvk {
 
     bool                            m_isSWVP;
     bool                            m_isD3D8Compatible;
+    bool                            m_isVCacheQuerySupported;
     bool                            m_amdATOC          = false;
     bool                            m_nvATOC           = false;
     bool                            m_ffZTest          = false;

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -1466,6 +1466,8 @@ namespace dxvk {
     D3D9Adapter*                    m_adapter;
     Rc<DxvkDevice>                  m_dxvkDevice;
 
+    uint32_t                        m_vendorId;
+
     D3D9MemoryAllocator             m_memoryAllocator;
 
     // Second memory allocator used for D3D9 shader bytecode.
@@ -1568,7 +1570,6 @@ namespace dxvk {
 
     bool                            m_isSWVP;
     bool                            m_isD3D8Compatible;
-    bool                            m_isVCacheQuerySupported;
     bool                            m_amdATOC          = false;
     bool                            m_nvATOC           = false;
     bool                            m_ffZTest          = false;

--- a/src/d3d9/d3d9_format.h
+++ b/src/d3d9/d3d9_format.h
@@ -179,6 +179,8 @@ namespace dxvk {
 
   D3D9_FORMAT_BLOCK_SIZE GetFormatAlignedBlockSize(D3D9Format Format);
 
+  class D3D9Adapter;
+
   /**
    * \brief Format table
    *
@@ -191,6 +193,7 @@ namespace dxvk {
   public:
 
     D3D9VkFormatTable(
+            D3D9Adapter*     pParent,
       const Rc<DxvkAdapter>& adapter,
       const D3D9Options&     options);
 

--- a/src/d3d9/d3d9_options.cpp
+++ b/src/d3d9/d3d9_options.cpp
@@ -33,14 +33,14 @@ namespace dxvk {
     const Rc<DxvkAdapter> adapter = device != nullptr ? device->adapter() : nullptr;
 
     // Fetch these as a string representing a hexadecimal number and parse it.
-    this->customVendorId        = parsePciId(config.getOption<std::string>("d3d9.customVendorId"));
-    this->customDeviceId        = parsePciId(config.getOption<std::string>("d3d9.customDeviceId"));
-    this->customDeviceDesc      =            config.getOption<std::string>("d3d9.customDeviceDesc");
+    this->customVendorId                = parsePciId(config.getOption<std::string>("d3d9.customVendorId"));
+    this->customDeviceId                = parsePciId(config.getOption<std::string>("d3d9.customDeviceId"));
+    this->customDeviceDesc              = config.getOption<std::string> ("d3d9.customDeviceDesc");
 
-    const uint32_t vendorId = this->customVendorId != -1
-      ? this->customVendorId
-      : (adapter != nullptr ? adapter->deviceProperties().vendorID : 0);
-
+    this->hideNvidiaGpu                 = config.getOption<Tristate>    ("d3d9.hideNvidiaGpu",                 Tristate::Auto) == Tristate::True;
+    this->hideNvkGpu                    = config.getOption<Tristate>    ("d3d9.hideNvkGpu",                    Tristate::Auto) == Tristate::True;
+    this->hideAmdGpu                    = config.getOption<Tristate>    ("d3d9.hideAmdGpu",                    Tristate::Auto) == Tristate::True;
+    this->hideIntelGpu                  = config.getOption<Tristate>    ("d3d9.hideIntelGpu",                  Tristate::True) == Tristate::True;
     this->maxFrameLatency               = config.getOption<int32_t>     ("d3d9.maxFrameLatency",               0);
     this->maxFrameRate                  = config.getOption<int32_t>     ("d3d9.maxFrameRate",                  0);
     this->presentInterval               = config.getOption<int32_t>     ("d3d9.presentInterval",               -1);
@@ -54,12 +54,10 @@ namespace dxvk {
     this->maxAvailableMemory            = config.getOption<int32_t>     ("d3d9.maxAvailableMemory",            4096);
     this->supportDFFormats              = config.getOption<bool>        ("d3d9.supportDFFormats",              true);
     this->supportX4R4G4B4               = config.getOption<bool>        ("d3d9.supportX4R4G4B4",               true);
-    this->supportD16Lockable            = config.getOption<bool>        ("d3d9.supportD16Lockable",            false);
     this->useD32forD24                  = config.getOption<bool>        ("d3d9.useD32forD24",                  false);
     this->disableA8RT                   = config.getOption<bool>        ("d3d9.disableA8RT",                   false);
     this->invariantPosition             = config.getOption<bool>        ("d3d9.invariantPosition",             true);
     this->memoryTrackTest               = config.getOption<bool>        ("d3d9.memoryTrackTest",               false);
-    this->supportVCache                 = config.getOption<bool>        ("d3d9.supportVCache",                 vendorId == uint32_t(DxvkGpuVendor::Nvidia));
     this->forceSamplerTypeSpecConstants = config.getOption<bool>        ("d3d9.forceSamplerTypeSpecConstants", false);
     this->forceSwapchainMSAA            = config.getOption<int32_t>     ("d3d9.forceSwapchainMSAA",            -1);
     this->forceSampleRateShading        = config.getOption<bool>        ("d3d9.forceSampleRateShading",        false);
@@ -87,18 +85,18 @@ namespace dxvk {
 
     std::string floatEmulation = Config::toLower(config.getOption<std::string>("d3d9.floatEmulation", "auto"));
     if (floatEmulation == "strict") {
-      d3d9FloatEmulation = D3D9FloatEmulation::Strict;
+      this->d3d9FloatEmulation = D3D9FloatEmulation::Strict;
     } else if (floatEmulation == "false") {
-      d3d9FloatEmulation = D3D9FloatEmulation::Disabled;
+      this->d3d9FloatEmulation = D3D9FloatEmulation::Disabled;
     } else if (floatEmulation == "true") {
-      d3d9FloatEmulation = D3D9FloatEmulation::Enabled;
+      this->d3d9FloatEmulation = D3D9FloatEmulation::Enabled;
     } else {
       bool hasMulz = adapter != nullptr
                   && (adapter->matchesDriver(VK_DRIVER_ID_MESA_RADV)
                    || adapter->matchesDriver(VK_DRIVER_ID_MESA_NVK)
                    || adapter->matchesDriver(VK_DRIVER_ID_AMD_OPEN_SOURCE, Version(2, 0, 316), Version())
                    || adapter->matchesDriver(VK_DRIVER_ID_NVIDIA_PROPRIETARY, Version(565, 57, 1), Version()));
-      d3d9FloatEmulation = hasMulz ? D3D9FloatEmulation::Strict : D3D9FloatEmulation::Enabled;
+      this->d3d9FloatEmulation = hasMulz ? D3D9FloatEmulation::Strict : D3D9FloatEmulation::Enabled;
     }
 
     this->shaderDumpPath = env::getEnvVar("DXVK_SHADER_DUMP_PATH");

--- a/src/d3d9/d3d9_options.h
+++ b/src/d3d9/d3d9_options.h
@@ -22,6 +22,19 @@ namespace dxvk {
     int32_t customDeviceId;
     std::string customDeviceDesc;
 
+    /// Reports Nvidia GPUs running on the proprietary driver as a different
+    /// vendor (usually AMD)
+    bool hideNvidiaGpu;
+
+    /// Reports Nvidia GPUs running on NVK as a different vendor (usually AMD)
+    bool hideNvkGpu;
+
+    /// Reports AMD GPUs as a different vendor (usually Nvidia)
+    bool hideAmdGpu;
+
+    /// Reports Intel GPUs as a different vendor (usually AMD)
+    bool hideIntelGpu;
+
     /// Present interval. Overrides the value
     /// in D3DPRESENT_PARAMS used in swapchain present.
     int32_t presentInterval;
@@ -74,9 +87,6 @@ namespace dxvk {
     /// Support X4R4G4B4
     bool supportX4R4G4B4;
 
-    /// Support D16_LOCKABLE
-    bool supportD16Lockable;
-
     /// Use D32f for D24
     bool useD32forD24;
 
@@ -92,9 +102,6 @@ namespace dxvk {
     /// Whether or not to respect memory tracking for
     /// failing resource allocation.
     bool memoryTrackTest;
-
-    /// Support VCACHE query
-    bool supportVCache;
 
     /// Forced aspect ratio, disable other modes
     std::string forceAspectRatio;

--- a/src/d3d9/d3d9_query.cpp
+++ b/src/d3d9/d3d9_query.cpp
@@ -314,7 +314,7 @@ namespace dxvk {
   HRESULT D3D9Query::QuerySupported(D3D9DeviceEx* pDevice, D3DQUERYTYPE QueryType) {
     switch (QueryType) {
       case D3DQUERYTYPE_VCACHE:
-        if (!pDevice->GetOptions()->supportVCache)
+        if (!pDevice->SupportsVCacheQuery())
           return D3DERR_NOTAVAILABLE;
 
         return D3D_OK;

--- a/src/dxgi/dxgi_adapter.cpp
+++ b/src/dxgi/dxgi_adapter.cpp
@@ -293,7 +293,7 @@ namespace dxvk {
       uint16_t fallbackDevice = 0xbeef;
 
       if (!options->hideAmdGpu) {
-        // AMD RX 6700XT
+        // AMD RX 6700 XT
         fallbackVendor = uint16_t(DxvkGpuVendor::Amd);
         fallbackDevice = 0x73df;
       } else if (!options->hideNvidiaGpu) {
@@ -315,7 +315,9 @@ namespace dxvk {
         if (options->customDeviceId < 0)
           deviceProp.deviceID = fallbackDevice;
 
-        Logger::info(str::format("DXGI: Hiding actual GPU, reporting vendor ID 0x", std::hex, deviceProp.vendorID, ", device ID ", deviceProp.deviceID));
+        Logger::info(str::format("DXGI: Hiding actual GPU, reporting:\n",
+                                 "  vendor ID: 0x", std::hex, deviceProp.vendorID, "\n",
+                                 "  device ID: 0x", std::hex, deviceProp.deviceID, "\n"));
       }
     }
     

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -184,15 +184,15 @@ namespace dxvk {
       { "dxgi.customVendorId",              "10de" },
     }} },
     /* Crysis 3 - slower if it notices AMD card     *
-     * Apitrace mode helps massively in cpu bound   *
-     * game parts                                   */
+     * Cached dynamic buffers help massively        *
+     * in CPU bound game parts                      */
     { R"(\\Crysis3\.exe$)", {{
       { "dxgi.customVendorId",              "10de" },
       { "d3d11.cachedDynamicResources",     "a"    },
     }} },
     /* Crysis 3 Remastered                          *
-     * Apitrace mode helps massively in cpu bound   *
-     * game parts                                   */
+     * Cached dynamic buffers help massively        *
+     * in CPU bound game parts                      */
     { R"(\\Crysis3Remastered\.exe$)", {{
       { "d3d11.cachedDynamicResources",     "a"    },
     }} },
@@ -570,7 +570,7 @@ namespace dxvk {
        Needs NVAPI to avoid a forced AO + Smoke
        exploit so we must force AMD vendor ID.    */
     { R"(\\csgo\.exe$)", {{
-      { "d3d9.customVendorId",              "1002" },
+      { "d3d9.hideNvidiaGpu",               "True" },
     }} },
     /* Vampire - The Masquerade Bloodlines        */
     { R"(\\vampire\.exe$)", {{
@@ -584,7 +584,7 @@ namespace dxvk {
     }} },
     /* Skyrim (NVAPI)                             */
     { R"(\\TESV\.exe$)", {{
-      { "d3d9.customVendorId",              "1002" },
+      { "d3d9.hideNvidiaGpu",               "True" },
     }} },
     /* Hyperdimension Neptunia U: Action Unleashed */
     { R"(\\Neptunia\.exe$)", {{
@@ -599,7 +599,7 @@ namespace dxvk {
      * path for mirrors.
      * Also runs into issues after alt-tabbing.   */
     { R"(\\(GTAIV|EFLC)\.exe$)", {{
-      { "d3d9.customVendorId",              "1002" },
+      { "d3d9.hideNvidiaGpu",               "True" },
       { "dxgi.maxDeviceMemory",             "128" },
       { "d3d9.supportDFFormats",            "False" },
       { "d3d9.deviceLossOnFocusLoss",       "True" },
@@ -640,9 +640,10 @@ namespace dxvk {
       { "d3d9.customVendorId",              "10de" },
       { "d3d9.customDeviceId",              "0402" },
     }} },
-    /* Warhammer: Online                         */
+    /* Warhammer: Online                         *
+     * Overly bright ground textures on Nvidia   */
     { R"(\\(WAR(-64)?|WARTEST(-64)?)\.exe$)", {{
-      { "d3d9.customVendorId",              "1002" },
+      { "d3d9.hideNvidiaGpu",               "True" },
     }} },
     /* Dragon Nest                               */
     { R"(\\DragonNest_x64\.exe$)", {{
@@ -670,7 +671,7 @@ namespace dxvk {
     }} },
     /* Far Cry 1 has worse water rendering when it detects AMD GPUs */
     { R"(\\FarCry\.exe$)", {{
-      { "d3d9.customVendorId",              "10de" },
+      { "d3d9.hideAmdGpu",                  "True" },
     }} },
     /* Sine Mora EX */
     { R"(\\SineMoraEX\.exe$)", {{
@@ -734,12 +735,10 @@ namespace dxvk {
       { "d3d9.maxAvailableMemory",          "2048" },
     }} },
     /* Myst V End of Ages                       *
-     * White textures unless it sees Nvidia,    *
-     * Intel or ATI VendorId.                   *
-     * "Radeon" in gpu description also works.  *
-     * countLosable for resolution change crash.*/
+     * Resolution change crash and cached       *
+     * dynamic buffers for performance reasons  */
     { R"(\\eoa\.exe$)", {{
-      { "d3d9.customVendorId",              "10de" },
+      { "d3d9.cachedDynamicBuffers",        "True" },
       { "d3d9.countLosableResources",       "False" },
     }} },
     /* Supreme Commander & Forged Alliance Forever */
@@ -806,20 +805,11 @@ namespace dxvk {
     { R"(\\DAOrigins\.exe$)" , {{
       { "d3d9.allowDirectBufferMapping",    "False" },
     }} },
-    /* Fallout 3 - Doesn't like Intel Id       */
-    { R"(\\Fallout3\.exe$)", {{
-      { "d3d9.customVendorId",              "10de" },
-    }} },
     /* Sonic & All-Stars Racing Transformed    *
      * Helps performance when Resizable BAR    *
      * is enabled                              */
     { R"(\\ASN_App_PcDx9_Final\.exe$)", {{
       { "d3d9.cachedDynamicBuffers",        "True" },
-    }} },
-    /* Black Mesa                              *
-     * Artifacts & broken flashlight on Intel  */
-    { R"(\\bms\.exe$)", {{
-      { "d3d9.customVendorId",              "10de" },
     }} },
     /* Final Fantasy XIV - Direct3D 9 mode     *
      * Can crash with unmapping                */
@@ -939,8 +929,8 @@ namespace dxvk {
     /* Prototype                                 *
      * Incorrect shadows on AMD & Intel.         *
      * AA 4x can not be selected above 2GB vram  */
-    { R"(\\prototypef\.exe$)", {{ 
-      { "d3d9.supportDFFormats",            "False" },
+    { R"(\\prototypef\.exe$)", {{
+      { "d3d9.hideAmdGpu",                  "True" },
       { "dxgi.maxDeviceMemory",             "2047" },
     }} },
     /* STAR WARS: The Force Unleashed            *
@@ -1003,12 +993,10 @@ namespace dxvk {
     { R"(\\SecretWorldLegends\.exe$)", {{
       { "d3d9.memoryTrackTest",              "True" },
     }} },
-    /* Far Cry 2: Set vendor ID to Nvidia to       *
-     * avoid vegetation artifacts on Intel, and    *
-     * set apitrace mode to True to improve perf   *
-     * on all hardware.                            */
+    /* Far Cry 2:                                  *
+     * Set cached dynamic buffers to True to       *
+     * improve perf on all hardware.               */
     { R"(\\(FarCry2|farcry2game)\.exe$)", {{
-      { "d3d9.customVendorId",              "10de" },
       { "d3d9.cachedDynamicBuffers",        "True" },
     }} },
     /* Dark Sector - Crashes in places             */
@@ -1026,11 +1014,9 @@ namespace dxvk {
       { "d3d9.floatEmulation",              "Strict" },
     }} },
     /* Star Wars Empire at War & expansion         *
-     * On Intel the Water & Shader Detail option   *
-     * can't be modified. In base game the AA      *
-     * option dissapears at 2075MB vram and above  */
+     * In base game the AA option dissapears at    *
+     * 2075MB vram and above                       */
     { R"(\\(StarWarsG|sweaw|swfoc)\.exe$)", {{
-      { "d3d9.customVendorId",              "1002" },
       { "d3d9.maxAvailableMemory",          "2048" },
       { "d3d9.memoryTrackTest",             "True" },
     }} },


### PR DESCRIPTION
Closes #4860 and goes a bit beyond that to:
- clean up some vendorid jank in d3d9 code (now we determine what we're using in a single place)
- report all non-Intel, non-Nvidia and Non-AMD GPUs as AMD in d3d8/9 (this affects mobile GPU vendors) - I have not hidden this under a,  say, `d3d9.hideGenericGpu` config option, but I can do that if anyone thinks it's worthwhile.

Needs quite a bit of testing on Intel, AMD and mobile, as I was only able to confirm the new `d3d9.hideNvidiaGpu` option works as expected.

~We could also potentially rework some of the existing config options now, but I haven't really looked into any of that yet.~ ~Mostly done now, save for Warhammer, which I'm sure sure what is about.~ Done deal.