### PR TITLE
[d3d9] Properly report supported adapter/backbuffer formats

### DIFF
--- a/src/d3d9/d3d9_adapter.cpp
+++ b/src/d3d9/d3d9_adapter.cpp
@@ -883,7 +883,7 @@ namespace dxvk {
     m_modeCacheFormat = Format;
 
     // Skip unsupported formats
-    if (!IsSupportedAdapterFormat(Format))
+    if (!IsSupportedModeFormat(Format))
       return;
 
     auto& options = m_parent->GetOptions();

--- a/src/d3d9/d3d9_monitor.cpp
+++ b/src/d3d9/d3d9_monitor.cpp
@@ -27,8 +27,17 @@ namespace dxvk {
 
   bool IsSupportedAdapterFormat(
           D3D9Format Format) {
-    // D3D9Format::X1R5G5B5 is unsupported by native drivers and some apps, 
-    // such as the BGE SettingsApplication, rely on it not being exposed.
+    return Format == D3D9Format::A2R10G10B10
+        || Format == D3D9Format::X8R8G8B8
+        || Format == D3D9Format::X1R5G5B5
+        || Format == D3D9Format::R5G6B5;
+  }
+
+
+  bool IsSupportedModeFormat(
+          D3D9Format Format) {
+    // Native drivers list no modes for D3D9Format::X1R5G5B5, and some apps,
+    // such as the BGE SettingsApplication, rely on it not being advertised.
     return Format == D3D9Format::A2R10G10B10
         || Format == D3D9Format::X8R8G8B8
         || Format == D3D9Format::R5G6B5;
@@ -40,13 +49,22 @@ namespace dxvk {
           D3D9Format BackBufferFormat,
           BOOL       Windowed) {
     if (!Windowed) {
-      return (AdapterFormat == D3D9Format::A2R10G10B10 && BackBufferFormat == D3D9Format::A2R10G10B10) ||
-             (AdapterFormat == D3D9Format::X8R8G8B8    && BackBufferFormat == D3D9Format::X8R8G8B8) ||
-             (AdapterFormat == D3D9Format::X8R8G8B8    && BackBufferFormat == D3D9Format::A8R8G8B8) ||
-             (AdapterFormat == D3D9Format::R5G6B5      && BackBufferFormat == D3D9Format::R5G6B5);
+      // D3D9Format::X1R5G5B5 is not advertised by native
+      // drivers as a full screen adapter format.
+      return (AdapterFormat == D3D9Format::A2R10G10B10 && BackBufferFormat == D3D9Format::A2R10G10B10)
+          || (AdapterFormat == D3D9Format::X8R8G8B8    && BackBufferFormat == D3D9Format::X8R8G8B8)
+          || (AdapterFormat == D3D9Format::X8R8G8B8    && BackBufferFormat == D3D9Format::A8R8G8B8)
+          || (AdapterFormat == D3D9Format::R5G6B5      && BackBufferFormat == D3D9Format::R5G6B5);
     }
 
-    return IsSupportedBackBufferFormat(BackBufferFormat);
+    // D3D9Format::A2R10G10B10 is not advertised by native
+    // drivers as a windowed backbuffer format.
+    return BackBufferFormat == D3D9Format::A8R8G8B8
+        || BackBufferFormat == D3D9Format::X8R8G8B8
+        || BackBufferFormat == D3D9Format::A1R5G5B5
+        || BackBufferFormat == D3D9Format::X1R5G5B5
+        || BackBufferFormat == D3D9Format::R5G6B5
+        || BackBufferFormat == D3D9Format::Unknown;
   }
 
   bool IsSupportedBackBufferFormat(
@@ -54,6 +72,8 @@ namespace dxvk {
     return BackBufferFormat == D3D9Format::A2R10G10B10
         || BackBufferFormat == D3D9Format::A8R8G8B8
         || BackBufferFormat == D3D9Format::X8R8G8B8
+        || BackBufferFormat == D3D9Format::A1R5G5B5
+        || BackBufferFormat == D3D9Format::X1R5G5B5
         || BackBufferFormat == D3D9Format::R5G6B5
         || BackBufferFormat == D3D9Format::Unknown;
   }

--- a/src/d3d9/d3d9_monitor.h
+++ b/src/d3d9/d3d9_monitor.h
@@ -28,6 +28,15 @@ namespace dxvk {
   bool IsSupportedAdapterFormat(
           D3D9Format Format);
 
+  /**
+  * \brief Returns if a format is considered for mode enumeration.
+  *
+  * \param [in] Format The D3D9 format to query
+  * \returns If it is supported for mode enumeration.
+  */
+  bool IsSupportedModeFormat(
+          D3D9Format Format);
+
   bool IsSupportedBackBufferFormat(
           D3D9Format AdapterFormat,
           D3D9Format BackBufferFormat,


### PR DESCRIPTION
On a tangent, also noticed all vendors seem to report the following adapter/backbuffer format support:

```
Device back buffer format support (full screen):
  + The D3DFMT_A8R8G8B8 format is supported, device creation SUCCEEDED
  + The D3DFMT_X8R8G8B8 format is supported, device creation SUCCEEDED
  + The D3DFMT_R5G6B5 format is supported, device creation SUCCEEDED
  - The D3DFMT_X1R5G5B5 format is not supported
  - The D3DFMT_A1R5G5B5 format is not supported
  + The D3DFMT_A2R10G10B10 format is supported, device creation SUCCEEDED

Device back buffer format support (windowed):
  + The D3DFMT_A8R8G8B8 format is supported, device creation SUCCEEDED
  + The D3DFMT_X8R8G8B8 format is supported, device creation SUCCEEDED
  + The D3DFMT_R5G6B5 format is supported, device creation SUCCEEDED
  + The D3DFMT_X1R5G5B5 format is supported, device creation SUCCEEDED
  + The D3DFMT_A1R5G5B5 format is supported, device creation SUCCEEDED
  - The D3DFMT_A2R10G10B10 format is not supported
```

However, none will list any modes for D3DFMT_X1R5G5B5, which is what was causing the problems with the Beyond Good & Evil settings app. But the format IS a valid adapter format, and a valid backbuffer format in windowed mode. I've adjusted our reporting logic to reflect the above test results.