### PR TITLE
[d3d9] Add a modeCountCompatibility config option

### DIFF
--- a/dxvk.conf
+++ b/dxvk.conf
@@ -707,6 +707,23 @@
 # dxgi.forceRefreshRate = 0
 # d3d9.forceRefreshRate = 0
 
+# Mode Count Compatibility
+#
+# Attempts to aggressively limit the advertised mode count
+# by only listing the current desktop resolution and refresh
+# rate, along with a minimal list of fallback resolutions.
+#
+# Useful for titles that encounter issues when too many modes
+# are reported, e.g., AquaNox, AquaNox 2: Revelation.
+#
+# Can be used in conjunction with forceAspectRatio
+# and forceRefreshRate to further restrict reported modes.
+#
+# Supported values:
+# - True/False
+
+# d3d9.modeCountCompatibility = False
+
 # Enumerate by Displays
 #
 # Whether we should enumerate D3D9 adapters by display (windows behaviour)

--- a/src/d3d9/d3d9_adapter.h
+++ b/src/d3d9/d3d9_adapter.h
@@ -7,6 +7,8 @@
 
 #include "../dxvk/dxvk_adapter.h"
 
+#include "../wsi/wsi_monitor.h"
+
 namespace dxvk {
 
   class D3D9InterfaceEx;
@@ -101,6 +103,26 @@ namespace dxvk {
     bool IsD3D8Compatible() const;
 
   private:
+
+    // used as a global filter when mode count compatibility is enabled
+    inline bool IsCountCompatibleMode(const wsi::WsiMode& wsiMode) {
+      if (wsiMode.refreshRate.numerator / wsiMode.refreshRate.denominator != 60)
+        return false;
+
+      return (wsiMode.width == 640  && wsiMode.height == 480)
+          || (wsiMode.width == 800  && wsiMode.height == 600)
+          || (wsiMode.width == 1024 && wsiMode.height == 768)
+          || (wsiMode.width == 1280 && wsiMode.height == 1024)
+          || (wsiMode.width == 1280 && wsiMode.height == 720)
+          || (wsiMode.width == 1920 && wsiMode.height == 1080);
+    }
+
+    inline bool IsEquivalentMode(const wsi::WsiMode& wsiModeA, const wsi::WsiMode& wsiModeB) {
+      return wsiModeA.width  == wsiModeB.width  &&
+             wsiModeA.height == wsiModeB.height &&
+             (wsiModeA.refreshRate.numerator / wsiModeA.refreshRate.denominator ==
+              wsiModeB.refreshRate.numerator / wsiModeB.refreshRate.denominator);
+    }
 
     HRESULT CheckDeviceVkFormat(
           VkFormat        Format,

--- a/src/d3d9/d3d9_options.cpp
+++ b/src/d3d9/d3d9_options.cpp
@@ -62,6 +62,7 @@ namespace dxvk {
     this->forceSampleRateShading        = config.getOption<bool>        ("d3d9.forceSampleRateShading",        false);
     this->forceAspectRatio              = config.getOption<std::string> ("d3d9.forceAspectRatio",              "");
     this->forceRefreshRate              = config.getOption<int32_t>     ("d3d9.forceRefreshRate",              0u);
+    this->modeCountCompatibility        = config.getOption<bool>        ("d3d9.modeCountCompatibility",        false);
     this->enumerateByDisplays           = config.getOption<bool>        ("d3d9.enumerateByDisplays",           true);
     this->cachedDynamicBuffers          = config.getOption<bool>        ("d3d9.cachedDynamicBuffers",          false);
     this->deviceLocalConstantBuffers    = config.getOption<bool>        ("d3d9.deviceLocalConstantBuffers",    false);

--- a/src/d3d9/d3d9_options.h
+++ b/src/d3d9/d3d9_options.h
@@ -109,6 +109,9 @@ namespace dxvk {
     /// Forced refresh rate, disable other modes
     uint32_t forceRefreshRate;
 
+    /// Restrict the mode count to ensure a maximum total count of 24
+    bool modeCountCompatibility;
+
     /// Always use a spec constant to determine sampler type (instead of just in PS 1.x)
     /// Works around a game bug in Halo CE where it gives cube textures to 2d/volume samplers
     bool forceSamplerTypeSpecConstants;

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -1069,6 +1069,11 @@ namespace dxvk {
     { R"(\\Perilous Warp\\system(64)?\\game\.exe$)", {{
       { "d3d9.hideNvidiaGpu",               "True" },
     }} },
+    /* AquaNox 2: Does not start if too many      *
+     * modes/resolutions are advertised           */
+    { R"(\\AN2\.dat$)", {{
+      { "d3d9.modeCountCompatibility",      "True" },
+    }} },
 
     /**********************************************/
     /* D3D8 GAMES                                 */
@@ -1264,6 +1269,11 @@ namespace dxvk {
       { "d3d9.customVendorId",              "10de" },
       { "d3d9.customDeviceId",              "0250" },
       { "d3d9.customDeviceDesc", "NVIDIA GeForce4 Ti 4600" },
+    }} },
+    /* AquaNox: Does not start if too many        *
+     * modes/resolutions are advertised           */
+    { R"(\\Aqua\.exe$)", {{
+      { "d3d9.modeCountCompatibility",      "True" },
     }} },
   };
 


### PR DESCRIPTION
I've resurrected this, because the problem with the AquaNox games has come back to bite me even on my most recent Lunar Lake laptop. It seems that laptops in general (their screens in particular) simply expose too many modes for some games to be happy.

That can usually manifest as:
- higher resolutions are missing from in-game mode selection options
- lower resolutions get cut, which sometimes breaks the first-run configurations of games
- games overflow in their mode count logic and crash or refuse to start

There's always the option of coming up with an allow list of resolutions, similarly to how certain drivers apparently reduce excessive mode counts, but I'd rather have something user configurable, as we can't possibly account for all preferences and hardware combinations.

Edit: Revised version fixes #3255