### PR TITLE
[util] Add configs for alt-tabbing in Red Orchestra: Ostfront

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -1049,6 +1049,12 @@ namespace dxvk {
     { R"(\\THUMPER_dx9\.exe$)", {{
       { "d3d9.floatEmulation",              "Strict" },
     }} },
+    /* Red Orchestra: Ostfront 41-45 - Blinks,    *
+     * freeze, crash or goes Windowed on alt-tab  */
+    { R"(\\RedOrchestra\.exe$)", {{
+      { "d3d9.deviceLossOnFocusLoss",       "True" },
+      { "d3d9.countLosableResources",       "False" },
+    }} },
 
     /**********************************************/
     /* D3D8 GAMES                                 */


### PR DESCRIPTION
Prevents the game from blinking, freezing, crashing or going windowed mode when you alt-tab.