### PR TITLE
This PR adds missing documentation for the DXVK_FILTER_DEVICE_UUID environment variable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ The `DXVK_FRAME_RATE` environment variable can be used to limit the frame rate. 
 ### Device filter
 Some applications do not provide a method to select a different GPU. In that case, DXVK can be forced to use a given device:
 - `DXVK_FILTER_DEVICE_NAME="Device Name"` Selects devices with a matching Vulkan device name, which can be retrieved with tools such as `vulkaninfo`. Matches on substrings, so "VEGA" or "AMD RADV VEGA10" is supported if the full device name is "AMD RADV VEGA10 (LLVM 9.0.0)", for example. If the substring matches more than one device, the first device matched will be used.
+- `DXVK_FILTER_DEVICE_UUID="00000000000000000000000000000001"` Selects a device by matching its Vulkan device UUID, which can also be retrieved using tools such as `vulkaninfo`. The UUID must be a 32-character hexadecimal string with no dashes. This method provides more precise selection, especially when using multiple identical GPUs.
 
 **Note:** If the device filter is configured incorrectly, it may filter out all devices and applications will be unable to create a D3D device.
 


### PR DESCRIPTION
I previously added support for DXVK_FILTER_DEVICE_UUID to allow selecting a GPU by its Vulkan device UUID. This PR just updates the README to document it, forgot to include it earlier. Thanks.