### PR TITLE
[dxvk] Do not use scalar push constant layouts in built-in shaders

### DIFF
--- a/src/dxvk/dxvk_adapter.cpp
+++ b/src/dxvk/dxvk_adapter.cpp
@@ -366,7 +366,6 @@ namespace dxvk {
 
     // Used for better constant array packing in some cases
     enabledFeatures.vk12.uniformBufferStandardLayout = VK_TRUE;
-    enabledFeatures.vk12.scalarBlockLayout = VK_TRUE;
 
     // Required internally
     enabledFeatures.vk12.bufferDeviceAddress = VK_TRUE;

--- a/src/dxvk/shaders/dxvk_blit_frag_1d.frag
+++ b/src/dxvk/shaders/dxvk_blit_frag_1d.frag
@@ -9,15 +9,15 @@ layout(set = 1, binding = 0) uniform texture1DArray s_texture;
 layout(location = 0) in  vec2 i_pos;
 layout(location = 0) out vec4 o_color;
 
-layout(push_constant, scalar)
+layout(push_constant)
 uniform push_block {
-  vec3 p_src_coord0;
-  vec3 p_src_coord1;
+  float p_src_coord0_x, p_src_coord0_y, p_src_coord0_z;
+  float p_src_coord1_x, p_src_coord1_y, p_src_coord1_z;
   uint p_layer_count;
   uint p_sampler;
 };
 
 void main() {
-  float coord = mix(p_src_coord0.x, p_src_coord1.x, i_pos.x);
+  float coord = mix(p_src_coord0_x, p_src_coord1_x, i_pos.x);
   o_color = texture(sampler1DArray(s_texture, s_samplers[p_sampler]), vec2(coord, gl_Layer));
 }

--- a/src/dxvk/shaders/dxvk_blit_frag_2d.frag
+++ b/src/dxvk/shaders/dxvk_blit_frag_2d.frag
@@ -9,15 +9,18 @@ layout(set = 1, binding = 0) uniform texture2DArray s_texture;
 layout(location = 0) in  vec2 i_pos;
 layout(location = 0) out vec4 o_color;
 
-layout(push_constant, scalar)
+layout(push_constant)
 uniform push_block {
-  vec3 p_src_coord0;
-  vec3 p_src_coord1;
+  float p_src_coord0_x, p_src_coord0_y, p_src_coord0_z;
+  float p_src_coord1_x, p_src_coord1_y, p_src_coord1_z;
   uint p_layer_count;
   uint p_sampler;
 };
 
 void main() {
-  vec2 coord = mix(p_src_coord0.xy, p_src_coord1.xy, i_pos);
+  vec2 coord = mix(
+    vec2(p_src_coord0_x, p_src_coord0_y),
+    vec2(p_src_coord1_x, p_src_coord1_y), i_pos);
+
   o_color = texture(sampler2DArray(s_texture, s_samplers[p_sampler]), vec3(coord, gl_Layer));
 }

--- a/src/dxvk/shaders/dxvk_blit_frag_3d.frag
+++ b/src/dxvk/shaders/dxvk_blit_frag_3d.frag
@@ -9,16 +9,19 @@ layout(set = 1, binding = 0) uniform texture3D s_texture;
 layout(location = 0) in  vec2 i_pos;
 layout(location = 0) out vec4 o_color;
 
-layout(push_constant, scalar)
+layout(push_constant)
 uniform push_block {
-  vec3 p_src_coord0;
-  vec3 p_src_coord1;
+  float p_src_coord0_x, p_src_coord0_y, p_src_coord0_z;
+  float p_src_coord1_x, p_src_coord1_y, p_src_coord1_z;
   uint p_layer_count;
   uint p_sampler;
 };
 
 void main() {
-  vec3 coord = mix(p_src_coord0, p_src_coord1,
+  vec3 coord = mix(
+    vec3(p_src_coord0_x, p_src_coord0_y, p_src_coord0_z),
+    vec3(p_src_coord1_x, p_src_coord1_y, p_src_coord1_z),
     vec3(i_pos, (float(gl_Layer) + 0.5f) / float(p_layer_count)));
+
   o_color = texture(sampler3D(s_texture, s_samplers[p_sampler]), coord);
 }


### PR DESCRIPTION
Sigh. Should fix #4965.