### PR TITLE
[util] Add a deviceId spoof for Battle Engine Aquila

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -1057,8 +1057,15 @@ namespace dxvk {
     }} },
     /* Pirate Huner - Prevents crash              */
     { R"(\\PH\.exe$)", {{
-      { "d3d9.memoryTrackTest",          "True" },
-      { "d3d9.maxAvailableMemory",       "2048" },
+      { "d3d9.memoryTrackTest",             "True" },
+      { "d3d9.maxAvailableMemory",          "2048" },
+    }} },
+    /* Battle Engine Aquila - Enables additional  *
+     * graphical features and Nvidia particle fog */
+    { R"(\\BEA\.exe$)", {{
+      { "d3d9.customVendorId",              "10de" },
+      { "d3d9.customDeviceId",              "0330" },
+      { "d3d9.customDeviceDesc",            "NVIDIA GeForce FX 5900 Ultra" },
     }} },
 
     /**********************************************/


### PR DESCRIPTION
The game locks certain "FX" generation features behind certain deviceIds. I'd have gone with an ATI 9700, but it seemed to disable terrain lighting on that, so a GeForce FX 5900 Ultra it is. I've extracted the most performant deviceId from the game's own GPU list.

Technically one could add their own deviceId to that list manually, but I think it's worthwhile to spare end users the pain.