### PR TITLE
Improve device UUID filtering logic

### DIFF
--- a/src/dxvk/dxvk_device_filter.cpp
+++ b/src/dxvk/dxvk_device_filter.cpp
@@ -1,11 +1,12 @@
 #include "dxvk_device_filter.h"
 #include <iomanip>
+#include <sstream>
 
 namespace dxvk {
 
     DxvkDeviceFilter::DxvkDeviceFilter(
       DxvkDeviceFilterFlags flags,
-      const DxvkOptions&          options)
+      const DxvkOptions& options)
       : m_flags(flags) {
       m_matchDeviceName = env::getEnvVar("DXVK_FILTER_DEVICE_NAME");
       m_matchDeviceUUID = env::getEnvVar("DXVK_FILTER_DEVICE_UUID");
@@ -20,17 +21,14 @@ namespace dxvk {
         m_flags.set(DxvkDeviceFilterFlag::MatchDeviceUUID);
     }
 
-    DxvkDeviceFilter::~DxvkDeviceFilter() {}
+    DxvkDeviceFilter::~DxvkDeviceFilter() { }
 
-    /// 🔧 Conversor de UUID mais legível (hexadecimal)
+    /// 🔧 Conversor de UUID legível (hexadecimal, sem hífens)
     std::string convertUUID(const uint8_t uuid[VK_UUID_SIZE]) {
       std::ostringstream stream;
       stream << std::hex << std::setfill('0');
-      for (size_t i = 0; i < VK_UUID_SIZE; ++i) {
-        stream << std::setw(2) << static_cast<int>(uuid[i]);
-        if (i != VK_UUID_SIZE - 1)
-          stream << "-";
-      }
+      for (size_t i = 0; i < VK_UUID_SIZE; ++i)
+        stream << std::setw(2) << static_cast<uint32_t>(uuid[i] & 0xff); // Corrige sinais negativos
       return stream.str();
     }
 

--- a/src/dxvk/dxvk_device_filter.cpp
+++ b/src/dxvk/dxvk_device_filter.cpp
@@ -1,46 +1,73 @@
 #include "dxvk_device_filter.h"
+#include <iomanip>
 
 namespace dxvk {
-  
-  DxvkDeviceFilter::DxvkDeviceFilter(
-          DxvkDeviceFilterFlags flags,
-    const DxvkOptions&          options)
-  : m_flags(flags) {
-    m_matchDeviceName = env::getEnvVar("DXVK_FILTER_DEVICE_NAME");
 
-    if (m_matchDeviceName.empty())
-      m_matchDeviceName = options.deviceFilter;
+    DxvkDeviceFilter::DxvkDeviceFilter(
+      DxvkDeviceFilterFlags flags,
+      const DxvkOptions&          options)
+      : m_flags(flags) {
+      m_matchDeviceName = env::getEnvVar("DXVK_FILTER_DEVICE_NAME");
+      m_matchDeviceUUID = env::getEnvVar("DXVK_FILTER_DEVICE_UUID");
 
-    if (!m_matchDeviceName.empty())
-      m_flags.set(DxvkDeviceFilterFlag::MatchDeviceName);
-  }
-  
-  
-  DxvkDeviceFilter::~DxvkDeviceFilter() {
-    
-  }
-  
-  
-  bool DxvkDeviceFilter::testAdapter(const VkPhysicalDeviceProperties& properties) const {
-    if (properties.apiVersion < VK_MAKE_API_VERSION(0, 1, 3, 0)) {
-      Logger::warn(str::format("Skipping Vulkan ",
-        VK_API_VERSION_MAJOR(properties.apiVersion), ".",
-        VK_API_VERSION_MINOR(properties.apiVersion), " adapter: ",
-        properties.deviceName));
-      return false;
+      if (m_matchDeviceName.empty())
+        m_matchDeviceName = options.deviceFilter;
+
+      if (!m_matchDeviceName.empty())
+        m_flags.set(DxvkDeviceFilterFlag::MatchDeviceName);
+
+      if (!m_matchDeviceUUID.empty())
+        m_flags.set(DxvkDeviceFilterFlag::MatchDeviceUUID);
     }
 
-    if (m_flags.test(DxvkDeviceFilterFlag::MatchDeviceName)) {
-      if (std::string(properties.deviceName).find(m_matchDeviceName) == std::string::npos)
-        return false;
-    } else if (m_flags.test(DxvkDeviceFilterFlag::SkipCpuDevices)) {
-      if (properties.deviceType == VK_PHYSICAL_DEVICE_TYPE_CPU) {
-        Logger::warn(str::format("Skipping CPU adapter: ", properties.deviceName));
+    DxvkDeviceFilter::~DxvkDeviceFilter() {}
+
+    /// 🔧 Conversor de UUID mais legível (hexadecimal)
+    std::string convertUUID(const uint8_t uuid[VK_UUID_SIZE]) {
+      std::ostringstream stream;
+      stream << std::hex << std::setfill('0');
+      for (size_t i = 0; i < VK_UUID_SIZE; ++i) {
+        stream << std::setw(2) << static_cast<int>(uuid[i]);
+        if (i != VK_UUID_SIZE - 1)
+          stream << "-";
+      }
+      return stream.str();
+    }
+
+    bool DxvkDeviceFilter::testAdapter(const VkPhysicalDeviceProperties& properties) const {
+      if (properties.apiVersion < VK_MAKE_API_VERSION(0, 1, 3, 0)) {
+        Logger::warn(str::format("DXVK: Skipping Vulkan ",
+                                 VK_API_VERSION_MAJOR(properties.apiVersion), ".",
+                                 VK_API_VERSION_MINOR(properties.apiVersion), " adapter: ",
+                                 properties.deviceName));
         return false;
       }
+
+      if (m_flags.test(DxvkDeviceFilterFlag::MatchDeviceName)) {
+        if (std::string(properties.deviceName).find(m_matchDeviceName) == std::string::npos) {
+          Logger::warn(str::format("DXVK: Skipping device not matching name filter: ", properties.deviceName));
+          return false;
+        }
+      } else if (m_flags.test(DxvkDeviceFilterFlag::SkipCpuDevices)) {
+        if (properties.deviceType == VK_PHYSICAL_DEVICE_TYPE_CPU) {
+          Logger::warn(str::format("DXVK: Skipping CPU adapter: ", properties.deviceName));
+          return false;
+        }
+      }
+
+      return true;
     }
 
-    return true;
-  }
-  
+    bool DxvkDeviceFilter::testCreatedAdapter(const DxvkDeviceInfo& deviceInfo) const {
+      if (m_flags.test(DxvkDeviceFilterFlag::MatchDeviceUUID)) {
+        std::string uuidStr = convertUUID(deviceInfo.coreDeviceId.deviceUUID);
+        if (uuidStr.find(m_matchDeviceUUID) == std::string::npos) {
+          Logger::warn(str::format("DXVK: Skipping device not matching UUID filter: ", uuidStr));
+          return false;
+        }
+      }
+
+      return true;
+    }
+
 }

--- a/src/dxvk/dxvk_device_filter.cpp
+++ b/src/dxvk/dxvk_device_filter.cpp
@@ -58,7 +58,8 @@ namespace dxvk {
 
     bool DxvkDeviceFilter::testCreatedAdapter(const DxvkDeviceInfo& deviceInfo) const {
       if (m_flags.test(DxvkDeviceFilterFlag::MatchDeviceUUID)) {
-        std::string uuidStr = convertUUID(deviceInfo.coreDeviceId.deviceUUID);
+        std::string uuidStr = convertUUID(deviceInfo.properties11.deviceUUID);
+        Logger::info(str::format("UUID usado para filtro: ", convertUUID(deviceInfo.properties11.deviceUUID)));
         if (uuidStr.find(m_matchDeviceUUID) == std::string::npos) {
           Logger::warn(str::format("DXVK: Skipping device not matching UUID filter: ", uuidStr));
           return false;

--- a/src/dxvk/dxvk_device_filter.cpp
+++ b/src/dxvk/dxvk_device_filter.cpp
@@ -58,7 +58,7 @@ namespace dxvk {
 
     bool DxvkDeviceFilter::testCreatedAdapter(const DxvkDeviceInfo& deviceInfo) const {
       if (m_flags.test(DxvkDeviceFilterFlag::MatchDeviceUUID)) {
-        std::string uuidStr = convertUUID(deviceInfo.deviceID.deviceUUID);
+        std::string uuidStr = convertUUID(deviceInfo.vk11.deviceUUID);
         Logger::info(str::format("UUID usado para filtro: ", uuidStr));
         if (uuidStr.find(m_matchDeviceUUID) == std::string::npos) {
           Logger::warn(str::format("DXVK: Skipping device not matching UUID filter: ", uuidStr));
@@ -68,5 +68,4 @@ namespace dxvk {
 
       return true;
     }
-
 }

--- a/src/dxvk/dxvk_device_filter.cpp
+++ b/src/dxvk/dxvk_device_filter.cpp
@@ -58,8 +58,8 @@ namespace dxvk {
 
     bool DxvkDeviceFilter::testCreatedAdapter(const DxvkDeviceInfo& deviceInfo) const {
       if (m_flags.test(DxvkDeviceFilterFlag::MatchDeviceUUID)) {
-        std::string uuidStr = convertUUID(deviceInfo.properties11.deviceUUID);
-        Logger::info(str::format("UUID usado para filtro: ", convertUUID(deviceInfo.properties11.deviceUUID)));
+        std::string uuidStr = convertUUID(deviceInfo.deviceID.deviceUUID);
+        Logger::info(str::format("UUID usado para filtro: ", uuidStr));
         if (uuidStr.find(m_matchDeviceUUID) == std::string::npos) {
           Logger::warn(str::format("DXVK: Skipping device not matching UUID filter: ", uuidStr));
           return false;

--- a/src/dxvk/dxvk_device_filter.h
+++ b/src/dxvk/dxvk_device_filter.h
@@ -4,55 +4,65 @@
 #include "dxvk_options.h"
 
 namespace dxvk {
-  
-  /**
-   * \brief Device filter flags
-   * 
-   * The device filter flags specify which device
-   * properties are considered when testing adapters.
-   * If no flags are set, all devices pass the test.
-   */
-  enum class DxvkDeviceFilterFlag {
-    MatchDeviceName   = 0,
-    SkipCpuDevices    = 1,
-  };
-  
-  using DxvkDeviceFilterFlags = Flags<DxvkDeviceFilterFlag>;
-  
-  
-  /**
-   * \brief DXVK device filter
-   * 
-   * Used to select specific Vulkan devices to use
-   * with DXVK. This may be useful for games which
-   * do not offer an option to select the correct
-   * device.
-   */
-  class DxvkDeviceFilter {
-    
-  public:
-    
-    DxvkDeviceFilter(
-            DxvkDeviceFilterFlags flags,
-      const DxvkOptions&          options);
 
-    ~DxvkDeviceFilter();
-    
     /**
-     * \brief Tests an adapter
-     * 
-     * \param [in] properties Adapter properties
-     * \returns \c true if the test passes
+     * \brief Device filter flags
+     *
+     * The device filter flags specify which device
+     * properties are considered when testing adapters.
+     * If no flags are set, all devices pass the test.
      */
-    bool testAdapter(
-      const VkPhysicalDeviceProperties& properties) const;
-    
-  private:
-    
-    DxvkDeviceFilterFlags m_flags;
-    
-    std::string m_matchDeviceName;
-    
-  };
-  
+    enum class DxvkDeviceFilterFlag {
+        MatchDeviceName   = 0,
+        SkipCpuDevices    = 2,
+        MatchDeviceUUID   = 3,  // 🔥 Adiciona filtro por UUID
+    };
+
+    using DxvkDeviceFilterFlags = Flags<DxvkDeviceFilterFlag>;
+
+
+    /**
+     * \brief DXVK device filter
+     *
+     * Used to select specific Vulkan devices to use
+     * with DXVK. This may be useful for games which
+     * do not offer an option to select the correct
+     * device.
+     */
+    class DxvkDeviceFilter {
+
+    public:
+
+        DxvkDeviceFilter(
+          DxvkDeviceFilterFlags flags,
+          const DxvkOptions&          options);
+
+        ~DxvkDeviceFilter();
+
+        /**
+         * \brief Tests an adapter (pre-device creation)
+         *
+         * \param [in] properties Adapter properties
+         * \returns \c true if the test passes
+         */
+        bool testAdapter(
+          const VkPhysicalDeviceProperties& properties) const;
+
+        /**
+         * \brief Tests a fully created adapter
+         *
+         * This checks the Device UUID filter.
+         */
+        bool testCreatedAdapter(
+          const DxvkDeviceInfo& deviceInfo) const;
+
+    private:
+
+        DxvkDeviceFilterFlags m_flags;
+
+        std::string m_matchDeviceName;
+        std::string m_matchDeviceUUID;
+
+    };
+
 }

--- a/src/dxvk/dxvk_instance.cpp
+++ b/src/dxvk/dxvk_instance.cpp
@@ -269,14 +269,19 @@ namespace dxvk {
 
     for (uint32_t i = 0; i < numAdapters; i++) {
       if (filter.testAdapter(deviceProperties[i])) {
-        result.push_back(new DxvkAdapter(m_vki, adapters[i]));
+        auto adapter = new DxvkAdapter(m_vki, adapters[i]);
 
-        if (deviceProperties[i].deviceType == VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU)
-          numDGPU += 1;
-        else if (deviceProperties[i].deviceType == VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU)
-          numIGPU += 1;
+        if (filter.testCreatedAdapter(adapter->devicePropertiesExt())) {
+          result.push_back(adapter);
+
+          if (deviceProperties[i].deviceType == VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU)
+            numDGPU += 1;
+          else if (deviceProperties[i].deviceType == VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU)
+            numIGPU += 1;
+        } else {
+          // Se falhar no UUID, descarta
+        }
       }
-    }
     
     std::stable_sort(result.begin(), result.end(),
       [] (const Rc<DxvkAdapter>& a, const Rc<DxvkAdapter>& b) -> bool {

--- a/src/dxvk/dxvk_instance.cpp
+++ b/src/dxvk/dxvk_instance.cpp
@@ -279,9 +279,10 @@ namespace dxvk {
           else if (deviceProperties[i].deviceType == VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU)
             numIGPU += 1;
         } else {
-          // Se falhar no UUID, descarta
+          delete adapter; // Libera se não passar no filtro de UUID// Se falhar no UUID, descarta
         }
       }
+    }
     
     std::stable_sort(result.begin(), result.end(),
       [] (const Rc<DxvkAdapter>& a, const Rc<DxvkAdapter>& b) -> bool {


### PR DESCRIPTION
This is a replacement for PR #2408.

This PR improves and corrects the UUID filtering logic in `DxvkDeviceFilter`,
ensuring proper selection based on Vulkan `deviceUUID`. It also prevents memory
leaks by cleaning up rejected adapters and simplifies the adapter query logic.

Closes #2408.