### PR TITLE
[d3d9] Properly determine support for vendor hacks

### DIFF
--- a/src/d3d9/d3d9_adapter.h
+++ b/src/d3d9/d3d9_adapter.h
@@ -79,6 +79,10 @@ namespace dxvk {
 
     Rc<DxvkAdapter> GetDXVKAdapter() { return m_adapter; }
 
+    uint32_t GetVendorId() const {
+      return m_vendorId;
+    }
+
     D3D9_VK_FORMAT_MAPPING GetFormatMapping(D3D9Format Format) const {
       return m_d3d9Formats.GetFormatMapping(Format);
     }
@@ -96,19 +100,24 @@ namespace dxvk {
 
     void CacheModes(D3D9Format Format);
 
+    void CacheIdentifierInfo();
+
     D3D9InterfaceEx*              m_parent;
 
     Rc<DxvkAdapter>               m_adapter;
     UINT                          m_ordinal;
     UINT                          m_displayIndex;
 
+    GUID                          m_deviceGuid;
+    uint32_t                      m_vendorId;
+    uint32_t                      m_deviceId;
+    std::string                   m_deviceDesc;
+    std::string                   m_deviceDriver;
+
     std::vector<D3DDISPLAYMODEEX> m_modes;
     D3D9Format                    m_modeCacheFormat;
 
     const D3D9VkFormatTable       m_d3d9Formats;
-
-    // Ensure GPU hiding only gets logged once per adapter
-    bool                          m_notifyHidingGpu = true;
 
   };
 

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -193,11 +193,6 @@ namespace dxvk {
     m_activeRTsWhichAreTextures = 0;
     m_alphaSwizzleRTs = 0;
     m_lastHazardsRT = 0;
-
-    // Determine used vendor ID
-    D3DADAPTER_IDENTIFIER9 adapterId9;
-    HRESULT res = m_adapter->GetAdapterIdentifier(0, &adapterId9);
-    m_vendorId = SUCCEEDED(res) ? adapterId9.VendorId : 0;
   }
 
 
@@ -2254,25 +2249,28 @@ namespace dxvk {
     bool changed = old != Value;
 
     if (likely(changed)) {
-      const bool oldClipPlaneEnabled = IsClipPlaneEnabled();
+      const uint32_t vendorId            = m_adapter->GetVendorId();
+      const bool     isNvidia            = vendorId == uint32_t(DxvkGpuVendor::Nvidia);
+      const bool     isAmd               = vendorId == uint32_t(DxvkGpuVendor::Amd);
+      const bool     isIntel             = vendorId == uint32_t(DxvkGpuVendor::Intel);
 
-      const bool oldDepthBiasEnabled = IsDepthBiasEnabled();
-
-      const bool oldATOC = IsAlphaToCoverageEnabled();
-      const bool oldNVDB = states[D3DRS_ADAPTIVETESS_X] == uint32_t(D3D9Format::NVDB);
-      const bool oldAlphaTest = IsAlphaTestEnabled();
+      const bool     oldClipPlaneEnabled = IsClipPlaneEnabled();
+      const bool     oldDepthBiasEnabled = IsDepthBiasEnabled();
+      const bool     oldATOC             = !m_isD3D8Compatible ? IsAlphaToCoverageEnabled() : false;
+      const bool     oldNVDB             = !m_isD3D8Compatible ? states[D3DRS_ADAPTIVETESS_X] == uint32_t(D3D9Format::NVDB) : false;
+      const bool     oldAlphaTest        = IsAlphaTestEnabled();
 
       states[State] = Value;
 
-      // AMD's driver hack for ATOC and RESZ.
+      // AMD's driver hack for ATOC, RESZ, INST and CENT (also supported on Nvidia)
       if (unlikely(State == D3DRS_POINTSIZE &&
-                   m_vendorId == uint32_t(DxvkGpuVendor::Amd))) {
-        // ATOC
+                   !m_isD3D8Compatible && !isIntel)) {
+        // ATOC (AMD specific)
         constexpr uint32_t AlphaToCoverageEnable  = uint32_t(D3D9Format::A2M1);
         constexpr uint32_t AlphaToCoverageDisable = uint32_t(D3D9Format::A2M0);
 
-        if (Value == AlphaToCoverageEnable
-         || Value == AlphaToCoverageDisable) {
+        if ((Value == AlphaToCoverageEnable
+          || Value == AlphaToCoverageDisable) && isAmd) {
           m_amdATOC = Value == AlphaToCoverageEnable;
 
           bool newATOC = IsAlphaToCoverageEnabled();
@@ -2287,19 +2285,36 @@ namespace dxvk {
           return D3D_OK;
         }
 
-        // RESZ
+        // RESZ (AMD specific - once supported by Intel
+        // as well, however modern drivers do not expose it)
         constexpr uint32_t RESZ = 0x7fa05000;
-        if (Value == RESZ) {
+        if (Value == RESZ && isAmd) {
           ResolveZ();
+          return D3D_OK;
+        }
+
+        // INST (AMD specific)
+        if (unlikely(Value == uint32_t(D3D9Format::INST) && isAmd)) {
+          // Geometry instancing is supported by SM3, but ATI/AMD
+          // exposed this hack to retroactively enable it on their
+          // SM2-capable hardware. It's esentially a no-op.
+          return D3D_OK;
+        }
+
+        // CENT (AMD & Nvidia)
+        if (unlikely(Value == uint32_t(D3D9Format::CENT))) {
+          // Centroid (alternate pixel center) hack.
+          // Taken into account anyway, so yet another no-op.
           return D3D_OK;
         }
       }
 
-      // Nvidia/Intel's driver hack for ATOC.
+      // Nvidia's driver hack for ATOC (also supported on Intel), COPM and SSAA
       if (unlikely(State == D3DRS_ADAPTIVETESS_Y &&
-                   (m_vendorId == uint32_t(DxvkGpuVendor::Nvidia)
-                 || m_vendorId == uint32_t(DxvkGpuVendor::Intel)))) {
+                   !m_isD3D8Compatible && !isAmd)) {
+        // ATOC (Nvidia & Intel)
         constexpr uint32_t AlphaToCoverageEnable  = uint32_t(D3D9Format::ATOC);
+        // Disabling both ATOC and SSAA is done using D3DFMT_UNKNOWN (0)
         constexpr uint32_t AlphaToCoverageDisable = 0;
 
         if (Value == AlphaToCoverageEnable
@@ -2318,9 +2333,16 @@ namespace dxvk {
           return D3D_OK;
         }
 
-        if (unlikely(Value == uint32_t(D3D9Format::COPM))) {
+        // COPM (Nvidia specific)
+        if (unlikely(Value == uint32_t(D3D9Format::COPM) && isNvidia)) {
           // UE3 calls this MinimalNVIDIADriverShaderOptimization
           Logger::info("D3D9DeviceEx::SetRenderState: MinimalNVIDIADriverShaderOptimization is unsupported");
+          return D3D_OK;
+        }
+
+        // SSAA (Nvidia specific)
+        if (unlikely(Value == uint32_t(D3D9Format::SSAA) && isNvidia)) {
+          Logger::warn("D3D9DeviceEx::SetRenderState: Transparency supersampling is unsupported");
           return D3D_OK;
         }
       }
@@ -2553,14 +2575,16 @@ namespace dxvk {
         case D3DRS_ADAPTIVETESS_X:
         case D3DRS_ADAPTIVETESS_Z:
         case D3DRS_ADAPTIVETESS_W:
-          if (states[D3DRS_ADAPTIVETESS_X] == uint32_t(D3D9Format::NVDB) || oldNVDB) {
+          // Nvidia specific depth bounds test hack
+          if (!m_isD3D8Compatible &&
+              (states[D3DRS_ADAPTIVETESS_X] == uint32_t(D3D9Format::NVDB) || oldNVDB) &&
+              isNvidia) {
             m_flags.set(D3D9DeviceFlag::DirtyDepthBounds);
 
             if (m_state.depthStencil != nullptr && m_state.renderStates[D3DRS_ZENABLE])
               m_flags.set(D3D9DeviceFlag::DirtyFramebuffer);
-            break;
           }
-        [[fallthrough]];
+          break;
 
         default:
           static bool s_errorShown[256];
@@ -4538,7 +4562,7 @@ namespace dxvk {
 
 
   bool D3D9DeviceEx::SupportsVCacheQuery() const {
-    return m_vendorId == uint32_t(DxvkGpuVendor::Nvidia);
+    return m_adapter->GetVendorId() == uint32_t(DxvkGpuVendor::Nvidia);
   }
 
 

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -1462,8 +1462,6 @@ namespace dxvk {
     D3D9Adapter*                    m_adapter;
     Rc<DxvkDevice>                  m_dxvkDevice;
 
-    uint32_t                        m_vendorId;
-
     D3D9MemoryAllocator             m_memoryAllocator;
 
     // Second memory allocator used for D3D9 shader bytecode.

--- a/src/d3d9/d3d9_format.cpp
+++ b/src/d3d9/d3d9_format.cpp
@@ -403,6 +403,8 @@ namespace dxvk {
 
       case D3D9Format::ATOC: return {}; // Driver hack, handled elsewhere
 
+      case D3D9Format::SSAA: return {}; // Driver hack, handled elsewhere
+
       case D3D9Format::INTZ: return {
         VK_FORMAT_D24_UNORM_S8_UINT,
         VK_FORMAT_UNDEFINED,
@@ -466,9 +468,7 @@ namespace dxvk {
     const Rc<DxvkAdapter>& adapter,
     const D3D9Options&     options) {
 
-    D3DADAPTER_IDENTIFIER9 adapterId9;
-    HRESULT res = pParent->GetAdapterIdentifier(0, &adapterId9);
-    const uint32_t vendorId = SUCCEEDED(res) ? adapterId9.VendorId : 0;
+    const uint32_t vendorId = pParent->GetVendorId();
 
     // NVIDIA does not natively support any DF formats
     m_dfSupport = vendorId == uint32_t(DxvkGpuVendor::Nvidia) ? false : options.supportDFFormats;

--- a/src/d3d9/d3d9_format.h
+++ b/src/d3d9/d3d9_format.h
@@ -110,6 +110,7 @@ namespace dxvk {
     // Not supported but exist
     AI44 = MAKEFOURCC('A', 'I', '4', '4'),
     IA44 = MAKEFOURCC('I', 'A', '4', '4'),
+    CENT = MAKEFOURCC('C', 'E', 'N', 'T'),
     R2VB = MAKEFOURCC('R', '2', 'V', 'B'),
     COPM = MAKEFOURCC('C', 'O', 'P', 'M'),
     SSAA = MAKEFOURCC('S', 'S', 'A', 'A'),


### PR DESCRIPTION
In addition to gating vendor hacks behind their proper vendorIds, we should also properly report support for said hacks in `CheckDeviceFormat`, as querying for support is the first step in any guide that describes these hacks. I definitely think exposing some of these on all the vendors is asking for trouble, especially considering how poorly some d3d9 games actually behave when faced with unexpected support for certain features.

Also took the liberty to cache device specific identifier data in the adapter, since it won't change during its lifetime and some queries can get spammed both internally and by external calls. I'm also getting the (cached) vendorId for the device from the adapter now.

~~D3D8 doesn't seem to expose *any* vendor hacks (the entire madness probably came into being a bit later), so I've handled this accordingly too.~~ Actually, the NULL and RESZ (on AMD) hacks seem to be exposed in D3D8 as well, based on what modern native drivers report.

I will write tests to confirm all the `CheckDeviceFormat` behavior on all vendors, both on olden and modern drivers, otherwise I think @K0bin will murder me :sweat_smile:, so WIP for now.

P.S.: 
- Reference for R2VB: https://web.archive.org/web/20150517205947/http://developer.amd.com/wordpress/media/2012/10/R2VB_programming.pdf
- Reference for ATOC/SSAA: https://web.archive.org/web/20061006161816/http://download.nvidia.com/developer/SDK/Individual_Samples/DEMOS/Direct3D9/src/AntiAliasingWithTransparency/docs/AntiAliasingWithTransparency.pdf