### PR TITLE
[d3d11] Support planar outputs in video processor

### DIFF
--- a/src/d3d11/d3d11_video.cpp
+++ b/src/d3d11/d3d11_video.cpp
@@ -208,11 +208,6 @@ namespace dxvk {
         throw DxvkError("Invalid view dimension");
     }
 
-    m_subresources.aspectMask = aspectMask;
-    m_subresources.baseArrayLayer = viewInfo.layerIndex;
-    m_subresources.layerCount = viewInfo.layerCount;
-    m_subresources.mipLevel = viewInfo.mipIndex;
-
     for (uint32_t i = 0; aspectMask && i < m_views.size(); i++) {
       viewInfo.aspects = vk::getNextAspect(aspectMask);
 

--- a/src/d3d11/d3d11_video.cpp
+++ b/src/d3d11/d3d11_video.cpp
@@ -1247,7 +1247,8 @@ namespace dxvk {
       cStreamState  = *pStreamState,
       cImage        = view->GetImage(),
       cViews        = view->GetViews(),
-      cIsYCbCr      = view->IsYCbCr()
+      cIsYCbCr      = view->IsYCbCr(),
+      cDstExtent    = m_dstExtent
     ] (DxvkContext* ctx) {
       DxvkImageUsageInfo usage = { };
       usage.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
@@ -1259,14 +1260,14 @@ namespace dxvk {
       VkViewport viewport;
       viewport.x        = 0.0f;
       viewport.y        = 0.0f;
-      viewport.width    = float(m_dstExtent.width);
-      viewport.height   = float(m_dstExtent.height);
+      viewport.width    = float(cDstExtent.width);
+      viewport.height   = float(cDstExtent.height);
       viewport.minDepth = 0.0f;
       viewport.maxDepth = 1.0f;
 
       VkRect2D scissor;
       scissor.offset = { 0, 0 };
-      scissor.extent = m_dstExtent;
+      scissor.extent = cDstExtent;
 
       if (cStreamState.dstRectEnabled) {
         viewport.x      = float(cStreamState.dstRect.left);

--- a/src/d3d11/d3d11_video.cpp
+++ b/src/d3d11/d3d11_video.cpp
@@ -1268,8 +1268,10 @@ namespace dxvk {
       cStreamState  = *pStreamState,
       cImage        = view->GetCommon().GetImage(),
       cViews        = view->GetCommon().GetViews(),
-      cIsYCbCr      = view->GetCommon().IsYCbCr(),
-      cDstExtent    = m_dstExtent
+      cSrcIsYCbCr   = view->GetCommon().IsYCbCr(),
+      cDstIsYCbCr   = m_dstIsYCbCr,
+      cDstExtent    = m_dstExtent,
+      cExportMode   = m_exportMode
     ] (DxvkContext* ctx) {
       DxvkImageUsageInfo usage = { };
       usage.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
@@ -1322,8 +1324,9 @@ namespace dxvk {
       uboData.yMin = 0.0f;
       uboData.yMax = 1.0f;
       uboData.isPlanar = cViews[1] != nullptr;
+      uboData.exportMode = cExportMode;
 
-      if (cIsYCbCr)
+      if (cSrcIsYCbCr && !cDstIsYCbCr)
         ApplyYCbCrMatrix(uboData.colorMatrix, cStreamState.colorSpace.YCbCr_Matrix);
 
       if (cStreamState.colorSpace.Nominal_Range) {

--- a/src/d3d11/d3d11_video.h
+++ b/src/d3d11/d3d11_video.h
@@ -177,29 +177,18 @@ namespace dxvk {
     void STDMETHODCALLTYPE GetDesc(
             D3D11_VIDEO_PROCESSOR_INPUT_VIEW_DESC* pDesc);
 
-    bool IsYCbCr() const {
-      return m_isYCbCr;
-    }
-
-    Rc<DxvkImage> GetImage() const {
-      return GetCommonTexture(m_resource.ptr())->GetImage();
-    }
-
-    std::array<Rc<DxvkImageView>, 2> GetViews() const {
-      return m_views;
+    const VideoProcessorView& GetCommon() const {
+      return m_common;
     }
 
   private:
 
-    Com<ID3D11Resource>                   m_resource;
+    VideoProcessorView                    m_common;
     D3D11_VIDEO_PROCESSOR_INPUT_VIEW_DESC m_desc;
-    std::array<Rc<DxvkImageView>, 2>      m_views;
-    bool                                  m_isYCbCr = false;
 
     D3DDestructionNotifier                m_destructionNotifier;
 
-    static bool IsYCbCrFormat(DXGI_FORMAT Format);
-
+    static DxvkImageViewKey CreateViewInfo(const D3D11_VIDEO_PROCESSOR_INPUT_VIEW_DESC& Desc);
   };
 
 

--- a/src/d3d11/d3d11_video.h
+++ b/src/d3d11/d3d11_video.h
@@ -218,14 +218,19 @@ namespace dxvk {
       return m_view;
     }
 
+    const VideoProcessorView& GetCommon() const {
+      return m_common;
+    }
+
   private:
 
-    Com<ID3D11Resource>                     m_resource;
+    VideoProcessorView                      m_common;
     D3D11_VIDEO_PROCESSOR_OUTPUT_VIEW_DESC  m_desc;
     Rc<DxvkImageView>                       m_view;
 
     D3DDestructionNotifier                  m_destructionNotifier;
 
+    static DxvkImageViewKey CreateViewInfo(const D3D11_VIDEO_PROCESSOR_OUTPUT_VIEW_DESC& Desc);
   };
 
 

--- a/src/d3d11/d3d11_video.h
+++ b/src/d3d11/d3d11_video.h
@@ -641,7 +641,7 @@ namespace dxvk {
     void ApplyYCbCrMatrix(float pColorMatrix[3][4], bool UseBt709);
 
     void BindOutputView(
-            ID3D11VideoProcessorOutputView* pOutputView);
+            Rc<DxvkImageView> dxvkView);
 
     void BlitStream(
       const D3D11VideoProcessorStreamState* pStreamState,

--- a/src/d3d11/d3d11_video.h
+++ b/src/d3d11/d3d11_video.h
@@ -146,10 +146,6 @@ namespace dxvk {
       return GetCommonTexture(m_resource.ptr())->GetImage();
     }
 
-    VkImageSubresourceLayers GetImageSubresources() const {
-      return m_subresources;
-    }
-
     std::array<Rc<DxvkImageView>, 2> GetViews() const {
       return m_views;
     }
@@ -158,7 +154,6 @@ namespace dxvk {
 
     Com<ID3D11Resource>                   m_resource;
     D3D11_VIDEO_PROCESSOR_INPUT_VIEW_DESC m_desc;
-    VkImageSubresourceLayers              m_subresources;
     std::array<Rc<DxvkImageView>, 2>      m_views;
     bool                                  m_isYCbCr = false;
 

--- a/src/d3d11/d3d11_video.h
+++ b/src/d3d11/d3d11_video.h
@@ -117,6 +117,45 @@ namespace dxvk {
 
 
 
+  class VideoProcessorView {
+
+  public:
+
+    VideoProcessorView(
+            D3D11Device*            pDevice,
+            ID3D11Resource*         pResource,
+            DxvkImageViewKey        viewInfo);
+
+    ~VideoProcessorView();
+
+    bool IsYCbCr() const {
+      return m_isYCbCr;
+    }
+
+    Rc<DxvkImage> GetImage() const {
+      return GetCommonTexture(m_resource.ptr())->GetImage();
+    }
+
+    std::array<Rc<DxvkImageView>, 2> GetViews() const {
+      return m_views;
+    }
+
+    ID3D11Resource *GetResource() {
+      return m_resource.ref();
+    }
+
+  private:
+
+    Com<ID3D11Resource>                   m_resource;
+    std::array<Rc<DxvkImageView>, 2>      m_views;
+    bool                                  m_isYCbCr = false;
+
+    static bool IsYCbCrFormat(DXGI_FORMAT Format);
+
+  };
+
+
+
   class D3D11VideoProcessorInputView : public D3D11DeviceChild<ID3D11VideoProcessorInputView> {
 
   public:

--- a/src/d3d11/d3d11_video.h
+++ b/src/d3d11/d3d11_video.h
@@ -608,12 +608,19 @@ namespace dxvk {
 
   private:
 
+    enum ExportMode : uint32_t {
+      ExportRGBA = 0,
+      ExportY    = 1,
+      ExportCbCr = 2,
+    };
+
     struct alignas(16) UboData {
       float colorMatrix[3][4];
       float coordMatrix[3][2];
       VkRect2D srcRect;
       float yMin, yMax;
       VkBool32 isPlanar;
+      ExportMode exportMode;
     };
 
     D3D11ImmediateContext*  m_ctx;
@@ -623,7 +630,9 @@ namespace dxvk {
     Rc<DxvkShader>          m_fs;
     Rc<DxvkBuffer>          m_ubo;
 
-    VkExtent2D m_dstExtent = { 0u, 0u };
+    VkExtent2D m_dstExtent  = { 0u, 0u };
+    bool       m_dstIsYCbCr = false;
+    ExportMode m_exportMode = ExportRGBA;
 
     bool m_resourcesCreated = false;
 

--- a/src/d3d11/shaders/d3d11_video_blit_frag.frag
+++ b/src/d3d11/shaders/d3d11_video_blit_frag.frag
@@ -2,6 +2,10 @@
 
 #extension GL_EXT_samplerless_texture_functions : require
 
+#define EXPORT_RGBA (0u)
+#define EXPORT_Y (1u)
+#define EXPORT_CbCr (2u)
+
 // Can't use matrix types here since even a two-row
 // matrix will be padded to 16 bytes per column for
 // absolutely no reason
@@ -18,6 +22,7 @@ uniform ubo_t {
   float y_min;
   float y_max;
   bool is_planar;
+  uint export_mode;
 };
 
 layout(location = 0) in vec2 i_texcoord;
@@ -90,5 +95,10 @@ void main() {
     accum += factor.x * factor.y * color;
   }
 
-  o_color = accum;
+  if (export_mode == EXPORT_RGBA)
+    o_color = accum;
+  else if (export_mode == EXPORT_Y)
+    o_color = vec4(accum.g, 0.0, 0.0, 1.0);
+  else if (export_mode == EXPORT_CbCr)
+    o_color = vec4(accum.br, 0.0, 1.0);
 }


### PR DESCRIPTION
This aims to support the game JR East Train Simulator, which uses the video processor with input and output streams both in the NV12 format.

Vulkan does not (usually?) support rendering to a G8_B8R8_2PLANE_420_UNORM (=NV12) view (it lacks the COLOR_ATTACHMENT_BIT in features - tho I've only checked on a modern AMD gpu).

Two passes are necessary since the Y and CbCr views may have different dimensions (in the case of NV12, CbCr is half the size of the Y view).

Since the creation of the output view now significantly overlaps with the input view's code (both have to iterate over the aspectMask to create views), I've introduced a superclass `VideoProcessorView` to share the behavior.

In case of planar output, the output view still creates a view in its "native" format, to support being cleared by `D3D11CommonContext::ClearView`.
