### PR TITLE
Implement per-stage push data blocks and raw resource bindings

### DIFF
--- a/src/d3d11/d3d11_context.cpp
+++ b/src/d3d11/d3d11_context.cpp
@@ -3431,7 +3431,8 @@ namespace dxvk {
     EmitCs([
       cPushConstants = pc
     ] (DxvkContext* ctx) {
-      ctx->pushConstants(0, sizeof(cPushConstants), &cPushConstants);
+      ctx->pushData(VK_SHADER_STAGE_ALL_GRAPHICS,
+        0, sizeof(cPushConstants), &cPushConstants);
     });
   }
 
@@ -4890,7 +4891,7 @@ namespace dxvk {
       // Initialize push constants
       DxbcPushConstants pc;
       pc.rasterizerSampleCount = 1;
-      ctx->pushConstants(0, sizeof(pc), &pc);
+      ctx->pushData(VK_SHADER_STAGE_ALL_GRAPHICS, 0, sizeof(pc), &pc);
     });
   }
 

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -3221,7 +3221,7 @@ namespace dxvk {
 
       ctx->bindShader<VK_SHADER_STAGE_GEOMETRY_BIT>(std::move(shader));
       ctx->bindResourceBufferView(VK_SHADER_STAGE_GEOMETRY_BIT, getSWVPBufferSlot(), std::move(bufferView));
-      ctx->pushData(VK_SHADER_STAGE_ALL_GRAPHICS, sizeof(D3D9RenderStateInfo), sizeof(byteOffset), &byteOffset);
+      ctx->pushData(VK_SHADER_STAGE_GEOMETRY_BIT, 0u, sizeof(byteOffset), &byteOffset);
       ctx->draw(1u, &draw);
       ctx->bindResourceBufferView(VK_SHADER_STAGE_GEOMETRY_BIT, getSWVPBufferSlot(), nullptr);
       ctx->bindShader<VK_SHADER_STAGE_GEOMETRY_BIT>(nullptr);

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -3221,7 +3221,7 @@ namespace dxvk {
 
       ctx->bindShader<VK_SHADER_STAGE_GEOMETRY_BIT>(std::move(shader));
       ctx->bindResourceBufferView(VK_SHADER_STAGE_GEOMETRY_BIT, getSWVPBufferSlot(), std::move(bufferView));
-      ctx->pushConstants(sizeof(D3D9RenderStateInfo), sizeof(byteOffset), &byteOffset);
+      ctx->pushData(VK_SHADER_STAGE_ALL_GRAPHICS, sizeof(D3D9RenderStateInfo), sizeof(byteOffset), &byteOffset);
       ctx->draw(1u, &draw);
       ctx->bindResourceBufferView(VK_SHADER_STAGE_GEOMETRY_BIT, getSWVPBufferSlot(), nullptr);
       ctx->bindShader<VK_SHADER_STAGE_GEOMETRY_BIT>(nullptr);
@@ -6071,7 +6071,8 @@ namespace dxvk {
     EmitCs([
       cData = *constData
     ](DxvkContext* ctx) {
-      ctx->pushConstants(Offset, Length, &cData);
+      // Render state uses the shared push constant block
+      ctx->pushData(VK_SHADER_STAGE_ALL_GRAPHICS, Offset, Length, &cData);
     });
   }
 

--- a/src/d3d9/d3d9_fixed_function.cpp
+++ b/src/d3d9/d3d9_fixed_function.cpp
@@ -889,7 +889,7 @@ namespace dxvk {
     info.inputMask = m_inputMask;
     info.outputMask = m_outputMask;
     info.flatShadingInputs = m_flatShadingMask;
-    info.pushConstSize = sizeof(D3D9RenderStateInfo);
+    info.sharedPushData = DxvkPushDataBlock(0u, sizeof(D3D9RenderStateInfo), 4u, 0u);
 
     return new DxvkShader(info, m_module.compile());
   }

--- a/src/d3d9/d3d9_swvp_emu.cpp
+++ b/src/d3d9/d3d9_swvp_emu.cpp
@@ -310,7 +310,8 @@ namespace dxvk {
       info.stage = VK_SHADER_STAGE_GEOMETRY_BIT;
       info.bindingCount = 1;
       info.bindings = &m_bufferBinding;
-      info.pushConstSize = sizeof(D3D9RenderStateInfo) + sizeof(D3D9SwvpEmuArgs);
+      info.sharedPushData = DxvkPushDataBlock(0u,
+        sizeof(D3D9RenderStateInfo) + sizeof(D3D9SwvpEmuArgs), 4u, 0u);
       info.inputMask = m_inputMask;
       info.inputTopology = VK_PRIMITIVE_TOPOLOGY_POINT_LIST;
 

--- a/src/d3d9/d3d9_swvp_emu.cpp
+++ b/src/d3d9/d3d9_swvp_emu.cpp
@@ -121,7 +121,7 @@ namespace dxvk {
       m_module.decorate(push_const_t, spv::DecorationBlock);
       m_module.setDebugName(push_const_t, "pc_t");
       m_module.setDebugMemberName(push_const_t, 0, "offset");
-      m_module.memberDecorateOffset(push_const_t, 0, sizeof(D3D9RenderStateInfo));
+      m_module.memberDecorateOffset(push_const_t, 0, 0);
 
       uint32_t push_const_uint_ptr_t = m_module.defPointerType(uint_t, spv::StorageClassPushConstant);
       uint32_t push_const_ptr_t = m_module.defPointerType(push_const_t, spv::StorageClassPushConstant);
@@ -310,8 +310,7 @@ namespace dxvk {
       info.stage = VK_SHADER_STAGE_GEOMETRY_BIT;
       info.bindingCount = 1;
       info.bindings = &m_bufferBinding;
-      info.sharedPushData = DxvkPushDataBlock(0u,
-        sizeof(D3D9RenderStateInfo) + sizeof(D3D9SwvpEmuArgs), 4u, 0u);
+      info.localPushData = DxvkPushDataBlock(0u, sizeof(D3D9SwvpEmuArgs), 4u, 0u);
       info.inputMask = m_inputMask;
       info.inputTopology = VK_PRIMITIVE_TOPOLOGY_POINT_LIST;
 

--- a/src/dxbc/dxbc_analysis.cpp
+++ b/src/dxbc/dxbc_analysis.cpp
@@ -67,6 +67,12 @@ namespace dxvk {
         m_analysis->usesDerivatives = true;
       } break;
 
+      case DxbcInstClass::TextureQueryMs:
+      case DxbcInstClass::TextureQueryMsPos: {
+        if (ins.src[0].type == DxbcOperandType::Rasterizer)
+          m_analysis->usesSampleCount = true;
+      } break;
+
       case DxbcInstClass::ControlFlow: {
         if (ins.op == DxbcOpcode::Discard)
           m_analysis->usesKill = true;

--- a/src/dxbc/dxbc_analysis.cpp
+++ b/src/dxbc/dxbc_analysis.cpp
@@ -55,6 +55,11 @@ namespace dxvk {
         }
       } break;
 
+      case DxbcInstClass::AtomicCounter: {
+        const uint32_t registerId = ins.dst[1].idx[0].offset;
+        m_analysis->uavCounterMask |= uint64_t(1u) << registerId;
+      } break;
+
       case DxbcInstClass::TextureSample:
       case DxbcInstClass::TextureGather:
       case DxbcInstClass::TextureQueryLod:

--- a/src/dxbc/dxbc_analysis.h
+++ b/src/dxbc/dxbc_analysis.h
@@ -60,6 +60,7 @@ namespace dxvk {
     
     bool usesDerivatives  = false;
     bool usesKill         = false;
+    bool usesSampleCount  = false;
   };
   
   /**

--- a/src/dxbc/dxbc_analysis.h
+++ b/src/dxbc/dxbc_analysis.h
@@ -55,6 +55,8 @@ namespace dxvk {
     DxbcClipCullInfo clipCullOut;
 
     DxbcBindingMask bindings = { };
+
+    uint64_t uavCounterMask = 0u;
     
     bool usesDerivatives  = false;
     bool usesKill         = false;

--- a/src/dxbc/dxbc_compiler.cpp
+++ b/src/dxbc/dxbc_compiler.cpp
@@ -247,7 +247,7 @@ namespace dxvk {
     info.outputTopology = m_outputTopology;
 
     if (m_ps.pushConstantId)
-      info.pushConstSize = sizeof(DxbcPushConstants);
+      info.sharedPushData = DxvkPushDataBlock(0u, sizeof(DxbcPushConstants), 4u, 0u);
 
     if (m_programInfo.type() == DxbcProgramType::HullShader)
       info.patchVertexCount = m_hs.vertexCountIn;

--- a/src/dxbc/dxbc_compiler.h
+++ b/src/dxbc/dxbc_compiler.h
@@ -191,8 +191,8 @@ namespace dxvk {
     uint32_t builtinLayer         = 0;
     uint32_t builtinViewportId    = 0;
     uint32_t builtinInnerCoverageId = 0;
-    
-    uint32_t pushConstantId       = 0;
+
+    uint32_t rasterizerPushIndex = 0u;
   };
   
   
@@ -476,6 +476,11 @@ namespace dxvk {
     std::array<DxbcShaderResource, 128> m_textures;
     std::array<DxbcUav,             64> m_uavs;
 
+    uint32_t m_pushDataId = 0u;
+
+    DxvkPushDataBlock m_sharedPushData;
+    DxvkPushDataBlock m_localPushData;
+
     bool m_hasGloballyCoherentUav = false;
     bool m_hasRasterizerOrderedUav = false;
 
@@ -532,6 +537,7 @@ namespace dxvk {
     // Struct type used for UAV counter buffers
     uint32_t m_uavCtrStructType  = 0;
     uint32_t m_uavCtrPointerType = 0;
+    uint32_t m_uavCtrBdaType = 0;
     
     ////////////////////////////////
     // Function IDs for subroutines
@@ -1210,7 +1216,11 @@ namespace dxvk {
     uint32_t emitBuiltinTessLevelInner(
             spv::StorageClass storageClass);
 
-    uint32_t emitPushConstants();
+    void emitUavCounterTypes();
+
+    void emitUavCounterBindings();
+
+    void emitPushData();
 
     ////////////////
     // Misc methods

--- a/src/dxbc/dxbc_decoder.h
+++ b/src/dxbc/dxbc_decoder.h
@@ -73,7 +73,6 @@ namespace dxvk {
     DxbcResourceType  type          = DxbcResourceType::Typed;
     DxbcImageInfo     imageInfo;
     uint32_t          varId         = 0;
-    uint32_t          specId        = 0;
     DxbcScalarType    sampledType   = DxbcScalarType::Float32;
     uint32_t          sampledTypeId = 0;
     uint32_t          imageTypeId   = 0;
@@ -95,13 +94,13 @@ namespace dxvk {
     DxbcImageInfo     imageInfo;
     uint32_t          varId         = 0;
     uint32_t          ctrId         = 0;
-    uint32_t          specId        = 0;
     DxbcScalarType    sampledType   = DxbcScalarType::Float32;
     uint32_t          sampledTypeId = 0;
     uint32_t          imageTypeId   = 0;
     uint32_t          structStride  = 0;
     uint32_t          coherence     = 0;
     bool              isRawSsbo     = false;
+    bool              isBdaCounter  = false;
   };
   
   

--- a/src/dxso/dxso_compiler.cpp
+++ b/src/dxso/dxso_compiler.cpp
@@ -229,7 +229,7 @@ namespace dxvk {
     info.bindings = m_bindings.data();
     info.inputMask = m_inputMask;
     info.outputMask = m_outputMask;
-    info.pushConstSize = sizeof(D3D9RenderStateInfo);
+    info.sharedPushData = DxvkPushDataBlock(0u, sizeof(D3D9RenderStateInfo), 4u, 0u);
 
     if (m_programInfo.type() == DxsoProgramTypes::PixelShader)
       info.flatShadingInputs = m_ps.flatShadingMask;

--- a/src/dxvk/dxvk_buffer.cpp
+++ b/src/dxvk/dxvk_buffer.cpp
@@ -27,6 +27,9 @@ namespace dxvk {
       m_info.debugName = nullptr;
     }
 
+    // Unconditionally enable BDA usage
+    m_info.usage |= VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT;
+
     // Create and assign actual buffer resource
     assignStorage(allocateStorage());
   }

--- a/src/dxvk/dxvk_cmdlist.cpp
+++ b/src/dxvk/dxvk_cmdlist.cpp
@@ -546,17 +546,18 @@ namespace dxvk {
     }
 
     // Update push constants
-    DxvkPushConstantRange pushConstants = layout->getPushConstantRange();
+    DxvkPushDataBlock pushDataBlock = layout->getPushData();
 
-    if (pushDataSize && pushConstants.getSize()) {
+    if (pushDataSize && !pushDataBlock.isEmpty()) {
       std::array<char, MaxTotalPushDataSize> dataCopy;
       std::memcpy(dataCopy.data(), pushData,
         std::min(dataCopy.size(), pushDataSize));
 
       this->cmdPushConstants(cmdBuffer,
         layout->getPipelineLayout(),
-        pushConstants.getStageMask(), 0u,
-        pushConstants.getSize(),
+        pushDataBlock.getStageMask(),
+        pushDataBlock.getOffset(),
+        pushDataBlock.getSize(),
         dataCopy.data());
     }
   }

--- a/src/dxvk/dxvk_cmdlist.cpp
+++ b/src/dxvk/dxvk_cmdlist.cpp
@@ -1,3 +1,4 @@
+
 #include "dxvk_cmdlist.h"
 #include "dxvk_device.h"
 
@@ -548,7 +549,7 @@ namespace dxvk {
     DxvkPushConstantRange pushConstants = layout->getPushConstantRange();
 
     if (pushDataSize && pushConstants.getSize()) {
-      std::array<char, MaxPushConstantSize> dataCopy;
+      std::array<char, MaxTotalPushDataSize> dataCopy;
       std::memcpy(dataCopy.data(), pushData,
         std::min(dataCopy.size(), pushDataSize));
 

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -7330,7 +7330,7 @@ namespace dxvk {
     // any resource previously bound as read-only cannot have been written by
     // the same pipeline.
     VkShaderStageFlags dirtyStageMask = m_descriptorState.getDirtyStageMask(
-      DxvkDescriptorClass::Buffer | DxvkDescriptorClass::View);
+      DxvkDescriptorClass::Buffer | DxvkDescriptorClass::View | DxvkDescriptorClass::Raw);
     dirtyStageMask &= layout->getNonemptyStageMask();
 
     for (auto stageIndex : bit::BitMask(uint32_t(dirtyStageMask))) {

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -5973,9 +5973,9 @@ namespace dxvk {
     // Mark compute resources and push constants as dirty
     m_descriptorState.dirtyStages(VK_SHADER_STAGE_COMPUTE_BIT);
 
-    auto pushConstants = newPipeline->getLayout()->getLayout(DxvkPipelineLayoutType::Merged)->getPushConstantRange();
+    auto pushData = newPipeline->getLayout()->getLayout(DxvkPipelineLayoutType::Merged)->getPushData();
 
-    if (pushConstants.getSize()) {
+    if (!pushData.isEmpty()) {
       m_flags.set(DxvkContextFlag::CpHasPushConstants,
                   DxvkContextFlag::DirtyPushConstants);
     }
@@ -6123,9 +6123,9 @@ namespace dxvk {
       m_descriptorState.dirtyStages(VK_SHADER_STAGE_ALL_GRAPHICS);
 
     // Also update push constant status when we know the final layout
-    DxvkPushConstantRange pushConstants = m_state.gp.pipeline->getLayout()->getLayout(newPipelineLayoutType)->getPushConstantRange();
+    auto pushData = m_state.gp.pipeline->getLayout()->getLayout(newPipelineLayoutType)->getPushData();
 
-    if (pushConstants.getSize()) {
+    if (!pushData.isEmpty()) {
       m_flags.set(DxvkContextFlag::GpHasPushConstants,
                   DxvkContextFlag::DirtyPushConstants);
     }
@@ -7069,16 +7069,17 @@ namespace dxvk {
     // Optimized pipelines may have push constants trimmed, so look up
     // the exact layout used for the currently bound pipeline.
     auto layout = bindings->getLayout(getActivePipelineLayoutType(BindPoint));
-    auto pushConstants = layout->getPushConstantRange();
+    auto pushData = layout->getPushData();
 
-    if (unlikely(!pushConstants.getSize()))
+    if (unlikely(!pushData.getSize()))
       return;
 
     m_cmd->cmdPushConstants(DxvkCmdBuffer::ExecBuffer,
       layout->getPipelineLayout(),
-      pushConstants.getStageMask(), 0u,
-      pushConstants.getSize(),
-      &m_state.pc.data[0u]);
+      pushData.getStageMask(),
+      pushData.getOffset(),
+      pushData.getSize(),
+      &m_state.pc.data[pushData.getOffset()]);
   }
   
 

--- a/src/dxvk/dxvk_context.h
+++ b/src/dxvk/dxvk_context.h
@@ -978,20 +978,25 @@ namespace dxvk {
       const DxvkImageUsageInfo&       usageInfo);
 
     /**
-     * \brief Updates push constants
+     * \brief Updates push data
      * 
-     * Updates the given push constant range.
+     * \param [in] stages Stage to set data for. If multiple
+     *    stages are set, this will push to the shared block.
      * \param [in] offset Byte offset of data to update
      * \param [in] size Number of bytes to update
      * \param [in] data Pointer to raw data
      */
-    void pushConstants(
+    void pushData(
+            VkShaderStageFlags        stages,
             uint32_t                  offset,
             uint32_t                  size,
       const void*                     data) {
-      std::memcpy(&m_state.pc.data[offset], data, size);
+      uint32_t index = DxvkPushDataBlock::computeIndex(stages);
 
-      m_flags.set(DxvkContextFlag::DirtyPushConstants);
+      uint32_t baseOffset = computePushDataBlockOffset(index);
+      std::memcpy(&m_state.pc.constantData[baseOffset + offset], data, size);
+
+      m_dirtyPushDataBlocks |= 1u << index;
     }
 
     /**
@@ -1372,6 +1377,7 @@ namespace dxvk {
     DxvkContextState        m_state;
     DxvkContextFeatures     m_features;
     DxvkDescriptorState     m_descriptorState;
+    uint32_t                m_dirtyPushDataBlocks = 0u;
 
     Rc<DxvkDescriptorPool>  m_descriptorPool;
     Rc<DxvkDescriptorPoolSet> m_descriptorManager;
@@ -1748,7 +1754,7 @@ namespace dxvk {
     void updateDynamicState();
 
     template<VkPipelineBindPoint BindPoint>
-    void updatePushConstants();
+    void updatePushData();
     
     template<bool Resolve = true>
     bool commitComputeState();
@@ -2162,6 +2168,10 @@ namespace dxvk {
     void beginActiveDebugRegions();
 
     void endActiveDebugRegions();
+
+    static uint32_t computePushDataBlockOffset(uint32_t index) {
+      return index ? MaxSharedPushDataSize + MaxPerStagePushDataSize * (index - 1u) : 0u;
+    }
 
     static bool formatsAreCopyCompatible(
             VkFormat                  imageFormat,

--- a/src/dxvk/dxvk_context_state.h
+++ b/src/dxvk/dxvk_context_state.h
@@ -140,7 +140,7 @@ namespace dxvk {
 
 
   struct DxvkPushConstantState {
-    char data[MaxPushConstantSize];
+    char data[MaxSharedPushDataSize];
   };
 
 

--- a/src/dxvk/dxvk_context_state.h
+++ b/src/dxvk/dxvk_context_state.h
@@ -58,7 +58,6 @@ namespace dxvk {
     CpHasPushConstants,         ///< Compute pipeline uses push constants
 
     DirtyDrawBuffer,            ///< Indirect argument buffer is dirty
-    DirtyPushConstants,         ///< Push constant data has changed
 
     ForceWriteAfterWriteSync,   ///< Ignores barrier control flags for write-after-write hazards
 
@@ -139,8 +138,9 @@ namespace dxvk {
   };
 
 
-  struct DxvkPushConstantState {
-    char data[MaxSharedPushDataSize];
+  struct DxvkPushDataState {
+    std::array<char, MaxTotalPushDataSize> constantData = { };
+    std::array<char, MaxTotalPushDataSize> resourceData = { };
   };
 
 
@@ -212,7 +212,7 @@ namespace dxvk {
     DxvkVertexInputState      vi;
     DxvkViewportState         vp;
     DxvkOutputMergerState     om;
-    DxvkPushConstantState     pc;
+    DxvkPushDataState         pc;
     DxvkXfbState              xfb;
     DxvkDynamicState          dyn;
     

--- a/src/dxvk/dxvk_device.cpp
+++ b/src/dxvk/dxvk_device.cpp
@@ -229,15 +229,19 @@ namespace dxvk {
 
 
   const DxvkPipelineLayout* DxvkDevice::createBuiltInPipelineLayout(
-          VkShaderStageFlags              pushConstantStages,
-          VkDeviceSize                    pushConstantSize,
+          VkShaderStageFlags              pushDataStages,
+          VkDeviceSize                    pushDataSize,
           uint32_t                        bindingCount,
     const DxvkDescriptorSetLayoutBinding* bindings) {
     DxvkPipelineLayoutKey key(DxvkPipelineLayoutType::Merged);
 
-    if (pushConstantSize) {
-      key.addStages(pushConstantStages);
-      key.addPushConstantRange(DxvkPushConstantRange(pushConstantStages, pushConstantSize));
+    if (pushDataSize) {
+      key.addStages(pushDataStages);
+
+      DxvkPushDataBlock pushData(pushDataStages,
+        0u, pushDataSize, sizeof(uint32_t), 0u);
+
+      key.addPushData(pushData);
     }
 
     if (bindingCount) {

--- a/src/dxvk/dxvk_device.h
+++ b/src/dxvk/dxvk_device.h
@@ -390,15 +390,15 @@ namespace dxvk {
     /**
      * \brief Creates built-in pipeline layout
      *
-     * \param [in] pushConstantStages Push constant stage mask
-     * \param [in] pushConstantSize Push constant size
+     * \param [in] pushDataStages Push data stage mask
+     * \param [in] pushDataSize Push data size
      * \param [in] bindingCount Number of resource bindings
      * \param [in] bindings Resource bindings
      * \returns Unique pipeline layout
      */
     const DxvkPipelineLayout* createBuiltInPipelineLayout(
-            VkShaderStageFlags              pushConstantStages,
-            VkDeviceSize                    pushConstantSize,
+            VkShaderStageFlags              pushDataStages,
+            VkDeviceSize                    pushDataSize,
             uint32_t                        bindingCount,
       const DxvkDescriptorSetLayoutBinding* bindings);
 

--- a/src/dxvk/dxvk_limits.h
+++ b/src/dxvk/dxvk_limits.h
@@ -19,7 +19,10 @@ namespace dxvk {
     MaxNumSpecConstants         =    12,
     MaxUniformBufferSize        = 65536,
     MaxVertexBindingStride      =  2048,
-    MaxPushConstantSize         =    64,
+    MaxTotalPushDataSize        =   256,
+    MaxSharedPushDataSize       =    64,
+    MaxPerStagePushDataSize     =    32,
+    MaxReservedPushDataSize     =    32,
   };
   
 }

--- a/src/dxvk/dxvk_pipelayout.cpp
+++ b/src/dxvk/dxvk_pipelayout.cpp
@@ -18,8 +18,11 @@ namespace dxvk {
   }
 
 
-  void DxvkDescriptorSetLayoutKey::add(DxvkDescriptorSetLayoutBinding binding) {
+  uint32_t DxvkDescriptorSetLayoutKey::add(DxvkDescriptorSetLayoutBinding binding) {
+    uint32_t index = m_bindings.size();
+
     m_bindings.push_back(binding);
+    return index;
   }
 
 
@@ -242,13 +245,13 @@ namespace dxvk {
     for (size_t i = 0; i < bindings.bindingCount; i++) {
       auto binding = bindings.bindings[i];
       auto set = setInfos.map[computeSetForBinding(type, binding)];
+      auto bindingIndex = setLayoutKeys[set].add(DxvkDescriptorSetLayoutBinding(binding));
 
       DxvkShaderBinding srcMapping(binding.getStageMask(), binding.getSet(), binding.getBinding());
-      DxvkShaderBinding dstMapping(binding.getStageMask(), set, setLayoutKeys[set].getBindingCount());
+      DxvkShaderBinding dstMapping(binding.getStageMask(), set, bindingIndex);
 
       layout.bindingMap.add(srcMapping, dstMapping);
 
-      setLayoutKeys[set].add(DxvkDescriptorSetLayoutBinding(binding));
       layout.setStateMasks[set] |= computeStateMask(binding);
 
       if (binding.getDescriptorCount()) {

--- a/src/dxvk/dxvk_pipelayout.cpp
+++ b/src/dxvk/dxvk_pipelayout.cpp
@@ -255,17 +255,21 @@ namespace dxvk {
       layout.setStateMasks[set] |= computeStateMask(binding);
 
       if (binding.getDescriptorCount()) {
-        appendDescriptors(layout.setDescriptors[set], binding, dstMapping);
-
         if (binding.getDescriptorType() == VK_DESCRIPTOR_TYPE_SAMPLER
          || binding.getDescriptorType() == VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER)
           appendDescriptors(layout.setSamplers[set], binding, dstMapping);
 
-        if (binding.getDescriptorType() != VK_DESCRIPTOR_TYPE_SAMPLER) {
-          if (binding.isUniformBuffer())
-            appendDescriptors(layout.setUniformBuffers[set], binding, dstMapping);
-          else
-            appendDescriptors(layout.setResources[set], binding, dstMapping);
+        if (binding.usesDescriptor()) {
+          appendDescriptors(layout.setDescriptors[set], binding, dstMapping);
+
+          if (binding.getDescriptorType() != VK_DESCRIPTOR_TYPE_SAMPLER) {
+            if (binding.isUniformBuffer())
+              appendDescriptors(layout.setUniformBuffers[set], binding, dstMapping);
+            else
+              appendDescriptors(layout.setResources[set], binding, dstMapping);
+          }
+        } else {
+          appendDescriptors(layout.setRawBindings[set], binding, dstMapping);
         }
       }
     }

--- a/src/dxvk/dxvk_pipelayout.cpp
+++ b/src/dxvk/dxvk_pipelayout.cpp
@@ -123,7 +123,14 @@ namespace dxvk {
     m_bindPoint = (key.getStageMask() == VK_SHADER_STAGE_COMPUTE_BIT)
       ? VK_PIPELINE_BIND_POINT_COMPUTE
       : VK_PIPELINE_BIND_POINT_GRAPHICS;
-    m_pushConstants = key.getPushConstantRange();
+
+    m_pushMask = key.getPushDataMask();
+
+    for (auto i : bit::BitMask(m_pushMask)) {
+      m_pushData[i] = key.getPushDataBlock(i);
+      m_pushDataMerged.merge(m_pushData[i]);
+      m_pushDataMerged.makeAbsolute();
+    }
 
     // Gather descriptor set layout objects, some of these may be null.
     std::array<VkDescriptorSetLayout, DxvkPipelineLayoutKey::MaxSets> setLayouts = { };
@@ -137,8 +144,8 @@ namespace dxvk {
 
     // Set up push constant range, if any
     VkPushConstantRange pushConstantRange = { };
-    pushConstantRange.stageFlags = m_pushConstants.getStageMask();
-    pushConstantRange.size = m_pushConstants.getSize();
+    pushConstantRange.stageFlags = m_pushDataMerged.getStageMask();
+    pushConstantRange.size = m_pushDataMerged.getSize();
 
     VkPipelineLayoutCreateInfo layoutInfo = { VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO };
 
@@ -177,18 +184,37 @@ namespace dxvk {
   }
 
 
-  void DxvkShaderBindingMap::add(DxvkShaderBinding srcBinding, DxvkShaderBinding dstBinding) {
-    m_entries.insert_or_assign(srcBinding, dstBinding);
+  void DxvkShaderBindingMap::addBinding(DxvkShaderBinding srcBinding, DxvkShaderBinding dstBinding) {
+    m_bindings.insert_or_assign(srcBinding, dstBinding);
   }
 
 
-  const DxvkShaderBinding* DxvkShaderBindingMap::find(DxvkShaderBinding srcBinding) const {
-    auto entry = m_entries.find(srcBinding);
+  void DxvkShaderBindingMap::addPushData(const DxvkPushDataBlock& block, uint32_t offset) {
+    m_pushData.push_back(std::make_pair(block, offset));
+  }
 
-    if (entry == m_entries.end())
+
+  const DxvkShaderBinding* DxvkShaderBindingMap::mapBinding(DxvkShaderBinding srcBinding) const {
+    auto entry = m_bindings.find(srcBinding);
+
+    if (entry == m_bindings.end())
       return nullptr;
 
     return &entry->second;
+  }
+
+
+  uint32_t DxvkShaderBindingMap::mapPushData(VkShaderStageFlags stage, uint32_t offset) const {
+    for (size_t i = 0u; i < m_pushData.size(); i++) {
+      const auto& block = m_pushData[i];
+
+      if ((block.first.getStageMask() & stage)
+       && offset >= block.first.getOffset()
+       && offset < block.first.getOffset() + block.first.getSize())
+        return block.second + offset - block.first.getOffset();
+    }
+
+    return -1u;
   }
 
 
@@ -199,13 +225,11 @@ namespace dxvk {
     auto stageMask = builder.getStageMask();
 
     // Fill metadata structures that are independent of set layouts
-    buildMetadata(builder.getBindings());
+    buildMetadata(builder);
 
     // Build pipeline layout for graphics pipeline libraries if applicable
-    if ((stageMask & VK_SHADER_STAGE_ALL_GRAPHICS) && device->canUseGraphicsPipelineLibrary()) {
-      buildPipelineLayout(DxvkPipelineLayoutType::Independent, stageMask,
-        builder.getBindings(), builder.getPushConstantRange(), manager);
-    }
+    if ((stageMask & VK_SHADER_STAGE_ALL_GRAPHICS) && device->canUseGraphicsPipelineLibrary())
+      buildPipelineLayout(DxvkPipelineLayoutType::Independent, device, builder, manager);
 
     // Build pipeline layout for monolithic pipelines if binding
     // layouts for all shader stages are known
@@ -216,10 +240,8 @@ namespace dxvk {
                 && (stageMask & VK_SHADER_STAGE_VERTEX_BIT);
     }
 
-    if (isComplete) {
-      buildPipelineLayout(DxvkPipelineLayoutType::Merged, stageMask,
-        builder.getBindings(), builder.getPushConstantRange(), manager);
-    }
+    if (isComplete)
+      buildPipelineLayout(DxvkPipelineLayoutType::Merged, device, builder, manager);
   }
 
 
@@ -229,11 +251,13 @@ namespace dxvk {
 
 
   void DxvkPipelineBindings::buildPipelineLayout(
-          DxvkPipelineLayoutType    type,
-          VkShaderStageFlags        stageMask,
-          DxvkPipelineBindingRange  bindings,
-          DxvkPushConstantRange     pushConstants,
-          DxvkPipelineManager*      manager) {
+          DxvkPipelineLayoutType      type,
+          DxvkDevice*                 device,
+    const DxvkPipelineLayoutBuilder&  builder,
+          DxvkPipelineManager*        manager) {
+    auto stageMask = builder.getStageMask();
+    auto bindings = builder.getBindings();
+
     auto& layout = m_layouts[uint32_t(type)];
 
     // Determine descriptor sets covered by this layout
@@ -250,7 +274,7 @@ namespace dxvk {
       DxvkShaderBinding srcMapping(binding.getStageMask(), binding.getSet(), binding.getBinding());
       DxvkShaderBinding dstMapping(binding.getStageMask(), set, bindingIndex);
 
-      layout.bindingMap.add(srcMapping, dstMapping);
+      layout.bindingMap.addBinding(srcMapping, dstMapping);
 
       layout.setStateMasks[set] |= computeStateMask(binding);
 
@@ -282,19 +306,72 @@ namespace dxvk {
         setLayouts[i] = manager->createDescriptorSetLayout(setLayoutKeys[i]);
     }
 
-    // Push constant state is shared by all stages, so we need to
-    if (type == DxvkPipelineLayoutType::Independent)
-      pushConstants = DxvkPushConstantRange(VK_SHADER_STAGE_ALL_GRAPHICS, MaxSharedPushDataSize);
+    // Process and re-map data blocks
+    std::array<DxvkPushDataBlock, DxvkPushDataBlock::MaxBlockCount> pushDataBlocks = { };
 
+    uint32_t pushDataMask = builder.getPushDataMask();
+    uint32_t pushDataSize = 0u;
+
+    if (type == DxvkPipelineLayoutType::Independent) {
+      // For independent layouts, we don't know in advance how the other stages
+      // are going to use their push constants, so allocate the maximum amount.
+      VkShaderStageFlags stageMask = VK_SHADER_STAGE_ALL_GRAPHICS & util::shaderStages(device->getShaderPipelineStages());
+
+      pushDataSize = MaxSharedPushDataSize;
+      uint32_t index = DxvkPushDataBlock::computeIndex(stageMask);
+
+      pushDataBlocks[index] = DxvkPushDataBlock(stageMask, 0u, pushDataSize, 4u, 0u);
+      pushDataMask |= 1u << index;
+
+      for (auto i : bit::BitMask(stageMask)) {
+        auto stage = VkShaderStageFlagBits(1u << i);
+        index = DxvkPushDataBlock::computeIndex(stage);
+
+        pushDataBlocks[index] = DxvkPushDataBlock(stage,
+          pushDataSize, MaxPerStagePushDataSize, 4u, 0u);
+
+        pushDataSize += MaxPerStagePushDataSize;
+        pushDataMask |= 1u << index;
+      }
+    }
+
+    for (auto i : bit::BitMask(builder.getPushDataMask())) {
+      const auto block = builder.getPushDataBlock(i);
+
+      if (type == DxvkPipelineLayoutType::Independent) {
+        // Merge resource mask into existing block
+        pushDataBlocks[i].merge(block);
+      } else {
+        pushDataSize = align(pushDataSize, block.getAlignment());
+
+        pushDataBlocks[i] = block;
+        pushDataBlocks[i].rebase(pushDataSize);
+
+        pushDataSize += block.getSize();
+      }
+
+      layout.bindingMap.addPushData(block, pushDataBlocks[i].getOffset());
+    }
+
+    // Compact the array based on the bit mask
+    uint32_t pushDataBlockCount = 0u;
+
+    for (auto i : bit::BitMask(pushDataMask))
+      pushDataBlocks[pushDataBlockCount++] = pushDataBlocks[i];
+
+    // Create the actual pipeline layout
     DxvkPipelineLayoutKey key(type, stageMask,
-      pushConstants, setInfos.count, setLayouts.data());
+      pushDataBlockCount, pushDataBlocks.data(),
+      setInfos.count, setLayouts.data());
 
     layout.layout = manager->createPipelineLayout(key);
   }
 
 
   void DxvkPipelineBindings::buildMetadata(
-            DxvkPipelineBindingRange  bindings) {
+    const DxvkPipelineLayoutBuilder&  builder) {
+    auto bindings = builder.getBindings();
+
     for (size_t i = 0; i < bindings.bindingCount; i++) {
       auto binding = bindings.bindings[i];
 
@@ -459,9 +536,14 @@ namespace dxvk {
   }
 
 
-  void DxvkPipelineLayoutBuilder::addPushConstants(
-          DxvkPushConstantRange     range) {
-    m_pushConstants.merge(range);
+  void DxvkPipelineLayoutBuilder::addPushData(
+          DxvkPushDataBlock         block) {
+    uint32_t index = DxvkPushDataBlock::computeIndex(block.getStageMask());
+
+    if (!block.isEmpty()) {
+      m_pushMask |= 1u << index;
+      m_pushData[index].merge(block);
+    }
   }
 
 
@@ -487,7 +569,10 @@ namespace dxvk {
   void DxvkPipelineLayoutBuilder::addLayout(
     const DxvkPipelineLayoutBuilder& layout) {
     m_stageMask |= layout.m_stageMask;
-    m_pushConstants.merge(layout.m_pushConstants);
+    m_pushMask |= layout.m_pushMask;
+
+    for (auto i : bit::BitMask(layout.getPushDataMask()))
+      m_pushData[i].merge(layout.getPushDataBlock(i));
 
     addBindings(layout.m_bindings.size(), layout.m_bindings.data());
   }

--- a/src/dxvk/dxvk_pipelayout.cpp
+++ b/src/dxvk/dxvk_pipelayout.cpp
@@ -284,7 +284,7 @@ namespace dxvk {
 
     // Push constant state is shared by all stages, so we need to
     if (type == DxvkPipelineLayoutType::Independent)
-      pushConstants = DxvkPushConstantRange(VK_SHADER_STAGE_ALL_GRAPHICS, MaxPushConstantSize);
+      pushConstants = DxvkPushConstantRange(VK_SHADER_STAGE_ALL_GRAPHICS, MaxSharedPushDataSize);
 
     DxvkPipelineLayoutKey key(type, stageMask,
       pushConstants, setInfos.count, setLayouts.data());

--- a/src/dxvk/dxvk_pipelayout.h
+++ b/src/dxvk/dxvk_pipelayout.h
@@ -497,6 +497,13 @@ namespace dxvk {
       m_size        (uint16_t(size)),
       m_resourceMask(uint64_t(resourceMask)) { }
 
+    DxvkPushDataBlock(
+            uint32_t                  offset,
+            uint32_t                  size,
+            uint32_t                  alignment,
+            uint64_t                  resourceMask)
+    : DxvkPushDataBlock(0u, offset, size, alignment, resourceMask) { }
+
     /**
      * \brief Queries stage mask
      * \returns Stage mask

--- a/src/dxvk/dxvk_pipelayout.h
+++ b/src/dxvk/dxvk_pipelayout.h
@@ -396,14 +396,13 @@ namespace dxvk {
     }
 
     /**
-     * \brief Adds base offset to block offset
+     * \bief Changes block offset
      *
-     * The offset may be adjusted after determining the
-     * exact layout of push data in memory.
-     * \param [in] baseOffset Base block offset, in bytes
+     * Used when remapping push data to its final memory layout.
+     * \param [in] offset New absolute block offset
      */
-    void addBlockOffset(uint32_t baseOffset) {
-      m_blockOffset += baseOffset;
+    void setBlockOffset(uint32_t offset) {
+      m_blockOffset = offset;
     }
 
     /**
@@ -615,9 +614,11 @@ namespace dxvk {
      *
      * Useful when remapping push constant ranges.
      * \param [in] newOffset New block offset
+     * \param [in] newSize New block size
      */
-    void rebase(uint32_t newOffset) {
+    void rebase(uint32_t newOffset, uint32_t newSize) {
       m_offset = newOffset;
+      m_size = newSize;
     }
 
     /**
@@ -1556,8 +1557,8 @@ namespace dxvk {
      * \param [in] set Set index
      * \returns List of all non-descriptor bindings.
      */
-    DxvkPipelineBindingRange getRawBindingsInSet(DxvkPipelineLayoutType type, uint32_t set) const {
-      return makeBindingRange(m_layouts[uint32_t(type)].setRawBindings[set]);
+    DxvkPipelineBindingRange getRawBindings(DxvkPipelineLayoutType type) const {
+      return makeBindingRange(m_layouts[uint32_t(type)].rawBindings);
     }
 
     /**
@@ -1624,10 +1625,10 @@ namespace dxvk {
       std::array<BindingList, MaxSets>  setSamplers          = { };
       std::array<BindingList, MaxSets>  setResources         = { };
       std::array<BindingList, MaxSets>  setUniformBuffers    = { };
-      std::array<BindingList, MaxSets>  setRawBindings       = { };
 
       std::array<uint32_t, MaxSets>     setStateMasks = { };
 
+      BindingList                       rawBindings = { };
       DxvkShaderBindingMap              bindingMap = { };
 
       const DxvkPipelineLayout*         layout = nullptr;

--- a/src/dxvk/dxvk_pipelayout.h
+++ b/src/dxvk/dxvk_pipelayout.h
@@ -92,8 +92,9 @@ namespace dxvk {
     static constexpr uint32_t Buffer  = 1u << 0u;
     static constexpr uint32_t View    = 1u << 8u;
     static constexpr uint32_t Sampler = 1u << 16u;
+    static constexpr uint32_t Raw     = 1u << 24u;
 
-    static constexpr uint32_t All = Buffer | View | Sampler;
+    static constexpr uint32_t All = Buffer | View | Sampler | Raw;
   };
 
 
@@ -108,11 +109,11 @@ namespace dxvk {
     DxvkDescriptorState() = default;
 
     void dirtyBuffers(VkShaderStageFlags stages) {
-      m_dirtyMask |= computeMask(stages, DxvkDescriptorClass::Buffer);
+      m_dirtyMask |= computeMask(stages, DxvkDescriptorClass::Buffer | DxvkDescriptorClass::Raw);
     }
 
     void dirtyViews(VkShaderStageFlags stages) {
-      m_dirtyMask |= computeMask(stages, DxvkDescriptorClass::View);
+      m_dirtyMask |= computeMask(stages, DxvkDescriptorClass::View | DxvkDescriptorClass::Raw);
     }
 
     void dirtySamplers(VkShaderStageFlags stages) {
@@ -129,6 +130,10 @@ namespace dxvk {
 
     bool hasDirtyResources(VkShaderStageFlags stages) const {
       return bool(m_dirtyMask & computeMask(stages, DxvkDescriptorClass::All));
+    }
+
+    bool hasDirtyRawDescriptors(VkShaderStageFlags stages) {
+      return bool(m_dirtyMask & computeMask(stages, DxvkDescriptorClass::Raw));
     }
 
     bool testDirtyMask(uint32_t mask) const {

--- a/src/dxvk/dxvk_pipelayout.h
+++ b/src/dxvk/dxvk_pipelayout.h
@@ -4,6 +4,8 @@
 #include <unordered_map>
 #include <vector>
 
+#include "../util/util_small_vector.h"
+
 #include "dxvk_hash.h"
 #include "dxvk_include.h"
 #include "dxvk_limits.h"
@@ -1651,6 +1653,19 @@ namespace dxvk {
     void buildPipelineLayout(
             DxvkPipelineLayoutType      type,
             DxvkDevice*                 device,
+      const DxvkPipelineLayoutBuilder&  builder,
+            DxvkPipelineManager*        manager);
+
+    small_vector<DxvkPushDataBlock, DxvkPushDataBlock::MaxBlockCount>
+    buildPushDataBlocks(
+            DxvkPipelineLayoutType      type,
+            DxvkDevice*                 device,
+      const DxvkPipelineLayoutBuilder&  builder,
+            DxvkPipelineManager*        manager);
+
+    small_vector<const DxvkDescriptorSetLayout*, MaxSets>
+    buildDescriptorSetLayouts(
+            DxvkPipelineLayoutType      type,
       const DxvkPipelineLayoutBuilder&  builder,
             DxvkPipelineManager*        manager);
 

--- a/src/dxvk/dxvk_pipelayout.h
+++ b/src/dxvk/dxvk_pipelayout.h
@@ -515,8 +515,9 @@ namespace dxvk {
      *
      * Useful to construct set layouts on the fly.
      * \param [in] binding Binding info
+     * \returns Binding index
      */
-    void add(DxvkDescriptorSetLayoutBinding binding);
+    uint32_t add(DxvkDescriptorSetLayoutBinding binding);
 
     /**
      * \brief Checks for equality

--- a/src/dxvk/dxvk_shader.cpp
+++ b/src/dxvk/dxvk_shader.cpp
@@ -161,8 +161,11 @@ namespace dxvk {
     }
 
     if (info.pushConstSize && usesPushConstants) {
-      m_layout.addPushConstants(DxvkPushConstantRange(
-        m_info.stage, info.pushConstSize));
+      VkShaderStageFlags stage = (m_info.stage & VK_SHADER_STAGE_ALL_GRAPHICS)
+        ? VK_SHADER_STAGE_ALL_GRAPHICS : VK_SHADER_STAGE_COMPUTE_BIT;
+
+      m_layout.addPushData(DxvkPushDataBlock(
+        stage, 0u, info.pushConstSize, 4u, 0u));
     }
 
     // Don't set pipeline library flag if the shader
@@ -185,7 +188,7 @@ namespace dxvk {
     // Remap resource binding IDs
     if (bindings) {
       for (const auto& info : m_bindingOffsets) {
-        auto mappedBinding = bindings->find(DxvkShaderBinding(
+        auto mappedBinding = bindings->mapBinding(DxvkShaderBinding(
           m_info.stage, info.setIndex, info.bindingIndex));
 
         if (mappedBinding) {

--- a/src/dxvk/dxvk_shader.cpp
+++ b/src/dxvk/dxvk_shader.cpp
@@ -57,15 +57,16 @@ namespace dxvk {
 
     // Run an analysis pass over the SPIR-V code to gather some
     // info that we may need during pipeline compilation.
-    bool usesPushConstants = false;
+    uint32_t pushConstantStructId = 0u;
 
     std::vector<BindingOffsets> bindingOffsets;
     std::vector<uint32_t> varIds;
     std::vector<uint32_t> sampleMaskIds;
+    std::unordered_map<uint32_t, uint32_t> pushConstantTypes;
 
     SpirvCodeBuffer code = std::move(spirv);
     uint32_t o1VarId = 0;
-    
+
     for (auto ins : code) {
       if (ins.opCode() == spv::OpDecorate) {
         if (ins.arg(2) == spv::DecorationBinding) {
@@ -143,12 +144,35 @@ namespace dxvk {
             m_flags.set(DxvkShaderFlag::ExportsSampleMask);
         }
 
-        if (ins.arg(3) == spv::StorageClassPushConstant)
-          usesPushConstants = true;
+        if (ins.arg(3) == spv::StorageClassPushConstant) {
+          auto type = pushConstantTypes.find(ins.arg(1));
+
+          if (type != pushConstantTypes.end())
+            pushConstantStructId = type->second;
+        }
+      }
+
+      if (ins.opCode() == spv::OpTypePointer) {
+        if (ins.arg(2) == spv::StorageClassPushConstant)
+          pushConstantTypes.insert({ ins.arg(1), ins.arg(3) });
       }
 
       // Ignore the actual shader code, there's nothing interesting for us in there.
       if (ins.opCode() == spv::OpFunction)
+        break;
+    }
+
+    for (auto ins : code) {
+      if (ins.opCode() == spv::OpMemberDecorate
+       && ins.arg(1) == pushConstantStructId
+       && ins.arg(3) == spv::DecorationOffset) {
+        auto& e = m_pushDataOffsets.emplace_back();
+        e.codeOffset = ins.offset() + 4;
+        e.pushOffset = ins.arg(4);
+      }
+
+      // Can exit even earlier here since decorations come up early
+      if (ins.opCode() == spv::OpFunction || ins.opCode() == spv::OpTypeVoid)
         break;
     }
 
@@ -160,7 +184,7 @@ namespace dxvk {
         m_bindingOffsets.push_back(info);
     }
 
-    if (info.pushConstSize && usesPushConstants) {
+    if (info.pushConstSize && pushConstantStructId) {
       VkShaderStageFlags stage = (m_info.stage & VK_SHADER_STAGE_ALL_GRAPHICS)
         ? VK_SHADER_STAGE_ALL_GRAPHICS : VK_SHADER_STAGE_COMPUTE_BIT;
 
@@ -197,6 +221,13 @@ namespace dxvk {
           if (info.setOffset)
             code[info.setOffset] = mappedBinding->getSet();
         }
+      }
+
+      for (const auto& info : m_pushDataOffsets) {
+        uint32_t offset = bindings->mapPushData(m_info.stage, info.pushOffset);
+
+        if (offset < MaxTotalPushDataSize)
+          code[info.codeOffset] = offset;
       }
     }
 

--- a/src/dxvk/dxvk_shader.cpp
+++ b/src/dxvk/dxvk_shader.cpp
@@ -184,12 +184,25 @@ namespace dxvk {
         m_bindingOffsets.push_back(info);
     }
 
-    if (info.pushConstSize && pushConstantStructId) {
-      VkShaderStageFlags stage = (m_info.stage & VK_SHADER_STAGE_ALL_GRAPHICS)
-        ? VK_SHADER_STAGE_ALL_GRAPHICS : VK_SHADER_STAGE_COMPUTE_BIT;
+    if (pushConstantStructId) {
+      if (!info.sharedPushData.isEmpty()) {
+        auto stageMask = (info.stage & VK_SHADER_STAGE_ALL_GRAPHICS)
+          ? VK_SHADER_STAGE_ALL_GRAPHICS : VK_SHADER_STAGE_COMPUTE_BIT;
 
-      m_layout.addPushData(DxvkPushDataBlock(
-        stage, 0u, info.pushConstSize, 4u, 0u));
+        m_layout.addPushData(DxvkPushDataBlock(stageMask,
+          info.sharedPushData.getOffset(),
+          info.sharedPushData.getSize(),
+          info.sharedPushData.getAlignment(),
+          info.sharedPushData.getResourceDwordMask()));
+      }
+
+      if (!info.localPushData.isEmpty()) {
+        m_layout.addPushData(DxvkPushDataBlock(info.stage,
+          info.localPushData.getOffset(),
+          info.localPushData.getSize(),
+          info.localPushData.getAlignment(),
+          info.localPushData.getResourceDwordMask()));
+      }
     }
 
     // Don't set pipeline library flag if the shader

--- a/src/dxvk/dxvk_shader.h
+++ b/src/dxvk/dxvk_shader.h
@@ -254,6 +254,11 @@ namespace dxvk {
       uint32_t setOffset = 0u;
     };
 
+    struct PushDataOffsets {
+      uint32_t codeOffset = 0u;
+      uint32_t pushOffset = 0u;
+    };
+
     DxvkShaderCreateInfo          m_info;
     SpirvCompressedBuffer         m_code;
     
@@ -268,6 +273,7 @@ namespace dxvk {
     std::atomic<bool>             m_needsLibraryCompile = { true };
 
     std::vector<BindingOffsets>   m_bindingOffsets;
+    std::vector<PushDataOffsets>  m_pushDataOffsets;
 
     DxvkPipelineLayoutBuilder     m_layout;
 

--- a/src/dxvk/dxvk_shader.h
+++ b/src/dxvk/dxvk_shader.h
@@ -52,8 +52,9 @@ namespace dxvk {
     uint32_t outputMask = 0;
     /// Flat shading input mask
     uint32_t flatShadingInputs = 0;
-    /// Push constant range
-    uint32_t pushConstSize = 0;
+    /// Push data blocks
+    DxvkPushDataBlock sharedPushData;
+    DxvkPushDataBlock localPushData;
     /// Rasterized stream, or -1
     int32_t xfbRasterizedStream = 0;
     /// Tess control patch vertex count

--- a/src/spirv/spirv_module.cpp
+++ b/src/spirv/spirv_module.cpp
@@ -345,6 +345,20 @@ namespace dxvk {
   }
   
   
+  uint32_t SpirvModule::constvec2u32(
+          uint32_t                x,
+          uint32_t                y) {
+    std::array<uint32_t, 2> args = {{
+      this->constu32(x), this->constu32(y),
+    }};
+
+    uint32_t scalarTypeId = this->defIntType(32, 0);
+    uint32_t vectorTypeId = this->defVectorType(scalarTypeId, 2);
+
+    return this->constComposite(vectorTypeId, args.size(), args.data());
+  }
+
+
   uint32_t SpirvModule::constvec4u32(
           uint32_t                x,
           uint32_t                y,

--- a/src/spirv/spirv_module.h
+++ b/src/spirv/spirv_module.h
@@ -174,6 +174,10 @@ namespace dxvk {
             bool                    z,
             bool                    w);
     
+    uint32_t constvec2u32(
+            uint32_t                x,
+            uint32_t                y);
+
     uint32_t constvec4u32(
             uint32_t                x,
             uint32_t                y,


### PR DESCRIPTION
Draft because this requires some targeted tests for edge cases that games aren't knonw to run into.

This adds two things:

- A more flexible push data abstraction that allows graphics shaders to access a 64-byte *shared* push data block (e.g. for D3D9 render state stuff) that is available to the entire pipeline, and up to 32 bytes of *private* push data which is only available to the given shader, without having to be aware of what any other shaders in the same pipeline do. The backend will rearrange push constant structs on its own and ensure to pull data from the correct places. One use case for this is the byte offset passed into the D3D9 SWVP geometry shader, which doesn't interact with anything else.

- Raw resource bindings that don't go through a descriptor, and instead pass a buffer address or descriptor index via push constants. For now, this is only done for UAV counters since we kinda rely on robustness everywhere, but the goal is to move samplers to this system as well and make them bindless.