### PR TITLE
[d3d9/dxgi] Add a force refresh rate config option

### DIFF
--- a/dxvk.conf
+++ b/dxvk.conf
@@ -694,6 +694,26 @@
 
 # d3d9.forceAspectRatio = ""
 
+# Force Refresh Rate
+#
+# Only exposes modes with a given refresh rate.
+# Useful for titles such as
+# Metal Gear Rising: Revengeance, that select
+# the lowest supported refresh rate. A value
+# of 0 will disable the option.
+#
+# Note that many titles are known to break in
+# various ways (physics, rendering, etc.) when
+# forcing high refresh rates. USE WITH CAUTION.
+#
+# Please do not report issues with this option.
+#
+# Supported values:
+# - Any integer refresh rate value in Hz, ie. 60, 120
+
+# dxgi.forceRefreshRate = 0
+# d3d9.forceRefreshRate = 0
+
 # Enumerate by Displays
 #
 # Whether we should enumerate D3D9 adapters by display (windows behaviour)

--- a/src/d3d8/d3d8_interface.h
+++ b/src/d3d8/d3d8_interface.h
@@ -17,13 +17,18 @@ namespace dxvk {
   */
   class D3D8Interface final : public ComObjectClamp<IDirect3D8> {
 
+    // These must be valid render target formats, and as per the
+    // D3D8 documentation: "Render target formats are restricted to
+    // D3DFMT_X1R5G5B5, D3DFMT_R5G6B5, D3DFMT_X8R8G8B8, and D3DFMT_A8R8G8B8."
+    //
+    // Additionally, the documentation states: "Applications should not
+    // specify a DisplayFormat that contains an alpha channel."
+    //
+    // While D3DFMT_X1R5G5B5 is technically valid, no drivers list
+    // modes for it, therefore including it in caching queries is redundant.
     static constexpr d3d9::D3DFORMAT ADAPTER_FORMATS[] = {
-      d3d9::D3DFMT_A1R5G5B5,
-      //d3d9::D3DFMT_A2R10G10B10, (not in D3D8)
-      d3d9::D3DFMT_A8R8G8B8,
-      d3d9::D3DFMT_R5G6B5,
-      d3d9::D3DFMT_X1R5G5B5,
-      d3d9::D3DFMT_X8R8G8B8
+      d3d9::D3DFMT_X8R8G8B8,
+      d3d9::D3DFMT_R5G6B5
     };
 
   public:

--- a/src/d3d9/d3d9_adapter.h
+++ b/src/d3d9/d3d9_adapter.h
@@ -100,6 +100,10 @@ namespace dxvk {
 
     void CacheModes(D3D9Format Format);
 
+    void FilterModesByFormat(
+          D3D9Format Format,
+          const bool ApplyOptionsFilter);
+
     void CacheIdentifierInfo();
 
     D3D9InterfaceEx*              m_parent;

--- a/src/d3d9/d3d9_options.cpp
+++ b/src/d3d9/d3d9_options.cpp
@@ -62,6 +62,7 @@ namespace dxvk {
     this->forceSwapchainMSAA            = config.getOption<int32_t>     ("d3d9.forceSwapchainMSAA",            -1);
     this->forceSampleRateShading        = config.getOption<bool>        ("d3d9.forceSampleRateShading",        false);
     this->forceAspectRatio              = config.getOption<std::string> ("d3d9.forceAspectRatio",              "");
+    this->forceRefreshRate              = config.getOption<int32_t>     ("d3d9.forceRefreshRate",              0u);
     this->enumerateByDisplays           = config.getOption<bool>        ("d3d9.enumerateByDisplays",           true);
     this->cachedDynamicBuffers          = config.getOption<bool>        ("d3d9.cachedDynamicBuffers",          false);
     this->deviceLocalConstantBuffers    = config.getOption<bool>        ("d3d9.deviceLocalConstantBuffers",    false);

--- a/src/d3d9/d3d9_options.h
+++ b/src/d3d9/d3d9_options.h
@@ -106,6 +106,9 @@ namespace dxvk {
     /// Forced aspect ratio, disable other modes
     std::string forceAspectRatio;
 
+    /// Forced refresh rate, disable other modes
+    uint32_t forceRefreshRate;
+
     /// Always use a spec constant to determine sampler type (instead of just in PS 1.x)
     /// Works around a game bug in Halo CE where it gives cube textures to 2d/volume samplers
     bool forceSamplerTypeSpecConstants;

--- a/src/dxgi/dxgi_options.cpp
+++ b/src/dxgi/dxgi_options.cpp
@@ -90,8 +90,9 @@ namespace dxvk {
     this->maxDeviceMemory = VkDeviceSize(config.getOption<int32_t>("dxgi.maxDeviceMemory", 0)) << 20;
     this->maxSharedMemory = VkDeviceSize(config.getOption<int32_t>("dxgi.maxSharedMemory", 0)) << 20;
 
-    this->maxFrameRate = config.getOption<int32_t>("dxgi.maxFrameRate", 0);
-    this->syncInterval = config.getOption<int32_t>("dxgi.syncInterval", -1);
+    this->maxFrameRate     = config.getOption<int32_t>("dxgi.maxFrameRate", 0);
+    this->syncInterval     = config.getOption<int32_t>("dxgi.syncInterval", -1);
+    this->forceRefreshRate = config.getOption<int32_t>("dxgi.forceRefreshRate", 0u);
 
     // We don't support dcomp swapchains and some games may rely on them failing on creation
     this->enableDummyCompositionSwapchain = config.getOption<bool>("dxgi.enableDummyCompositionSwapchain", false);

--- a/src/dxgi/dxgi_options.h
+++ b/src/dxgi/dxgi_options.h
@@ -55,6 +55,9 @@ namespace dxvk {
     /// Sync interval. Overrides the value
     /// passed to IDXGISwapChain::Present.
     int32_t syncInterval;
+
+    /// Forced refresh rate, disable other modes
+    uint32_t forceRefreshRate;
   };
   
 }

--- a/src/dxgi/dxgi_output.cpp
+++ b/src/dxgi/dxgi_output.cpp
@@ -24,9 +24,10 @@ namespace dxvk {
     const Com<DxgiFactory>& factory,
     const Com<DxgiAdapter>& adapter,
               HMONITOR      monitor)
-  : m_monitorInfo(factory->GetMonitorInfo()),
-    m_adapter(adapter),
-    m_monitor(monitor) {
+  : m_factory     ( factory ),
+    m_adapter     ( adapter ),
+    m_monitorInfo ( factory->GetMonitorInfo() ),
+    m_monitor     ( monitor ) {
     CacheMonitorData();
   }
   
@@ -165,7 +166,13 @@ namespace dxvk {
     std::vector<DXGI_MODE_DESC1> modes(modeCount);
     GetDisplayModeList1(targetFormat, DXGI_ENUM_MODES_SCALING, &modeCount, modes.data());
 
-    FilterModesByDesc(modes, *pModeToMatch);
+    const DxgiOptions* options = m_factory->GetOptions();
+
+    DXGI_MODE_DESC1 modeToMatch = *pModeToMatch;
+    if (options->forceRefreshRate)
+      modeToMatch.RefreshRate = {options->forceRefreshRate, 1u};
+
+    FilterModesByDesc(modes, modeToMatch);
     FilterModesByDesc(modes, defaultMode);
 
     if (modes.empty())
@@ -175,11 +182,12 @@ namespace dxvk {
 
     Logger::debug(str::format(
       "DXGI: For mode ",
-        pModeToMatch->Width, "x", pModeToMatch->Height, "@",
-        pModeToMatch->RefreshRate.Denominator ? (pModeToMatch->RefreshRate.Numerator / pModeToMatch->RefreshRate.Denominator) : 0,
+        modeToMatch.Width, "x", modeToMatch.Height, "@",
+        modeToMatch.RefreshRate.Denominator ? (modeToMatch.RefreshRate.Numerator / modeToMatch.RefreshRate.Denominator) : 0,
       " found closest mode ",
         pClosestMatch->Width, "x", pClosestMatch->Height, "@",
         pClosestMatch->RefreshRate.Denominator ? (pClosestMatch->RefreshRate.Numerator / pClosestMatch->RefreshRate.Denominator) : 0));
+
     return S_OK;
   }
 

--- a/src/dxgi/dxgi_output.h
+++ b/src/dxgi/dxgi_output.h
@@ -129,9 +129,10 @@ namespace dxvk {
 
   private:
     
+    Com<DxgiFactory> m_factory;
+    Com<DxgiAdapter> m_adapter;
     DxgiMonitorInfo* m_monitorInfo = nullptr;
-    Com<DxgiAdapter> m_adapter = nullptr;
-    HMONITOR         m_monitor = nullptr;
+    HMONITOR         m_monitor     = nullptr;
 
     wsi::WsiDisplayMetadata m_metadata = {};
 


### PR DESCRIPTION
Closes #4421, although it's not directly meant to enable people into forcing higher refresh rates, it can be used for that too.

It's more useful to fix situations where stubborn games force the lowest refresh rate available, by limiting the listed modes to only a single refresh rate. Drafted until I've tested it a bit more.

P.S.: I've kept it in line with how the forceAspectRatio option behaves, but we can potentially make this a bit more clever (to support stuff like "max" as well), though hhhhnnnggggg, it certainly has the potential to explode on certain setups, I think.