### PR TITLE
Optionally enable maintenance6 for null index buffer

### DIFF
--- a/VP_DXVK_requirements.json
+++ b/VP_DXVK_requirements.json
@@ -101,6 +101,7 @@
         "dxvk_common_optional": {
             "extensions": {
                 "VK_KHR_load_store_op_none": 1,
+                "VK_KHR_maintenance6": 1,
                 "VK_KHR_maintenance7": 1,
                 "VK_KHR_present_id": 1,
                 "VK_KHR_present_wait": 1,
@@ -116,6 +117,9 @@
                 "VkPhysicalDeviceVulkan11Features": {
                     "shaderInt16": true,
                     "storagePushConstant16": true
+                },
+                "VkPhysicalDeviceMaintenance6FeaturesKHR": {
+                    "maintenance6": true
                 },
                 "VkPhysicalDeviceMaintenance7FeaturesKHR": {
                     "maintenance7": true

--- a/src/dxvk/dxvk_adapter.cpp
+++ b/src/dxvk/dxvk_adapter.cpp
@@ -451,6 +451,8 @@ namespace dxvk {
 
     // Enable maintenance features if supported. maintenance5 is required.
     enabledFeatures.khrMaintenance5.maintenance5 = VK_TRUE;
+    enabledFeatures.khrMaintenance6.maintenance6 =
+      m_deviceFeatures.khrMaintenance6.maintenance6;
     enabledFeatures.khrMaintenance7.maintenance7 =
       m_deviceFeatures.khrMaintenance7.maintenance7;
 
@@ -661,6 +663,10 @@ namespace dxvk {
           enabledFeatures.khrMaintenance5 = *reinterpret_cast<const VkPhysicalDeviceMaintenance5FeaturesKHR*>(f);
           break;
 
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_6_FEATURES_KHR:
+          enabledFeatures.khrMaintenance6 = *reinterpret_cast<const VkPhysicalDeviceMaintenance6FeaturesKHR*>(f);
+          break;
+
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_7_FEATURES_KHR:
           enabledFeatures.khrMaintenance7 = *reinterpret_cast<const VkPhysicalDeviceMaintenance7FeaturesKHR*>(f);
           break;
@@ -849,6 +855,11 @@ namespace dxvk {
       m_deviceInfo.khrMaintenance5.pNext = std::exchange(m_deviceInfo.core.pNext, &m_deviceInfo.khrMaintenance5);
     }
 
+    if (m_deviceExtensions.supports(VK_KHR_MAINTENANCE_6_EXTENSION_NAME)) {
+      m_deviceInfo.khrMaintenance6.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_6_PROPERTIES_KHR;
+      m_deviceInfo.khrMaintenance6.pNext = std::exchange(m_deviceInfo.core.pNext, &m_deviceInfo.khrMaintenance6);
+    }
+
     if (m_deviceExtensions.supports(VK_KHR_MAINTENANCE_7_EXTENSION_NAME)) {
       m_deviceInfo.khrMaintenance7.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_7_PROPERTIES_KHR;
       m_deviceInfo.khrMaintenance7.pNext = std::exchange(m_deviceInfo.core.pNext, &m_deviceInfo.khrMaintenance7);
@@ -994,6 +1005,11 @@ namespace dxvk {
       m_deviceFeatures.khrMaintenance5.pNext = std::exchange(m_deviceFeatures.core.pNext, &m_deviceFeatures.khrMaintenance5);
     }
 
+    if (m_deviceExtensions.supports(VK_KHR_MAINTENANCE_6_EXTENSION_NAME)) {
+      m_deviceFeatures.khrMaintenance6.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_6_FEATURES_KHR;
+      m_deviceFeatures.khrMaintenance6.pNext = std::exchange(m_deviceFeatures.core.pNext, &m_deviceFeatures.khrMaintenance6);
+    }
+
     if (m_deviceExtensions.supports(VK_KHR_MAINTENANCE_7_EXTENSION_NAME)) {
       m_deviceFeatures.khrMaintenance7.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_7_FEATURES_KHR;
       m_deviceFeatures.khrMaintenance7.pNext = std::exchange(m_deviceFeatures.core.pNext, &m_deviceFeatures.khrMaintenance7);
@@ -1083,6 +1099,7 @@ namespace dxvk {
       &devExtensions.khrExternalSemaphoreWin32,
       &devExtensions.khrLoadStoreOpNone,
       &devExtensions.khrMaintenance5,
+      &devExtensions.khrMaintenance6,
       &devExtensions.khrMaintenance7,
       &devExtensions.khrPipelineLibrary,
       &devExtensions.khrPresentId,
@@ -1230,6 +1247,11 @@ namespace dxvk {
     if (devExtensions.khrMaintenance5) {
       enabledFeatures.khrMaintenance5.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_5_FEATURES_KHR;
       enabledFeatures.khrMaintenance5.pNext = std::exchange(enabledFeatures.core.pNext, &enabledFeatures.khrMaintenance5);
+    }
+
+    if (devExtensions.khrMaintenance6) {
+      enabledFeatures.khrMaintenance6.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_6_FEATURES_KHR;
+      enabledFeatures.khrMaintenance6.pNext = std::exchange(enabledFeatures.core.pNext, &enabledFeatures.khrMaintenance6);
     }
 
     if (devExtensions.khrMaintenance7) {
@@ -1410,6 +1432,8 @@ namespace dxvk {
       "\n  extension supported                    : " << (features.khrLoadStoreOpNone ? "1" : "0") <<
       "\n" << VK_KHR_MAINTENANCE_5_EXTENSION_NAME <<
       "\n  maintenance5                           : " << (features.khrMaintenance5.maintenance5 ? "1" : "0") <<
+      "\n" << VK_KHR_MAINTENANCE_6_EXTENSION_NAME <<
+      "\n  maintenance6                           : " << (features.khrMaintenance6.maintenance6 ? "1" : "0") <<
       "\n" << VK_KHR_MAINTENANCE_7_EXTENSION_NAME <<
       "\n  maintenance7                           : " << (features.khrMaintenance7.maintenance7 ? "1" : "0") <<
       "\n" << VK_KHR_PRESENT_ID_EXTENSION_NAME <<

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -6799,30 +6799,38 @@ namespace dxvk {
   }
 
 
-  bool DxvkContext::updateIndexBufferBinding() {
-    if (unlikely(!m_state.vi.indexBuffer.length()))
-      return false;
-
+  void DxvkContext::updateIndexBufferBinding() {
     m_flags.clr(DxvkContextFlag::GpDirtyIndexBuffer);
-    auto bufferInfo = m_state.vi.indexBuffer.getSliceInfo();
 
-    VkDeviceSize align = m_state.vi.indexType == VK_INDEX_TYPE_UINT16 ? 2 : 4;
-    VkDeviceSize length = bufferInfo.size & ~(align - 1);
+    if (likely(m_state.vi.indexBuffer.length())) {
+      auto bufferInfo = m_state.vi.indexBuffer.getSliceInfo();
 
-    m_cmd->cmdBindIndexBuffer2(
-      bufferInfo.buffer, bufferInfo.offset,
-      length, m_state.vi.indexType);
+      VkDeviceSize align = m_state.vi.indexType == VK_INDEX_TYPE_UINT16 ? 2 : 4;
+      VkDeviceSize length = bufferInfo.size & ~(align - 1);
 
-    if (unlikely(m_state.vi.indexBuffer.buffer()->hasGfxStores())) {
-      accessBuffer(DxvkCmdBuffer::ExecBuffer, m_state.vi.indexBuffer,
-        VK_PIPELINE_STAGE_VERTEX_INPUT_BIT, VK_ACCESS_INDEX_READ_BIT, DxvkAccessOp::None);
+      m_cmd->cmdBindIndexBuffer2(
+        bufferInfo.buffer, bufferInfo.offset,
+        length, m_state.vi.indexType);
+
+      if (unlikely(m_state.vi.indexBuffer.buffer()->hasGfxStores())) {
+        accessBuffer(DxvkCmdBuffer::ExecBuffer, m_state.vi.indexBuffer,
+          VK_PIPELINE_STAGE_VERTEX_INPUT_BIT, VK_ACCESS_INDEX_READ_BIT, DxvkAccessOp::None);
+      }
+
+      m_renderPassBarrierSrc.stages |= VK_PIPELINE_STAGE_VERTEX_INPUT_BIT;
+      m_renderPassBarrierSrc.access |= VK_ACCESS_INDEX_READ_BIT;
+    } else if (m_device->features().khrMaintenance6.maintenance6) {
+      // Bind null index buffer to read all zeroes, not too useful but well-defined
+      m_cmd->cmdBindIndexBuffer2(VK_NULL_HANDLE, 0, VK_WHOLE_SIZE, m_state.vi.indexType);
+    } else {
+      // Bind dummy buffer that contains all zeroes
+      auto bufferInfo = m_common->dummyResources().bufferInfo();
+
+      m_cmd->cmdBindIndexBuffer2(bufferInfo.buffer,
+        bufferInfo.offset, bufferInfo.size, m_state.vi.indexType);
     }
 
-    m_renderPassBarrierSrc.stages |= VK_PIPELINE_STAGE_VERTEX_INPUT_BIT;
-    m_renderPassBarrierSrc.access |= VK_ACCESS_INDEX_READ_BIT;
-
     m_cmd->track(m_state.vi.indexBuffer.buffer(), DxvkAccess::Read);
-    return true;
   }
   
   
@@ -7263,10 +7271,8 @@ namespace dxvk {
         this->beginBarrierControlDebugRegion<VK_PIPELINE_BIND_POINT_GRAPHICS>();
     }
 
-    if (m_flags.test(DxvkContextFlag::GpDirtyIndexBuffer) && Indexed) {
-      if (unlikely(!this->updateIndexBufferBinding()))
-        return false;
-    }
+    if (m_flags.test(DxvkContextFlag::GpDirtyIndexBuffer) && Indexed)
+      this->updateIndexBufferBinding();
     
     if (m_flags.test(DxvkContextFlag::GpDirtyVertexBuffers))
       this->updateVertexBufferBindings();

--- a/src/dxvk/dxvk_context.h
+++ b/src/dxvk/dxvk_context.h
@@ -1747,7 +1747,7 @@ namespace dxvk {
       const Rc<DxvkImage>&          image,
       const VkImageSubresourceRange& subresources);
 
-    bool updateIndexBufferBinding();
+    void updateIndexBufferBinding();
     void updateVertexBufferBindings();
 
     void updateTransformFeedbackBuffers();

--- a/src/dxvk/dxvk_device_info.h
+++ b/src/dxvk/dxvk_device_info.h
@@ -30,6 +30,7 @@ namespace dxvk {
     VkPhysicalDeviceTransformFeedbackPropertiesEXT            extTransformFeedback;
     VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT       extVertexAttributeDivisor;
     VkPhysicalDeviceMaintenance5PropertiesKHR                 khrMaintenance5;
+    VkPhysicalDeviceMaintenance6PropertiesKHR                 khrMaintenance6;
     VkPhysicalDeviceMaintenance7PropertiesKHR                 khrMaintenance7;
   };
 
@@ -73,6 +74,7 @@ namespace dxvk {
     VkBool32                                                  khrExternalSemaphoreWin32;
     VkBool32                                                  khrLoadStoreOpNone;
     VkPhysicalDeviceMaintenance5FeaturesKHR                   khrMaintenance5;
+    VkPhysicalDeviceMaintenance6FeaturesKHR                   khrMaintenance6;
     VkPhysicalDeviceMaintenance7FeaturesKHR                   khrMaintenance7;
     VkPhysicalDevicePresentIdFeaturesKHR                      khrPresentId;
     VkPhysicalDevicePresentWaitFeaturesKHR                    khrPresentWait;

--- a/src/dxvk/dxvk_extensions.h
+++ b/src/dxvk/dxvk_extensions.h
@@ -322,6 +322,7 @@ namespace dxvk {
     DxvkExt khrExternalSemaphoreWin32         = { VK_KHR_EXTERNAL_SEMAPHORE_WIN32_EXTENSION_NAME,           DxvkExtMode::Optional };
     DxvkExt khrLoadStoreOpNone                = { VK_KHR_LOAD_STORE_OP_NONE_EXTENSION_NAME,                 DxvkExtMode::Optional };
     DxvkExt khrMaintenance5                   = { VK_KHR_MAINTENANCE_5_EXTENSION_NAME,                      DxvkExtMode::Required };
+    DxvkExt khrMaintenance6                   = { VK_KHR_MAINTENANCE_6_EXTENSION_NAME,                      DxvkExtMode::Optional };
     DxvkExt khrMaintenance7                   = { VK_KHR_MAINTENANCE_7_EXTENSION_NAME,                      DxvkExtMode::Optional };
     DxvkExt khrPipelineLibrary                = { VK_KHR_PIPELINE_LIBRARY_EXTENSION_NAME,                   DxvkExtMode::Optional };
     DxvkExt khrPresentId                      = { VK_KHR_PRESENT_ID_EXTENSION_NAME,                         DxvkExtMode::Optional };

--- a/src/vulkan/vulkan_loader.h
+++ b/src/vulkan/vulkan_loader.h
@@ -454,6 +454,15 @@ namespace dxvk::vk {
     VULKAN_FN(vkGetImageSubresourceLayout2KHR);
     #endif
 
+    #ifdef VK_KHR_maintenance6
+    VULKAN_FN(vkCmdBindDescriptorSets2KHR);
+    VULKAN_FN(vkCmdPushConstants2KHR);
+    VULKAN_FN(vkCmdPushDescriptorSet2KHR);
+    VULKAN_FN(vkCmdPushDescriptorSetWithTemplate2KHR);
+    VULKAN_FN(vkCmdSetDescriptorBufferOffsets2EXT);
+    VULKAN_FN(vkCmdBindDescriptorBufferEmbeddedSamplers2EXT);
+    #endif
+
     #ifdef VK_KHR_present_wait
     VULKAN_FN(vkWaitForPresentKHR);
     #endif


### PR DESCRIPTION
Instead of erroring out. Bit of an oversight from maintenance5 enablement.

Should be fairly non-controversial since it's optional anyway.