### PR TITLE
Post-descriptor buffer cleanup

### DIFF
--- a/dxvk.conf
+++ b/dxvk.conf
@@ -473,8 +473,8 @@
 # Controls descriptor model
 #
 # Enables or disables VK_EXT_descriptor_buffer usage. By default, this is
-# only enabled on AMD and Intel drivers in order to reduce CPU overhead;
-# it is likely to regress performance or stability on other vendors.
+# only enabled on AMD drivers in order to reduce CPU overhead; it is likely
+# to regress GPU-bound performance on other vendors.
 #
 # Supported values:
 # - Auto: Enable if supported on known-good drivers

--- a/src/dxbc/dxbc_compiler.cpp
+++ b/src/dxbc/dxbc_compiler.cpp
@@ -2884,7 +2884,8 @@ namespace dxvk {
 
     uint32_t sparseFeedbackId = 0;
 
-    bool useRawAccessChains = m_hasRawAccessChains && isSsbo && !imageOperands.sparse;
+    bool useRawAccessChains = m_hasRawAccessChains && isSsbo && !imageOperands.sparse
+      && (isStructured || !m_moduleInfo.options.rawAccessChainsOnlyStructured);
 
     DxbcRegisterValue index = emitRegisterLoad(ins.src[0], DxbcRegMask(true, false, false, false));
     DxbcRegisterValue offset = index;
@@ -3097,7 +3098,8 @@ namespace dxvk {
     }
 
     // Compute flat element index as necessary
-    bool useRawAccessChains = isSsbo && m_hasRawAccessChains;
+    bool useRawAccessChains = isSsbo && m_hasRawAccessChains
+      && (isStructured || !m_moduleInfo.options.rawAccessChainsOnlyStructured);
 
     DxbcRegisterValue index = emitRegisterLoad(ins.src[0], DxbcRegMask(true, false, false, false));
     DxbcRegisterValue offset = index;

--- a/src/dxbc/dxbc_options.cpp
+++ b/src/dxbc/dxbc_options.cpp
@@ -26,6 +26,9 @@ namespace dxvk {
     supportsTypedUavLoadR32 = (r32Features & VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT);
     supportsRawAccessChains = device->features().nvRawAccessChains.shaderRawAccessChains;
 
+    // Raw access chains are currently broken with byte-address SSBO and descriptor buffers
+    rawAccessChainsOnlyStructured = device->canUseDescriptorBuffer();
+
     switch (device->config().useRawSsbo) {
       case Tristate::Auto:  minSsboAlignment = devInfo.core.properties.limits.minStorageBufferOffsetAlignment; break;
       case Tristate::True:  minSsboAlignment =  4u; break;

--- a/src/dxbc/dxbc_options.h
+++ b/src/dxbc/dxbc_options.h
@@ -30,6 +30,9 @@ namespace dxvk {
     /// Determines whether raw access chains are supported
     bool supportsRawAccessChains = false;
 
+    /// Whether to use raw access chains on byte-address buffers
+    bool rawAccessChainsOnlyStructured = true;
+
     /// Clear thread-group shared memory to zero
     bool zeroInitWorkgroupMemory = false;
 

--- a/src/dxvk/dxvk_adapter.cpp
+++ b/src/dxvk/dxvk_adapter.cpp
@@ -296,8 +296,8 @@ namespace dxvk {
     if (m_deviceFeatures.extDescriptorBuffer.descriptorBuffer) {
       enableDescriptorBuffer = matchesDriver(VK_DRIVER_ID_MESA_RADV)
                             || matchesDriver(VK_DRIVER_ID_AMD_OPEN_SOURCE)
-                            || matchesDriver(VK_DRIVER_ID_AMD_PROPRIETARY)
-                            || matchesDriver(VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA);
+                            || matchesDriver(VK_DRIVER_ID_AMD_PROPRIETARY);
+
       applyTristate(enableDescriptorBuffer, instance->options().enableDescriptorBuffer);
     }
 

--- a/src/dxvk/dxvk_cmdlist.cpp
+++ b/src/dxvk/dxvk_cmdlist.cpp
@@ -609,7 +609,10 @@ namespace dxvk {
 
       // Populate descriptor arrays with necessary information
       small_vector<const DxvkDescriptor*, 8u> descriptors;
+      descriptors.reserve(descriptorCount);
+
       small_vector<DxvkDescriptor, 8u> buffers;
+      buffers.reserve(descriptorCount);
 
       for (uint32_t i = 0u; i < descriptorCount; i++) {
         const auto& info = descriptorInfos[i];

--- a/src/dxvk/dxvk_cmdlist.cpp
+++ b/src/dxvk/dxvk_cmdlist.cpp
@@ -791,7 +791,7 @@ namespace dxvk {
     if (!cmdBuffer || !m_descriptorRange)
       return;
 
-    auto samplerInfo = m_device->getSamplerDescriptorSet();
+    auto samplerInfo = m_device->getSamplerDescriptorHeap();
     auto resourceInfo = m_descriptorRange->getHeapInfo();
 
     std::array<VkDescriptorBufferBindingInfoEXT, 2u> heaps = { };

--- a/src/dxvk/dxvk_descriptor_heap.h
+++ b/src/dxvk/dxvk_descriptor_heap.h
@@ -16,7 +16,7 @@ namespace dxvk {
    * Stores buffer properties for the purpose of
    * binding the descriptor heap.
    */
-  struct DxvkResourceDescriptorHeapBindingInfo {
+  struct DxvkDescriptorHeapBindingInfo {
     VkBuffer        buffer      = VK_NULL_HANDLE;
     VkDeviceAddress gpuAddress  = 0u;
     VkDeviceSize    heapSize    = 0u;
@@ -78,8 +78,8 @@ namespace dxvk {
      * buffer once.
      * \returns Buffer slice for descriptor heap binding
      */
-    DxvkResourceDescriptorHeapBindingInfo getHeapInfo() const {
-      DxvkResourceDescriptorHeapBindingInfo result = { };
+    DxvkDescriptorHeapBindingInfo getHeapInfo() const {
+      DxvkDescriptorHeapBindingInfo result = { };
       result.buffer = m_rangeInfo.buffer;
       result.gpuAddress = m_rangeInfo.gpuAddress - m_rangeInfo.offset;
       result.heapSize = m_heapSize;

--- a/src/dxvk/dxvk_device.h
+++ b/src/dxvk/dxvk_device.h
@@ -510,6 +510,14 @@ namespace dxvk {
     }
 
     /**
+     * \brief Queries sampler descriptor set
+     * \returns Global sampler set and layout
+     */
+    DxvkDescriptorHeapBindingInfo getSamplerDescriptorHeap() {
+      return m_objects.samplerPool().getDescriptorHeapInfo();
+    }
+
+    /**
      * \brief Retreves current frame ID
      * \returns Current frame ID
      */

--- a/src/dxvk/dxvk_pipelayout.cpp
+++ b/src/dxvk/dxvk_pipelayout.cpp
@@ -154,26 +154,49 @@ namespace dxvk {
           DxvkDevice*                 device,
     const DxvkPipelineLayoutKey&      key)
   : m_device(device), m_flags(key.getFlags()) {
+    initMetadata(key);
+    initPipelineLayout(key);
+  }
+
+
+  DxvkPipelineLayout::~DxvkPipelineLayout() {
     auto vk = m_device->vkd();
 
+    vk->vkDestroyPipelineLayout(vk->device(), m_legacy.layout, nullptr);
+  }
+
+
+  void DxvkPipelineLayout::initMetadata(
+    const DxvkPipelineLayoutKey&      key) {
     // Determine bind point based on shader stages
     m_bindPoint = (key.getStageMask() == VK_SHADER_STAGE_COMPUTE_BIT)
       ? VK_PIPELINE_BIND_POINT_COMPUTE
       : VK_PIPELINE_BIND_POINT_GRAPHICS;
 
-    m_pushMask = key.getPushDataMask();
-
-    for (auto i : bit::BitMask(m_pushMask)) {
-      m_pushData[i] = key.getPushDataBlock(i);
-      m_pushDataMerged.merge(m_pushData[i]);
-      m_pushDataMerged.makeAbsolute();
-    }
-
+    // Get set layouts from pipeline layout key and compute memory size
     for (uint32_t i = 0; i < key.getDescriptorSetCount(); i++) {
-      m_setMemorySize += key.getDescriptorSetLayout(i)
+      m_setLayouts[i] = key.getDescriptorSetLayout(i);
+
+      m_heap.setMemorySize += key.getDescriptorSetLayout(i)
         ? key.getDescriptorSetLayout(i)->getMemorySize()
         : 0u;
     }
+
+    // Compute merged push data block from all used blocks
+    m_pushData.blockMask = key.getPushDataMask();
+
+    for (auto i : bit::BitMask(m_pushData.blockMask)) {
+      m_pushData.blocks[i] = key.getPushDataBlock(i);
+
+      m_pushData.mergedBlock.merge(m_pushData.blocks[i]);
+      m_pushData.mergedBlock.makeAbsolute();
+    }
+  }
+
+
+  void DxvkPipelineLayout::initPipelineLayout(
+    const DxvkPipelineLayoutKey&      key) {
+    auto vk = m_device->vkd();
 
     // Gather descriptor set layout objects, some of these may be null.
     small_vector<VkDescriptorSetLayout, DxvkPipelineLayoutKey::MaxSets + 1u> setLayouts;
@@ -181,15 +204,13 @@ namespace dxvk {
     if (m_flags.test(DxvkPipelineLayoutFlag::UsesSamplerHeap))
       setLayouts.push_back(m_device->getSamplerDescriptorSet().layout);
 
-    for (uint32_t i = 0; i < key.getDescriptorSetCount(); i++) {
-      m_setLayouts[i] = key.getDescriptorSetLayout(i);
+    for (uint32_t i = 0; i < key.getDescriptorSetCount(); i++)
       setLayouts.push_back(m_setLayouts[i] ? m_setLayouts[i]->getSetLayout() : VK_NULL_HANDLE);
-    }
 
     // Set up push constant range, if any
     VkPushConstantRange pushConstantRange = { };
-    pushConstantRange.stageFlags = m_pushDataMerged.getStageMask();
-    pushConstantRange.size = m_pushDataMerged.getSize();
+    pushConstantRange.stageFlags = m_pushData.mergedBlock.getStageMask();
+    pushConstantRange.size = m_pushData.mergedBlock.getSize();
 
     VkPipelineLayoutCreateInfo layoutInfo = { VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO };
 
@@ -206,15 +227,8 @@ namespace dxvk {
       layoutInfo.pPushConstantRanges = &pushConstantRange;
     }
 
-    if (vk->vkCreatePipelineLayout(vk->device(), &layoutInfo, nullptr, &m_layout))
+    if (vk->vkCreatePipelineLayout(vk->device(), &layoutInfo, nullptr, &m_legacy.layout))
       throw DxvkError("DxvkPipelineLayout: Failed to create pipeline layout");
-  }
-
-
-  DxvkPipelineLayout::~DxvkPipelineLayout() {
-    auto vk = m_device->vkd();
-
-    vk->vkDestroyPipelineLayout(vk->device(), m_layout, nullptr);
   }
 
 

--- a/src/dxvk/dxvk_pipelayout.cpp
+++ b/src/dxvk/dxvk_pipelayout.cpp
@@ -187,9 +187,7 @@ namespace dxvk {
 
     for (auto i : bit::BitMask(m_pushData.blockMask)) {
       m_pushData.blocks[i] = key.getPushDataBlock(i);
-
       m_pushData.mergedBlock.merge(m_pushData.blocks[i]);
-      m_pushData.mergedBlock.makeAbsolute();
     }
   }
 

--- a/src/dxvk/dxvk_pipelayout.h
+++ b/src/dxvk/dxvk_pipelayout.h
@@ -1196,7 +1196,7 @@ namespace dxvk {
      * \returns Pipeline layout handle
      */
     VkPipelineLayout getPipelineLayout() const {
-      return m_layout;
+      return m_legacy.layout;
     }
 
     /**
@@ -1227,14 +1227,14 @@ namespace dxvk {
      * descriptor range from the resource heap.
      */
     VkDeviceSize getDescriptorMemorySize() const {
-      return m_setMemorySize;
+      return m_heap.setMemorySize;
     }
 
     /**
      * \brief Queries non-empty push data block mask
      */
     uint32_t getPushDataMask() const {
-      return m_pushMask;
+      return m_pushData.blockMask;
     }
 
     /**
@@ -1243,7 +1243,7 @@ namespace dxvk {
      * This block includes all stages and all bytes.
      */
     DxvkPushDataBlock getPushData() const {
-      return m_pushDataMerged;
+      return m_pushData.mergedBlock;
     }
 
     /**
@@ -1253,7 +1253,7 @@ namespace dxvk {
      * \returns Push data block
      */
     DxvkPushDataBlock getPushDataBlock(uint32_t index) const {
-      return m_pushData[index];
+      return m_pushData.blocks[index];
     }
 
   private:
@@ -1263,14 +1263,27 @@ namespace dxvk {
     DxvkPipelineLayoutFlags m_flags;
     VkPipelineBindPoint     m_bindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
 
-    uint32_t                                                        m_pushMask = 0u;
-    DxvkPushDataBlock                                               m_pushDataMerged;
-    std::array<DxvkPushDataBlock, DxvkPushDataBlock::MaxBlockCount> m_pushData = { };
-
-    VkDeviceSize            m_setMemorySize = 0u;
     std::array<const DxvkDescriptorSetLayout*, DxvkPipelineLayoutKey::MaxSets> m_setLayouts = { };
 
-    VkPipelineLayout        m_layout = VK_NULL_HANDLE;
+    struct {
+      VkPipelineLayout  layout = VK_NULL_HANDLE;
+    } m_legacy;
+
+    struct {
+      DxvkPushDataBlock mergedBlock = { };
+      uint32_t          blockMask   = 0u;
+      std::array<DxvkPushDataBlock, DxvkPushDataBlock::MaxBlockCount> blocks = { };
+    } m_pushData;
+
+    struct {
+      VkDeviceSize      setMemorySize = 0u;
+    } m_heap;
+
+    void initMetadata(
+      const DxvkPipelineLayoutKey&      key);
+
+    void initPipelineLayout(
+      const DxvkPipelineLayoutKey&      key);
 
   };
 

--- a/src/dxvk/dxvk_pipelayout.h
+++ b/src/dxvk/dxvk_pipelayout.h
@@ -887,7 +887,7 @@ namespace dxvk {
      * \returns Descriptor set layout
      */
     VkDescriptorSetLayout getSetLayout() const {
-      return m_layout;
+      return m_legacy.layout;
     }
 
     /**
@@ -895,7 +895,7 @@ namespace dxvk {
      * \returns Descriptor update template
      */
     VkDescriptorUpdateTemplate getSetUpdateTemplate() const {
-      return m_template;
+      return m_legacy.updateTemplate;
     }
 
     /**
@@ -903,7 +903,7 @@ namespace dxvk {
      * \returns Space required in descriptor heap
      */
     VkDeviceSize getMemorySize() const {
-      return m_memorySize;
+      return m_heap.memorySize;
     }
 
     /**
@@ -916,20 +916,23 @@ namespace dxvk {
     void update(
             void*                   dst,
       const DxvkDescriptor**        descriptors) const {
-      m_update.update(dst, descriptors);
+      m_heap.update.update(dst, descriptors);
     }
 
   private:
 
     DxvkDevice*                   m_device;
-    bool                          m_empty     = 0u;
+    bool                          m_empty     = false;
 
-    VkDeviceSize                  m_memorySize = 0u;
+    struct {
+      VkDescriptorSetLayout       layout          = VK_NULL_HANDLE;
+      VkDescriptorUpdateTemplate  updateTemplate  = VK_NULL_HANDLE;
+    } m_legacy;
 
-    VkDescriptorSetLayout         m_layout    = VK_NULL_HANDLE;
-    VkDescriptorUpdateTemplate    m_template  = VK_NULL_HANDLE;
-
-    DxvkDescriptorUpdateList      m_update;
+    struct {
+      VkDeviceSize                memorySize = 0u;
+      DxvkDescriptorUpdateList    update;
+    } m_heap;
 
     void initSetLayout(const DxvkDescriptorSetLayoutKey& key);
 

--- a/src/dxvk/dxvk_sampler.h
+++ b/src/dxvk/dxvk_sampler.h
@@ -188,10 +188,7 @@ namespace dxvk {
      * \returns Sampler handle
      */
     DxvkSamplerDescriptor getDescriptor() const {
-      DxvkSamplerDescriptor result = { };
-      result.samplerObject = m_sampler;
-      result.samplerIndex = m_index;
-      return result;
+      return m_descriptor;
     }
     
     /**
@@ -210,8 +207,7 @@ namespace dxvk {
     DxvkSamplerPool*      m_pool      = nullptr;
     DxvkSamplerKey        m_key       = { };
 
-    VkSampler             m_sampler   = VK_NULL_HANDLE;
-    uint16_t              m_index     = 0u;
+    DxvkSamplerDescriptor m_descriptor = { };
 
     DxvkSampler*          m_lruPrev   = nullptr;
     DxvkSampler*          m_lruNext   = nullptr;
@@ -263,11 +259,19 @@ namespace dxvk {
      * \brief Writes sampler descriptor to pool
      *
      * \param [in] index Sampler index
-     * \param [in] sampler Sampler object
+     * \param [in] createInfo Sampler create info
+     * \returns Sampler descriptor
      */
-    void writeDescriptor(
+    DxvkSamplerDescriptor createSampler(
             uint16_t              index,
-            VkSampler             sampler);
+      const VkSamplerCreateInfo*  createInfo);
+
+    /**
+     * \brief Frees a sampler
+     * \param [in] sampler Sampler descriptor
+     */
+    void freeSampler(
+            DxvkSamplerDescriptor sampler);
 
   private:
 

--- a/src/dxvk/dxvk_sampler.h
+++ b/src/dxvk/dxvk_sampler.h
@@ -322,7 +322,7 @@ namespace dxvk {
   public:
 
     // Lower limit for sampler counts in Vulkan.
-    constexpr static uint32_t MaxSamplerCount = 4000u;
+    constexpr static uint32_t MaxSamplerCount = 2048u;
 
     // Minimum number of samplers to keep alive.
     constexpr static uint32_t MinSamplerCount = 1024u;

--- a/src/dxvk/dxvk_sampler.h
+++ b/src/dxvk/dxvk_sampler.h
@@ -6,6 +6,7 @@
 #include "../util/thread.h"
 
 #include "dxvk_descriptor.h"
+#include "dxvk_descriptor_heap.h"
 #include "dxvk_hash.h"
 #include "dxvk_include.h"
 
@@ -228,7 +229,6 @@ namespace dxvk {
   struct DxvkSamplerDescriptorSet {
     VkDescriptorSet       set         = VK_NULL_HANDLE;
     VkDescriptorSetLayout layout      = VK_NULL_HANDLE;
-    VkDeviceAddress       gpuAddress  = 0u;
   };
 
 
@@ -237,21 +237,27 @@ namespace dxvk {
    *
    * Manages a global descriptor pool and set for samplers.
    */
-  class DxvkSamplerDescriptorPool {
+  class DxvkSamplerDescriptorHeap {
 
   public:
 
-    DxvkSamplerDescriptorPool(
+    DxvkSamplerDescriptorHeap(
             DxvkDevice*               device,
             uint32_t                  size);
 
-    ~DxvkSamplerDescriptorPool();
+    ~DxvkSamplerDescriptorHeap();
 
     /**
      * \brief Retrieves descriptor set and layout
      * \returns Descriptor set and layout handles
      */
     DxvkSamplerDescriptorSet getDescriptorSetInfo() const;
+
+    /**
+     * \brief Retrieves descriptor heap info
+     * \returns Sampler heap address and size
+     */
+    DxvkDescriptorHeapBindingInfo getDescriptorHeapInfo() const;
 
     /**
      * \brief Writes sampler descriptor to pool
@@ -265,20 +271,26 @@ namespace dxvk {
 
   private:
 
-    DxvkDevice*           m_device    = nullptr;
+    DxvkDevice* m_device          = nullptr;
+    uint32_t    m_descriptorCount = 0u;
 
-    VkDescriptorPool      m_pool      = VK_NULL_HANDLE;
-    VkDescriptorSetLayout m_setLayout = VK_NULL_HANDLE;
-    VkDescriptorSet       m_set       = VK_NULL_HANDLE;
+    struct {
+      VkDescriptorPool      pool      = VK_NULL_HANDLE;
+      VkDescriptorSetLayout setLayout = VK_NULL_HANDLE;
+      VkDescriptorSet       set       = VK_NULL_HANDLE;
 
-    Rc<DxvkBuffer>        m_buffer    = nullptr;
+    } m_legacy;
 
-    VkDeviceSize          m_descriptorOffset  = 0u;
-    VkDeviceSize          m_descriptorSize    = 0u;
+    struct {
+      Rc<DxvkBuffer>        buffer    = nullptr;
 
-    void initDescriptorLayout(uint32_t descriptorCount);
+      VkDeviceSize          descriptorOffset  = 0u;
+      VkDeviceSize          descriptorSize    = 0u;
+    } m_heap;
 
-    void initDescriptorPool(uint32_t descriptorCount);
+    void initDescriptorLayout();
+
+    void initDescriptorPool();
 
     void initDescriptorBuffer();
 
@@ -330,7 +342,15 @@ namespace dxvk {
      * \returns Global sampler descriptor set and layout
      */
     DxvkSamplerDescriptorSet getDescriptorSetInfo() const {
-      return m_descriptorPool.getDescriptorSetInfo();
+      return m_descriptorHeap.getDescriptorSetInfo();
+    }
+
+    /**
+     * \brief Retrieves descriptor heap info
+     * \returns Sampler heap address and size
+     */
+    DxvkDescriptorHeapBindingInfo getDescriptorHeapInfo() const {
+      return m_descriptorHeap.getDescriptorHeapInfo();
     }
 
     /**
@@ -350,7 +370,7 @@ namespace dxvk {
 
     DxvkDevice* m_device;
 
-    DxvkSamplerDescriptorPool m_descriptorPool;
+    DxvkSamplerDescriptorHeap m_descriptorHeap;
 
     dxvk::mutex m_mutex;
     std::unordered_map<DxvkSamplerKey,

--- a/src/dxvk/dxvk_util.h
+++ b/src/dxvk/dxvk_util.h
@@ -110,50 +110,6 @@ namespace dxvk::util {
 
 
   /**
-   * \brief Built-in shader stage helper
-   *
-   * Useful when creating built-in pipelines.
-   */
-  class DxvkBuiltInShaderStages {
-
-  public:
-
-    uint32_t count() const {
-      return m_stageCount;
-    }
-
-    const VkPipelineShaderStageCreateInfo* infos() const {
-      return m_stages.data();
-    }
-
-    template<size_t N>
-    void addStage(VkShaderStageFlagBits stage, const uint32_t (&code)[N], const VkSpecializationInfo* specInfo) {
-      auto& moduleInfo = m_modules.at(m_stageCount);
-      moduleInfo.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
-      moduleInfo.codeSize = sizeof(uint32_t) * N;
-      moduleInfo.pCode = &code[0];
-
-      auto& stageInfo = m_stages.at(m_stageCount);
-      stageInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
-      stageInfo.pNext = &moduleInfo;
-      stageInfo.stage = stage;
-      stageInfo.pName = "main";
-      stageInfo.pSpecializationInfo = specInfo;
-
-      m_stageCount += 1u;
-    }
-
-  private:
-
-    uint32_t m_stageCount = 0u;
-
-    std::array<VkShaderModuleCreateInfo, 3>         m_modules = { };
-    std::array<VkPipelineShaderStageCreateInfo, 3>  m_stages  = { };
-
-  };
-
-
-  /**
    * \brief Gets pipeline stage flags for shader stages
    * 
    * \param [in] shaderStages Shader stage flags


### PR DESCRIPTION
To address some fallout from the descriptor buffer merge:
- Disable on ANV due to random perf loss
- Disable NV_raw_access_chains for byte address buffers to work around a hang
- Use smaller sampler set to fix NV performance with both binding models
- Couple of (largely cosmetic) changes to separate descriptor buffer-specific stuff from legacy model stuff