### PR TITLE
[d3d9] Rework render target binding logic

### DIFF
--- a/src/d3d9/d3d9_caps.h
+++ b/src/d3d9/d3d9_caps.h
@@ -31,5 +31,6 @@ namespace dxvk::caps {
 
   constexpr uint32_t MaxTexturesVS                = 4;
   constexpr uint32_t MaxTexturesPS                = 16;
+  constexpr uint32_t MaxTextures                  = MaxTexturesVS + MaxTexturesPS + 1; // 1 additional texture for the dmap sampler
 
 }

--- a/src/d3d9/d3d9_common_texture.cpp
+++ b/src/d3d9/d3d9_common_texture.cpp
@@ -698,6 +698,10 @@ namespace dxvk {
     if (unlikely(m_mapMode == D3D9_COMMON_TEXTURE_MAP_MODE_SYSTEMMEM))
       return;
 
+    // The backend will ignore the view layout anyway for images
+    // that have GENERAL (or FEEDBACK_LOOP) as their layout.
+    // This will always be the case for images that can be sampled.
+    // So just pick UNDEFINED here.
     m_sampleView.Color = CreateView(AllLayers, Lod,
       VK_IMAGE_USAGE_SAMPLED_BIT, VK_IMAGE_LAYOUT_UNDEFINED, false);
 

--- a/src/d3d9/d3d9_common_texture.h
+++ b/src/d3d9/d3d9_common_texture.h
@@ -353,16 +353,6 @@ namespace dxvk {
       return m_sampleView.Pick(srgb && IsSrgbCompatible());
     }
 
-    VkImageLayout DetermineRenderTargetLayout(VkImageLayout hazardLayout) const {
-      if (unlikely(m_transitionedToHazardLayout))
-        return hazardLayout;
-
-      return m_image != nullptr &&
-             m_image->info().tiling == VK_IMAGE_TILING_OPTIMAL
-        ? VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL
-        : VK_IMAGE_LAYOUT_GENERAL;
-    }
-
     Rc<DxvkImageView> CreateView(
             UINT                   Layer,
             UINT                   Lod,

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -3858,26 +3858,17 @@ namespace dxvk {
       m_textureSlotTracking.mismatchingTextureType &= ~newShaderMasks.samplerMask;
     }
 
-    // If we have any RTs we would have bound to the the FB
-    // not in the new shader mask, mark the framebuffer as dirty
-    // so we unbind them.
-    uint32_t boundMask = 0u;
-    uint32_t anyColorWriteMask = 0u;
-    for (uint32_t i = 0u; i < m_state.renderTargets.size(); i++) {
-      boundMask |= HasRenderTargetBound(i) << i;
-      anyColorWriteMask |= (m_state.renderStates[ColorWriteIndex(i)] != 0) << i;
-    }
+    // Check whether the color output mask or the mask of the used samplers
+    // forces us to deal with hazards in a different way.
+    if (likely(oldShaderMasks.samplerMask != newShaderMasks.samplerMask ||
+      oldShaderMasks.rtMask != newShaderMasks.rtMask))
+      UpdateActiveHazardsRT(
+        oldShaderMasks.rtMask | newShaderMasks.rtMask,
+        oldShaderMasks.samplerMask | newShaderMasks.samplerMask
+      );
 
-    uint32_t oldUseMask = boundMask & anyColorWriteMask & oldShaderMasks.rtMask;
-    uint32_t newUseMask = boundMask & anyColorWriteMask & newShaderMasks.rtMask;
-    if (oldUseMask != newUseMask)
-      m_flags.set(D3D9DeviceFlag::DirtyFramebuffer);
-
-    if (oldShaderMasks.samplerMask != newShaderMasks.samplerMask ||
-        oldShaderMasks.rtMask != newShaderMasks.rtMask) {
-      UpdateActiveHazardsRT(std::numeric_limits<uint32_t>::max());
-      UpdateActiveHazardsDS(std::numeric_limits<uint32_t>::max());
-    }
+    if (likely(oldShaderMasks.samplerMask != newShaderMasks.samplerMask))
+      UpdateActiveHazardsDS(oldShaderMasks.samplerMask | newShaderMasks.samplerMask);
 
     return D3D_OK;
   }
@@ -6156,11 +6147,10 @@ namespace dxvk {
     m_rtSlotTracking.canBeSampled &= ~bit;
 
     if (HasRenderTargetBound(index) &&
-        m_state.renderTargets[index]->GetBaseTexture() != nullptr &&
-        m_state.renderStates[ColorWriteIndex(index)] != 0)
+      m_state.renderTargets[index]->GetBaseTexture() != nullptr)
       m_rtSlotTracking.canBeSampled |= bit;
 
-    UpdateActiveHazardsRT(bit);
+    UpdateActiveHazardsRT(bit, std::numeric_limits<uint32_t>::max());
   }
 
   template <uint32_t Index>
@@ -6182,9 +6172,9 @@ namespace dxvk {
 
     m_textureSlotTracking.rtUsage                &= ~bit;
     m_textureSlotTracking.dsUsage                &= ~bit;
-    m_textureSlotTracking.bound                   &= ~bit;
-    m_textureSlotTracking.needsUpload             &= ~bit;
-    m_textureSlotTracking.needsMipGen             &= ~bit;
+    m_textureSlotTracking.bound                  &= ~bit;
+    m_textureSlotTracking.needsUpload            &= ~bit;
+    m_textureSlotTracking.needsMipGen            &= ~bit;
     m_textureSlotTracking.mismatchingTextureType &= ~bit;
 
     auto tex = GetCommonTexture(m_state.textures[index]);
@@ -6245,22 +6235,35 @@ namespace dxvk {
         UpdateActiveFetch4(index);
     }
 
-    if (unlikely(combinedUsage & D3DUSAGE_RENDERTARGET))
-      UpdateActiveHazardsRT(bit);
+    if (unlikely(combinedUsage & D3DUSAGE_RENDERTARGET)) {
+      UpdateActiveHazardsRT(std::numeric_limits<uint32_t>::max(), bit);
+    } else {
+      m_textureSlotTracking.hazardRT             &= ~bit;
+      m_textureSlotTracking.unresolvableHazardRT &= ~bit;
+    }
 
-    if (unlikely(combinedUsage & D3DUSAGE_DEPTHSTENCIL))
+    if (unlikely(combinedUsage & D3DUSAGE_DEPTHSTENCIL)) {
       UpdateActiveHazardsDS(bit);
+    } else {
+      m_textureSlotTracking.hazardDS             &= ~bit;
+      m_textureSlotTracking.unresolvableHazardDS &= ~bit;
+    }
   }
 
 
-  inline void D3D9DeviceEx::UpdateActiveHazardsRT(uint32_t texMask) {
-    auto masks = PSShaderMasks();
-    masks.rtMask      &= m_rtSlotTracking.canBeSampled;
-    masks.samplerMask &= m_textureSlotTracking.rtUsage & texMask;
+  inline void D3D9DeviceEx::UpdateActiveHazardsRT(uint32_t rtMask, uint32_t texMask) {
+    uint32_t oldHazardMask = m_textureSlotTracking.hazardRT;
+    m_textureSlotTracking.hazardRT             &= ~texMask;
+    m_textureSlotTracking.unresolvableHazardRT &= ~texMask;
 
-    m_textureSlotTracking.hazardRT = m_textureSlotTracking.hazardRT & (~texMask);
-    for (uint32_t rtIdx : bit::BitMask(masks.rtMask)) {
-      for (uint32_t samplerIdx : bit::BitMask(masks.samplerMask)) {
+    auto psMasks = PSShaderMasks();
+    rtMask  &= m_rtSlotTracking.canBeSampled & ((1u << caps::MaxTextures) - 1);
+    texMask &= m_textureSlotTracking.rtUsage & psMasks.samplerMask & ((1u << caps::MaxSimultaneousTextures) - 1);
+
+    for (uint32_t rtIdx : bit::BitMask(rtMask)) {
+      bool anyColorWrite = m_state.renderStates[ColorWriteIndex(rtIdx)] != 0;
+      bool shaderWritesToRt = (psMasks.rtMask & (1 << rtIdx)) != 0;
+      for (uint32_t samplerIdx : bit::BitMask(texMask)) {
         D3D9Surface* rtSurf = m_state.renderTargets[rtIdx].ptr();
 
         IDirect3DBaseTexture9* rtBase  = rtSurf->GetBaseTexture();
@@ -6274,39 +6277,69 @@ namespace dxvk {
         if (likely(rtSurf->GetMipLevel() != 0 || rtBase != texBase))
           continue;
 
+        // We can resolve the hazard by unbinding the RT.
         m_textureSlotTracking.hazardRT |= 1 << samplerIdx;
+
+        if (unlikely(anyColorWrite && shaderWritesToRt)) {
+          // We have to bind the RT, so we need FEEDBACK_LOOP_LAYOUT.
+          m_textureSlotTracking.unresolvableHazardRT |= 1 << samplerIdx;
+        }
       }
+    }
+
+    // Only dirty the framebuffer if we need to make changes for a new hazard
+    if (unlikely(m_textureSlotTracking.hazardRT & ~oldHazardMask) != 0) {
+      m_flags.set(D3D9DeviceFlag::DirtyFramebuffer);
     }
   }
 
 
   inline void D3D9DeviceEx::UpdateActiveHazardsDS(uint32_t texMask) {
+    uint32_t oldHazardMask = m_textureSlotTracking.hazardDS;
+    m_textureSlotTracking.hazardDS             &= ~texMask;
+    m_textureSlotTracking.unresolvableHazardDS &= ~texMask;
+
+    if (m_state.depthStencil == nullptr ||
+        m_state.depthStencil->GetBaseTexture() == nullptr)
+      return;
+
     auto masks = PSShaderMasks();
-    masks.samplerMask &= m_textureSlotTracking.dsUsage & texMask;
+    masks.samplerMask &= m_textureSlotTracking.dsUsage & texMask & ((1u << caps::MaxTextures) - 1);
 
-    m_textureSlotTracking.hazardDS = m_textureSlotTracking.hazardDS & (~texMask);
-    if (m_state.depthStencil != nullptr &&
-        m_state.depthStencil->GetBaseTexture() != nullptr) {
-      for (uint32_t samplerIdx : bit::BitMask(masks.samplerMask)) {
-        IDirect3DBaseTexture9* dsBase  = m_state.depthStencil->GetBaseTexture();
-        IDirect3DBaseTexture9* texBase = m_state.textures[samplerIdx];
+    bool usesDepthBuffer = m_state.renderStates[D3DRS_ZENABLE]
+      || m_state.renderStates[D3DRS_STENCILENABLE]
+      || m_state.renderStates[D3DRS_ADAPTIVETESS_X] == uint32_t(D3D9Format::NVDB);
 
-        if (likely(dsBase != texBase))
-          continue;
+    for (uint32_t samplerIdx : bit::BitMask(masks.samplerMask)) {
+      IDirect3DBaseTexture9* dsBase  = m_state.depthStencil->GetBaseTexture();
+      IDirect3DBaseTexture9* texBase = m_state.textures[samplerIdx];
 
-        m_textureSlotTracking.hazardDS |= 1 << samplerIdx;
+      if (likely(dsBase != texBase))
+        continue;
+
+      // We can resolve the hazard by unbinding the DS.
+      m_textureSlotTracking.hazardDS |= 1 << samplerIdx;
+
+      if (unlikely(usesDepthBuffer)) {
+        // We have to bind the DS, so we need FEEDBACK_LOOP_LAYOUT.
+        m_textureSlotTracking.unresolvableHazardDS |= 1 << samplerIdx;
       }
+    }
+
+    // Only dirty the framebuffer if we need to make changes for a new hazard
+    if (unlikely(m_textureSlotTracking.hazardDS & ~oldHazardMask) != 0) {
+      m_flags.set(D3D9DeviceFlag::DirtyFramebuffer);
     }
   }
 
 
-  void D3D9DeviceEx::MarkRenderHazards() {
+  void D3D9DeviceEx::EmitFeedbackLoopBarriers() {
     struct {
       uint8_t RT : 1;
       uint8_t DS : 1;
     } hazardState;
-    hazardState.RT = m_textureSlotTracking.hazardRT != 0;
-    hazardState.DS = m_textureSlotTracking.hazardDS != 0;
+    hazardState.RT = m_textureSlotTracking.unresolvableHazardRT != 0;
+    hazardState.DS = m_textureSlotTracking.unresolvableHazardDS != 0;
 
     EmitCs([
       cHazardState = hazardState
@@ -6330,19 +6363,9 @@ namespace dxvk {
         VK_ACCESS_SHADER_READ_BIT);
     });
 
-    for (uint32_t samplerIdx : bit::BitMask(m_textureSlotTracking.hazardRT)) {
+    for (uint32_t samplerIdx : bit::BitMask(m_textureSlotTracking.unresolvableHazardRT | m_textureSlotTracking.unresolvableHazardDS)) {
       // Guaranteed to not be nullptr...
       auto tex = GetCommonTexture(m_state.textures[samplerIdx]);
-      if (unlikely(!tex->MarkTransitionedToHazardLayout())) {
-        TransitionImage(tex, m_hazardLayout);
-        m_flags.set(D3D9DeviceFlag::DirtyFramebuffer);
-      }
-    }
-
-    bool zWriteEnabled = m_state.renderStates[D3DRS_ZWRITEENABLE];
-    if (m_textureSlotTracking.hazardDS != 0 && zWriteEnabled) {
-      // Guaranteed to not be nullptr...
-      auto tex = m_state.depthStencil->GetCommonTexture();
       if (unlikely(!tex->MarkTransitionedToHazardLayout())) {
         TransitionImage(tex, m_hazardLayout);
         m_flags.set(D3D9DeviceFlag::DirtyFramebuffer);
@@ -6618,107 +6641,132 @@ namespace dxvk {
 
 
   void D3D9DeviceEx::BindFramebuffer() {
+    constexpr size_t DsvIndex = caps::MaxSimultaneousRenderTargets;
+
     m_flags.clr(D3D9DeviceFlag::DirtyFramebuffer);
 
     DxvkRenderTargets attachments;
 
     bool srgb = m_state.renderStates[D3DRS_SRGBWRITEENABLE];
 
-    // D3D9 doesn't have the concept of a framebuffer object,
-    // so we'll just create a new one every time the render
-    // target bindings are updated. Set up the attachments.
-    VkSampleCountFlagBits sampleCount = VK_SAMPLE_COUNT_FLAG_BITS_MAX_ENUM;
-
     // Some games break if render targets that get disabled using the color write mask
     // end up shrinking the render area. So we don't bind those.
     // (This impacted Dead Space 1.)
+    // We also unbind render targets if they aren't used for rendering but get sampled.
     // But we want to minimize frame buffer changes because those
     // break up the current render pass. So we dont unbind for disabled color write masks
     // if the RT has the same size or is bigger than the smallest active RT.
+    std::array<VkExtent2D, DsvIndex + 1u> rtExtents = { };
+    std::array<VkSampleCountFlags, DsvIndex + 1u> rtSampleCounts = { };
 
-    const D3D9ShaderMasks psShaderMasks = PSShaderMasks();
+    const auto& psMasks = PSShaderMasks();
 
-    uint32_t boundMask = 0u;
-    uint32_t anyColorWriteMask = 0u;
-    uint32_t limitsRenderAreaMask = 0u;
+    VkSampleCountFlags sampleCount = 0u;
+
     VkExtent2D renderArea = { ~0u, ~0u };
+
     for (uint32_t i = 0u; i < m_state.renderTargets.size(); i++) {
       if (!HasRenderTargetBound(i))
         continue;
 
-      const DxvkImageCreateInfo& rtImageInfo = m_state.renderTargets[i]->GetCommonTexture()->GetImage()->info();
+      // Check if the render target is also bound as a texture for sampling.
+      // If that's the case, check whether we can skip binding the render target
+      // because writing to it is disabled anyway
+      // (using the color write mask or by the current pixel shader).
+      bool hasHazard = false;
+      for (uint32_t samplerIdx : bit::BitMask(m_textureSlotTracking.hazardRT)) {
+        D3D9Surface* rtSurf = m_state.renderTargets[i].ptr();
 
-      // Dont bind it if the sample count doesnt match
-      if (likely(sampleCount == VK_SAMPLE_COUNT_FLAG_BITS_MAX_ENUM))
-        sampleCount = rtImageInfo.sampleCount;
-      else if (unlikely(sampleCount != rtImageInfo.sampleCount))
-        continue;
+        IDirect3DBaseTexture9* rtBase  = rtSurf->GetBaseTexture();
+        IDirect3DBaseTexture9* texBase = m_state.textures[samplerIdx];
 
-      // Dont bind it if the pixel shader doesnt write to it
-      if (!(psShaderMasks.rtMask & (1 << i)))
-        continue;
-
-      boundMask |= 1 << i;
-
-      VkExtent2D rtExtent = m_state.renderTargets[i]->GetSurfaceExtent();
-      bool rtLimitsRenderArea = rtExtent.width < renderArea.width || rtExtent.height < renderArea.height;
-      limitsRenderAreaMask |= rtLimitsRenderArea << i;
-
-      // It will only get bound if its not smaller than the others.
-      // So RTs with a disabled color write mask will never impact the render area.
-      if (m_state.renderStates[ColorWriteIndex(i)] == 0)
-        continue;
-
-      anyColorWriteMask |= 1 << i;
-
-      if (rtExtent.width < renderArea.width && rtExtent.height < renderArea.height) {
-        // It's smaller on both axis, so the previous RTs no longer limit the size
-        limitsRenderAreaMask = 1 << i;
+        if (likely(rtSurf->GetMipLevel() == 0 && rtBase == texBase)) {
+          hasHazard = true;
+          break;
+        }
       }
 
-      renderArea.width = std::min(renderArea.width, rtExtent.width);
-      renderArea.height = std::min(renderArea.height, rtExtent.height);
-    }
+      const uint32_t rtBit = 1u << i;
+      const bool writtenTo = (psMasks.rtMask & rtBit) != 0
+          && m_state.renderStates[ColorWriteIndex(i)] != 0;
 
-    bool dsvBound = false;
-    if (m_state.depthStencil != nullptr) {
-      // We only need to skip binding the DSV if it would shrink the render area
-      // despite not being used, otherwise we might end up with unnecessary render pass spills
-      bool anyDSStateEnabled = m_state.renderStates[D3DRS_ZENABLE]
-        || m_state.renderStates[D3DRS_ZWRITEENABLE]
-        || m_state.renderStates[D3DRS_STENCILENABLE]
-        || m_nvdbEnabled;
+      // The texture is bound for sampling and as an RT but the RT isn't actually used for writing.
+      // Not assigning an extent to rtExtents[i] will lead to it getting skipped when we get to binding the rt.
+      if (hasHazard && !writtenTo)
+        continue;
 
-      VkExtent2D dsvExtent = m_state.depthStencil->GetSurfaceExtent();
-      bool dsvLimitsRenderArea = dsvExtent.width < renderArea.width || dsvExtent.height < renderArea.height;
+      rtExtents[i] = m_state.renderTargets[i]->GetSurfaceExtent();
+      rtSampleCounts[i] = m_state.renderTargets[i]->GetCommonTexture()->GetImage()->info().sampleCount;
 
-      const DxvkImageCreateInfo& dsImageInfo = m_state.depthStencil->GetCommonTexture()->GetImage()->info();
-      const bool sampleCountMatches = sampleCount == VK_SAMPLE_COUNT_FLAG_BITS_MAX_ENUM || sampleCount == dsImageInfo.sampleCount;
+      // If writing to the RT is disabled it shouldn't impact the render area.
+      if (!writtenTo)
+        continue;
 
-      dsvBound = sampleCountMatches && (anyDSStateEnabled || !dsvLimitsRenderArea);
-      if (sampleCountMatches && anyDSStateEnabled && dsvExtent.width < renderArea.width && dsvExtent.height < renderArea.height) {
-        // It's smaller on both axis, so the previous RTs no longer limit the size
-        limitsRenderAreaMask = 0u;
+      if (sampleCount == 0)
+        sampleCount = rtSampleCounts[i];
+
+      if (sampleCount & rtSampleCounts[i]) {
+        renderArea.width = std::min(renderArea.width, rtExtents[i].width);
+        renderArea.height = std::min(renderArea.height, rtExtents[i].height);
       }
     }
 
-    // We only need to skip binding the RT if it would shrink the render area
-    // despite not having color writes enabled,
-    // otherwise we might end up with unnecessary render pass spills
-    boundMask &= (anyColorWriteMask | ~limitsRenderAreaMask);
-    for (uint32_t i : bit::BitMask(boundMask))
-      attachments.color[i].view = m_state.renderTargets[i]->GetRenderTargetView(srgb);
+    // Similarly check if the DSV is bound for sampling and as a DSV
+    // and whether it is actually required.
+    bool usesDepthBuffer = m_state.renderStates[D3DRS_ZENABLE]
+      || m_state.renderStates[D3DRS_STENCILENABLE]
+      || m_state.renderStates[D3DRS_ADAPTIVETESS_X] == uint32_t(D3D9Format::NVDB);
 
-    const bool depthWrite = m_state.renderStates[D3DRS_ZWRITEENABLE];
+    if (m_state.depthStencil != nullptr && (m_textureSlotTracking.hazardDS == 0 || usesDepthBuffer)) {
+      rtExtents[DsvIndex] = m_state.depthStencil->GetSurfaceExtent();
+      rtSampleCounts[DsvIndex] = m_state.depthStencil->GetCommonTexture()->GetImage()->info().sampleCount;
+      if (usesDepthBuffer) {
+        if (sampleCount == 0)
+          sampleCount = rtSampleCounts[DsvIndex];
 
-    if (dsvBound)
+        if (sampleCount & rtSampleCounts[DsvIndex]) {
+          renderArea.width = std::min(renderArea.width, rtExtents[DsvIndex].width);
+          renderArea.height = std::min(renderArea.height, rtExtents[DsvIndex].height);
+        }
+      }
+    }
+
+    // We've skipped all render targets because they'd needlessly impact the render area.
+    // Just pick one and use the extents for the render area and sample count
+    for (uint32_t i = 0; i < rtExtents.size() && sampleCount == 0; i++) {
+      if (rtSampleCounts[i] == 0)
+        continue;
+
+      sampleCount = rtSampleCounts[i];
+      renderArea.width = rtExtents[i].width;
+      renderArea.height = rtExtents[i].height;
+    }
+
+    for (uint32_t i = 0u; i < m_state.renderTargets.size(); i++) {
+      if (HasRenderTargetBound(i)
+        && rtExtents[i].width >= renderArea.width
+        && rtExtents[i].height >= renderArea.height
+        && rtSampleCounts[i] == sampleCount)
+          attachments.color[i].view = m_state.renderTargets[i]->GetRenderTargetView(srgb);
+    }
+
+    // Based on the render area and sample count of actively used render targets,
+    // bind any render target that does not further restrict the render area.
+    bool depthWrite = m_state.renderStates[D3DRS_ZWRITEENABLE];
+
+    if (m_state.depthStencil != nullptr
+     && rtExtents[DsvIndex].width >= renderArea.width
+     && rtExtents[DsvIndex].height >= renderArea.height
+     && rtSampleCounts[DsvIndex] == sampleCount)
       attachments.depth.view = m_state.depthStencil->GetDepthStencilView(depthWrite);
 
+    // Work out feedback loop layouts based on bound render targets
     VkImageAspectFlags feedbackLoopAspects = 0u;
+
     if (m_hazardLayout == VK_IMAGE_LAYOUT_ATTACHMENT_FEEDBACK_LOOP_OPTIMAL_EXT) {
-      if (m_textureSlotTracking.hazardRT != 0)
+      if (m_textureSlotTracking.unresolvableHazardRT != 0)
         feedbackLoopAspects |= VK_IMAGE_ASPECT_COLOR_BIT;
-      if (m_textureSlotTracking.hazardDS != 0 && depthWrite)
+      if (m_textureSlotTracking.unresolvableHazardDS != 0 && depthWrite)
         feedbackLoopAspects |= VK_IMAGE_ASPECT_DEPTH_BIT;
     }
 
@@ -7249,15 +7297,8 @@ namespace dxvk {
 
 
   void D3D9DeviceEx::PrepareDraw(D3DPRIMITIVETYPE PrimitiveType, bool UploadVBOs, bool UploadIBO) {
-    if (unlikely(m_textureSlotTracking.hazardRT != 0 || m_textureSlotTracking.hazardDS != 0))
-      MarkRenderHazards();
-
-    if (unlikely((!m_textureSlotTracking.lastHazardDS) != (!m_textureSlotTracking.hazardDS))
-     || unlikely((!m_textureSlotTracking.lastHazardRT) != (!m_textureSlotTracking.hazardRT))) {
-      m_flags.set(D3D9DeviceFlag::DirtyFramebuffer);
-      m_textureSlotTracking.lastHazardDS = m_textureSlotTracking.hazardDS;
-      m_textureSlotTracking.lastHazardRT = m_textureSlotTracking.hazardRT;
-    }
+    if (unlikely(m_textureSlotTracking.unresolvableHazardRT != 0 || m_textureSlotTracking.unresolvableHazardDS != 0))
+      EmitFeedbackLoopBarriers();
 
     if (likely(UploadVBOs)) {
       const uint32_t usedBuffersMask = m_state.vertexDecl != nullptr ? m_state.vertexDecl->GetStreamMask() : ~0u;

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -159,6 +159,14 @@ namespace dxvk {
     /** Whether the texture bound to a slot has D3DUSAGE_DEPTHSTENCIL */
     uint32_t dsUsage = 0;
 
+    /** Whether the texture bound to a slot is also bound as a render target
+     * and the render target is actually used for writing. */
+    uint32_t unresolvableHazardRT = 0;
+
+    /** Whether the texture bound to a slot is also bound as the depth stencil surface
+     * and depth stencil surface is actually used for depth testing. */
+    uint32_t unresolvableHazardDS = 0;
+
     /** Whether the texture bound to a slot is also bound as a render target */
     uint32_t hazardRT = 0;
 
@@ -173,12 +181,6 @@ namespace dxvk {
 
     /** Whether there's a texture bound to a slot that needs to have its mip maps generated */
     uint32_t needsMipGen = 0;
-
-    /** `hazardRT` the last time PrepareDraw was called. Used to check if it changed.  */
-    uint32_t lastHazardRT = 0;
-
-    /** `hazardDS` the last time PrepareDraw was called Used to check if it changed. */
-    uint32_t lastHazardDS = 0;
   };
 
   struct D3D9RTSlotTracking {
@@ -938,11 +940,11 @@ namespace dxvk {
 
     void UpdateTextureBitmasks(uint32_t index, DWORD combinedUsage);
 
-    void UpdateActiveHazardsRT(uint32_t rtMask);
+    void UpdateActiveHazardsRT(uint32_t rtMask, uint32_t texMask);
 
     void UpdateActiveHazardsDS(uint32_t texMask);
 
-    void MarkRenderHazards();
+    void EmitFeedbackLoopBarriers();
 
     void UpdateActiveFetch4(uint32_t stateSampler);
 

--- a/src/d3d9/d3d9_subresource.h
+++ b/src/d3d9/d3d9_subresource.h
@@ -76,18 +76,6 @@ namespace dxvk {
       return m_texture->CalcSubresource(m_face, m_mipLevel);
     }
 
-    inline const Rc<DxvkImageView>& GetImageView(bool Srgb) {
-      Rc<DxvkImageView>& view = m_sampleView.Pick(Srgb);
-
-      if (unlikely(!view && !IsNull())) {
-        view = m_texture->CreateView(m_face, m_mipLevel,
-          VK_IMAGE_USAGE_SAMPLED_BIT, VK_IMAGE_LAYOUT_UNDEFINED,
-          Srgb && m_isSrgbCompatible);
-      }
-
-      return view;
-    }
-
     inline const Rc<DxvkImageView>& GetRenderTargetView(bool Srgb) {
       Rc<DxvkImageView>& view = m_renderTargetView.Pick(Srgb);
 
@@ -138,7 +126,6 @@ namespace dxvk {
       // Only used for swap chain back buffers that don't
       // have a container and all have identical properties
       std::swap(m_texture,          Other->m_texture);
-      std::swap(m_sampleView,       Other->m_sampleView);
       std::swap(m_renderTargetView, Other->m_renderTargetView);
     }
 
@@ -153,8 +140,7 @@ namespace dxvk {
     UINT                    m_mipLevel         : 16;
     UINT                    m_isSrgbCompatible : 1;
     UINT                    m_isNull           : 1;
-  
-    D3D9ColorView           m_sampleView;
+
     D3D9ColorView           m_renderTargetView;
 
     Rc<DxvkImageView>       m_dsvReadWrite;

--- a/src/d3d9/d3d9_subresource.h
+++ b/src/d3d9/d3d9_subresource.h
@@ -92,6 +92,10 @@ namespace dxvk {
       Rc<DxvkImageView>& view = m_renderTargetView.Pick(Srgb);
 
       if (unlikely(!view && !IsNull())) {
+        // The backend will ignore the view layout anyway for images
+        // that have GENERAL (or FEEDBACK_LOOP) as their layout.
+        // Because of that, we don't need to pay special attention here
+        // to whether the image was transitioned because of a feedback loop.
         view = m_texture->CreateView(m_face, m_mipLevel,
           VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT,
           VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
@@ -107,6 +111,10 @@ namespace dxvk {
         : m_dsvReadOnly;
 
       if (unlikely(!view)) {
+        // The backend will ignore the view layout anyway for images
+        // that have GENERAL (or FEEDBACK_LOOP) as their layout.
+        // Because of that, we don't need to pay special attention here
+        // to whether the image was transitioned because of a feedback loop.
         VkImageLayout layout = Writable
           ? VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL
           : VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_STENCIL_ATTACHMENT_OPTIMAL;

--- a/src/d3d9/d3d9_swapchain.cpp
+++ b/src/d3d9/d3d9_swapchain.cpp
@@ -832,7 +832,7 @@ namespace dxvk {
     VkResult status = VK_SUCCESS;
 
     Rc<DxvkImage> swapImage = m_backBuffers[0]->GetCommonTexture()->GetImage();
-    Rc<DxvkImageView> swapImageView = m_backBuffers[0]->GetImageView(false);
+    Rc<DxvkImageView> swapImageView = m_backBuffers[0]->GetCommonTexture()->GetSampleView(false);
 
     // Presentation semaphores and WSI swap chain image
     PresenterSync sync = { };
@@ -1023,6 +1023,7 @@ namespace dxvk {
     desc.Usage              = D3DUSAGE_RENDERTARGET;
     desc.Discard            = FALSE;
     desc.IsBackBuffer       = TRUE;
+    // The texture will get sampled for presentation.
     desc.IsAttachmentOnly   = FALSE;
     // we cannot respect D3DPRESENTFLAG_LOCKABLE_BACKBUFFER here because
     // we might need to lock for the BlitGDI fallback path


### PR DESCRIPTION
Bind all RTs unless we need to skip them to resolve a hazard or avoid restricting the render area.

The rewritten `BindFramebuffer`-code is based on #4973.

Binding a texture for sampling, binding a render target, changing the shader or changing a color write mask calls
`UpdateActiveHazardsRT` with a masks for the changed textures/rts. This function then scans for hazards and checks if those can be resolved by unbinding the render target. If that's possible, the  bit in `unboundHazardRT` is set and the `DirtyFramebuffer` bit is set. `unboundHazardRT` will then get checked when rebinding the render targets.

If its not possible to resolve the hazard by unbinding. the bit in `hazardRT` is set which makes DXVK transition the RT to LAYOUT_FEEDBACK_LOOP at draw time just like before.

Fixes #4900