### PR TITLE
[d3d8/9] Clean up CheckDeviceFormat and CreateImageSurface formats

### DIFF
--- a/src/d3d8/d3d8_device.cpp
+++ b/src/d3d8/d3d8_device.cpp
@@ -331,6 +331,9 @@ namespace dxvk {
     if (unlikely(ppTexture == nullptr))
       return D3DERR_INVALIDCALL;
 
+    if (unlikely(isD3D9ExclusiveFormat(Format)))
+      return D3DERR_INVALIDCALL;
+
     // Nvidia & Intel workaround for The Lord of the Rings: The Fellowship of the Ring
     if (m_d3d8Options.placeP8InScratch && Format == D3DFMT_P8)
       Pool = D3DPOOL_SCRATCH;
@@ -371,6 +374,9 @@ namespace dxvk {
     if (unlikely(ppVolumeTexture == nullptr))
       return D3DERR_INVALIDCALL;
 
+    if (unlikely(isD3D9ExclusiveFormat(Format)))
+      return D3DERR_INVALIDCALL;
+
     Com<d3d9::IDirect3DVolumeTexture9> pVolume9 = nullptr;
     HRESULT res = GetD3D9()->CreateVolumeTexture(
       Width, Height, Depth, Levels,
@@ -401,6 +407,9 @@ namespace dxvk {
     InitReturnPtr(ppCubeTexture);
 
     if (unlikely(ppCubeTexture == nullptr))
+      return D3DERR_INVALIDCALL;
+
+    if (unlikely(isD3D9ExclusiveFormat(Format)))
       return D3DERR_INVALIDCALL;
 
     Com<d3d9::IDirect3DCubeTexture9> pCube9 = nullptr;
@@ -481,6 +490,12 @@ namespace dxvk {
     if (unlikely(ppSurface == nullptr))
       return D3DERR_INVALIDCALL;
 
+    if (unlikely(isD3D9ExclusiveFormat(Format)))
+      return D3DERR_INVALIDCALL;
+
+    if (unlikely(!isRenderTargetFormat(Format)))
+      return D3DERR_INVALIDCALL;
+
     Com<d3d9::IDirect3DSurface9> pSurf9 = nullptr;
     HRESULT res = GetD3D9()->CreateRenderTarget(
       Width,
@@ -512,6 +527,9 @@ namespace dxvk {
     InitReturnPtr(ppSurface);
 
     if (unlikely(ppSurface == nullptr))
+      return D3DERR_INVALIDCALL;
+
+    if (unlikely(isD3D9ExclusiveFormat(Format)))
       return D3DERR_INVALIDCALL;
 
     Com<d3d9::IDirect3DSurface9> pSurf9 = nullptr;
@@ -546,7 +564,13 @@ namespace dxvk {
     if (unlikely(ppSurface == nullptr))
       return D3DERR_INVALIDCALL;
 
-    D3DPOOL pool = isUnsupportedSurfaceFormat(Format) ? D3DPOOL_SCRATCH : D3DPOOL_SYSTEMMEM;
+    // CreateImageSurface is generally guaranteed to succeed even with unsupported
+    // formats, however D3D9 exclusive formats fail on native D3D8.
+    if (unlikely(isD3D9ExclusiveFormat(Format)))
+      return D3DERR_INVALIDCALL;
+
+    const bool isSupportedSurfaceFormat = m_bridge->IsSupportedSurfaceFormat(d3d9::D3DFORMAT(Format));
+    D3DPOOL pool = isSupportedSurfaceFormat ? D3DPOOL_SYSTEMMEM : D3DPOOL_SCRATCH;
 
     Com<d3d9::IDirect3DSurface9> pSurf = nullptr;
     HRESULT res = GetD3D9()->CreateOffscreenPlainSurface(
@@ -794,10 +818,10 @@ namespace dxvk {
             case d3d9::D3DPOOL_SCRATCH: {
               // SCRATCH -> DEFAULT: memcpy to a SYSTEMMEM temporary buffer and use UpdateSurface
 
+              const bool isSupportedSurfaceFormat = m_bridge->IsSupportedSurfaceFormat(srcDesc.Format);
               // UpdateSurface will not work on surface formats unsupported by D3DPOOL_DEFAULT
-              if (unlikely(isUnsupportedSurfaceFormat(D3DFORMAT(srcDesc.Format)))) {
+              if (unlikely(!isSupportedSurfaceFormat))
                 return logError(D3DERR_INVALIDCALL);
-              }
 
               Com<IDirect3DSurface8> pTempImageSurface;
               // The temporary image surface is guaranteed to end up in SYSTEMMEM for supported formats

--- a/src/d3d8/d3d8_format.h
+++ b/src/d3d8/d3d8_format.h
@@ -16,28 +16,6 @@ namespace dxvk {
     return isDXT(D3DFORMAT(fmt));
   }
 
-  constexpr bool isUnsupportedSurfaceFormat(D3DFORMAT fmt) {
-    // mirror what dxvk doesn't support in terms of d3d9 surface formats
-    return fmt == D3DFMT_R8G8B8
-        || fmt == D3DFMT_R3G3B2
-        || fmt == D3DFMT_A8R3G3B2
-        || fmt == D3DFMT_A8P8
-        || fmt == D3DFMT_P8;
-        // not included in the d3d8 spec
-        //|| fmt == D3DFMT_CXV8U8;
-  }
-
-  constexpr bool isSupportedDepthStencilFormat(D3DFORMAT fmt) {
-    // native d3d8 doesn't support D3DFMT_D32, D3DFMT_D15S1 or D3DFMT_D24X4S4
-    return fmt == D3DFMT_D16_LOCKABLE
-        || fmt == D3DFMT_D16
-        //|| fmt == D3DFMT_D32
-        //|| fmt == D3DFMT_D15S1
-        //|| fmt == D3DFMT_D24X4S4
-        || fmt == D3DFMT_D24S8
-        || fmt == D3DFMT_D24X8;
-  }
-
   constexpr bool isDepthStencilFormat(D3DFORMAT fmt) {
     return fmt == D3DFMT_D16_LOCKABLE
         || fmt == D3DFMT_D16
@@ -46,6 +24,48 @@ namespace dxvk {
         || fmt == D3DFMT_D24X4S4
         || fmt == D3DFMT_D24S8
         || fmt == D3DFMT_D24X8;
+  }
+
+  // The d3d8 documentation states: Render target formats are restricted to
+  // D3DFMT_X1R5G5B5, D3DFMT_R5G6B5, D3DFMT_X8R8G8B8, and D3DFMT_A8R8G8B8.
+  // This limited RT format support is confirmed by age-accurate drivers.
+  constexpr bool isRenderTargetFormat(D3DFORMAT fmt) {
+    return fmt == D3DFMT_X1R5G5B5
+        || fmt == D3DFMT_R5G6B5
+        || fmt == D3DFMT_X8R8G8B8
+        || fmt == D3DFMT_A8R8G8B8
+        // NULL format support was later added to d3d9 with
+        // GeForce 6 series cards, and also advertised in d3d8.
+        || fmt == (D3DFORMAT) MAKEFOURCC('N', 'U', 'L', 'L');
+  }
+
+  // Some games will exhaustively query all formats in the 0-100 range,
+  // so filter out some known formats which are exclusive to d3d9
+  constexpr bool isD3D9ExclusiveFormat(D3DFORMAT fmt) {
+    const d3d9::D3DFORMAT d3d9Fmt = d3d9::D3DFORMAT(fmt);
+
+    return d3d9Fmt == d3d9::D3DFMT_A8B8G8R8            //32
+        || d3d9Fmt == d3d9::D3DFMT_X8B8G8R8            //33
+        || d3d9Fmt == d3d9::D3DFMT_A2R10G10B10         //35
+        || d3d9Fmt == d3d9::D3DFMT_A16B16G16R16        //36
+        || d3d9Fmt == d3d9::D3DFMT_L16                 //81
+        || d3d9Fmt == d3d9::D3DFMT_D32F_LOCKABLE       //82
+        || d3d9Fmt == d3d9::D3DFMT_D24FS8              //83
+        || d3d9Fmt == d3d9::D3DFMT_D32_LOCKABLE        //84
+        || d3d9Fmt == d3d9::D3DFMT_S8_LOCKABLE         //85
+        || d3d9Fmt == d3d9::D3DFMT_Q16W16V16U16        //110
+        || d3d9Fmt == d3d9::D3DFMT_R16F                //111
+        || d3d9Fmt == d3d9::D3DFMT_G16R16F             //112
+        || d3d9Fmt == d3d9::D3DFMT_A16B16G16R16F       //113
+        || d3d9Fmt == d3d9::D3DFMT_R32F                //114
+        || d3d9Fmt == d3d9::D3DFMT_G32R32F             //115
+        || d3d9Fmt == d3d9::D3DFMT_A32B32G32R32F       //116
+        || d3d9Fmt == d3d9::D3DFMT_CxV8U8              //117
+        || d3d9Fmt == d3d9::D3DFMT_A1                  //118
+        || d3d9Fmt == d3d9::D3DFMT_A2B10G10R10_XR_BIAS //119
+        || d3d9Fmt == (d3d9::D3DFORMAT) MAKEFOURCC('D', 'F', '1', '6')
+        || d3d9Fmt == (d3d9::D3DFORMAT) MAKEFOURCC('D', 'F', '2', '4')
+        || d3d9Fmt == (d3d9::D3DFORMAT) MAKEFOURCC('I', 'N', 'T', 'Z');
   }
 
   // Get bytes per pixel (or 4x4 block for DXT)
@@ -81,8 +101,6 @@ namespace dxvk {
       case D3DFMT_A8R8G8B8:
       case D3DFMT_X8R8G8B8:
       case D3DFMT_A2B10G10R10:
-      //case D3DFMT_A8B8G8R8:
-      //case D3DFMT_X8B8G8R8:
       case D3DFMT_G16R16:
       case D3DFMT_X8L8V8U8:
       case D3DFMT_Q8W8V8U8:

--- a/src/d3d8/d3d8_interface.h
+++ b/src/d3d8/d3d8_interface.h
@@ -87,6 +87,12 @@ namespace dxvk {
         DWORD           Usage,
         D3DRESOURCETYPE RType,
         D3DFORMAT       CheckFormat) {
+      if (unlikely(isD3D9ExclusiveFormat(CheckFormat)))
+        return D3DERR_NOTAVAILABLE;
+
+      if (unlikely((Usage & D3DUSAGE_RENDERTARGET) && !isRenderTargetFormat(CheckFormat)))
+        return D3DERR_NOTAVAILABLE;
+
       return m_d3d9->CheckDeviceFormat(
         Adapter,
         (d3d9::D3DDEVTYPE)DeviceType,
@@ -120,16 +126,20 @@ namespace dxvk {
         D3DFORMAT AdapterFormat,
         D3DFORMAT RenderTargetFormat,
         D3DFORMAT DepthStencilFormat) {
-      if (isSupportedDepthStencilFormat(DepthStencilFormat))
-        return m_d3d9->CheckDepthStencilMatch(
-          Adapter,
-          (d3d9::D3DDEVTYPE)DeviceType,
-          (d3d9::D3DFORMAT)AdapterFormat,
-          (d3d9::D3DFORMAT)RenderTargetFormat,
-          (d3d9::D3DFORMAT)DepthStencilFormat
-        );
+      if (unlikely(isD3D9ExclusiveFormat(RenderTargetFormat)
+                || isD3D9ExclusiveFormat(DepthStencilFormat)))
+        return D3DERR_NOTAVAILABLE;
 
-      return D3DERR_NOTAVAILABLE;
+      if (unlikely(!isRenderTargetFormat(RenderTargetFormat)))
+        return D3DERR_NOTAVAILABLE;
+
+      return m_d3d9->CheckDepthStencilMatch(
+        Adapter,
+        (d3d9::D3DDEVTYPE)DeviceType,
+        (d3d9::D3DFORMAT)AdapterFormat,
+        (d3d9::D3DFORMAT)RenderTargetFormat,
+        (d3d9::D3DFORMAT)DepthStencilFormat
+      );
     }
 
     HRESULT STDMETHODCALLTYPE GetDeviceCaps(

--- a/src/d3d9/d3d9_adapter.h
+++ b/src/d3d9/d3d9_adapter.h
@@ -84,12 +84,16 @@ namespace dxvk {
     }
 
     D3D9_VK_FORMAT_MAPPING GetFormatMapping(D3D9Format Format) const {
-      return m_d3d9Formats.GetFormatMapping(Format);
+      return m_d3d9Formats->GetFormatMapping(Format);
     }
 
     const DxvkFormatInfo* GetUnsupportedFormatInfo(D3D9Format Format) const {
-      return m_d3d9Formats.GetUnsupportedFormatInfo(Format);
+      return m_d3d9Formats->GetUnsupportedFormatInfo(Format);
     }
+
+    bool IsExtended() const;
+
+    bool IsD3D8Compatible() const;
 
   private:
 
@@ -118,10 +122,10 @@ namespace dxvk {
     std::string                   m_deviceDesc;
     std::string                   m_deviceDriver;
 
-    std::vector<D3DDISPLAYMODEEX> m_modes;
-    D3D9Format                    m_modeCacheFormat;
+    std::vector<D3DDISPLAYMODEEX>            m_modes;
+    D3D9Format                               m_modeCacheFormat;
 
-    const D3D9VkFormatTable       m_d3d9Formats;
+    std::unique_ptr<const D3D9VkFormatTable> m_d3d9Formats;
 
   };
 

--- a/src/d3d9/d3d9_bridge.cpp
+++ b/src/d3d9/d3d9_bridge.cpp
@@ -4,6 +4,7 @@
 #include "d3d9_bridge.h"
 #include "d3d9_swapchain.h"
 #include "d3d9_surface.h"
+#include "d3d9_format.h"
 
 namespace dxvk {
 
@@ -86,6 +87,11 @@ namespace dxvk {
       m_device->MarkTextureMipsDirty(dstTextureInfo);
 
     return D3D_OK;
+  }
+
+  bool DxvkD3D8Bridge::IsSupportedSurfaceFormat(D3DFORMAT Format) {
+    auto mapping = m_device->LookupFormat(EnumerateFormat(Format));
+    return mapping.IsValid();
   }
 
   DxvkD3D8InterfaceBridge::DxvkD3D8InterfaceBridge(D3D9InterfaceEx* pObject)

--- a/src/d3d9/d3d9_bridge.h
+++ b/src/d3d9/d3d9_bridge.h
@@ -19,6 +19,7 @@ IDxvkD3D8Bridge : public IUnknown {
   // D3D8 keeps D3D9 objects contained in a namespace.
   #ifdef DXVK_D3D9_NAMESPACE
     using IDirect3DSurface9 = d3d9::IDirect3DSurface9;
+    using D3DFORMAT = d3d9::D3DFORMAT;
   #endif
 
   /**
@@ -34,6 +35,13 @@ IDxvkD3D8Bridge : public IUnknown {
       IDirect3DSurface9*        pSrcSurface,
       const RECT*               pSrcRect,
       const POINT*              pDestPoint) = 0;
+
+  /**
+   * \brief Checks if a particular surface format is supported by D3D9
+   *
+   * \param [in] Format D3DFORMAT value to be checked
+   */
+  virtual bool IsSupportedSurfaceFormat(D3DFORMAT Format) = 0;
 };
 
 /**
@@ -83,6 +91,8 @@ namespace dxvk {
         IDirect3DSurface9*        pSrcSurface,
         const RECT*               pSrcRect,
         const POINT*              pDestPoint);
+
+    bool IsSupportedSurfaceFormat(D3DFORMAT Format);
 
   private:
 

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -4230,6 +4230,11 @@ namespace dxvk {
     // Docs: Off-screen plain surfaces are always lockable, regardless of their pool types.
     desc.IsLockable         = TRUE;
 
+    // Because they are always lockable, image surfaces / offscreen plain surfaces
+    // are restricted to using lockable depth stencil formats.
+    if (IsDepthStencilFormat(desc.Format) && !IsLockableDepthStencilFormat(desc.Format))
+      return D3DERR_INVALIDCALL;
+
     if (FAILED(D3D9CommonTexture::NormalizeTextureProperties(this, D3DRTYPE_SURFACE, &desc)))
       return D3DERR_INVALIDCALL;
 

--- a/src/d3d9/d3d9_format.h
+++ b/src/d3d9/d3d9_format.h
@@ -221,8 +221,10 @@ namespace dxvk {
 
     bool CheckImageFormatSupport(
       const Rc<DxvkAdapter>&      Adapter,
-      VkFormat              Format,
-      VkFormatFeatureFlags2 Features) const;
+            VkFormat              Format,
+            VkFormatFeatureFlags2 Features) const;
+
+    D3D9Adapter* m_parent = nullptr;
 
     bool m_d24s8Support;
     bool m_d16s8Support;


### PR DESCRIPTION
Clean up mostly of d3d8 format support on `CheckDeviceFormat` and `CreateImageSurface`, which addresses the following corner cases:
- d3d8 `CheckDeviceFormat` shouldn't report support for d3d9-exclusive formats
- `CreateImageSurface` should work even with unsupported formats, including lockable depth formats ~(to be confirmed on native)~, similarly to how `CreateOffscreenPlainSurface` with `D3DPOOL_SCRATCH` behaves in d3d9
- volume textures can't be used as render targets, yet we were advertising support (fixed)... some native drivers seem to do that too for some reason, although creation will fail on them as well
- `W11V11U10` is not available in d3d9, so should not be advertised outside of d3d8 (this brings us in line with native and WineD3D)
- `A2B10G10R10_XR_BIAS` does not appear to be used or supported on native, so removed support for it accordingly
- a more limited selection of render target formats for d3d8, to be in line with age-accurate drivers (modern drivers seem to expose all that d3d9 exposes, which is... hardly ideal).