### PR TITLE
Fix crash with in destroySwapchain with nullptr m_swapchain

### DIFF
--- a/src/dxvk/dxvk_presenter.cpp
+++ b/src/dxvk/dxvk_presenter.cpp
@@ -1180,7 +1180,8 @@ namespace dxvk {
       m_vkd->vkDestroyFence(m_vkd->device(), sem.fence, nullptr);
     }
 
-    m_vkd->vkDestroySwapchainKHR(m_vkd->device(), m_swapchain, nullptr);
+    if (m_swapchain)
+      m_vkd->vkDestroySwapchainKHR(m_vkd->device(), m_swapchain, nullptr);
 
     m_images.clear();
     m_semaphores.clear();


### PR DESCRIPTION
Fix crash (in Bandicam/other Vulkan layers) when destroySwapchain is  called but m_swapchain is already null. Hit this pretty quickly with bandicam and the Superposition demo.