### PR TITLE
Bindless samplers (and UAV counters)

### DIFF
--- a/src/d3d11/d3d11_context.cpp
+++ b/src/d3d11/d3d11_context.cpp
@@ -3431,7 +3431,8 @@ namespace dxvk {
     EmitCs([
       cPushConstants = pc
     ] (DxvkContext* ctx) {
-      ctx->pushConstants(0, sizeof(cPushConstants), &cPushConstants);
+      ctx->pushData(VK_SHADER_STAGE_ALL_GRAPHICS,
+        0, sizeof(cPushConstants), &cPushConstants);
     });
   }
 
@@ -4890,7 +4891,7 @@ namespace dxvk {
       // Initialize push constants
       DxbcPushConstants pc;
       pc.rasterizerSampleCount = 1;
-      ctx->pushConstants(0, sizeof(pc), &pc);
+      ctx->pushData(VK_SHADER_STAGE_ALL_GRAPHICS, 0, sizeof(pc), &pc);
     });
   }
 

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -3221,7 +3221,7 @@ namespace dxvk {
 
       ctx->bindShader<VK_SHADER_STAGE_GEOMETRY_BIT>(std::move(shader));
       ctx->bindResourceBufferView(VK_SHADER_STAGE_GEOMETRY_BIT, getSWVPBufferSlot(), std::move(bufferView));
-      ctx->pushData(VK_SHADER_STAGE_ALL_GRAPHICS, sizeof(D3D9RenderStateInfo), sizeof(byteOffset), &byteOffset);
+      ctx->pushData(VK_SHADER_STAGE_GEOMETRY_BIT, 0u, sizeof(byteOffset), &byteOffset);
       ctx->draw(1u, &draw);
       ctx->bindResourceBufferView(VK_SHADER_STAGE_GEOMETRY_BIT, getSWVPBufferSlot(), nullptr);
       ctx->bindShader<VK_SHADER_STAGE_GEOMETRY_BIT>(nullptr);

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -3221,7 +3221,7 @@ namespace dxvk {
 
       ctx->bindShader<VK_SHADER_STAGE_GEOMETRY_BIT>(std::move(shader));
       ctx->bindResourceBufferView(VK_SHADER_STAGE_GEOMETRY_BIT, getSWVPBufferSlot(), std::move(bufferView));
-      ctx->pushConstants(sizeof(D3D9RenderStateInfo), sizeof(byteOffset), &byteOffset);
+      ctx->pushData(VK_SHADER_STAGE_ALL_GRAPHICS, sizeof(D3D9RenderStateInfo), sizeof(byteOffset), &byteOffset);
       ctx->draw(1u, &draw);
       ctx->bindResourceBufferView(VK_SHADER_STAGE_GEOMETRY_BIT, getSWVPBufferSlot(), nullptr);
       ctx->bindShader<VK_SHADER_STAGE_GEOMETRY_BIT>(nullptr);
@@ -6071,7 +6071,8 @@ namespace dxvk {
     EmitCs([
       cData = *constData
     ](DxvkContext* ctx) {
-      ctx->pushConstants(Offset, Length, &cData);
+      // Render state uses the shared push constant block
+      ctx->pushData(VK_SHADER_STAGE_ALL_GRAPHICS, Offset, Length, &cData);
     });
   }
 

--- a/src/d3d9/d3d9_fixed_function.cpp
+++ b/src/d3d9/d3d9_fixed_function.cpp
@@ -889,7 +889,7 @@ namespace dxvk {
     info.inputMask = m_inputMask;
     info.outputMask = m_outputMask;
     info.flatShadingInputs = m_flatShadingMask;
-    info.pushConstSize = sizeof(D3D9RenderStateInfo);
+    info.sharedPushData = DxvkPushDataBlock(0u, sizeof(D3D9RenderStateInfo), 4u, 0u);
 
     return new DxvkShader(info, m_module.compile());
   }

--- a/src/d3d9/d3d9_format_helpers.cpp
+++ b/src/d3d9/d3d9_format_helpers.cpp
@@ -158,7 +158,7 @@ namespace dxvk {
       { VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT },
     }};
 
-    return m_device->createBuiltInPipelineLayout(VK_SHADER_STAGE_COMPUTE_BIT,
+    return m_device->createBuiltInPipelineLayout(0u, VK_SHADER_STAGE_COMPUTE_BIT,
       sizeof(VkExtent2D), bindings.size(), bindings.data());
   }
 

--- a/src/d3d9/d3d9_swvp_emu.cpp
+++ b/src/d3d9/d3d9_swvp_emu.cpp
@@ -121,7 +121,7 @@ namespace dxvk {
       m_module.decorate(push_const_t, spv::DecorationBlock);
       m_module.setDebugName(push_const_t, "pc_t");
       m_module.setDebugMemberName(push_const_t, 0, "offset");
-      m_module.memberDecorateOffset(push_const_t, 0, sizeof(D3D9RenderStateInfo));
+      m_module.memberDecorateOffset(push_const_t, 0, MaxSharedPushDataSize);
 
       uint32_t push_const_uint_ptr_t = m_module.defPointerType(uint_t, spv::StorageClassPushConstant);
       uint32_t push_const_ptr_t = m_module.defPointerType(push_const_t, spv::StorageClassPushConstant);
@@ -310,8 +310,7 @@ namespace dxvk {
       info.stage = VK_SHADER_STAGE_GEOMETRY_BIT;
       info.bindingCount = 1;
       info.bindings = &m_bufferBinding;
-      info.sharedPushData = DxvkPushDataBlock(0u,
-        sizeof(D3D9RenderStateInfo) + sizeof(D3D9SwvpEmuArgs), 4u, 0u);
+      info.localPushData = DxvkPushDataBlock(MaxSharedPushDataSize, sizeof(D3D9SwvpEmuArgs), 4u, 0u);
       info.inputMask = m_inputMask;
       info.inputTopology = VK_PRIMITIVE_TOPOLOGY_POINT_LIST;
 

--- a/src/d3d9/d3d9_swvp_emu.cpp
+++ b/src/d3d9/d3d9_swvp_emu.cpp
@@ -310,7 +310,8 @@ namespace dxvk {
       info.stage = VK_SHADER_STAGE_GEOMETRY_BIT;
       info.bindingCount = 1;
       info.bindings = &m_bufferBinding;
-      info.pushConstSize = sizeof(D3D9RenderStateInfo) + sizeof(D3D9SwvpEmuArgs);
+      info.sharedPushData = DxvkPushDataBlock(0u,
+        sizeof(D3D9RenderStateInfo) + sizeof(D3D9SwvpEmuArgs), 4u, 0u);
       info.inputMask = m_inputMask;
       info.inputTopology = VK_PRIMITIVE_TOPOLOGY_POINT_LIST;
 

--- a/src/dxbc/dxbc_analysis.cpp
+++ b/src/dxbc/dxbc_analysis.cpp
@@ -67,6 +67,12 @@ namespace dxvk {
         m_analysis->usesDerivatives = true;
       } break;
 
+      case DxbcInstClass::TextureQueryMs:
+      case DxbcInstClass::TextureQueryMsPos: {
+        if (ins.src[0].type == DxbcOperandType::Rasterizer)
+          m_analysis->usesSampleCount = true;
+      } break;
+
       case DxbcInstClass::ControlFlow: {
         if (ins.op == DxbcOpcode::Discard)
           m_analysis->usesKill = true;

--- a/src/dxbc/dxbc_analysis.cpp
+++ b/src/dxbc/dxbc_analysis.cpp
@@ -55,6 +55,11 @@ namespace dxvk {
         }
       } break;
 
+      case DxbcInstClass::AtomicCounter: {
+        const uint32_t registerId = ins.dst[1].idx[0].offset;
+        m_analysis->uavCounterMask |= uint64_t(1u) << registerId;
+      } break;
+
       case DxbcInstClass::TextureSample:
       case DxbcInstClass::TextureGather:
       case DxbcInstClass::TextureQueryLod:

--- a/src/dxbc/dxbc_analysis.h
+++ b/src/dxbc/dxbc_analysis.h
@@ -60,6 +60,7 @@ namespace dxvk {
     
     bool usesDerivatives  = false;
     bool usesKill         = false;
+    bool usesSampleCount  = false;
   };
   
   /**

--- a/src/dxbc/dxbc_analysis.h
+++ b/src/dxbc/dxbc_analysis.h
@@ -55,6 +55,8 @@ namespace dxvk {
     DxbcClipCullInfo clipCullOut;
 
     DxbcBindingMask bindings = { };
+
+    uint64_t uavCounterMask = 0u;
     
     bool usesDerivatives  = false;
     bool usesKill         = false;

--- a/src/dxbc/dxbc_compiler.cpp
+++ b/src/dxbc/dxbc_compiler.cpp
@@ -249,6 +249,7 @@ namespace dxvk {
     info.outputTopology = m_outputTopology;
     info.sharedPushData = m_sharedPushData;
     info.localPushData = m_localPushData;
+    info.samplerHeap = DxvkShaderBinding(VK_SHADER_STAGE_ALL, DxbcGlobalSamplerSet, 0u);
 
     if (m_programInfo.type() == DxbcProgramType::HullShader)
       info.patchVertexCount = m_hs.vertexCountIn;
@@ -293,8 +294,8 @@ namespace dxvk {
         return this->emitDclConstantBuffer(ins);
         
       case DxbcOpcode::DclSampler:
-        return this->emitDclSampler(ins);
-      
+        return; /* no op */
+
       case DxbcOpcode::DclStream:
         return this->emitDclStream(ins);
         
@@ -877,41 +878,6 @@ namespace dxvk {
   }
 
 
-  void DxbcCompiler::emitDclSampler(const DxbcShaderInstruction& ins) {
-    // dclSampler takes one operand:
-    //    (dst0) The sampler register to declare
-    const uint32_t samplerId = ins.dst[0].idx[0].offset;
-    
-    // The sampler type is opaque, but we still have to
-    // define a pointer and a variable in oder to use it
-    const uint32_t samplerType = m_module.defSamplerType();
-    const uint32_t samplerPtrType = m_module.defPointerType(
-      samplerType, spv::StorageClassUniformConstant);
-    
-    // Define the sampler variable
-    const uint32_t varId = m_module.newVar(samplerPtrType,
-      spv::StorageClassUniformConstant);
-    m_module.setDebugName(varId,
-      str::format("s", samplerId).c_str());
-    
-    m_samplers.at(samplerId).varId  = varId;
-    m_samplers.at(samplerId).typeId = samplerType;
-    
-    // Compute binding slot index for the sampler
-    auto bindingId = nextBindingId();
-    
-    m_module.decorateDescriptorSet(varId, bindingId.getSet());
-    m_module.decorateBinding(varId, bindingId.getBinding());
-    
-    // Store descriptor info for the shader interface
-    auto& binding = m_bindings.emplace_back();
-    binding.set             = bindingId.getSet();
-    binding.binding         = bindingId.getBinding();
-    binding.resourceIndex   = computeSamplerBinding(m_programInfo.type(), samplerId);
-    binding.descriptorType  = VK_DESCRIPTOR_TYPE_SAMPLER;
-  }
-  
-  
   void DxbcCompiler::emitDclStream(const DxbcShaderInstruction& ins) {
     if (ins.dst[0].idx[0].offset != 0 && m_moduleInfo.xfb == nullptr)
       Logger::err("Dxbc: Multiple streams not supported");
@@ -5268,11 +5234,38 @@ namespace dxvk {
     if (!baseId)
       return 0;
 
+    uint32_t uintTypeId = getScalarTypeId(DxbcScalarType::Uint32);
+
+    uint32_t samplerTypeId = m_module.defSamplerType();
+    uint32_t samplerPtrId = m_module.defPointerType(samplerTypeId, spv::StorageClassUniformConstant);
+
+    uint32_t memberId = m_module.constu32(samplerResource.member);
+
+    uint32_t samplerIndexId = 0u;
+
+    if (m_moduleInfo.options.supports16BitPushData) {
+      uint32_t uint16TypeId = m_module.defIntType(16, 0);
+      uint32_t uint16PtrId = m_module.defPointerType(uint16TypeId, spv::StorageClassPushConstant);
+
+      samplerIndexId = m_module.opUConvert(uintTypeId, m_module.opLoad(uint16TypeId,
+        m_module.opAccessChain(uint16PtrId, m_pushDataId, 1u, &memberId)));
+    } else {
+      uint32_t uintPtrId = m_module.defPointerType(uintTypeId, spv::StorageClassPushConstant);
+
+      samplerIndexId = m_module.opLoad(uintTypeId,
+        m_module.opAccessChain(uintPtrId, m_pushDataId, 1u, &memberId));
+
+      samplerIndexId = m_module.opBitFieldUExtract(uintTypeId, samplerIndexId,
+        m_module.constu32(samplerResource.word * 16u), m_module.constu32(16u));
+    }
+
+    uint32_t sampler = m_module.opLoad(samplerTypeId,
+      m_module.opAccessChain(samplerPtrId, m_samplerHeapId, 1u, &samplerIndexId));
+
     uint32_t sampledImageType = m_module.defSampledImageType(baseId);
 
     return m_module.opSampledImage(sampledImageType,
-      m_module.opLoad(textureResource.imageTypeId, textureResource.varId),
-      m_module.opLoad(samplerResource.typeId,      samplerResource.varId));
+      m_module.opLoad(textureResource.imageTypeId, textureResource.varId), sampler);
   }
   
   
@@ -7856,6 +7849,40 @@ namespace dxvk {
   }
 
 
+  void DxbcCompiler::emitSamplerArray() {
+    m_module.enableCapability(spv::CapabilityRuntimeDescriptorArray);
+
+    uint32_t samplerArray = m_module.defRuntimeArrayTypeUnique(m_module.defSamplerType());
+    uint32_t samplerPtr = m_module.defPointerType(samplerArray, spv::StorageClassUniformConstant);
+
+    m_samplerHeapId = m_module.newVar(samplerPtr, spv::StorageClassUniformConstant);
+    m_module.setDebugName(m_samplerHeapId, "sampler_heap");
+
+    m_module.decorateBinding(m_samplerHeapId, 0u);
+    m_module.decorateDescriptorSet(m_samplerHeapId, DxbcGlobalSamplerSet);
+  }
+
+
+  void DxbcCompiler::emitPushSampler(uint32_t samplerIndex, uint32_t baseMember, uint32_t offset) {
+    auto& sampler = m_samplers.at(samplerIndex);
+    sampler.typeId = m_module.defSamplerType();
+
+    if (m_moduleInfo.options.supports16BitPushData) {
+      sampler.member = baseMember + offset / sizeof(uint16_t);
+      sampler.word = 0u;
+    } else {
+      sampler.member = baseMember + offset / sizeof(uint32_t);
+      sampler.word = (offset % sizeof(uint32_t)) / sizeof(uint16_t);
+    }
+
+    auto& binding = m_bindings.emplace_back();
+    binding.resourceIndex     = computeSamplerBinding(m_programInfo.type(), samplerIndex);
+    binding.descriptorType    = VK_DESCRIPTOR_TYPE_SAMPLER;
+    binding.blockOffset       = MaxSharedPushDataSize + offset;
+    binding.flags.set(DxvkDescriptorFlag::PushData);
+  }
+
+
   void DxbcCompiler::emitPushData() {
     small_vector<uint32_t, 32> members;
     small_vector<uint32_t, 32> offsets;
@@ -7863,6 +7890,7 @@ namespace dxvk {
 
     // Shared push constants
     uint32_t uintTypeId = m_module.defIntType(32, 0);
+    uint32_t uint16TypeId = 0u;
     uint32_t sharedOffset = 0u;
 
     if (m_analysis->usesSampleCount) {
@@ -7882,7 +7910,54 @@ namespace dxvk {
 
     uint32_t localOffset = 0u;
     uint32_t localAlign = sizeof(uint32_t);
-    uint64_t resourceMask = 0u;
+
+    // Add sampler indices. Since many drivers do not support 16-bit push
+    // constants, emit them as dwords, but assign two samplers to each dword.
+    uint32_t samplerMask = m_analysis->bindings.samplerMask;
+
+    if (samplerMask) {
+      emitSamplerArray();
+
+      if (m_moduleInfo.options.supports16BitPushData) {
+        m_module.enableCapability(spv::CapabilityInt16);
+        uint16TypeId = m_module.defIntType(16, 0);
+      }
+    }
+
+    uint32_t firstSampler = members.size();
+
+    while (samplerMask) {
+      uint32_t s0 = bit::tzcnt(samplerMask); samplerMask &= samplerMask - 1u;
+      uint32_t s1 = bit::tzcnt(samplerMask); samplerMask &= samplerMask - 1u;
+
+      if (m_moduleInfo.options.supports16BitPushData) {
+        members.push_back(uint16TypeId);
+        members.push_back(uint16TypeId);
+
+        offsets.push_back(MaxSharedPushDataSize + localOffset);
+        offsets.push_back(MaxSharedPushDataSize + localOffset + sizeof(uint16_t));
+
+        names.push_back(str::format("s", s0, "_idx"));
+
+        if (s1 < DxbcSamplersPerStage)
+          names.push_back(str::format("s", s1, "_idx"));
+        else
+          names.push_back("reserved");
+      } else {
+        members.push_back(uintTypeId);
+        offsets.push_back(MaxSharedPushDataSize + localOffset);
+        names.push_back(s1 < DxbcSamplersPerStage
+          ? str::format("s", s0, "_s", s1, "_idx")
+          : str::format("s", s0, "_idx"));
+      }
+
+      emitPushSampler(s0, firstSampler, localOffset);
+
+      if (s1 < DxbcSamplersPerStage)
+        emitPushSampler(s1, firstSampler, localOffset + sizeof(uint16_t));
+
+      localOffset += sizeof(uint32_t);
+    }
 
     // Add as many UAV counters as we can fit into the push data block
     if (m_analysis->uavCounterMask && localOffset + sizeof(uint64_t) <= localMaxSize) {
@@ -7902,9 +7977,6 @@ namespace dxvk {
         offsets.push_back(MaxSharedPushDataSize + localOffset);
         names.push_back(str::format("u", uav, "_ctr"));
 
-        // Mark two consecutive dwords as being sourced from resources
-        resourceMask |= 0x3 << (localOffset / sizeof(uint32_t));
-
         // Declare the actual binding
         auto& binding = m_bindings.emplace_back();
         binding.resourceIndex     = computeUavCounterBinding(m_programInfo.type(), uav);
@@ -7916,6 +7988,9 @@ namespace dxvk {
         localOffset += sizeof(uint64_t);
       }
     }
+
+    // All local members we declared so far are resources
+    uint64_t resourceMask = (1ull << (localOffset / sizeof(uint32_t))) - 1u;
 
     // Guess we're not using anything?
     if (members.empty())

--- a/src/dxbc/dxbc_compiler.cpp
+++ b/src/dxbc/dxbc_compiler.cpp
@@ -247,7 +247,7 @@ namespace dxvk {
     info.outputTopology = m_outputTopology;
 
     if (m_ps.pushConstantId)
-      info.pushConstSize = sizeof(DxbcPushConstants);
+      info.sharedPushData = DxvkPushDataBlock(0u, sizeof(DxbcPushConstants), 4u, 0u);
 
     if (m_programInfo.type() == DxbcProgramType::HullShader)
       info.patchVertexCount = m_hs.vertexCountIn;

--- a/src/dxbc/dxbc_compiler.cpp
+++ b/src/dxbc/dxbc_compiler.cpp
@@ -33,17 +33,19 @@ namespace dxvk {
     // Set the memory model. This is the same for all shaders.
     m_module.enableCapability(
       spv::CapabilityVulkanMemoryModel);
+    m_module.enableCapability(
+      spv::CapabilityPhysicalStorageBufferAddresses);
 
     m_module.setMemoryModel(
-      spv::AddressingModelLogical,
+      spv::AddressingModelPhysicalStorageBuffer64,
       spv::MemoryModelVulkan);
-    
+
     // Make sure our interface registers are clear
     for (uint32_t i = 0; i < DxbcMaxInterfaceRegs; i++) {
       m_vRegs.at(i) = DxbcRegisterPointer { };
       m_oRegs.at(i) = DxbcRegisterPointer { };
     }
-    
+
     this->emitInit();
   }
   
@@ -245,9 +247,8 @@ namespace dxvk {
     info.outputMask = m_outputMask;
     info.inputTopology = m_inputTopology;
     info.outputTopology = m_outputTopology;
-
-    if (m_ps.pushConstantId)
-      info.sharedPushData = DxvkPushDataBlock(0u, sizeof(DxbcPushConstants), 4u, 0u);
+    info.sharedPushData = m_sharedPushData;
+    info.localPushData = m_localPushData;
 
     if (m_programInfo.type() == DxbcProgramType::HullShader)
       info.patchVertexCount = m_hs.vertexCountIn;
@@ -1034,18 +1035,16 @@ namespace dxvk {
     // Declare a specialization constant which will
     // store whether or not the resource is bound.
     if (isUav) {
-      DxbcUav uav;
+      auto& uav = m_uavs.at(registerId);
       uav.type          = DxbcResourceType::Typed;
       uav.imageInfo     = typeInfo;
       uav.varId         = varId;
-      uav.ctrId         = 0;
       uav.sampledType   = sampledType;
       uav.sampledTypeId = sampledTypeId;
       uav.imageTypeId   = imageTypeId;
       uav.structStride  = 0;
       uav.coherence     = getUavCoherence(registerId, ins.controls.uavFlags());
       uav.isRawSsbo     = false;
-      m_uavs.at(registerId) = uav;
     } else {
       DxbcShaderResource res;
       res.type          = DxbcResourceType::Typed;
@@ -1192,18 +1191,16 @@ namespace dxvk {
     m_module.decorateBinding(varId, bindingId.getBinding());
     
     if (isUav) {
-      DxbcUav uav;
+      auto& uav = m_uavs.at(registerId);
       uav.type          = resType;
       uav.imageInfo     = typeInfo;
       uav.varId         = varId;
-      uav.ctrId         = 0;
       uav.sampledType   = sampledType;
       uav.sampledTypeId = sampledTypeId;
       uav.imageTypeId   = resTypeId;
       uav.structStride  = resStride;
       uav.coherence     = getUavCoherence(registerId, ins.controls.uavFlags());
       uav.isRawSsbo     = useRawSsbo;
-      m_uavs.at(registerId) = uav;
     } else {
       DxbcShaderResource res;
       res.type          = resType;
@@ -1453,33 +1450,20 @@ namespace dxvk {
   
   uint32_t DxbcCompiler::emitDclUavCounter(uint32_t regId) {
     // Declare a structure type which holds the UAV counter
-    if (m_uavCtrStructType == 0) {
-      const uint32_t t_u32    = m_module.defIntType(32, 0);
-      const uint32_t t_struct = m_module.defStructTypeUnique(1, &t_u32);
-      
-      m_module.decorate(t_struct, spv::DecorationBlock);
-      m_module.memberDecorateOffset(t_struct, 0, 0);
-      
-      m_module.setDebugName      (t_struct, "uav_meta");
-      m_module.setDebugMemberName(t_struct, 0, "ctr");
-      
-      m_uavCtrStructType  = t_struct;
-      m_uavCtrPointerType = m_module.defPointerType(
-        t_struct, spv::StorageClassStorageBuffer);
-    }
-    
+    if (!m_uavCtrPointerType)
+      m_uavCtrPointerType = m_module.defPointerType(m_uavCtrStructType, spv::StorageClassStorageBuffer);
+
     // Declare the buffer variable
-    const uint32_t varId = m_module.newVar(
-      m_uavCtrPointerType, spv::StorageClassStorageBuffer);
-    
+    uint32_t varId = m_module.newVar(m_uavCtrPointerType, spv::StorageClassStorageBuffer);
+
     m_module.setDebugName(varId,
-      str::format("u", regId, "_meta").c_str());
-    
+      str::format("u", regId, "_ctr").c_str());
+
     auto bindingId = nextBindingId();
 
     m_module.decorateDescriptorSet(varId, bindingId.getSet());
     m_module.decorateBinding(varId, bindingId.getBinding());
-    
+
     // Declare the storage buffer binding
     auto& binding = m_bindings.emplace_back();
     binding.set               = bindingId.getSet();
@@ -2552,21 +2536,48 @@ namespace dxvk {
     //    (dst1) The UAV whose counter is going to be modified
     const uint32_t registerId = ins.dst[1].idx[0].offset;
     
-    if (m_uavs.at(registerId).ctrId == 0)
-      m_uavs.at(registerId).ctrId = emitDclUavCounter(registerId);
-    
+    uint32_t prevBlockId = m_module.getBlockId();
+    uint32_t nullCheckIf = 0u;
+    uint32_t nullCheckEnd = 0u;
+
     // Get a pointer to the atomic counter in question
+    uint32_t ctrVarId = m_uavs.at(registerId).ctrId;
+
     DxbcRegisterInfo ptrType;
     ptrType.type.ctype   = DxbcScalarType::Uint32;
     ptrType.type.ccount  = 1;
     ptrType.type.alength = 0;
     ptrType.sclass = spv::StorageClassStorageBuffer;
-    
-    uint32_t zeroId = m_module.consti32(0);
+
+    if (m_uavs.at(registerId).isBdaCounter) {
+      uint32_t memberId = m_module.constu32(m_uavs.at(registerId).ctrId);
+
+      ctrVarId = m_module.opLoad(m_uavCtrBdaType, m_module.opAccessChain(
+        m_module.defPointerType(m_uavCtrBdaType, spv::StorageClassPushConstant),
+        m_pushDataId, 1u, &memberId));
+
+      ptrType.sclass = spv::StorageClassPhysicalStorageBuffer;
+
+      nullCheckIf = m_module.allocateId();
+      nullCheckEnd = m_module.allocateId();
+
+      uint32_t boolType = getScalarTypeId(DxbcScalarType::Bool);
+      uint32_t bvecType = getVectorTypeId({ DxbcScalarType::Bool, 2u });
+      uint32_t uvecType = getVectorTypeId({ DxbcScalarType::Uint32, 2u });
+
+      uint32_t validCond = m_module.opAny(boolType,
+        m_module.opINotEqual(bvecType,
+          m_module.opBitcast(uvecType, ctrVarId),
+          m_module.constvec2u32(0u, 0u)));
+
+      m_module.opSelectionMerge(nullCheckEnd, spv::SelectionControlMaskNone);
+      m_module.opBranchConditional(validCond, nullCheckIf, nullCheckEnd);
+      m_module.opLabel(nullCheckIf);
+    }
+
+    uint32_t zeroId = m_module.constu32(0);
     uint32_t ptrId  = m_module.opAccessChain(
-      getPointerTypeId(ptrType),
-      m_uavs.at(registerId).ctrId,
-      1, &zeroId);
+      getPointerTypeId(ptrType), ctrVarId, 1, &zeroId);
     
     // Define memory scope and semantics based on the operands
     uint32_t scope     = spv::ScopeQueueFamily;
@@ -2601,6 +2612,18 @@ namespace dxvk {
           "DxbcCompiler: Unhandled instruction: ",
           ins.op));
         return;
+    }
+
+    if (m_uavs.at(registerId).isBdaCounter) {
+      m_module.opBranch(nullCheckEnd);
+      m_module.opLabel(nullCheckEnd);
+
+      std::array<SpirvPhiLabel, 2u> labels = {{
+        { value.id, nullCheckIf },
+        { zeroId,   prevBlockId },
+      }};
+
+      value.id = m_module.opPhi(getVectorTypeId(value.type), labels.size(), labels.data());
     }
 
     // Store the result
@@ -5687,18 +5710,15 @@ namespace dxvk {
     if (resource.type == DxbcOperandType::Rasterizer) {
       // SPIR-V has no gl_NumSamples equivalent, so we
       // have to work around it using a push constant
-      if (!m_ps.pushConstantId)
-        m_ps.pushConstantId = emitPushConstants();
-
       uint32_t uintTypeId = m_module.defIntType(32, 0);
       uint32_t ptrTypeId = m_module.defPointerType(uintTypeId, spv::StorageClassPushConstant);
-      uint32_t index = m_module.constu32(0);
+      uint32_t index = m_module.constu32(m_ps.rasterizerPushIndex);
 
       DxbcRegisterValue result;
       result.type.ctype  = DxbcScalarType::Uint32;
       result.type.ccount = 1;
       result.id = m_module.opLoad(uintTypeId,
-        m_module.opAccessChain(ptrTypeId, m_ps.pushConstantId, 1, &index));
+        m_module.opAccessChain(ptrTypeId, m_pushDataId, 1, &index));
       return result;
     } else {
       DxbcBufferInfo info = getBufferInfo(resource);
@@ -6942,6 +6962,14 @@ namespace dxvk {
       case DxbcProgramType::ComputeShader:  emitCsInit(); break;
       default: throw DxvkError("Invalid shader stage");
     }
+
+    // Declare push data block
+    emitUavCounterTypes();
+    emitPushData();
+
+    // Needs to be done after push data so we
+    // know which counters to get from where
+    emitUavCounterBindings();
   }
   
   
@@ -7802,21 +7830,116 @@ namespace dxvk {
     m_module.decorate(id, spv::DecorationPatch);
     return id;
   }
-  
-  
-  uint32_t DxbcCompiler::emitPushConstants() {
-    uint32_t uintTypeId = m_module.defIntType(32, 0);
-    uint32_t structTypeId = m_module.defStructTypeUnique(1, &uintTypeId);
 
-    m_module.setDebugName(structTypeId, "pc_t");
-    m_module.setDebugMemberName(structTypeId, 0, "RasterizerSampleCount");
-    m_module.memberDecorateOffset(structTypeId, 0, 0);
+
+  void DxbcCompiler::emitUavCounterTypes() {
+    if (!m_analysis->uavCounterMask)
+      return;
+
+    uint32_t uintTypeId = m_module.defIntType(32, 0);
+
+    m_uavCtrStructType = m_module.defStructTypeUnique(1u, &uintTypeId);
+
+    m_module.decorate(m_uavCtrStructType, spv::DecorationBlock);
+    m_module.memberDecorateOffset(m_uavCtrStructType, 0, 0);
+
+    m_module.setDebugName      (m_uavCtrStructType, "uav_ctr_t");
+    m_module.setDebugMemberName(m_uavCtrStructType, 0, "m");
+  }
+
+
+  void DxbcCompiler::emitUavCounterBindings() {
+    for (uint32_t uav : bit::BitMask(m_analysis->uavCounterMask)) {
+      if (!m_uavs[uav].isBdaCounter)
+        m_uavs[uav].ctrId = emitDclUavCounter(uav);
+    }
+  }
+
+
+  void DxbcCompiler::emitPushData() {
+    small_vector<uint32_t, 32> members;
+    small_vector<uint32_t, 32> offsets;
+    small_vector<std::string, 32> names;
+
+    // Shared push constants
+    uint32_t uintTypeId = m_module.defIntType(32, 0);
+    uint32_t sharedOffset = 0u;
+
+    if (m_analysis->usesSampleCount) {
+      members.push_back(uintTypeId);
+      offsets.push_back(sharedOffset);
+      names.push_back("RasterizerSampleCount");
+
+      sharedOffset += sizeof(uint32_t);
+    }
+
+    // Per-stage push constants. In compute shaders, we can use the
+    // entire push constant space since there are no shared blocks.
+    uint32_t localMaxSize = MaxPerStagePushDataSize;
+
+    if (m_programInfo.type() == DxbcProgramType::ComputeShader)
+      localMaxSize = MaxTotalPushDataSize - MaxReservedPushDataSize;
+
+    uint32_t localOffset = 0u;
+    uint32_t localAlign = sizeof(uint32_t);
+    uint64_t resourceMask = 0u;
+
+    // Add as many UAV counters as we can fit into the push data block
+    if (m_analysis->uavCounterMask && localOffset + sizeof(uint64_t) <= localMaxSize) {
+      m_uavCtrBdaType = m_module.defPointerType(m_uavCtrStructType, spv::StorageClassPhysicalStorageBuffer);
+
+      localAlign = sizeof(uint64_t);
+      localOffset = align(localOffset, localAlign);
+
+      for (uint32_t uav : bit::BitMask(m_analysis->uavCounterMask)) {
+        if (localOffset + sizeof(uint64_t) > localMaxSize)
+          break;
+
+        m_uavs[uav].ctrId = members.size();
+        m_uavs[uav].isBdaCounter = true;
+
+        members.push_back(m_uavCtrBdaType);
+        offsets.push_back(MaxSharedPushDataSize + localOffset);
+        names.push_back(str::format("u", uav, "_ctr"));
+
+        // Mark two consecutive dwords as being sourced from resources
+        resourceMask |= 0x3 << (localOffset / sizeof(uint32_t));
+
+        // Declare the actual binding
+        auto& binding = m_bindings.emplace_back();
+        binding.resourceIndex     = computeUavCounterBinding(m_programInfo.type(), uav);
+        binding.descriptorType    = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+        binding.access            = VK_ACCESS_SHADER_READ_BIT | VK_ACCESS_SHADER_WRITE_BIT;
+        binding.blockOffset       = MaxSharedPushDataSize + localOffset;
+        binding.flags.set(DxvkDescriptorFlag::PushData);
+
+        localOffset += sizeof(uint64_t);
+      }
+    }
+
+    // Guess we're not using anything?
+    if (members.empty())
+      return;
+
+    // Write back metadata
+    m_sharedPushData = DxvkPushDataBlock(0u, sharedOffset, sizeof(uint32_t), 0u);
+    m_localPushData = DxvkPushDataBlock(MaxSharedPushDataSize, localOffset, localAlign, resourceMask);
+
+    // Declare the actual push constant type and variable
+    uint32_t structTypeId = m_module.defStructTypeUnique(members.size(), members.data());
+    m_module.setDebugName(structTypeId, "push_data_t");
+    m_module.decorate(structTypeId, spv::DecorationBlock);
+
+    for (size_t i = 0u; i < names.size(); i++)
+      m_module.setDebugMemberName(structTypeId, i, names[i].c_str());
+
+    for (size_t i = 0u; i < offsets.size(); i++)
+      m_module.memberDecorateOffset(structTypeId, i, offsets[i]);
 
     uint32_t ptrTypeId = m_module.defPointerType(structTypeId, spv::StorageClassPushConstant);
-    uint32_t varId = m_module.newVar(ptrTypeId, spv::StorageClassPushConstant);
+    m_pushDataId = m_module.newVar(ptrTypeId, spv::StorageClassPushConstant);
 
-    m_module.setDebugName(varId, "pc");
-    return varId;
+    m_module.setDebugName(m_pushDataId, "push_data");
   }
 
 

--- a/src/dxbc/dxbc_compiler.cpp
+++ b/src/dxbc/dxbc_compiler.cpp
@@ -1542,10 +1542,7 @@ namespace dxvk {
 
     // Tightly pack vec2 or scalar arrays if possible. Don't bother with
     // vec3 since we'd rather have properly vectorized loads in that case.
-    if (m_moduleInfo.options.supportsTightIcbPacking && componentCount <= 2u)
-      m_icbComponents = componentCount;
-    else
-      m_icbComponents = 4u;
+    m_icbComponents = componentCount <= 2u ? componentCount : 4u;
 
     // Immediate constant buffer can be read out of bounds, declare
     // it with the maximum possible size and rely on robustness.

--- a/src/dxbc/dxbc_compiler.h
+++ b/src/dxbc/dxbc_compiler.h
@@ -191,8 +191,8 @@ namespace dxvk {
     uint32_t builtinLayer         = 0;
     uint32_t builtinViewportId    = 0;
     uint32_t builtinInnerCoverageId = 0;
-    
-    uint32_t pushConstantId       = 0;
+
+    uint32_t rasterizerPushIndex = 0u;
   };
   
   
@@ -476,6 +476,11 @@ namespace dxvk {
     std::array<DxbcShaderResource, 128> m_textures;
     std::array<DxbcUav,             64> m_uavs;
 
+    uint32_t m_pushDataId = 0u;
+
+    DxvkPushDataBlock m_sharedPushData;
+    DxvkPushDataBlock m_localPushData;
+
     bool m_hasGloballyCoherentUav = false;
     bool m_hasRasterizerOrderedUav = false;
 
@@ -532,6 +537,7 @@ namespace dxvk {
     // Struct type used for UAV counter buffers
     uint32_t m_uavCtrStructType  = 0;
     uint32_t m_uavCtrPointerType = 0;
+    uint32_t m_uavCtrBdaType = 0;
     
     ////////////////////////////////
     // Function IDs for subroutines
@@ -1210,7 +1216,11 @@ namespace dxvk {
     uint32_t emitBuiltinTessLevelInner(
             spv::StorageClass storageClass);
 
-    uint32_t emitPushConstants();
+    void emitUavCounterTypes();
+
+    void emitUavCounterBindings();
+
+    void emitPushData();
 
     ////////////////
     // Misc methods

--- a/src/dxbc/dxbc_compiler.h
+++ b/src/dxbc/dxbc_compiler.h
@@ -477,6 +477,7 @@ namespace dxvk {
     std::array<DxbcUav,             64> m_uavs;
 
     uint32_t m_pushDataId = 0u;
+    uint32_t m_samplerHeapId = 0u;
 
     DxvkPushDataBlock m_sharedPushData;
     DxvkPushDataBlock m_localPushData;
@@ -1219,6 +1220,10 @@ namespace dxvk {
     void emitUavCounterTypes();
 
     void emitUavCounterBindings();
+
+    void emitSamplerArray();
+
+    void emitPushSampler(uint32_t samplerIndex, uint32_t baseMember, uint32_t offset);
 
     void emitPushData();
 

--- a/src/dxbc/dxbc_decoder.h
+++ b/src/dxbc/dxbc_decoder.h
@@ -46,7 +46,8 @@ namespace dxvk {
    * used together with a texture resource.
    */
   struct DxbcSampler {
-    uint32_t varId  = 0;
+    uint32_t member = 0;
+    uint32_t word = 0;
     uint32_t typeId = 0;
   };
   

--- a/src/dxbc/dxbc_decoder.h
+++ b/src/dxbc/dxbc_decoder.h
@@ -73,7 +73,6 @@ namespace dxvk {
     DxbcResourceType  type          = DxbcResourceType::Typed;
     DxbcImageInfo     imageInfo;
     uint32_t          varId         = 0;
-    uint32_t          specId        = 0;
     DxbcScalarType    sampledType   = DxbcScalarType::Float32;
     uint32_t          sampledTypeId = 0;
     uint32_t          imageTypeId   = 0;
@@ -95,13 +94,13 @@ namespace dxvk {
     DxbcImageInfo     imageInfo;
     uint32_t          varId         = 0;
     uint32_t          ctrId         = 0;
-    uint32_t          specId        = 0;
     DxbcScalarType    sampledType   = DxbcScalarType::Float32;
     uint32_t          sampledTypeId = 0;
     uint32_t          imageTypeId   = 0;
     uint32_t          structStride  = 0;
     uint32_t          coherence     = 0;
     bool              isRawSsbo     = false;
+    bool              isBdaCounter  = false;
   };
   
   

--- a/src/dxbc/dxbc_options.cpp
+++ b/src/dxbc/dxbc_options.cpp
@@ -39,7 +39,6 @@ namespace dxvk {
     disableMsaa              = options.disableMsaa;
     forceSampleRateShading   = options.forceSampleRateShading;
     enableSampleShadingInterlock = device->features().extFragmentShaderInterlock.fragmentShaderSampleInterlock;
-    supportsTightIcbPacking  = device->features().vk12.uniformBufferStandardLayout;
     supports16BitPushData    = device->features().vk11.storagePushConstant16;
 
     // ANV up to mesa 25.0.2 breaks when we *don't* explicitly write point size

--- a/src/dxbc/dxbc_options.cpp
+++ b/src/dxbc/dxbc_options.cpp
@@ -40,6 +40,7 @@ namespace dxvk {
     forceSampleRateShading   = options.forceSampleRateShading;
     enableSampleShadingInterlock = device->features().extFragmentShaderInterlock.fragmentShaderSampleInterlock;
     supportsTightIcbPacking  = device->features().vk12.uniformBufferStandardLayout;
+    supports16BitPushData    = device->features().vk11.storagePushConstant16;
 
     // ANV up to mesa 25.0.2 breaks when we *don't* explicitly write point size
     needsPointSizeExport = device->adapter()->matchesDriver(VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA, Version(), Version(25, 0, 3));

--- a/src/dxbc/dxbc_options.h
+++ b/src/dxbc/dxbc_options.h
@@ -63,6 +63,9 @@ namespace dxvk {
     /// Whether to enable sincos emulation
     bool sincosEmulation = false;
 
+    /// Whether device suppors 16-bit push constants
+    bool supports16BitPushData = false;
+
     /// Float control flags
     DxbcFloatControlFlags floatControl;
 

--- a/src/dxbc/dxbc_options.h
+++ b/src/dxbc/dxbc_options.h
@@ -53,10 +53,6 @@ namespace dxvk {
     // Enable per-sample interlock if supported
     bool enableSampleShadingInterlock = false;
 
-    /// Use tightly packed arrays for immediate
-    /// constant buffers if possible
-    bool supportsTightIcbPacking = false;
-
     /// Whether exporting point size is required
     bool needsPointSizeExport = false;
 

--- a/src/dxbc/dxbc_util.h
+++ b/src/dxbc/dxbc_util.h
@@ -28,9 +28,11 @@ namespace dxvk {
 
     DxbcUavIndexGraphics        = DxbcSrvTotal,
     DxbcUavIndexCompute         = DxbcUavIndexGraphics + DxbcUavPerPipeline * 2u,
+
+    DxbcGlobalSamplerSet        = 15u,
   };
 
-  
+
   /**
    * \brief Shader binding mask
    *

--- a/src/dxso/dxso_compiler.cpp
+++ b/src/dxso/dxso_compiler.cpp
@@ -461,7 +461,7 @@ namespace dxvk {
     m_vs.functionId = m_module.allocateId();
     m_module.setDebugName(m_vs.functionId, "vs_main");
 
-    this->setupRenderStateInfo();
+    this->setupRenderStateInfo(caps::MaxTexturesVS + 1u);
 
     m_specUbo = SetupSpecUBO(m_module, m_bindings);
 
@@ -507,7 +507,7 @@ namespace dxvk {
     m_ps.functionId = m_module.allocateId();
     m_module.setDebugName(m_ps.functionId, "ps_main");
 
-    this->setupRenderStateInfo();
+    this->setupRenderStateInfo(caps::MaxTexturesPS);
     this->emitPsSharedConstants();
 
     m_specUbo = SetupSpecUBO(m_module, m_bindings);
@@ -688,6 +688,9 @@ namespace dxvk {
           uint32_t        idx,
           DxsoTextureType type) {
     m_usedSamplers |= (1u << idx);
+
+    if (!m_samplerArray)
+      m_samplerArray = SetupSamplerArray(m_module);
 
     VkImageViewType viewType = VK_IMAGE_VIEW_TYPE_MAX_ENUM;
 
@@ -3579,8 +3582,11 @@ void DxsoCompiler::emitControlFlowGenericLoop(
   }
 
 
-  void DxsoCompiler::setupRenderStateInfo() {
-    m_rsBlock = SetupRenderStateBlock(m_module);
+  void DxsoCompiler::setupRenderStateInfo(uint32_t samplerCount) {
+    auto blockInfo = SetupRenderStateBlock(m_module, (1u << samplerCount) - 1u);
+
+    m_rsBlock = blockInfo.first;
+    m_rsFirstSampler = blockInfo.second;
   }
 
 

--- a/src/dxso/dxso_compiler.cpp
+++ b/src/dxso/dxso_compiler.cpp
@@ -229,7 +229,7 @@ namespace dxvk {
     info.bindings = m_bindings.data();
     info.inputMask = m_inputMask;
     info.outputMask = m_outputMask;
-    info.pushConstSize = sizeof(D3D9RenderStateInfo);
+    info.sharedPushData = DxvkPushDataBlock(0u, sizeof(D3D9RenderStateInfo), 4u, 0u);
 
     if (m_programInfo.type() == DxsoProgramTypes::PixelShader)
       info.flatShadingInputs = m_ps.flatShadingMask;

--- a/src/dxso/dxso_compiler.h
+++ b/src/dxso/dxso_compiler.h
@@ -364,6 +364,10 @@ namespace dxvk {
     uint32_t m_specUbo = 0;
 
     uint32_t m_rsBlock = 0;
+    uint32_t m_rsFirstSampler = 0u;
+
+    uint32_t m_samplerArray = 0u;
+
     uint32_t m_mainFuncLabel = 0;
 
     //////////////////////////////////////
@@ -681,7 +685,7 @@ namespace dxvk {
     void emitInputSetup();
 
     void emitVsClipping();
-    void setupRenderStateInfo();
+    void setupRenderStateInfo(uint32_t samplerCount);
     void emitFog();
     void emitPsProcessing();
     void emitOutputDepthClamp();

--- a/src/dxso/dxso_compiler.h
+++ b/src/dxso/dxso_compiler.h
@@ -102,10 +102,11 @@ namespace dxvk {
   struct DxsoSamplerInfo {
     uint32_t dimensions = 0;
 
-    uint32_t varId = 0;
-    uint32_t typeId = 0;
-
+    uint32_t imageVarId = 0;
     uint32_t imageTypeId = 0;
+
+    uint32_t sampledTypeId = 0u;
+    uint32_t samplerIndex = 0u;
   };
 
   enum DxsoSamplerType : uint32_t {
@@ -369,6 +370,8 @@ namespace dxvk {
     uint32_t m_samplerArray = 0u;
 
     uint32_t m_mainFuncLabel = 0;
+
+    DxvkPushDataBlock m_samplerPushData;
 
     //////////////////////////////////////
     // Common function definition methods

--- a/src/dxvk/dxvk_adapter.cpp
+++ b/src/dxvk/dxvk_adapter.cpp
@@ -365,6 +365,13 @@ namespace dxvk {
     enabledFeatures.vk12.descriptorBindingPartiallyBound = VK_TRUE;
     enabledFeatures.vk12.runtimeDescriptorArray = VK_TRUE;
 
+    // Convenience feature, we can work without this
+    enabledFeatures.core.features.shaderInt16 =
+      m_deviceFeatures.core.features.shaderInt16;
+    enabledFeatures.vk11.storagePushConstant16 =
+      m_deviceFeatures.vk11.storagePushConstant16 &&
+      m_deviceFeatures.core.features.shaderInt16;
+
     // Only enable the base image robustness feature if robustness 2 isn't
     // supported, since this is only a subset of what we actually want.
     enabledFeatures.vk13.robustImageAccess =

--- a/src/dxvk/dxvk_adapter.cpp
+++ b/src/dxvk/dxvk_adapter.cpp
@@ -351,8 +351,8 @@ namespace dxvk {
     enabledFeatures.vk12.timelineSemaphore = VK_TRUE;
 
     // Used for better constant array packing in some cases
-    enabledFeatures.vk12.uniformBufferStandardLayout =
-      m_deviceFeatures.vk12.uniformBufferStandardLayout;
+    enabledFeatures.vk12.uniformBufferStandardLayout = VK_TRUE;
+    enabledFeatures.vk12.scalarBlockLayout = VK_TRUE;
 
     // Required internally
     enabledFeatures.vk12.bufferDeviceAddress = VK_TRUE;

--- a/src/dxvk/dxvk_adapter.cpp
+++ b/src/dxvk/dxvk_adapter.cpp
@@ -357,6 +357,14 @@ namespace dxvk {
     // Required internally
     enabledFeatures.vk12.bufferDeviceAddress = VK_TRUE;
 
+    // Features required for bindless samplers
+    enabledFeatures.core.features.shaderSampledImageArrayDynamicIndexing = VK_TRUE;
+    enabledFeatures.vk12.descriptorIndexing = VK_TRUE;
+    enabledFeatures.vk12.descriptorBindingSampledImageUpdateAfterBind = VK_TRUE;
+    enabledFeatures.vk12.descriptorBindingUpdateUnusedWhilePending = VK_TRUE;
+    enabledFeatures.vk12.descriptorBindingPartiallyBound = VK_TRUE;
+    enabledFeatures.vk12.runtimeDescriptorArray = VK_TRUE;
+
     // Only enable the base image robustness feature if robustness 2 isn't
     // supported, since this is only a subset of what we actually want.
     enabledFeatures.vk13.robustImageAccess =

--- a/src/dxvk/dxvk_buffer.cpp
+++ b/src/dxvk/dxvk_buffer.cpp
@@ -27,6 +27,9 @@ namespace dxvk {
       m_info.debugName = nullptr;
     }
 
+    // Unconditionally enable BDA usage
+    m_info.usage |= VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT;
+
     // Create and assign actual buffer resource
     assignStorage(allocateStorage());
   }

--- a/src/dxvk/dxvk_cmdlist.cpp
+++ b/src/dxvk/dxvk_cmdlist.cpp
@@ -546,17 +546,18 @@ namespace dxvk {
     }
 
     // Update push constants
-    DxvkPushConstantRange pushConstants = layout->getPushConstantRange();
+    DxvkPushDataBlock pushDataBlock = layout->getPushData();
 
-    if (pushDataSize && pushConstants.getSize()) {
+    if (pushDataSize && !pushDataBlock.isEmpty()) {
       std::array<char, MaxTotalPushDataSize> dataCopy;
       std::memcpy(dataCopy.data(), pushData,
         std::min(dataCopy.size(), pushDataSize));
 
       this->cmdPushConstants(cmdBuffer,
         layout->getPipelineLayout(),
-        pushConstants.getStageMask(), 0u,
-        pushConstants.getSize(),
+        pushDataBlock.getStageMask(),
+        pushDataBlock.getOffset(),
+        pushDataBlock.getSize(),
         dataCopy.data());
     }
   }

--- a/src/dxvk/dxvk_cmdlist.cpp
+++ b/src/dxvk/dxvk_cmdlist.cpp
@@ -1,3 +1,4 @@
+
 #include "dxvk_cmdlist.h"
 #include "dxvk_device.h"
 
@@ -548,7 +549,7 @@ namespace dxvk {
     DxvkPushConstantRange pushConstants = layout->getPushConstantRange();
 
     if (pushDataSize && pushConstants.getSize()) {
-      std::array<char, MaxPushConstantSize> dataCopy;
+      std::array<char, MaxTotalPushDataSize> dataCopy;
       std::memcpy(dataCopy.data(), pushData,
         std::min(dataCopy.size(), pushDataSize));
 

--- a/src/dxvk/dxvk_cmdlist.cpp
+++ b/src/dxvk/dxvk_cmdlist.cpp
@@ -491,10 +491,6 @@ namespace dxvk {
         auto& descriptor = descriptors.emplace_back();
 
         switch (info.descriptorType) {
-          case VK_DESCRIPTOR_TYPE_SAMPLER: {
-            descriptor.image.sampler = info.sampler.samplerObject;
-          } break;
-
           case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER:
           case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER: {
             if (info.descriptor) {
@@ -539,10 +535,18 @@ namespace dxvk {
         setLayout->getSetUpdateTemplate(),
         descriptors.data());
 
+      // Bind set as well as the global sampler heap, if requested
+      small_vector<VkDescriptorSet, 2u> sets;
+
+      if (layout->usesSamplerHeap())
+        sets.push_back(m_device->getSamplerDescriptorSet().set);
+
+      sets.push_back(set);
+
       this->cmdBindDescriptorSets(cmdBuffer,
         layout->getBindPoint(),
         layout->getPipelineLayout(),
-        0u, 1u, &set);
+        0u, sets.size(), sets.data());
     }
 
     // Update push constants

--- a/src/dxvk/dxvk_cmdlist.cpp
+++ b/src/dxvk/dxvk_cmdlist.cpp
@@ -517,15 +517,6 @@ namespace dxvk {
               descriptor.image = info.descriptor->legacy.image;
           } break;
 
-          case VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER: {
-            descriptor.image.sampler = info.sampler.samplerObject;
-
-            if (info.descriptor) {
-              descriptor.image.imageView = info.descriptor->legacy.image.imageView;
-              descriptor.image.imageLayout = info.descriptor->legacy.image.imageLayout;
-            }
-          } break;
-
           default:
             Logger::err(str::format("Unhandled descriptor type ", info.descriptorType));
         }

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -7330,7 +7330,7 @@ namespace dxvk {
     // any resource previously bound as read-only cannot have been written by
     // the same pipeline.
     VkShaderStageFlags dirtyStageMask = m_descriptorState.getDirtyStageMask(
-      DxvkDescriptorClass::Buffer | DxvkDescriptorClass::View);
+      DxvkDescriptorClass::Buffer | DxvkDescriptorClass::View | DxvkDescriptorClass::Raw);
     dirtyStageMask &= layout->getNonemptyStageMask();
 
     for (auto stageIndex : bit::BitMask(uint32_t(dirtyStageMask))) {

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -6500,9 +6500,12 @@ namespace dxvk {
         uint32_t countMask = dirtySetMask + (dirtySetMask & -dirtySetMask);
         uint32_t count = bit::bsf(countMask) - first;
 
+        // Global sampler set will always be bound to index 0
+        uint32_t setIndex = first + uint32_t(pipelineLayout->usesSamplerHeap());
+
         m_cmd->cmdBindDescriptorSets(DxvkCmdBuffer::ExecBuffer,
           BindPoint, pipelineLayout->getPipelineLayout(),
-          first, count, &sets[first]);
+          setIndex, count, &sets[first]);
 
         dirtySetMask &= countMask;
       } while (dirtySetMask);

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -1306,8 +1306,7 @@ namespace dxvk {
     Rc<DxvkSampler> sampler = createBlitSampler(filter);
 
     DxvkDescriptorWrite imageDescriptor = { };
-    imageDescriptor.descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
-    imageDescriptor.sampler = sampler->getDescriptor();
+    imageDescriptor.descriptorType = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
 
     // Common render pass info
     VkRenderingAttachmentInfo attachmentInfo = { VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO };
@@ -1353,6 +1352,7 @@ namespace dxvk {
       pushConstants.srcCoord0  = { 0.0f, 0.0f, 0.0f };
       pushConstants.srcCoord1  = { 1.0f, 1.0f, 1.0f };
       pushConstants.layerCount = passExtent.depth;
+      pushConstants.sampler = sampler->getDescriptor().samplerIndex;
 
       if (i) {
         addImageLayoutTransition(*imageView->image(),
@@ -3408,9 +3408,8 @@ namespace dxvk {
     Rc<DxvkSampler> sampler = createBlitSampler(filter);
 
     DxvkDescriptorWrite imageDescriptor = { };
-    imageDescriptor.descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+    imageDescriptor.descriptorType = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
     imageDescriptor.descriptor = srcView->getDescriptor();
-    imageDescriptor.sampler = sampler->getDescriptor();
     
     // Compute shader parameters for the operation
     VkExtent3D srcExtent = srcView->mipLevelExtent(0);
@@ -3425,6 +3424,7 @@ namespace dxvk {
       float(srcOffsetsAdjusted[1].y) / float(srcExtent.height),
       float(srcOffsetsAdjusted[1].z) / float(srcExtent.depth) };
     pushConstants.layerCount = dstView->info().layerCount;
+    pushConstants.sampler = sampler->getDescriptor().samplerIndex;
 
     m_cmd->cmdBindPipeline(DxvkCmdBuffer::ExecBuffer,
       VK_PIPELINE_BIND_POINT_GRAPHICS, pipeInfo.pipeline);

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -5973,9 +5973,9 @@ namespace dxvk {
     // Mark compute resources and push constants as dirty
     m_descriptorState.dirtyStages(VK_SHADER_STAGE_COMPUTE_BIT);
 
-    auto pushConstants = newPipeline->getLayout()->getLayout(DxvkPipelineLayoutType::Merged)->getPushConstantRange();
+    auto pushData = newPipeline->getLayout()->getLayout(DxvkPipelineLayoutType::Merged)->getPushData();
 
-    if (pushConstants.getSize()) {
+    if (!pushData.isEmpty()) {
       m_flags.set(DxvkContextFlag::CpHasPushConstants,
                   DxvkContextFlag::DirtyPushConstants);
     }
@@ -6123,9 +6123,9 @@ namespace dxvk {
       m_descriptorState.dirtyStages(VK_SHADER_STAGE_ALL_GRAPHICS);
 
     // Also update push constant status when we know the final layout
-    DxvkPushConstantRange pushConstants = m_state.gp.pipeline->getLayout()->getLayout(newPipelineLayoutType)->getPushConstantRange();
+    auto pushData = m_state.gp.pipeline->getLayout()->getLayout(newPipelineLayoutType)->getPushData();
 
-    if (pushConstants.getSize()) {
+    if (!pushData.isEmpty()) {
       m_flags.set(DxvkContextFlag::GpHasPushConstants,
                   DxvkContextFlag::DirtyPushConstants);
     }
@@ -7069,16 +7069,17 @@ namespace dxvk {
     // Optimized pipelines may have push constants trimmed, so look up
     // the exact layout used for the currently bound pipeline.
     auto layout = bindings->getLayout(getActivePipelineLayoutType(BindPoint));
-    auto pushConstants = layout->getPushConstantRange();
+    auto pushData = layout->getPushData();
 
-    if (unlikely(!pushConstants.getSize()))
+    if (unlikely(!pushData.getSize()))
       return;
 
     m_cmd->cmdPushConstants(DxvkCmdBuffer::ExecBuffer,
       layout->getPipelineLayout(),
-      pushConstants.getStageMask(), 0u,
-      pushConstants.getSize(),
-      &m_state.pc.data[0u]);
+      pushData.getStageMask(),
+      pushData.getOffset(),
+      pushData.getSize(),
+      &m_state.pc.data[pushData.getOffset()]);
   }
   
 

--- a/src/dxvk/dxvk_context.h
+++ b/src/dxvk/dxvk_context.h
@@ -1703,6 +1703,9 @@ namespace dxvk {
     void invalidateState();
 
     template<VkPipelineBindPoint BindPoint>
+    void updateSamplerSet(const DxvkPipelineLayout* layout);
+
+    template<VkPipelineBindPoint BindPoint>
     void updateResourceBindings(const DxvkPipelineBindings* layout);
 
     void updateComputeShaderResources();

--- a/src/dxvk/dxvk_context.h
+++ b/src/dxvk/dxvk_context.h
@@ -978,20 +978,25 @@ namespace dxvk {
       const DxvkImageUsageInfo&       usageInfo);
 
     /**
-     * \brief Updates push constants
+     * \brief Updates push data
      * 
-     * Updates the given push constant range.
+     * \param [in] stages Stage to set data for. If multiple
+     *    stages are set, this will push to the shared block.
      * \param [in] offset Byte offset of data to update
      * \param [in] size Number of bytes to update
      * \param [in] data Pointer to raw data
      */
-    void pushConstants(
+    void pushData(
+            VkShaderStageFlags        stages,
             uint32_t                  offset,
             uint32_t                  size,
       const void*                     data) {
-      std::memcpy(&m_state.pc.data[offset], data, size);
+      uint32_t index = DxvkPushDataBlock::computeIndex(stages);
 
-      m_flags.set(DxvkContextFlag::DirtyPushConstants);
+      uint32_t baseOffset = computePushDataBlockOffset(index);
+      std::memcpy(&m_state.pc.constantData[baseOffset + offset], data, size);
+
+      m_dirtyPushDataBlocks |= 1u << index;
     }
 
     /**
@@ -1372,6 +1377,7 @@ namespace dxvk {
     DxvkContextState        m_state;
     DxvkContextFeatures     m_features;
     DxvkDescriptorState     m_descriptorState;
+    uint32_t                m_dirtyPushDataBlocks = 0u;
 
     Rc<DxvkDescriptorPool>  m_descriptorPool;
     Rc<DxvkDescriptorPoolSet> m_descriptorManager;
@@ -1748,7 +1754,7 @@ namespace dxvk {
     void updateDynamicState();
 
     template<VkPipelineBindPoint BindPoint>
-    void updatePushConstants();
+    void updatePushData();
     
     template<bool Resolve = true>
     bool commitComputeState();
@@ -2162,6 +2168,10 @@ namespace dxvk {
     void beginActiveDebugRegions();
 
     void endActiveDebugRegions();
+
+    static uint32_t computePushDataBlockOffset(uint32_t index) {
+      return index ? MaxSharedPushDataSize + MaxPerStagePushDataSize * (index - 1u) : 0u;
+    }
 
     static bool formatsAreCopyCompatible(
             VkFormat                  imageFormat,

--- a/src/dxvk/dxvk_context.h
+++ b/src/dxvk/dxvk_context.h
@@ -996,7 +996,7 @@ namespace dxvk {
       uint32_t baseOffset = computePushDataBlockOffset(index);
       std::memcpy(&m_state.pc.constantData[baseOffset + offset], data, size);
 
-      m_dirtyPushDataBlocks |= 1u << index;
+      m_flags.set(DxvkContextFlag::DirtyPushData);
     }
 
     /**
@@ -1377,7 +1377,6 @@ namespace dxvk {
     DxvkContextState        m_state;
     DxvkContextFeatures     m_features;
     DxvkDescriptorState     m_descriptorState;
-    uint32_t                m_dirtyPushDataBlocks = 0u;
 
     Rc<DxvkDescriptorPool>  m_descriptorPool;
     Rc<DxvkDescriptorPoolSet> m_descriptorManager;

--- a/src/dxvk/dxvk_context_state.h
+++ b/src/dxvk/dxvk_context_state.h
@@ -140,7 +140,7 @@ namespace dxvk {
 
 
   struct DxvkPushConstantState {
-    char data[MaxPushConstantSize];
+    char data[MaxSharedPushDataSize];
   };
 
 

--- a/src/dxvk/dxvk_context_state.h
+++ b/src/dxvk/dxvk_context_state.h
@@ -58,7 +58,6 @@ namespace dxvk {
     CpHasPushConstants,         ///< Compute pipeline uses push constants
 
     DirtyDrawBuffer,            ///< Indirect argument buffer is dirty
-    DirtyPushConstants,         ///< Push constant data has changed
 
     ForceWriteAfterWriteSync,   ///< Ignores barrier control flags for write-after-write hazards
 
@@ -139,8 +138,9 @@ namespace dxvk {
   };
 
 
-  struct DxvkPushConstantState {
-    char data[MaxSharedPushDataSize];
+  struct DxvkPushDataState {
+    std::array<char, MaxTotalPushDataSize> constantData = { };
+    std::array<char, MaxTotalPushDataSize> resourceData = { };
   };
 
 
@@ -212,7 +212,7 @@ namespace dxvk {
     DxvkVertexInputState      vi;
     DxvkViewportState         vp;
     DxvkOutputMergerState     om;
-    DxvkPushConstantState     pc;
+    DxvkPushDataState         pc;
     DxvkXfbState              xfb;
     DxvkDynamicState          dyn;
     

--- a/src/dxvk/dxvk_context_state.h
+++ b/src/dxvk/dxvk_context_state.h
@@ -50,14 +50,15 @@ namespace dxvk {
     GpDynamicMultisampleState,  ///< Multisample state is dynamic
     GpDynamicRasterizerState,   ///< Cull mode and front face are dynamic
     GpDynamicVertexStrides,     ///< Vertex buffer strides are dynamic
-    GpHasPushConstants,         ///< Graphics pipeline uses push constants
+    GpHasPushData,              ///< Graphics pipeline uses push data
     GpIndependentSets,          ///< Graphics pipeline layout was created with independent sets
 
     CpDirtyPipelineState,       ///< Compute pipeline is out of date
     CpDirtySpecConstants,       ///< Compute spec constants are out of date
-    CpHasPushConstants,         ///< Compute pipeline uses push constants
+    CpHasPushData,              ///< Compute pipeline uses push data
 
     DirtyDrawBuffer,            ///< Indirect argument buffer is dirty
+    DirtyPushData,              ///< Push data needs to be updated
 
     ForceWriteAfterWriteSync,   ///< Ignores barrier control flags for write-after-write hazards
 

--- a/src/dxvk/dxvk_descriptor.h
+++ b/src/dxvk/dxvk_descriptor.h
@@ -35,6 +35,7 @@ namespace dxvk {
    */
   struct DxvkSamplerDescriptor {
     VkSampler samplerObject = VK_NULL_HANDLE;
+    uint16_t samplerIndex = 0u;
   };
 
 }

--- a/src/dxvk/dxvk_descriptor_pool.cpp
+++ b/src/dxvk/dxvk_descriptor_pool.cpp
@@ -297,9 +297,7 @@ namespace dxvk {
     // Samplers and uniform buffers may be special on some implementations
     // so we should allocate space for a reasonable number of both, but
     // assume that all other descriptor types share pool memory.
-    std::array<VkDescriptorPoolSize, 8> pools = {{
-      { VK_DESCRIPTOR_TYPE_SAMPLER,                m_maxSets * 1  },
-      { VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, m_maxSets / 4  },
+    std::array<VkDescriptorPoolSize, 6> pools = {{
       { VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE,          m_maxSets / 2  },
       { VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,          m_maxSets / 64 },
       { VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER,   m_maxSets / 2  },

--- a/src/dxvk/dxvk_device.cpp
+++ b/src/dxvk/dxvk_device.cpp
@@ -229,11 +229,12 @@ namespace dxvk {
 
 
   const DxvkPipelineLayout* DxvkDevice::createBuiltInPipelineLayout(
+          DxvkPipelineLayoutFlags         flags,
           VkShaderStageFlags              pushDataStages,
           VkDeviceSize                    pushDataSize,
           uint32_t                        bindingCount,
     const DxvkDescriptorSetLayoutBinding* bindings) {
-    DxvkPipelineLayoutKey key(DxvkPipelineLayoutType::Merged);
+    DxvkPipelineLayoutKey key(DxvkPipelineLayoutType::Merged, flags);
 
     if (pushDataSize) {
       key.addStages(pushDataStages);

--- a/src/dxvk/dxvk_device.cpp
+++ b/src/dxvk/dxvk_device.cpp
@@ -229,15 +229,19 @@ namespace dxvk {
 
 
   const DxvkPipelineLayout* DxvkDevice::createBuiltInPipelineLayout(
-          VkShaderStageFlags              pushConstantStages,
-          VkDeviceSize                    pushConstantSize,
+          VkShaderStageFlags              pushDataStages,
+          VkDeviceSize                    pushDataSize,
           uint32_t                        bindingCount,
     const DxvkDescriptorSetLayoutBinding* bindings) {
     DxvkPipelineLayoutKey key(DxvkPipelineLayoutType::Merged);
 
-    if (pushConstantSize) {
-      key.addStages(pushConstantStages);
-      key.addPushConstantRange(DxvkPushConstantRange(pushConstantStages, pushConstantSize));
+    if (pushDataSize) {
+      key.addStages(pushDataStages);
+
+      DxvkPushDataBlock pushData(pushDataStages,
+        0u, pushDataSize, sizeof(uint32_t), 0u);
+
+      key.addPushData(pushData);
     }
 
     if (bindingCount) {

--- a/src/dxvk/dxvk_device.h
+++ b/src/dxvk/dxvk_device.h
@@ -390,6 +390,7 @@ namespace dxvk {
     /**
      * \brief Creates built-in pipeline layout
      *
+     * \param [in] flags Pipeline layout flags
      * \param [in] pushDataStages Push data stage mask
      * \param [in] pushDataSize Push data size
      * \param [in] bindingCount Number of resource bindings
@@ -397,6 +398,7 @@ namespace dxvk {
      * \returns Unique pipeline layout
      */
     const DxvkPipelineLayout* createBuiltInPipelineLayout(
+            DxvkPipelineLayoutFlags         flags,
             VkShaderStageFlags              pushDataStages,
             VkDeviceSize                    pushDataSize,
             uint32_t                        bindingCount,

--- a/src/dxvk/dxvk_device.h
+++ b/src/dxvk/dxvk_device.h
@@ -483,6 +483,14 @@ namespace dxvk {
     }
 
     /**
+     * \brief Queries sampler descriptor set
+     * \returns Global sampler set and layout
+     */
+    DxvkSamplerDescriptorSet getSamplerDescriptorSet() {
+      return m_objects.samplerPool().getDescriptorSetInfo();
+    }
+
+    /**
      * \brief Retreves current frame ID
      * \returns Current frame ID
      */

--- a/src/dxvk/dxvk_device.h
+++ b/src/dxvk/dxvk_device.h
@@ -390,15 +390,15 @@ namespace dxvk {
     /**
      * \brief Creates built-in pipeline layout
      *
-     * \param [in] pushConstantStages Push constant stage mask
-     * \param [in] pushConstantSize Push constant size
+     * \param [in] pushDataStages Push data stage mask
+     * \param [in] pushDataSize Push data size
      * \param [in] bindingCount Number of resource bindings
      * \param [in] bindings Resource bindings
      * \returns Unique pipeline layout
      */
     const DxvkPipelineLayout* createBuiltInPipelineLayout(
-            VkShaderStageFlags              pushConstantStages,
-            VkDeviceSize                    pushConstantSize,
+            VkShaderStageFlags              pushDataStages,
+            VkDeviceSize                    pushDataSize,
             uint32_t                        bindingCount,
       const DxvkDescriptorSetLayoutBinding* bindings);
 

--- a/src/dxvk/dxvk_limits.h
+++ b/src/dxvk/dxvk_limits.h
@@ -19,7 +19,10 @@ namespace dxvk {
     MaxNumSpecConstants         =    12,
     MaxUniformBufferSize        = 65536,
     MaxVertexBindingStride      =  2048,
-    MaxPushConstantSize         =    64,
+    MaxTotalPushDataSize        =   256,
+    MaxSharedPushDataSize       =    64,
+    MaxPerStagePushDataSize     =    32,
+    MaxReservedPushDataSize     =    32,
   };
   
 }

--- a/src/dxvk/dxvk_meta_blit.cpp
+++ b/src/dxvk/dxvk_meta_blit.cpp
@@ -60,7 +60,7 @@ namespace dxvk {
   const DxvkPipelineLayout* DxvkMetaBlitObjects::createPipelineLayout() const {
     DxvkDescriptorSetLayoutBinding binding = { VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1, VK_SHADER_STAGE_FRAGMENT_BIT };
 
-    return m_device->createBuiltInPipelineLayout(VK_SHADER_STAGE_FRAGMENT_BIT,
+    return m_device->createBuiltInPipelineLayout(0u, VK_SHADER_STAGE_FRAGMENT_BIT,
       sizeof(DxvkMetaBlitPushConstants), 1, &binding);
   }
 

--- a/src/dxvk/dxvk_meta_blit.cpp
+++ b/src/dxvk/dxvk_meta_blit.cpp
@@ -58,10 +58,10 @@ namespace dxvk {
   
   
   const DxvkPipelineLayout* DxvkMetaBlitObjects::createPipelineLayout() const {
-    DxvkDescriptorSetLayoutBinding binding = { VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1, VK_SHADER_STAGE_FRAGMENT_BIT };
+    DxvkDescriptorSetLayoutBinding binding = { VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, 1, VK_SHADER_STAGE_FRAGMENT_BIT };
 
-    return m_device->createBuiltInPipelineLayout(0u, VK_SHADER_STAGE_FRAGMENT_BIT,
-      sizeof(DxvkMetaBlitPushConstants), 1, &binding);
+    return m_device->createBuiltInPipelineLayout(DxvkPipelineLayoutFlag::UsesSamplerHeap,
+      VK_SHADER_STAGE_FRAGMENT_BIT, sizeof(DxvkMetaBlitPushConstants), 1, &binding);
   }
 
 

--- a/src/dxvk/dxvk_meta_blit.h
+++ b/src/dxvk/dxvk_meta_blit.h
@@ -22,9 +22,9 @@ namespace dxvk {
    */
   struct DxvkMetaBlitPushConstants {
     DxvkMetaBlitOffset srcCoord0;
-    uint32_t           pad1;
     DxvkMetaBlitOffset srcCoord1;
     uint32_t           layerCount;
+    uint32_t           sampler;
   };
   
   /**

--- a/src/dxvk/dxvk_meta_clear.cpp
+++ b/src/dxvk/dxvk_meta_clear.cpp
@@ -104,7 +104,7 @@ namespace dxvk {
           VkDescriptorType        descriptorType) {
     DxvkDescriptorSetLayoutBinding bindInfo = { descriptorType, 1, VK_SHADER_STAGE_COMPUTE_BIT };
 
-    return m_device->createBuiltInPipelineLayout(VK_SHADER_STAGE_COMPUTE_BIT,
+    return m_device->createBuiltInPipelineLayout(0u, VK_SHADER_STAGE_COMPUTE_BIT,
       sizeof(DxvkMetaClearArgs), 1, &bindInfo);
   }
 

--- a/src/dxvk/dxvk_meta_copy.cpp
+++ b/src/dxvk/dxvk_meta_copy.cpp
@@ -206,7 +206,7 @@ namespace dxvk {
     }};
 
     DxvkMetaCopyPipeline pipeline;
-    pipeline.layout = m_device->createBuiltInPipelineLayout(VK_SHADER_STAGE_COMPUTE_BIT,
+    pipeline.layout = m_device->createBuiltInPipelineLayout(0u, VK_SHADER_STAGE_COMPUTE_BIT,
       sizeof(DxvkFormattedBufferCopyArgs), bindings.size(), bindings.data());
     pipeline.pipeline = m_device->createBuiltInComputePipeline(pipeline.layout,
       util::DxvkBuiltInShaderStage(dxvk_copy_buffer_image, nullptr));
@@ -222,7 +222,7 @@ namespace dxvk {
     }};
 
     DxvkMetaCopyPipeline pipeline = { };
-    pipeline.layout = m_device->createBuiltInPipelineLayout(VK_SHADER_STAGE_FRAGMENT_BIT,
+    pipeline.layout = m_device->createBuiltInPipelineLayout(0u, VK_SHADER_STAGE_FRAGMENT_BIT,
       sizeof(VkOffset2D), bindings.size(), bindings.data());
 
     VkImageAspectFlags aspect = lookupFormatInfo(key.format)->aspectMask;
@@ -274,7 +274,7 @@ namespace dxvk {
     }};
 
     DxvkMetaCopyPipeline pipeline;
-    pipeline.layout = m_device->createBuiltInPipelineLayout(VK_SHADER_STAGE_FRAGMENT_BIT,
+    pipeline.layout = m_device->createBuiltInPipelineLayout(0u, VK_SHADER_STAGE_FRAGMENT_BIT,
       sizeof(DxvkBufferImageCopyArgs), bindings.size(), bindings.data());
 
     // We don't support color right now
@@ -362,7 +362,7 @@ namespace dxvk {
       { VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE,        1, VK_SHADER_STAGE_COMPUTE_BIT },
     }};
 
-    pipeline.layout = m_device->createBuiltInPipelineLayout(VK_SHADER_STAGE_COMPUTE_BIT,
+    pipeline.layout = m_device->createBuiltInPipelineLayout(0u, VK_SHADER_STAGE_COMPUTE_BIT,
       sizeof(DxvkBufferImageCopyArgs), bindings.size(), bindings.data());
 
     if (key.imageViewType != VK_IMAGE_VIEW_TYPE_2D_ARRAY) {

--- a/src/dxvk/dxvk_meta_resolve.cpp
+++ b/src/dxvk/dxvk_meta_resolve.cpp
@@ -95,7 +95,7 @@ namespace dxvk {
     }};
 
     DxvkMetaResolvePipeline pipeline = { };
-    pipeline.layout = m_device->createBuiltInPipelineLayout(VK_SHADER_STAGE_FRAGMENT_BIT,
+    pipeline.layout = m_device->createBuiltInPipelineLayout(0u, VK_SHADER_STAGE_FRAGMENT_BIT,
       sizeof(VkOffset2D), bindings.size(), bindings.data());
 
     auto formatInfo = lookupFormatInfo(key.format);

--- a/src/dxvk/dxvk_objects.h
+++ b/src/dxvk/dxvk_objects.h
@@ -24,8 +24,8 @@ namespace dxvk {
     DxvkObjects(DxvkDevice* device)
     : m_device          (device),
       m_memoryManager   (device),
-      m_pipelineManager (device),
       m_samplerPool     (device),
+      m_pipelineManager (device),
       m_eventPool       (device),
       m_queryPool       (device),
       m_dummyResources  (device) {
@@ -77,9 +77,9 @@ namespace dxvk {
     DxvkDevice*                   m_device;
 
     DxvkMemoryAllocator           m_memoryManager;
+    DxvkSamplerPool               m_samplerPool;
     DxvkPipelineManager           m_pipelineManager;
 
-    DxvkSamplerPool               m_samplerPool;
     DxvkGpuEventPool              m_eventPool;
     DxvkGpuQueryPool              m_queryPool;
 

--- a/src/dxvk/dxvk_pipelayout.cpp
+++ b/src/dxvk/dxvk_pipelayout.cpp
@@ -18,8 +18,11 @@ namespace dxvk {
   }
 
 
-  void DxvkDescriptorSetLayoutKey::add(DxvkDescriptorSetLayoutBinding binding) {
+  uint32_t DxvkDescriptorSetLayoutKey::add(DxvkDescriptorSetLayoutBinding binding) {
+    uint32_t index = m_bindings.size();
+
     m_bindings.push_back(binding);
+    return index;
   }
 
 
@@ -242,13 +245,13 @@ namespace dxvk {
     for (size_t i = 0; i < bindings.bindingCount; i++) {
       auto binding = bindings.bindings[i];
       auto set = setInfos.map[computeSetForBinding(type, binding)];
+      auto bindingIndex = setLayoutKeys[set].add(DxvkDescriptorSetLayoutBinding(binding));
 
       DxvkShaderBinding srcMapping(binding.getStageMask(), binding.getSet(), binding.getBinding());
-      DxvkShaderBinding dstMapping(binding.getStageMask(), set, setLayoutKeys[set].getBindingCount());
+      DxvkShaderBinding dstMapping(binding.getStageMask(), set, bindingIndex);
 
       layout.bindingMap.add(srcMapping, dstMapping);
 
-      setLayoutKeys[set].add(DxvkDescriptorSetLayoutBinding(binding));
       layout.setStateMasks[set] |= computeStateMask(binding);
 
       if (binding.getDescriptorCount()) {

--- a/src/dxvk/dxvk_pipelayout.cpp
+++ b/src/dxvk/dxvk_pipelayout.cpp
@@ -389,10 +389,6 @@ namespace dxvk {
 
       if (binding.getDescriptorCount()) {
         if (binding.usesDescriptor()) {
-          if (binding.getDescriptorType() == VK_DESCRIPTOR_TYPE_SAMPLER
-           || binding.getDescriptorType() == VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER)
-            appendDescriptors(layout.setSamplers[set], binding, dstMapping);
-
           appendDescriptors(layout.setDescriptors[set], binding, dstMapping);
 
           if (binding.getDescriptorType() != VK_DESCRIPTOR_TYPE_SAMPLER) {
@@ -402,6 +398,7 @@ namespace dxvk {
               appendDescriptors(layout.setResources[set], binding, dstMapping);
           }
         } else {
+          // Compute correct push data offset for the resource
           auto offset = layout.bindingMap.mapPushData(
             binding.getStageMask(), binding.getBlockOffset());
 
@@ -410,7 +407,11 @@ namespace dxvk {
 
           binding.setBlockOffset(offset);
 
-          appendDescriptors(layout.rawBindings, binding, dstMapping);
+          // This can be either a sampler or raw buffer address
+          if (binding.getDescriptorType() == VK_DESCRIPTOR_TYPE_SAMPLER)
+            appendDescriptors(layout.samplers, binding, dstMapping);
+          else
+            appendDescriptors(layout.vaBindings, binding, dstMapping);
         }
       }
     }

--- a/src/dxvk/dxvk_pipelayout.cpp
+++ b/src/dxvk/dxvk_pipelayout.cpp
@@ -415,6 +415,15 @@ namespace dxvk {
       }
     }
 
+    // Remap sampler descriptor heap bindings
+    if (flags.test(DxvkPipelineLayoutFlag::UsesSamplerHeap)) {
+      DxvkShaderBinding dstMapping(builder.getStageMask(), 0u, 0u);
+
+      for (uint32_t i = 0u; i < builder.getSamplerHeapBindingCount(); i++) {
+        layout.bindingMap.addBinding(builder.getSamplerHeapBinding(i), dstMapping);
+      }
+    }
+
     // Create the actual descriptor set layout objects
     small_vector<const DxvkDescriptorSetLayout*, MaxSets> setLayouts(setInfos.count);
 
@@ -655,6 +664,12 @@ namespace dxvk {
   }
 
 
+  void DxvkPipelineLayoutBuilder::addSamplerHeap(
+    const DxvkShaderBinding&        binding) {
+    m_samplerHeaps.push_back(binding);
+  }
+
+
   void DxvkPipelineLayoutBuilder::addLayout(
     const DxvkPipelineLayoutBuilder& layout) {
     m_stageMask |= layout.m_stageMask;
@@ -670,6 +685,9 @@ namespace dxvk {
     }
 
     addBindings(layout.m_bindings.size(), layout.m_bindings.data());
+
+    for (uint32_t i = 0u; i < layout.getSamplerHeapBindingCount(); i++)
+      addSamplerHeap(layout.getSamplerHeapBinding(i));
   }
 
 }

--- a/src/dxvk/dxvk_pipelayout.cpp
+++ b/src/dxvk/dxvk_pipelayout.cpp
@@ -255,17 +255,21 @@ namespace dxvk {
       layout.setStateMasks[set] |= computeStateMask(binding);
 
       if (binding.getDescriptorCount()) {
-        appendDescriptors(layout.setDescriptors[set], binding, dstMapping);
-
         if (binding.getDescriptorType() == VK_DESCRIPTOR_TYPE_SAMPLER
          || binding.getDescriptorType() == VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER)
           appendDescriptors(layout.setSamplers[set], binding, dstMapping);
 
-        if (binding.getDescriptorType() != VK_DESCRIPTOR_TYPE_SAMPLER) {
-          if (binding.isUniformBuffer())
-            appendDescriptors(layout.setUniformBuffers[set], binding, dstMapping);
-          else
-            appendDescriptors(layout.setResources[set], binding, dstMapping);
+        if (binding.usesDescriptor()) {
+          appendDescriptors(layout.setDescriptors[set], binding, dstMapping);
+
+          if (binding.getDescriptorType() != VK_DESCRIPTOR_TYPE_SAMPLER) {
+            if (binding.isUniformBuffer())
+              appendDescriptors(layout.setUniformBuffers[set], binding, dstMapping);
+            else
+              appendDescriptors(layout.setResources[set], binding, dstMapping);
+          }
+        } else {
+          appendDescriptors(layout.setRawBindings[set], binding, dstMapping);
         }
       }
     }

--- a/src/dxvk/dxvk_pipelayout.cpp
+++ b/src/dxvk/dxvk_pipelayout.cpp
@@ -510,20 +510,9 @@ namespace dxvk {
         return DxvkDescriptorState::computeMask(
           binding.getStageMask(), DxvkDescriptorClass::Sampler | DxvkDescriptorClass::View);
 
-      case VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE:
-      case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE:
-      case VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER:
-      case VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:
-        return DxvkDescriptorState::computeMask(
-          binding.getStageMask(), DxvkDescriptorClass::View);
-
-      case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER:
-      case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER:
-        return DxvkDescriptorState::computeMask(
-          binding.getStageMask(), DxvkDescriptorClass::Buffer);
-
       default:
-        throw DxvkError("Unhandled descriptor type");
+        return DxvkDescriptorState::computeMask(binding.getStageMask(),
+          binding.isUniformBuffer() ? DxvkDescriptorClass::Buffer : DxvkDescriptorClass::View);
     }
   }
 

--- a/src/dxvk/dxvk_pipelayout.cpp
+++ b/src/dxvk/dxvk_pipelayout.cpp
@@ -383,11 +383,11 @@ namespace dxvk {
       }
 
       if (binding.getDescriptorCount()) {
-        if (binding.getDescriptorType() == VK_DESCRIPTOR_TYPE_SAMPLER
-         || binding.getDescriptorType() == VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER)
-          appendDescriptors(layout.setSamplers[set], binding, dstMapping);
-
         if (binding.usesDescriptor()) {
+          if (binding.getDescriptorType() == VK_DESCRIPTOR_TYPE_SAMPLER
+           || binding.getDescriptorType() == VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER)
+            appendDescriptors(layout.setSamplers[set], binding, dstMapping);
+
           appendDescriptors(layout.setDescriptors[set], binding, dstMapping);
 
           if (binding.getDescriptorType() != VK_DESCRIPTOR_TYPE_SAMPLER) {

--- a/src/dxvk/dxvk_pipelayout.cpp
+++ b/src/dxvk/dxvk_pipelayout.cpp
@@ -284,7 +284,7 @@ namespace dxvk {
 
     // Push constant state is shared by all stages, so we need to
     if (type == DxvkPipelineLayoutType::Independent)
-      pushConstants = DxvkPushConstantRange(VK_SHADER_STAGE_ALL_GRAPHICS, MaxPushConstantSize);
+      pushConstants = DxvkPushConstantRange(VK_SHADER_STAGE_ALL_GRAPHICS, MaxSharedPushDataSize);
 
     DxvkPipelineLayoutKey key(type, stageMask,
       pushConstants, setInfos.count, setLayouts.data());

--- a/src/dxvk/dxvk_pipelayout.h
+++ b/src/dxvk/dxvk_pipelayout.h
@@ -1716,6 +1716,7 @@ namespace dxvk {
     small_vector<const DxvkDescriptorSetLayout*, MaxSets>
     buildDescriptorSetLayouts(
             DxvkPipelineLayoutType      type,
+            DxvkPipelineLayoutFlags     flags,
       const DxvkPipelineLayoutBuilder&  builder,
             DxvkPipelineManager*        manager);
 

--- a/src/dxvk/dxvk_pipelayout.h
+++ b/src/dxvk/dxvk_pipelayout.h
@@ -497,6 +497,13 @@ namespace dxvk {
       m_size        (uint16_t(size)),
       m_resourceMask(uint64_t(resourceMask)) { }
 
+    DxvkPushDataBlock(
+            uint32_t                  offset,
+            uint32_t                  size,
+            uint32_t                  alignment,
+            uint64_t                  resourceMask)
+    : DxvkPushDataBlock(0u, offset, size, alignment, resourceMask) { }
+
     /**
      * \brief Queries stage mask
      * \returns Stage mask

--- a/src/dxvk/dxvk_pipelayout.h
+++ b/src/dxvk/dxvk_pipelayout.h
@@ -70,10 +70,9 @@ namespace dxvk {
     // For merged pipelines, use one set containing per unique
     // descriptor class. We can reasonably expect uniform buffers
     // to be rebound more often than views and samplers.
-    static constexpr uint32_t GpSetCount                = 3u;
-    static constexpr uint32_t GpSamplers                = 0u;
-    static constexpr uint32_t GpViews                   = 1u;
-    static constexpr uint32_t GpBuffers                 = 2u;
+    static constexpr uint32_t GpSetCount                = 2u;
+    static constexpr uint32_t GpViews                   = 0u;
+    static constexpr uint32_t GpBuffers                 = 1u;
 
     // For compute shaders, put everything into one set since it is
     // very likely that all types of resources get changed at once.
@@ -81,7 +80,7 @@ namespace dxvk {
     static constexpr uint32_t CpSetCount                = 1u;
 
     // Maximum number of descriptor sets per layout
-    static constexpr uint32_t SetCount                  = 3u;
+    static constexpr uint32_t SetCount                  = 2u;
   };
 
 

--- a/src/dxvk/dxvk_pipelayout.h
+++ b/src/dxvk/dxvk_pipelayout.h
@@ -1245,6 +1245,14 @@ namespace dxvk {
       m_binding (uint16_t(binding)) { }
 
     /**
+     * \brief Queries stage mask
+     * \returns Stage mask
+     */
+    VkShaderStageFlags getStageMask() const {
+      return VkShaderStageFlags(m_stages);
+    }
+
+    /**
      * \brief Queries set index
      * \returns Set index
      */
@@ -1423,6 +1431,24 @@ namespace dxvk {
     }
 
     /**
+     * \brief Queries number of sampler heap bindings
+     * \returns Sampler heap binding count
+     */
+    uint32_t getSamplerHeapBindingCount() const {
+      return m_samplerHeaps.size();
+    }
+
+    /**
+     * \brief Queries sampler heap binding info
+     *
+     * \param [in] index Sampler heap binding index
+     * \returns Set and binding for a given shader stage
+     */
+    DxvkShaderBinding getSamplerHeapBinding(uint32_t index) const {
+      return m_samplerHeaps[index];
+    }
+
+    /**
      * \brief Adds push data block
      * \param [in] range Push data block
      */
@@ -1442,6 +1468,15 @@ namespace dxvk {
       const DxvkShaderDescriptor*     bindings);
 
     /**
+     * \brief Adds sampler heap declaration
+     *
+     * Used so that the sampler binding can be remapped.
+     * \param [in] binding Sampler heap binding info
+     */
+    void addSamplerHeap(
+      const DxvkShaderBinding&        binding);
+
+    /**
      * \brief Merges another layout
      *
      * Adds push constants and bindings from the given
@@ -1458,7 +1493,8 @@ namespace dxvk {
     uint32_t                                                        m_pushMask = 0u;
     std::array<DxvkPushDataBlock, DxvkPushDataBlock::MaxBlockCount> m_pushData = { };
 
-    std::vector<DxvkShaderDescriptor> m_bindings;
+    small_vector<DxvkShaderDescriptor, 32u> m_bindings;
+    small_vector<DxvkShaderBinding, 4u> m_samplerHeaps;
 
   };
 

--- a/src/dxvk/dxvk_pipelayout.h
+++ b/src/dxvk/dxvk_pipelayout.h
@@ -396,14 +396,13 @@ namespace dxvk {
     }
 
     /**
-     * \brief Adds base offset to block offset
+     * \bief Changes block offset
      *
-     * The offset may be adjusted after determining the
-     * exact layout of push data in memory.
-     * \param [in] baseOffset Base block offset, in bytes
+     * Used when remapping push data to its final memory layout.
+     * \param [in] offset New absolute block offset
      */
-    void addBlockOffset(uint32_t baseOffset) {
-      m_blockOffset += baseOffset;
+    void setBlockOffset(uint32_t offset) {
+      m_blockOffset = offset;
     }
 
     /**
@@ -615,9 +614,11 @@ namespace dxvk {
      *
      * Useful when remapping push constant ranges.
      * \param [in] newOffset New block offset
+     * \param [in] newSize New block size
      */
-    void rebase(uint32_t newOffset) {
+    void rebase(uint32_t newOffset, uint32_t newSize) {
       m_offset = newOffset;
+      m_size = newSize;
     }
 
     /**
@@ -1556,8 +1557,8 @@ namespace dxvk {
      * \param [in] set Set index
      * \returns List of all non-descriptor bindings.
      */
-    DxvkPipelineBindingRange getRawBindingsInSet(DxvkPipelineLayoutType type, uint32_t set) const {
-      return makeBindingRange(m_layouts[uint32_t(type)].setRawBindings[set]);
+    DxvkPipelineBindingRange getRawBindings(DxvkPipelineLayoutType type) const {
+      return makeBindingRange(m_layouts[uint32_t(type)].rawBindings);
     }
 
     /**
@@ -1624,10 +1625,10 @@ namespace dxvk {
       std::array<BindingList, MaxSets>  setSamplers          = { };
       std::array<BindingList, MaxSets>  setResources         = { };
       std::array<BindingList, MaxSets>  setUniformBuffers    = { };
-      std::array<BindingList, MaxSets>  setRawBindings       = { };
 
       std::array<uint32_t, MaxSets>     setStateMasks = { };
 
+      BindingList                       rawBindings = { };
       DxvkShaderBindingMap              bindingMap = { };
 
       const DxvkPipelineLayout*         layout = nullptr;

--- a/src/dxvk/dxvk_pipelayout.h
+++ b/src/dxvk/dxvk_pipelayout.h
@@ -92,8 +92,9 @@ namespace dxvk {
     static constexpr uint32_t Buffer  = 1u << 0u;
     static constexpr uint32_t View    = 1u << 8u;
     static constexpr uint32_t Sampler = 1u << 16u;
+    static constexpr uint32_t Raw     = 1u << 24u;
 
-    static constexpr uint32_t All = Buffer | View | Sampler;
+    static constexpr uint32_t All = Buffer | View | Sampler | Raw;
   };
 
 
@@ -108,11 +109,11 @@ namespace dxvk {
     DxvkDescriptorState() = default;
 
     void dirtyBuffers(VkShaderStageFlags stages) {
-      m_dirtyMask |= computeMask(stages, DxvkDescriptorClass::Buffer);
+      m_dirtyMask |= computeMask(stages, DxvkDescriptorClass::Buffer | DxvkDescriptorClass::Raw);
     }
 
     void dirtyViews(VkShaderStageFlags stages) {
-      m_dirtyMask |= computeMask(stages, DxvkDescriptorClass::View);
+      m_dirtyMask |= computeMask(stages, DxvkDescriptorClass::View | DxvkDescriptorClass::Raw);
     }
 
     void dirtySamplers(VkShaderStageFlags stages) {
@@ -129,6 +130,10 @@ namespace dxvk {
 
     bool hasDirtyResources(VkShaderStageFlags stages) const {
       return bool(m_dirtyMask & computeMask(stages, DxvkDescriptorClass::All));
+    }
+
+    bool hasDirtyRawDescriptors(VkShaderStageFlags stages) {
+      return bool(m_dirtyMask & computeMask(stages, DxvkDescriptorClass::Raw));
     }
 
     bool testDirtyMask(uint32_t mask) const {

--- a/src/dxvk/dxvk_pipelayout.h
+++ b/src/dxvk/dxvk_pipelayout.h
@@ -925,8 +925,10 @@ namespace dxvk {
     DxvkPipelineLayoutKey() = default;
 
     DxvkPipelineLayoutKey(
-            DxvkPipelineLayoutType    type)
-    : m_type          (type) { }
+            DxvkPipelineLayoutType    type,
+            DxvkPipelineLayoutFlags   flags)
+    : m_type          (type),
+      m_flags         (flags) { }
 
     DxvkPipelineLayoutKey(
             DxvkPipelineLayoutType    type,

--- a/src/dxvk/dxvk_pipelayout.h
+++ b/src/dxvk/dxvk_pipelayout.h
@@ -4,6 +4,8 @@
 #include <unordered_map>
 #include <vector>
 
+#include "../util/util_small_vector.h"
+
 #include "dxvk_hash.h"
 #include "dxvk_include.h"
 #include "dxvk_limits.h"
@@ -1651,6 +1653,19 @@ namespace dxvk {
     void buildPipelineLayout(
             DxvkPipelineLayoutType      type,
             DxvkDevice*                 device,
+      const DxvkPipelineLayoutBuilder&  builder,
+            DxvkPipelineManager*        manager);
+
+    small_vector<DxvkPushDataBlock, DxvkPushDataBlock::MaxBlockCount>
+    buildPushDataBlocks(
+            DxvkPipelineLayoutType      type,
+            DxvkDevice*                 device,
+      const DxvkPipelineLayoutBuilder&  builder,
+            DxvkPipelineManager*        manager);
+
+    small_vector<const DxvkDescriptorSetLayout*, MaxSets>
+    buildDescriptorSetLayouts(
+            DxvkPipelineLayoutType      type,
       const DxvkPipelineLayoutBuilder&  builder,
             DxvkPipelineManager*        manager);
 

--- a/src/dxvk/dxvk_pipelayout.h
+++ b/src/dxvk/dxvk_pipelayout.h
@@ -515,8 +515,9 @@ namespace dxvk {
      *
      * Useful to construct set layouts on the fly.
      * \param [in] binding Binding info
+     * \returns Binding index
      */
-    void add(DxvkDescriptorSetLayoutBinding binding);
+    uint32_t add(DxvkDescriptorSetLayoutBinding binding);
 
     /**
      * \brief Checks for equality

--- a/src/dxvk/dxvk_sampler.cpp
+++ b/src/dxvk/dxvk_sampler.cpp
@@ -143,7 +143,7 @@ namespace dxvk {
     VkDescriptorSetLayoutBinding binding = { };
     binding.descriptorType = VK_DESCRIPTOR_TYPE_SAMPLER;
     binding.descriptorCount = size;
-    binding.stageFlags = VK_SHADER_STAGE_ALL;
+    binding.stageFlags = VK_SHADER_STAGE_ALL_GRAPHICS | VK_SHADER_STAGE_COMPUTE_BIT;
 
     VkDescriptorBindingFlags bindingFlags =
       VK_DESCRIPTOR_BINDING_UPDATE_AFTER_BIND_BIT |

--- a/src/dxvk/dxvk_sampler.h
+++ b/src/dxvk/dxvk_sampler.h
@@ -143,7 +143,8 @@ namespace dxvk {
     
     DxvkSampler(
             DxvkSamplerPool*        pool,
-      const DxvkSamplerKey&         key);
+      const DxvkSamplerKey&         key,
+            uint16_t                index);
 
     ~DxvkSampler();
 
@@ -187,6 +188,7 @@ namespace dxvk {
     DxvkSamplerDescriptor getDescriptor() const {
       DxvkSamplerDescriptor result = { };
       result.samplerObject = m_sampler;
+      result.samplerIndex = m_index;
       return result;
     }
     
@@ -207,6 +209,7 @@ namespace dxvk {
     DxvkSamplerKey        m_key       = { };
 
     VkSampler             m_sampler   = VK_NULL_HANDLE;
+    uint16_t              m_index     = 0u;
 
     DxvkSampler*          m_lruPrev   = nullptr;
     DxvkSampler*          m_lruNext   = nullptr;
@@ -277,6 +280,10 @@ namespace dxvk {
     std::unordered_map<DxvkSamplerKey,
       DxvkSampler, DxvkHash, DxvkEq> m_samplers;
 
+    small_vector<uint16_t, MaxSamplerCount> m_freeList;
+
+    Rc<DxvkSampler> m_default = nullptr;
+
     DxvkSampler* m_lruHead = nullptr;
     DxvkSampler* m_lruTail = nullptr;
 
@@ -286,6 +293,10 @@ namespace dxvk {
     void releaseSampler(DxvkSampler* sampler);
 
     void destroyLeastRecentlyUsedSampler();
+
+    uint16_t allocateSamplerIndex();
+
+    void freeSamplerIndex(uint16_t index);
 
   };
 

--- a/src/dxvk/dxvk_sampler.h
+++ b/src/dxvk/dxvk_sampler.h
@@ -222,6 +222,59 @@ namespace dxvk {
 
 
   /**
+   * \brief Global sampler set and layout
+   */
+  struct DxvkSamplerDescriptorSet {
+    VkDescriptorSet       set     = VK_NULL_HANDLE;
+    VkDescriptorSetLayout layout  = VK_NULL_HANDLE;
+  };
+
+
+  /**
+   * \brief Sampler descriptor pool
+   *
+   * Manages a global descriptor pool and set for samplers.
+   */
+  class DxvkSamplerDescriptorPool {
+
+  public:
+
+    DxvkSamplerDescriptorPool(
+            DxvkDevice*               device,
+            uint32_t                  size);
+
+    ~DxvkSamplerDescriptorPool();
+
+    /**
+     * \brief Retrieves descriptor set and layout
+     * \returns Descriptor set and layout handles
+     */
+    DxvkSamplerDescriptorSet getDescriptorSetInfo() const {
+      return { m_set, m_setLayout };
+    }
+
+    /**
+     * \brief Writes sampler descriptor to pool
+     *
+     * \param [in] index Sampler index
+     * \param [in] sampler Sampler object
+     */
+    void writeDescriptor(
+            uint16_t              index,
+            VkSampler             sampler);
+
+  private:
+
+    DxvkDevice*           m_device    = nullptr;
+
+    VkDescriptorPool      m_pool      = VK_NULL_HANDLE;
+    VkDescriptorSetLayout m_setLayout = VK_NULL_HANDLE;
+    VkDescriptorSet       m_set       = VK_NULL_HANDLE;
+
+  };
+
+
+  /**
    * \brief Sampler statistics
    */
   struct DxvkSamplerStats {
@@ -260,6 +313,16 @@ namespace dxvk {
     Rc<DxvkSampler> createSampler(const DxvkSamplerKey& key);
 
     /**
+     * \brief Queries the global sampler descriptor set
+     *
+     * Required to bind the set, and for pipeline creation.
+     * \returns Global sampler descriptor set and layout
+     */
+    DxvkSamplerDescriptorSet getDescriptorSetInfo() const {
+      return m_descriptorPool.getDescriptorSetInfo();
+    }
+
+    /**
      * \brief Retrieves sampler statistics
      *
      * Note that these might be out of date immediately.
@@ -275,6 +338,8 @@ namespace dxvk {
   private:
 
     DxvkDevice* m_device;
+
+    DxvkSamplerDescriptorPool m_descriptorPool;
 
     dxvk::mutex m_mutex;
     std::unordered_map<DxvkSamplerKey,

--- a/src/dxvk/dxvk_shader.cpp
+++ b/src/dxvk/dxvk_shader.cpp
@@ -205,6 +205,12 @@ namespace dxvk {
       }
     }
 
+    if (info.samplerHeap.getStageMask() & info.stage) {
+      m_layout.addSamplerHeap(DxvkShaderBinding(info.stage,
+        info.samplerHeap.getSet(),
+        info.samplerHeap.getBinding()));
+    }
+
     // Don't set pipeline library flag if the shader
     // doesn't actually support pipeline libraries
     m_needsLibraryCompile = canUsePipelineLibrary(true);

--- a/src/dxvk/dxvk_shader.cpp
+++ b/src/dxvk/dxvk_shader.cpp
@@ -161,8 +161,11 @@ namespace dxvk {
     }
 
     if (info.pushConstSize && usesPushConstants) {
-      m_layout.addPushConstants(DxvkPushConstantRange(
-        m_info.stage, info.pushConstSize));
+      VkShaderStageFlags stage = (m_info.stage & VK_SHADER_STAGE_ALL_GRAPHICS)
+        ? VK_SHADER_STAGE_ALL_GRAPHICS : VK_SHADER_STAGE_COMPUTE_BIT;
+
+      m_layout.addPushData(DxvkPushDataBlock(
+        stage, 0u, info.pushConstSize, 4u, 0u));
     }
 
     // Don't set pipeline library flag if the shader
@@ -185,7 +188,7 @@ namespace dxvk {
     // Remap resource binding IDs
     if (bindings) {
       for (const auto& info : m_bindingOffsets) {
-        auto mappedBinding = bindings->find(DxvkShaderBinding(
+        auto mappedBinding = bindings->mapBinding(DxvkShaderBinding(
           m_info.stage, info.setIndex, info.bindingIndex));
 
         if (mappedBinding) {

--- a/src/dxvk/dxvk_shader.cpp
+++ b/src/dxvk/dxvk_shader.cpp
@@ -57,15 +57,16 @@ namespace dxvk {
 
     // Run an analysis pass over the SPIR-V code to gather some
     // info that we may need during pipeline compilation.
-    bool usesPushConstants = false;
+    uint32_t pushConstantStructId = 0u;
 
     std::vector<BindingOffsets> bindingOffsets;
     std::vector<uint32_t> varIds;
     std::vector<uint32_t> sampleMaskIds;
+    std::unordered_map<uint32_t, uint32_t> pushConstantTypes;
 
     SpirvCodeBuffer code = std::move(spirv);
     uint32_t o1VarId = 0;
-    
+
     for (auto ins : code) {
       if (ins.opCode() == spv::OpDecorate) {
         if (ins.arg(2) == spv::DecorationBinding) {
@@ -143,12 +144,35 @@ namespace dxvk {
             m_flags.set(DxvkShaderFlag::ExportsSampleMask);
         }
 
-        if (ins.arg(3) == spv::StorageClassPushConstant)
-          usesPushConstants = true;
+        if (ins.arg(3) == spv::StorageClassPushConstant) {
+          auto type = pushConstantTypes.find(ins.arg(1));
+
+          if (type != pushConstantTypes.end())
+            pushConstantStructId = type->second;
+        }
+      }
+
+      if (ins.opCode() == spv::OpTypePointer) {
+        if (ins.arg(2) == spv::StorageClassPushConstant)
+          pushConstantTypes.insert({ ins.arg(1), ins.arg(3) });
       }
 
       // Ignore the actual shader code, there's nothing interesting for us in there.
       if (ins.opCode() == spv::OpFunction)
+        break;
+    }
+
+    for (auto ins : code) {
+      if (ins.opCode() == spv::OpMemberDecorate
+       && ins.arg(1) == pushConstantStructId
+       && ins.arg(3) == spv::DecorationOffset) {
+        auto& e = m_pushDataOffsets.emplace_back();
+        e.codeOffset = ins.offset() + 4;
+        e.pushOffset = ins.arg(4);
+      }
+
+      // Can exit even earlier here since decorations come up early
+      if (ins.opCode() == spv::OpFunction || ins.opCode() == spv::OpTypeVoid)
         break;
     }
 
@@ -160,7 +184,7 @@ namespace dxvk {
         m_bindingOffsets.push_back(info);
     }
 
-    if (info.pushConstSize && usesPushConstants) {
+    if (info.pushConstSize && pushConstantStructId) {
       VkShaderStageFlags stage = (m_info.stage & VK_SHADER_STAGE_ALL_GRAPHICS)
         ? VK_SHADER_STAGE_ALL_GRAPHICS : VK_SHADER_STAGE_COMPUTE_BIT;
 
@@ -197,6 +221,13 @@ namespace dxvk {
           if (info.setOffset)
             code[info.setOffset] = mappedBinding->getSet();
         }
+      }
+
+      for (const auto& info : m_pushDataOffsets) {
+        uint32_t offset = bindings->mapPushData(m_info.stage, info.pushOffset);
+
+        if (offset < MaxTotalPushDataSize)
+          code[info.codeOffset] = offset;
       }
     }
 

--- a/src/dxvk/dxvk_shader.cpp
+++ b/src/dxvk/dxvk_shader.cpp
@@ -184,12 +184,25 @@ namespace dxvk {
         m_bindingOffsets.push_back(info);
     }
 
-    if (info.pushConstSize && pushConstantStructId) {
-      VkShaderStageFlags stage = (m_info.stage & VK_SHADER_STAGE_ALL_GRAPHICS)
-        ? VK_SHADER_STAGE_ALL_GRAPHICS : VK_SHADER_STAGE_COMPUTE_BIT;
+    if (pushConstantStructId) {
+      if (!info.sharedPushData.isEmpty()) {
+        auto stageMask = (info.stage & VK_SHADER_STAGE_ALL_GRAPHICS)
+          ? VK_SHADER_STAGE_ALL_GRAPHICS : VK_SHADER_STAGE_COMPUTE_BIT;
 
-      m_layout.addPushData(DxvkPushDataBlock(
-        stage, 0u, info.pushConstSize, 4u, 0u));
+        m_layout.addPushData(DxvkPushDataBlock(stageMask,
+          info.sharedPushData.getOffset(),
+          info.sharedPushData.getSize(),
+          info.sharedPushData.getAlignment(),
+          info.sharedPushData.getResourceDwordMask()));
+      }
+
+      if (!info.localPushData.isEmpty()) {
+        m_layout.addPushData(DxvkPushDataBlock(info.stage,
+          info.localPushData.getOffset(),
+          info.localPushData.getSize(),
+          info.localPushData.getAlignment(),
+          info.localPushData.getResourceDwordMask()));
+      }
     }
 
     // Don't set pipeline library flag if the shader

--- a/src/dxvk/dxvk_shader.h
+++ b/src/dxvk/dxvk_shader.h
@@ -55,6 +55,8 @@ namespace dxvk {
     /// Push data blocks
     DxvkPushDataBlock sharedPushData;
     DxvkPushDataBlock localPushData;
+    /// Descriptor set and binding of global sampler heap
+    DxvkShaderBinding samplerHeap;
     /// Rasterized stream, or -1
     int32_t xfbRasterizedStream = 0;
     /// Tess control patch vertex count

--- a/src/dxvk/dxvk_shader.h
+++ b/src/dxvk/dxvk_shader.h
@@ -254,6 +254,11 @@ namespace dxvk {
       uint32_t setOffset = 0u;
     };
 
+    struct PushDataOffsets {
+      uint32_t codeOffset = 0u;
+      uint32_t pushOffset = 0u;
+    };
+
     DxvkShaderCreateInfo          m_info;
     SpirvCompressedBuffer         m_code;
     
@@ -268,6 +273,7 @@ namespace dxvk {
     std::atomic<bool>             m_needsLibraryCompile = { true };
 
     std::vector<BindingOffsets>   m_bindingOffsets;
+    std::vector<PushDataOffsets>  m_pushDataOffsets;
 
     DxvkPipelineLayoutBuilder     m_layout;
 

--- a/src/dxvk/dxvk_shader.h
+++ b/src/dxvk/dxvk_shader.h
@@ -52,8 +52,9 @@ namespace dxvk {
     uint32_t outputMask = 0;
     /// Flat shading input mask
     uint32_t flatShadingInputs = 0;
-    /// Push constant range
-    uint32_t pushConstSize = 0;
+    /// Push data blocks
+    DxvkPushDataBlock sharedPushData;
+    DxvkPushDataBlock localPushData;
     /// Rasterized stream, or -1
     int32_t xfbRasterizedStream = 0;
     /// Tess control patch vertex count

--- a/src/dxvk/dxvk_swapchain_blitter.cpp
+++ b/src/dxvk/dxvk_swapchain_blitter.cpp
@@ -703,7 +703,7 @@ namespace dxvk {
       { VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1, VK_SHADER_STAGE_FRAGMENT_BIT },
     }};
 
-    return m_device->createBuiltInPipelineLayout(VK_SHADER_STAGE_FRAGMENT_BIT,
+    return m_device->createBuiltInPipelineLayout(0u, VK_SHADER_STAGE_FRAGMENT_BIT,
       sizeof(PushConstants), bindings.size(), bindings.data());
   }
 
@@ -713,7 +713,7 @@ namespace dxvk {
       { VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1, VK_SHADER_STAGE_FRAGMENT_BIT },
     }};
 
-    return m_device->createBuiltInPipelineLayout(VK_SHADER_STAGE_VERTEX_BIT,
+    return m_device->createBuiltInPipelineLayout(0u, VK_SHADER_STAGE_VERTEX_BIT,
       sizeof(CursorPushConstants), bindings.size(), bindings.data());
   }
 

--- a/src/dxvk/dxvk_swapchain_blitter.h
+++ b/src/dxvk/dxvk_swapchain_blitter.h
@@ -193,6 +193,8 @@ namespace dxvk {
       VkOffset2D dstOffset;
       VkOffset2D cursorOffset;
       VkExtent2D cursorExtent;
+      uint32_t   samplerGamma;
+      uint32_t   samplerCursor;
     };
 
     struct CursorSpecConstants {
@@ -204,6 +206,7 @@ namespace dxvk {
       VkExtent2D dstExtent;
       VkOffset2D cursorOffset;
       VkExtent2D cursorExtent;
+      uint32_t   sampler;
     };
 
     Rc<DxvkDevice>      m_device;
@@ -220,7 +223,6 @@ namespace dxvk {
     Rc<DxvkImageView>   m_cursorView;
     VkRect2D            m_cursorRect = { };
 
-    Rc<DxvkSampler>     m_samplerPresent;
     Rc<DxvkSampler>     m_samplerGamma;
     Rc<DxvkSampler>     m_samplerCursorLinear;
     Rc<DxvkSampler>     m_samplerCursorNearest;

--- a/src/dxvk/hud/dxvk_hud_item.cpp
+++ b/src/dxvk/hud/dxvk_hud_item.cpp
@@ -460,7 +460,7 @@ namespace dxvk::hud {
       { VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT },
     }};
 
-    m_computePipelineLayout = m_device->createBuiltInPipelineLayout(
+    m_computePipelineLayout = m_device->createBuiltInPipelineLayout(0u,
       VK_SHADER_STAGE_COMPUTE_BIT, sizeof(ComputePushConstants),
       bindings.size(), bindings.data());
 
@@ -474,7 +474,7 @@ namespace dxvk::hud {
       { VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_FRAGMENT_BIT },
     }};
 
-    return m_device->createBuiltInPipelineLayout(
+    return m_device->createBuiltInPipelineLayout(0u,
       VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT,
       sizeof(RenderPushConstants), bindings.size(), bindings.data());
   }
@@ -1066,7 +1066,7 @@ namespace dxvk::hud {
       { VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_FRAGMENT_BIT },
     }};
 
-    return m_device->createBuiltInPipelineLayout(
+    return m_device->createBuiltInPipelineLayout(0u,
       VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT,
       sizeof(HudPushConstants), bindings.size(), bindings.data());
   }

--- a/src/dxvk/hud/dxvk_hud_renderer.cpp
+++ b/src/dxvk/hud/dxvk_hud_renderer.cpp
@@ -460,7 +460,7 @@ namespace dxvk::hud {
       { VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,  1, VK_SHADER_STAGE_FRAGMENT_BIT },
     }};
 
-    return m_device->createBuiltInPipelineLayout(
+    return m_device->createBuiltInPipelineLayout(0u,
       VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT,
       sizeof(HudPushConstants), bindings.size(), bindings.data());
   }

--- a/src/dxvk/hud/dxvk_hud_renderer.cpp
+++ b/src/dxvk/hud/dxvk_hud_renderer.cpp
@@ -65,6 +65,7 @@ namespace dxvk::hud {
     m_pushConstants.surfaceSize = { extent.width, extent.height };
     m_pushConstants.opacity = options.opacity;
     m_pushConstants.scale = options.scale;
+    m_pushConstants.sampler = m_fontSampler->getDescriptor().samplerIndex;
 
     VkViewport viewport = { };
     viewport.x = 0.0f;
@@ -229,9 +230,8 @@ namespace dxvk::hud {
     descriptors[2u].descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER;
     descriptors[2u].descriptor = textView->getDescriptor(false);
 
-    descriptors[3u].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+    descriptors[3u].descriptorType = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
     descriptors[3u].descriptor = m_fontTextureView->getDescriptor();
-    descriptors[3u].sampler = m_fontSampler->getDescriptor();
 
     ctx->bindResources(DxvkCmdBuffer::ExecBuffer,
       m_textPipelineLayout, descriptors.size(), descriptors.data(),
@@ -457,10 +457,10 @@ namespace dxvk::hud {
       { VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,          1, VK_SHADER_STAGE_VERTEX_BIT   },
       { VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,          1, VK_SHADER_STAGE_VERTEX_BIT   },
       { VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER,    1, VK_SHADER_STAGE_VERTEX_BIT   },
-      { VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,  1, VK_SHADER_STAGE_FRAGMENT_BIT },
+      { VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE,           1, VK_SHADER_STAGE_FRAGMENT_BIT },
     }};
 
-    return m_device->createBuiltInPipelineLayout(0u,
+    return m_device->createBuiltInPipelineLayout(DxvkPipelineLayoutFlag::UsesSamplerHeap,
       VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT,
       sizeof(HudPushConstants), bindings.size(), bindings.data());
   }

--- a/src/dxvk/hud/dxvk_hud_renderer.h
+++ b/src/dxvk/hud/dxvk_hud_renderer.h
@@ -44,6 +44,7 @@ namespace dxvk::hud {
     VkExtent2D surfaceSize;
     float opacity;
     float scale;
+    uint32_t sampler;
   };
 
 

--- a/src/dxvk/hud/shaders/hud_chunk_frag_background.frag
+++ b/src/dxvk/hud/shaders/hud_chunk_frag_background.frag
@@ -9,6 +9,7 @@ uniform push_data_t {
   uvec2 surface_size;
   float opacity;
   float scale;
+  uint  samplerIndex;
 };
 
 layout(location = 0) flat in uint v_active;

--- a/src/dxvk/hud/shaders/hud_chunk_frag_visualize.frag
+++ b/src/dxvk/hud/shaders/hud_chunk_frag_visualize.frag
@@ -23,6 +23,7 @@ uniform push_data_t {
   uvec2 surface_size;
   float opacity;
   float scale;
+  uint  samplerIndex;
 };
 
 void main() {

--- a/src/dxvk/hud/shaders/hud_chunk_vert_background.vert
+++ b/src/dxvk/hud/shaders/hud_chunk_vert_background.vert
@@ -17,6 +17,7 @@ uniform push_data_t {
   uvec2 surface_size;
   float opacity;
   float scale;
+  uint  samplerIndex;
 };
 
 vec2 unpack_u16(uint v) {

--- a/src/dxvk/hud/shaders/hud_chunk_vert_visualize.vert
+++ b/src/dxvk/hud/shaders/hud_chunk_vert_visualize.vert
@@ -17,6 +17,7 @@ uniform push_data_t {
   uvec2 surface_size;
   float opacity;
   float scale;
+  uint  samplerIndex;
 };
 
 layout(location = 0) out vec2 o_coord;

--- a/src/dxvk/hud/shaders/hud_graph_frag.frag
+++ b/src/dxvk/hud/shaders/hud_graph_frag.frag
@@ -24,6 +24,7 @@ uniform push_data_t {
   uvec2 surface_size;
   float opacity;
   float scale;
+  uint  samplerIndex;
   uint  packed_xy;
   uint  packed_wh;
   uint  frame_index;

--- a/src/dxvk/hud/shaders/hud_graph_vert.vert
+++ b/src/dxvk/hud/shaders/hud_graph_vert.vert
@@ -7,6 +7,7 @@ uniform push_data_t {
   uvec2 surface_size;
   float opacity;
   float scale;
+  uint  samplerIndex;
   uint  packed_xy;
   uint  packed_wh;
   uint  frame_index;

--- a/src/dxvk/hud/shaders/hud_text_frag.frag
+++ b/src/dxvk/hud/shaders/hud_text_frag.frag
@@ -1,16 +1,19 @@
-#version 450
+#version 460
 
 #extension GL_GOOGLE_include_directive : require
+#extension GL_EXT_nonuniform_qualifier : require
 
 #include "hud_frag_common.glsl"
 
-layout(binding = 3) uniform sampler2D s_font;
+layout(set = 0, binding = 0) uniform sampler s_samplers[];
+layout(set = 1, binding = 3) uniform texture2D s_font;
 
 layout(push_constant)
 uniform push_data_t {
   uvec2 surface_size;
   float opacity;
   float scale;
+  uint samplerIndex;
 };
 
 layout(location = 0) in vec2 v_texcoord;
@@ -19,7 +22,7 @@ layout(location = 1) in vec4 v_color;
 layout(location = 0) out vec4 o_color;
 
 float sampleAlpha(float alpha_bias, float dist_range) {
-  float value = textureLod(s_font, v_texcoord, 0).r + alpha_bias - 0.5f;
+  float value = textureLod(sampler2D(s_font, s_samplers[samplerIndex]), v_texcoord, 0).r + alpha_bias - 0.5f;
   float dist  = value * dot(vec2(dist_range, dist_range), 1.0f / fwidth(v_texcoord.xy));
   return clamp(dist + 0.5f, 0.0f, 1.0f);
 }

--- a/src/dxvk/hud/shaders/hud_text_vert.vert
+++ b/src/dxvk/hud/shaders/hud_text_vert.vert
@@ -12,12 +12,6 @@ struct glyph_info_t {
   uint packed_origin;
 };
 
-layout(binding = 0, std430)
-readonly buffer font_buffer_t {
-  font_info_t font_data;
-  glyph_info_t glyph_data[];
-};
-
 struct draw_info_t {
   uint text_offset;
   uint text_length_and_size;
@@ -25,18 +19,25 @@ struct draw_info_t {
   uint color;
 };
 
-layout(binding = 1, std430)
+layout(set = 1, binding = 0, std430)
+readonly buffer font_buffer_t {
+  font_info_t font_data;
+  glyph_info_t glyph_data[];
+};
+
+layout(set = 1, binding = 1, std430)
 readonly buffer draw_buffer_t {
   draw_info_t draw_infos[];
 };
 
-layout(binding = 2) uniform usamplerBuffer text_buffer;
+layout(set = 1, binding = 2) uniform usamplerBuffer text_buffer;
 
 layout(push_constant)
 uniform push_data_t {
   uvec2 surface_size;
   float opacity;
   float scale;
+  uint samplerIndex;
 };
 
 layout(location = 0) out vec2 o_texcoord;

--- a/src/dxvk/shaders/dxvk_blit_frag_1d.frag
+++ b/src/dxvk/shaders/dxvk_blit_frag_1d.frag
@@ -1,19 +1,23 @@
-#version 450
+#version 460
 
-layout(set = 0, binding = 0)
-uniform sampler1DArray s_texture;
+#extension GL_EXT_nonuniform_qualifier : require
+#extension GL_EXT_scalar_block_layout : require
+
+layout(set = 0, binding = 0) uniform sampler s_samplers[];
+layout(set = 1, binding = 0) uniform texture1DArray s_texture;
 
 layout(location = 0) in  vec2 i_pos;
 layout(location = 0) out vec4 o_color;
 
-layout(push_constant)
+layout(push_constant, scalar)
 uniform push_block {
   vec3 p_src_coord0;
   vec3 p_src_coord1;
   uint p_layer_count;
+  uint p_sampler;
 };
 
 void main() {
   float coord = mix(p_src_coord0.x, p_src_coord1.x, i_pos.x);
-  o_color = texture(s_texture, vec2(coord, gl_Layer));
+  o_color = texture(sampler1DArray(s_texture, s_samplers[p_sampler]), vec2(coord, gl_Layer));
 }

--- a/src/dxvk/shaders/dxvk_blit_frag_2d.frag
+++ b/src/dxvk/shaders/dxvk_blit_frag_2d.frag
@@ -1,19 +1,23 @@
-#version 450
+#version 460
 
-layout(set = 0, binding = 0)
-uniform sampler2DArray s_texture;
+#extension GL_EXT_nonuniform_qualifier : require
+#extension GL_EXT_scalar_block_layout : require
+
+layout(set = 0, binding = 0) uniform sampler s_samplers[];
+layout(set = 1, binding = 0) uniform texture2DArray s_texture;
 
 layout(location = 0) in  vec2 i_pos;
 layout(location = 0) out vec4 o_color;
 
-layout(push_constant)
+layout(push_constant, scalar)
 uniform push_block {
   vec3 p_src_coord0;
   vec3 p_src_coord1;
   uint p_layer_count;
+  uint p_sampler;
 };
 
 void main() {
   vec2 coord = mix(p_src_coord0.xy, p_src_coord1.xy, i_pos);
-  o_color = texture(s_texture, vec3(coord, gl_Layer));
+  o_color = texture(sampler2DArray(s_texture, s_samplers[p_sampler]), vec3(coord, gl_Layer));
 }

--- a/src/dxvk/shaders/dxvk_blit_frag_3d.frag
+++ b/src/dxvk/shaders/dxvk_blit_frag_3d.frag
@@ -1,20 +1,24 @@
-#version 450
+#version 460
 
-layout(set = 0, binding = 0)
-uniform sampler3D s_texture;
+#extension GL_EXT_nonuniform_qualifier : require
+#extension GL_EXT_scalar_block_layout : require
+
+layout(set = 0, binding = 0) uniform sampler s_samplers[];
+layout(set = 1, binding = 0) uniform texture3D s_texture;
 
 layout(location = 0) in  vec2 i_pos;
 layout(location = 0) out vec4 o_color;
 
-layout(push_constant)
+layout(push_constant, scalar)
 uniform push_block {
   vec3 p_src_coord0;
   vec3 p_src_coord1;
   uint p_layer_count;
+  uint p_sampler;
 };
 
 void main() {
   vec3 coord = mix(p_src_coord0, p_src_coord1,
     vec3(i_pos, (float(gl_Layer) + 0.5f) / float(p_layer_count)));
-  o_color = texture(s_texture, coord);
+  o_color = texture(sampler3D(s_texture, s_samplers[p_sampler]), coord);
 }

--- a/src/dxvk/shaders/dxvk_cursor_frag.frag
+++ b/src/dxvk/shaders/dxvk_cursor_frag.frag
@@ -1,5 +1,6 @@
 #version 460
 
+#extension GL_EXT_nonuniform_qualifier : require
 #extension GL_GOOGLE_include_directive : require
 
 #include "dxvk_color_space.glsl"
@@ -7,11 +8,19 @@
 layout(constant_id = 0) const uint s_color_space = VK_COLOR_SPACE_SRGB_NONLINEAR_KHR;
 layout(constant_id = 1) const bool s_srgb = false;
 
-layout(set = 0, binding = 0) uniform sampler2D s_texture;
+layout(set = 0, binding = 0) uniform sampler s_samplers[];
+layout(set = 1, binding = 0) uniform texture2D s_texture;
 
 layout(location = 0) in vec2 i_texcoord;
 layout(location = 0) out vec4 o_color;
 
+layout(push_constant)
+uniform present_info_t {
+  ivec2 dst_extent;
+  ivec2 cursor_offset;
+  ivec2 cursor_extent;
+  uint sampler_index;
+};
 
 vec4 linear_to_output(vec4 color) {
   switch (s_color_space) {
@@ -38,6 +47,6 @@ vec4 linear_to_output(vec4 color) {
 
 
 void main() {
-  o_color = linear_to_output(texture(s_texture, i_texcoord));
+  o_color = linear_to_output(texture(sampler2D(s_texture, s_samplers[sampler_index]), i_texcoord));
   o_color.rgb *= o_color.a;
 }

--- a/src/dxvk/shaders/dxvk_cursor_vert.vert
+++ b/src/dxvk/shaders/dxvk_cursor_vert.vert
@@ -5,6 +5,7 @@ uniform present_info_t {
   ivec2 dst_extent;
   ivec2 cursor_offset;
   ivec2 cursor_extent;
+  uint sampler_index;
 };
 
 layout(location = 0) out vec2 o_texcoord;

--- a/src/spirv/spirv_module.cpp
+++ b/src/spirv/spirv_module.cpp
@@ -1621,7 +1621,20 @@ namespace dxvk {
     m_code.putWord(operand);
     return resultId;
   }
-  
+
+
+  uint32_t SpirvModule::opUConvert(
+          uint32_t                resultType,
+          uint32_t                operand) {
+    uint32_t resultId = this->allocateId();
+
+    m_code.putIns (spv::OpUConvert, 4);
+    m_code.putWord(resultType);
+    m_code.putWord(resultId);
+    m_code.putWord(operand);
+    return resultId;
+  }
+
   
   uint32_t SpirvModule::opCompositeConstruct(
           uint32_t                resultType,

--- a/src/spirv/spirv_module.cpp
+++ b/src/spirv/spirv_module.cpp
@@ -345,6 +345,20 @@ namespace dxvk {
   }
   
   
+  uint32_t SpirvModule::constvec2u32(
+          uint32_t                x,
+          uint32_t                y) {
+    std::array<uint32_t, 2> args = {{
+      this->constu32(x), this->constu32(y),
+    }};
+
+    uint32_t scalarTypeId = this->defIntType(32, 0);
+    uint32_t vectorTypeId = this->defVectorType(scalarTypeId, 2);
+
+    return this->constComposite(vectorTypeId, args.size(), args.data());
+  }
+
+
   uint32_t SpirvModule::constvec4u32(
           uint32_t                x,
           uint32_t                y,

--- a/src/spirv/spirv_module.h
+++ b/src/spirv/spirv_module.h
@@ -604,7 +604,11 @@ namespace dxvk {
     uint32_t opConvertUtoF(
             uint32_t                resultType,
             uint32_t                operand);
-    
+
+    uint32_t opUConvert(
+            uint32_t                resultType,
+            uint32_t                operand);
+
     uint32_t opCompositeConstruct(
             uint32_t                resultType,
             uint32_t                valueCount,

--- a/src/spirv/spirv_module.h
+++ b/src/spirv/spirv_module.h
@@ -174,6 +174,10 @@ namespace dxvk {
             bool                    z,
             bool                    w);
     
+    uint32_t constvec2u32(
+            uint32_t                x,
+            uint32_t                y);
+
     uint32_t constvec4u32(
             uint32_t                x,
             uint32_t                y,


### PR DESCRIPTION
Basically #4934 except less buggy and with the stuff that it is actually supposed to be doing.

Moves all pure sampler descriptors to a dedicated descriptor set which we then index into via push constants. Similarly, buffers that don't strictly require robustness can now be accessed via their raw GPU address - annoyingly this only really applies to D3D11 UAV counters since we rely on robustness for everything else. Maybe someone digs up another D3D9 use case, but we're running kind of low on push data space there already anyway.

Seems to have a decent positive impact on CPU-bound performance in some D3D11 games that spam sampler descriptors already, and has the nice side effect of reducing the amount of memory we need for descriptor sets overall.

Also changes internal stuff to use the global sampler set rather than `COMBINED_IMAGE_SAMPLER`.