### PR TITLE
[dxvk] Call providers' initDeviceExtensions with initialized adapters

### DIFF
--- a/src/dxvk/dxvk_instance.cpp
+++ b/src/dxvk/dxvk_instance.cpp
@@ -56,9 +56,6 @@ namespace dxvk {
     if (!initVulkanInstance(args, flags))
       throw DxvkError("Failed to initialize DXVK.");
 
-    for (const auto& provider : m_extProviders)
-      provider->initDeviceExtensions(this);
-
     if (!initAdapters())
       throw DxvkError("Failed to initialize DXVK.");
   }
@@ -310,11 +307,6 @@ namespace dxvk {
         else if (deviceProperties[i].deviceType == VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU)
           numIGPU += 1;
 
-        for (const auto& provider : m_extProviders) {
-          adapter->enableExtensions(
-            provider->getDeviceExtensions(i));
-        }
-
         m_adapters.push_back(std::move(adapter));
       }
     }
@@ -350,6 +342,12 @@ namespace dxvk {
         VK_API_VERSION_MAJOR(DxvkVulkanApiVersion), ".",
         VK_API_VERSION_MINOR(DxvkVulkanApiVersion), " capable setup is required."));
       return false;
+    }
+
+    for (const auto& provider : m_extProviders) {
+      provider->initDeviceExtensions(this);
+      for (uint32_t i = 0; enumAdapters(i) != nullptr; i++)
+        enumAdapters(i)->enableExtensions(provider->getDeviceExtensions(i));
     }
 
     if (numDGPU == 1u && numIGPU == 1u)


### PR DESCRIPTION
Turns out we have 32 bit OpenVR spectacularly double broken in Proton now. One problem was introduced recently in Proton's vrclient (right now fixed in Proton Experimental [bleeding-edge] only, another is from recent dxvk commit 1ef2801d41c64629198e1d4626068842e3f0d6e9 .

The problem is that initDeviceExtensions for OpenVR provider depends on the adapters array being initialized, without that it can't get adapter ids and doesn't query any extensions.

That happens to work on 64 bit because of OpenXR initialization which effectively delivers the same set of native Vulkan extensions and initDeviceExtensions for OpenXR provider doesn't use dxvk adapters. But 32 bit wineopenxr is non-existent and the problem becomes apparent with 32 bit OpenVR / d3d11 games.