### PR TITLE
[d3d9/d3d11] Negative/Positive/Both clampLodBias

### DIFF
--- a/dxvk.conf
+++ b/dxvk.conf
@@ -12,7 +12,7 @@
 # as determine it based on the DXGIOutput's current ColorSpace instead of
 # using CheckColorSpaceSupport.
 # This defaults to the value of the DXVK_HDR environment variable.
-# 
+#
 # Supported values: True, False
 
 # dxgi.enableHDR = True
@@ -45,7 +45,7 @@
 # the standard -Win64-Shipping.exe naming scheme. May be needed to avoid
 # crashes in D3D11 games on HDR-enabled systems due to statically linked
 # AMDAGS.
-# 
+#
 # Supported values: True, False
 
 # dxgi.enableUe4Workarounds = False
@@ -55,7 +55,7 @@
 # rather than when creating the swap chain. Some games that start
 # rendering with a different graphics API may require this option,
 # or otherwise the window may stay black.
-# 
+#
 # Supported values: True, False
 
 # dxgi.deferSurfaceCreation = False
@@ -65,7 +65,7 @@
 # Enforce a stricter maximum frame latency. Overrides the application
 # setting specified by calling IDXGIDevice::SetMaximumFrameLatency.
 # Setting this to 0 will have no effect.
-# 
+#
 # Supported values : 0 - 16
 
 # dxgi.maxFrameLatency = 0
@@ -104,7 +104,7 @@
 #         The implementation will either use VK_NV_low_latency2 if supported
 #         by the driver, or a custom algorithm.
 # - False: Disable Reflex support as well as built-in latency reduction.
-  
+
 # dxvk.latencySleep = Auto
 
 
@@ -239,7 +239,7 @@
 
 # Overrides the maximum allowed tessellation factor. This can be used to
 # improve performance in titles which overuse tessellation.
-# 
+#
 # Supported values: Any number between 8 and 64
 
 # d3d11.maxTessFactor = 0
@@ -270,7 +270,7 @@
 # Overrides anisotropic filtering for all samplers. Set this to a positive
 # value to enable AF for all samplers in the game, or to 0 in order to
 # disable AF entirely. Negative values will have no effect.
-# 
+#
 # Supported values: Any number between 0 and 16
 
 # d3d11.samplerAnisotropy = -1
@@ -288,13 +288,14 @@
 # d3d9.samplerLodBias = 0.0
 
 
-# Clamps any negative LOD bias to 0. Applies after samplerLodBias has been
-# applied. May help with games that use a high negative LOD bias by default.
+# Clamps any LOD bias to 0. Applies after samplerLodBias has been
+# applied. Negative can reduce texture shimmering/moire. Positive can
+# improve texture quality but may introduce texture shimmering/moire.
 #
-# Supported values: True, False
+# Supported values: Negative, Positive, Both, None
 
-# d3d11.clampNegativeLodBias = False
-# d3d9.clampNegativeLodBias = False
+# d3d11.clampLodBias = "None"
+# d3d9.clampLodBias = "None"
 
 
 # Declares vertex positions as invariant in order to solve
@@ -421,7 +422,7 @@
 
 
 # Sets number of pipeline compiler threads.
-# 
+#
 # If the graphics pipeline library feature is enabled, the given
 # number of threads will be used for shader compilation. Some of
 # these threads will be reserved for high-priority work.
@@ -434,13 +435,13 @@
 
 
 # Toggles raw SSBO usage.
-# 
+#
 # Uses storage buffers to implement raw and structured buffer
 # views. Enabled by default on hardware which has a storage
 # buffer offset alignment requirement of 4 Bytes (e.g. AMD).
 # Enabling this may improve performance, but is not safe on
 # hardware with higher alignment requirements.
-# 
+#
 # Supported values:
 # - Auto: Don't change the default
 # - True, False: Always enable / disable
@@ -492,12 +493,12 @@
 
 
 # Sets enabled HUD elements
-# 
+#
 # Behaves like the DXVK_HUD environment variable if the
 # environment variable is not set, otherwise it will be
 # ignored. The syntax is identical.
 
-# dxvk.hud = 
+# dxvk.hud =
 
 
 # Reported shader model
@@ -505,7 +506,7 @@
 # The shader model to state that we support in the device
 # capabilities that the application queries. Note that
 # the value will be limited to 1 for D3D8 applications.
-# 
+#
 # Supported values:
 # - 0: Fixed-function only
 # - 1: Shader Model 1
@@ -516,7 +517,7 @@
 
 
 # DPI Awareness
-# 
+#
 # Decides whether we should call SetProcessDPIAware on device
 # creation. Helps avoid upscaling blur in modern Windows on
 # Hi-DPI screens/devices.
@@ -528,7 +529,7 @@
 
 
 # Strict Constant Copies
-# 
+#
 # Decides whether we should always copy defined constants to
 # the UBO when relative addressing is used, or only when the
 # relative addressing starts a defined constant.
@@ -540,7 +541,7 @@
 
 
 # Strict Pow
-# 
+#
 # Decides whether we have an opSelect for handling pow(0,0) = 0
 # otherwise it becomes undefined.
 #
@@ -588,7 +589,7 @@
 
 
 # Overrides the application's MSAA level on the swapchain
-# 
+#
 # Supported values: -1 (application) and 0 to 16 (user override)
 
 # d3d9.forceSwapchainMSAA = -1

--- a/src/d3d11/d3d11_options.cpp
+++ b/src/d3d11/d3d11_options.cpp
@@ -3,7 +3,7 @@
 #include "d3d11_options.h"
 
 namespace dxvk {
-  
+
   static bool IsAPITracingDXGI() {
 #ifdef _WIN32
     return !!::GetModuleHandle("dxgitrace.dll");
@@ -21,7 +21,7 @@ namespace dxvk {
     this->maxTessFactor         = config.getOption<int32_t>("d3d11.maxTessFactor", 0);
     this->samplerAnisotropy     = config.getOption<int32_t>("d3d11.samplerAnisotropy", -1);
     this->samplerLodBias        = config.getOption<float>("d3d11.samplerLodBias", 0.0f);
-    this->clampNegativeLodBias  = config.getOption<bool>("d3d11.clampNegativeLodBias", false);
+    this->clampLodBias          = config.getOption<std::string>("d3d11.clampLodBias", std::string());
     this->invariantPosition     = config.getOption<bool>("d3d11.invariantPosition", true);
     this->floatControls         = config.getOption<bool>("d3d11.floatControls", true);
     this->forceSampleRateShading = config.getOption<bool>("d3d11.forceSampleRateShading", false);
@@ -61,5 +61,5 @@ namespace dxvk {
     // Shader dump path is only available via an environment variable
     this->shaderDumpPath = env::getEnvVar("DXVK_SHADER_DUMP_PATH");
   }
-  
+
 }

--- a/src/d3d11/d3d11_options.h
+++ b/src/d3d11/d3d11_options.h
@@ -63,8 +63,8 @@ namespace dxvk {
     /// Enforces the given LOD bias for all samplers.
     float samplerLodBias = 0.0f;
 
-    /// Clamps negative LOD bias
-    bool clampNegativeLodBias = false;
+    /// Clamps LOD bias
+    std::string clampLodBias;
 
     /// Declare vertex positions in shaders as invariant
     bool invariantPosition = true;
@@ -117,5 +117,5 @@ namespace dxvk {
     /// Shader dump path
     std::string shaderDumpPath;
   };
-  
+
 }

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -4197,7 +4197,7 @@ namespace dxvk {
       const Com<D3D9Surface> surface = new D3D9Surface(this, &desc, IsExtended(), nullptr, pSharedHandle);
       m_initializer->InitTexture(surface->GetCommonTexture());
       *ppSurface = surface.ref();
-      
+
       if (desc.Pool == D3DPOOL_DEFAULT)
         m_losableResourceCounter++;
 
@@ -4442,7 +4442,7 @@ namespace dxvk {
           DWORD                      Stage,
           D3D9TextureStageStateTypes Type,
           DWORD                      Value) {
-    
+
     // Clamp values instead of checking and returning INVALID_CALL
     // Matches tests + Dawn of Magic 2 relies on it.
     Stage = std::min(Stage, DWORD(caps::TextureStageCount - 1));
@@ -7114,8 +7114,14 @@ namespace dxvk {
         float lodBias = cState.mipLodBias;
         lodBias += m_d3d9Options.samplerLodBias;
 
-        if (m_d3d9Options.clampNegativeLodBias)
+        auto clampLodBias = m_d3d9Options.clampLodBias;
+        if (clampLodBias == "Negative") {
           lodBias = std::max(lodBias, 0.0f);
+        } else if (clampLodBias == "Positive") {
+          lodBias = std::min(lodBias, 0.0f);
+        } else if (clampLodBias == "Both") {
+          lodBias = 0.0f;
+        }
 
         key.setLodRange(float(cState.maxMipLevel), 16.0f, lodBias);
       }

--- a/src/d3d9/d3d9_options.cpp
+++ b/src/d3d9/d3d9_options.cpp
@@ -9,7 +9,7 @@ namespace dxvk {
   static int32_t parsePciId(const std::string& str) {
     if (str.size() != 4)
       return -1;
-    
+
     int32_t id = 0;
 
     for (size_t i = 0; i < str.size(); i++) {
@@ -72,7 +72,7 @@ namespace dxvk {
     this->textureMemory                 = config.getOption<int32_t>     ("d3d9.textureMemory",                 100) << 20;
     this->deviceLossOnFocusLoss         = config.getOption<bool>        ("d3d9.deviceLossOnFocusLoss",         false);
     this->samplerLodBias                = config.getOption<float>       ("d3d9.samplerLodBias",                0.0f);
-    this->clampNegativeLodBias          = config.getOption<bool>        ("d3d9.clampNegativeLodBias",          false);
+    this->clampLodBias                  = config.getOption<std::string> ("d3d9.clampLodBias",                  "None");
     this->countLosableResources         = config.getOption<bool>        ("d3d9.countLosableResources",         true);
     this->reproducibleCommandStream     = config.getOption<bool>        ("d3d9.reproducibleCommandStream",     false);
     this->extraFrontbuffer              = config.getOption<bool>        ("d3d9.extraFrontbuffer",              false);

--- a/src/d3d9/d3d9_options.h
+++ b/src/d3d9/d3d9_options.h
@@ -129,8 +129,8 @@ namespace dxvk {
     /// Enforces the given LOD bias for all samplers.
     float samplerLodBias;
 
-    /// Clamps negative LOD bias
-    bool clampNegativeLodBias;
+    /// Clamps LOD bias
+    std::string clampLodBias;
 
     /// How much virtual memory will be used for textures (in MB).
     int32_t textureMemory;


### PR DESCRIPTION
Makes clampLodBias able to clamp positive and both instead of just negative.
Positive might prevent blurry textures. Not sure if any games do this, though.