### PR TITLE
[util] Disable direct image mapping for LEGO City Undercover

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -60,7 +60,7 @@ namespace dxvk {
     /* D3D11 GAMES                                */
     /**********************************************/
 
-    /* Batman Arkham Knight - doesn't like intel vendor id 
+    /* Batman Arkham Knight - doesn't like intel vendor id
       (refuses to boot if vendor isn't 0x10de or 0x1002)  */
     { R"(\\BatmanAK\.exe$)", {{
       { "dxgi.hideIntelGpu",                "True" },
@@ -427,12 +427,12 @@ namespace dxvk {
     { R"(\\EDF6\.exe$)", {{
       { "d3d11.enableContextLock",          "True" },
     }} },
-    /* Kena: Bridge of Spirits: intel water       * 
+    /* Kena: Bridge of Spirits: intel water       *
      * flickering issues                          */
     { R"(\\Kena-Win64-Shipping\.exe$)", {{
       { "dxgi.hideIntelGpu",                 "True" },
     }} },
-    /* GTA Definitive Edition trilogy             * 
+    /* GTA Definitive Edition trilogy             *
      * Static ags crash with HDR support          */
     { R"(\\(LibertyCity|ViceCity|SanAndreas)\.exe$)", {{
       { "dxgi.enableUe4Workarounds",        "True" },
@@ -460,6 +460,11 @@ namespace dxvk {
     /* Rocketbirds 2: Ignores row pitch for mapped *
      * images, corrupting intro video              */
     { R"(\\Rocketbirds 2\\Game\.exe$)", {{
+      { "d3d11.disableDirectImageMapping",  "True" },
+    }} },
+    /* LEGO City Undercover                        *
+     * Fixes graphical corruption on cutscenes     */
+    { R"(\\LEGOLCUR_DX11\.exe$)", {{
       { "d3d11.disableDirectImageMapping",  "True" },
     }} },
 
@@ -923,17 +928,17 @@ namespace dxvk {
     }} },
     /* STAR WARS: The Force Unleashed            *
      * Prevents black screen on each alt-tab     */
-    { R"(\\SWTFU\.exe$)", {{ 
+    { R"(\\SWTFU\.exe$)", {{
       { "d3d9.deviceLossOnFocusLoss",       "True" },
     }} },
     /* Fallout New Vegas - Various visual issues *
      * with mods such as New Vegas Reloaded      */
-    { R"(\\FalloutNV\.exe$)", {{ 
+    { R"(\\FalloutNV\.exe$)", {{
       { "d3d9.floatEmulation",              "Strict" },
     }} },
     /* Dungeons and Dragons: Dragonshard         *
      * Massive FPS decreases in some scenes      */
-    { R"(\\Dragonshard\.exe$)", {{ 
+    { R"(\\Dragonshard\.exe$)", {{
       { "d3d9.cachedDynamicBuffers",        "True" },
     }} },
     /* Battle for Middle-earth 2 and expansion   *


### PR DESCRIPTION
Closes #4997 