### PR TITLE
[d3d9] Implement Get/SetClipStatus

### DIFF
--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -2655,13 +2655,21 @@ namespace dxvk {
 
 
   HRESULT STDMETHODCALLTYPE D3D9DeviceEx::SetClipStatus(const D3DCLIPSTATUS9* pClipStatus) {
-    Logger::warn("D3D9DeviceEx::SetClipStatus: Stub");
+    if (unlikely(pClipStatus == nullptr))
+      return D3DERR_INVALIDCALL;
+
+    m_state.clipStatus = *pClipStatus;
+
     return D3D_OK;
   }
 
 
   HRESULT STDMETHODCALLTYPE D3D9DeviceEx::GetClipStatus(D3DCLIPSTATUS9* pClipStatus) {
-    Logger::warn("D3D9DeviceEx::GetClipStatus: Stub");
+    if (unlikely(pClipStatus == nullptr))
+      return D3DERR_INVALIDCALL;
+
+    *pClipStatus = m_state.clipStatus;
+
     return D3D_OK;
   }
 
@@ -3018,7 +3026,7 @@ namespace dxvk {
     D3D9DeviceLock lock = LockDevice();
 
     if (unlikely(m_state.vertexDecl == nullptr))
-        return D3DERR_INVALIDCALL;
+      return D3DERR_INVALIDCALL;
 
     if (unlikely(!PrimitiveCount))
       return S_OK;

--- a/src/d3d9/d3d9_state.h
+++ b/src/d3d9/d3d9_state.h
@@ -282,6 +282,8 @@ namespace dxvk {
     D3DVIEWPORT9                                        viewport = {};
     RECT                                                scissorRect = {};
 
+    D3DCLIPSTATUS9                                      clipStatus = {0, 0xffffffff};
+
     ItemType<std::array<
       D3D9ClipPlane,
       caps::MaxClipPlanes>>                             clipPlanes = {};


### PR DESCRIPTION
Might as well "un-stub" these, as it's fairly straight-forward, based on: https://learn.microsoft.com/en-us/windows/win32/api/d3d9/nf-d3d9-idirect3ddevice9-setclipstatus

There's two claims I've written a test for and have proved to be false:
- When D3DRS_CLIPPING is set to FALSE, ClipUnion and ClipIntersection are set to zero. (they are not set to 0, rather retain whatever values they have even after a draw call)
- Clip status is used during software vertex processing. Therefore, this method is not supported on pure or nonpure hardware processing devices. (Set/GetClipStatus return D3D_OK on all type of HWVP/Mixed/SWVP devices, but the clip status is most likely not updated & ignored outside of SWVP, I guess)

As for the actual implementation, I'm still not sure what the clip status is supposed to _actually_ do. Since it's a SWVP exclusive anyway, I doubt any games ever bothered with it much.

If I look at the footprint of the call, it's just 2 games we know of that use it:
- **Prince of Persia: The Two Thrones**, but it's using a Pure HWVP device, so most likely has no end effect. Could be something they set for compatibility with SWVP devices, but the game won't ever end up on one with dxvk.
- **I.G.I.-2: Covert Strike**, using a Mixed device and SWVP, so this is the only place it might actually be expected to work and do some clipping, although the game works fine as is.

~~Only validated against Nvidia so far, but I'll throw in AMD for good measure, then undraft.~~