### PR TITLE
Use barrier tracking for inline resolve attachments

### DIFF
--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -2485,7 +2485,7 @@ namespace dxvk {
         : VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
 
       bool isFullWrite = (resolve.depthMode || !(dstSubresource.aspectMask & VK_IMAGE_ASPECT_DEPTH_BIT))
-                      && (resolve.stencilMode  || !(dstSubresource.aspectMask & VK_IMAGE_ASPECT_STENCIL_BIT));
+                      && (resolve.stencilMode || !(dstSubresource.aspectMask & VK_IMAGE_ASPECT_STENCIL_BIT));
 
       if (isFullWrite)
         oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
@@ -2502,6 +2502,15 @@ namespace dxvk {
 
       bool needsNewBackingStorage = (dstImage->info().stages & graphicsStages)
         && dstImage->isTracked(m_trackingId, DxvkAccess::Write);
+
+      if (needsNewBackingStorage && dstImage->hasGfxStores()) {
+        needsNewBackingStorage = resourceHasAccess(*dstImage, dstSubresource, DxvkAccess::Read, DxvkAccessOp::None)
+                              || resourceHasAccess(*dstImage, dstSubresource, DxvkAccess::Write, DxvkAccessOp::None);
+      }
+
+      // Enable tracking so that we don't unnecessarily hit slow paths in the future
+      if (dstImage->info().stages & graphicsStages)
+        dstImage->trackGfxStores();
 
       if (needsNewBackingStorage) {
         auto imageSubresource = dstImage->getAvailableSubresources();

--- a/src/dxvk/dxvk_image.h
+++ b/src/dxvk/dxvk_image.h
@@ -307,6 +307,8 @@ namespace dxvk {
 
     /**
      * \brief Checks whether the image has graphics stores
+     *
+     * This may include attachment access for render passes.
      * \returns \c true if the image has graphics pipeline stores
      */
     bool hasGfxStores() const;
@@ -805,7 +807,7 @@ namespace dxvk {
 
 
   inline bool DxvkImageView::hasGfxStores() const {
-    return (m_properties.access & VK_ACCESS_SHADER_WRITE_BIT)
+    return (m_properties.access & (VK_ACCESS_SHADER_WRITE_BIT | VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT))
         && (m_image->hasGfxStores());
   }
 


### PR DESCRIPTION
Allows us to merge resolves into render passes more often.