### PR TITLE
Fix OSU crash due to null pointer in the backend

### DIFF
--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -3645,7 +3645,6 @@ namespace dxvk {
       // D3D9 doesn't actually unbind any vertex buffer when passing null.
       // Operation Flashpoint: Red River relies on this behavior.
       needsUpdate = false;
-      vbo.offset = 0;
     }
 
     if (needsUpdate)

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -493,6 +493,12 @@ namespace dxvk {
       ResetState(pPresentationParameters);
       m_implicitSwapchain->DestroyBackBuffers();
       m_autoDepthStencil = nullptr;
+
+      // Tests show that regular D3D9 ends the scene in Reset
+      // while D3D9Ex doesn't.
+      // Observed in Empires: Dawn of the Modern World (D3D8)
+      // and the OSU compatibility mode (D3D9Ex).
+      m_flags.clr(D3D9DeviceFlag::InScene);
     } else {
       // Extended devices only reset the bound render targets
       for (uint32_t i = 0; i < caps::MaxSimultaneousRenderTargets; i++) {
@@ -501,7 +507,6 @@ namespace dxvk {
       SetDepthStencilSurface(nullptr);
     }
 
-    m_flags.clr(D3D9DeviceFlag::InScene);
     m_cursor.ResetCursor();
 
     /*

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -6953,6 +6953,8 @@ namespace dxvk {
 
       m_renderPassBarrierSrc.stages |= VK_PIPELINE_STAGE_VERTEX_INPUT_BIT;
       m_renderPassBarrierSrc.access |= VK_ACCESS_INDEX_READ_BIT;
+
+      m_cmd->track(m_state.vi.indexBuffer.buffer(), DxvkAccess::Read);
     } else if (m_device->features().khrMaintenance6.maintenance6) {
       // Bind null index buffer to read all zeroes, not too useful but well-defined
       m_cmd->cmdBindIndexBuffer2(VK_NULL_HANDLE, 0, VK_WHOLE_SIZE, m_state.vi.indexType);
@@ -6963,8 +6965,6 @@ namespace dxvk {
       m_cmd->cmdBindIndexBuffer2(bufferInfo.buffer,
         bufferInfo.offset, bufferInfo.size, m_state.vi.indexType);
     }
-
-    m_cmd->track(m_state.vi.indexBuffer.buffer(), DxvkAccess::Read);
   }
   
   


### PR DESCRIPTION
Doesn't fi.x #4769 but still has some good stuff.

The backend commit should probably be backported to the v2.6.x branch.
I'll do that after the merge.