### PR TITLE
Enable descriptor buffers on ANV

### DIFF
--- a/src/dxvk/dxvk_device_info.cpp
+++ b/src/dxvk/dxvk_device_info.cpp
@@ -421,6 +421,7 @@ namespace dxvk {
                                  || m_properties.vk12.driverID == VK_DRIVER_ID_AMD_PROPRIETARY
                                  || m_properties.vk12.driverID == VK_DRIVER_ID_MESA_NVK
                                  || m_properties.vk12.driverID == VK_DRIVER_ID_NVIDIA_PROPRIETARY
+                                 || m_properties.vk12.driverID == VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA
                                  || m_properties.vk12.driverID == VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS
                                  || m_properties.vk12.driverID == VK_DRIVER_ID_MESA_LLVMPIPE;
 


### PR DESCRIPTION
Draft because we really need more data here.