### PR TITLE
[d3d9] Optimize StretchRect stretching resolves

### DIFF
--- a/src/d3d9/d3d9_common_texture.cpp
+++ b/src/d3d9/d3d9_common_texture.cpp
@@ -166,8 +166,9 @@ namespace dxvk {
        || (blockSize.Height && (pDesc->Height & (blockSize.Height - 1))))
         return D3DERR_INVALIDCALL;
     }
-    
-    if (FAILED(DecodeMultiSampleType(pDevice->GetDXVKDevice(), pDesc->MultiSample, pDesc->MultisampleQuality, nullptr)))
+
+    VkSampleCountFlagBits sampleCount;
+    if (FAILED(DecodeMultiSampleType(pDevice->GetDXVKDevice(), pDesc->MultiSample, pDesc->MultisampleQuality, &sampleCount)))
       return D3DERR_INVALIDCALL;
 
     // Using MANAGED pool with DYNAMIC usage is illegal
@@ -240,6 +241,10 @@ namespace dxvk {
        || pDesc->Format == D3D9Format::S8_LOCKABLE)
         return D3DERR_INVALIDCALL;
     }
+
+    // A multisample RT/DS must not be lockable
+    if (pDesc->IsLockable && sampleCount > VK_SAMPLE_COUNT_1_BIT)
+        return D3DERR_INVALIDCALL;
 
     return D3D_OK;
   }

--- a/src/dxvk/dxvk_meta_blit.h
+++ b/src/dxvk/dxvk_meta_blit.h
@@ -37,19 +37,22 @@ namespace dxvk {
   struct DxvkMetaBlitPipelineKey {
     VkImageViewType       viewType;
     VkFormat              viewFormat;
-    VkSampleCountFlagBits samples;
+    VkSampleCountFlagBits srcSamples;
+    VkSampleCountFlagBits dstSamples;
     
     bool eq(const DxvkMetaBlitPipelineKey& other) const {
       return this->viewType   == other.viewType
           && this->viewFormat == other.viewFormat
-          && this->samples    == other.samples;
+          && this->srcSamples    == other.srcSamples
+          && this->dstSamples    == other.dstSamples;
     }
     
     size_t hash() const {
       DxvkHashState result;
       result.add(uint32_t(this->viewType));
       result.add(uint32_t(this->viewFormat));
-      result.add(uint32_t(this->samples));
+      result.add(uint32_t(this->srcSamples));
+      result.add(uint32_t(this->dstSamples));
       return result;
     }
   };
@@ -112,7 +115,8 @@ namespace dxvk {
     DxvkMetaBlitPipeline getPipeline(
             VkImageViewType       viewType,
             VkFormat              viewFormat,
-            VkSampleCountFlagBits samples);
+            VkSampleCountFlagBits srcSamples,
+            VkSampleCountFlagBits dstSamples);
     
   private:
 
@@ -135,7 +139,8 @@ namespace dxvk {
     VkPipeline createPipeline(
             VkImageViewType             imageViewType,
             VkFormat                    format,
-            VkSampleCountFlagBits       samples) const;
+            VkSampleCountFlagBits       srcSamples,
+            VkSampleCountFlagBits       dstSamples) const;
     
   };
   

--- a/src/dxvk/meson.build
+++ b/src/dxvk/meson.build
@@ -2,6 +2,7 @@ dxvk_shaders = files([
   'shaders/dxvk_blit_frag_1d.frag',
   'shaders/dxvk_blit_frag_2d.frag',
   'shaders/dxvk_blit_frag_3d.frag',
+  'shaders/dxvk_blit_frag_2d_ms.frag',
 
   'shaders/dxvk_buffer_to_image_d.frag',
   'shaders/dxvk_buffer_to_image_ds_export.frag',

--- a/src/dxvk/shaders/dxvk_blit_frag_2d_ms.frag
+++ b/src/dxvk/shaders/dxvk_blit_frag_2d_ms.frag
@@ -1,0 +1,76 @@
+#version 460
+
+#extension GL_EXT_nonuniform_qualifier : require
+#extension GL_EXT_scalar_block_layout : require
+#extension GL_EXT_samplerless_texture_functions : enable
+
+layout(set = 0, binding = 0) uniform sampler s_samplers[];
+layout(set = 1, binding = 0) uniform texture2DMSArray s_image_ms;
+
+layout(location = 0) in  vec2 i_pos;
+layout(location = 0) out vec4 o_color;
+
+layout(push_constant)
+uniform push_block {
+  float p_src_coord0_x, p_src_coord0_y, p_src_coord0_z;
+  float p_src_coord1_x, p_src_coord1_y, p_src_coord1_z;
+  uint p_layer_count;
+};
+
+layout(constant_id = 0) const int c_samples = 1;
+
+const vec2 sample_positions[] = {
+  /* 2 samples */
+  vec2( 0.25f, 0.25f),
+  vec2(-0.25f,-0.25f),
+  /* 4 samples */
+  vec2(-0.125f,-0.375f),
+  vec2( 0.375f,-0.125f),
+  vec2(-0.375f, 0.125f),
+  vec2( 0.125f, 0.375f),
+  /* 8 samples */
+  vec2( 0.0625f,-0.1875f),
+  vec2(-0.0625f, 0.1875f),
+  vec2( 0.3125f, 0.0625f),
+  vec2(-0.1875f,-0.3125f),
+  vec2(-0.3125f, 0.3125f),
+  vec2(-0.4375f,-0.0625f),
+  vec2( 0.1875f, 0.4375f),
+  vec2( 0.4375f,-0.4375f),
+  /* 16 samples */
+  vec2( 0.0625f, 0.0625f),
+  vec2(-0.0625f,-0.1875f),
+  vec2(-0.1875f, 0.1250f),
+  vec2( 0.2500f,-0.0625f),
+  vec2(-0.3125f,-0.1250f),
+  vec2( 0.1250f, 0.3125f),
+  vec2( 0.3125f, 0.1875f),
+  vec2( 0.1875f,-0.3125f),
+  vec2(-0.1250f, 0.3750f),
+  vec2( 0.0000f,-0.4375f),
+  vec2(-0.2500f,-0.3750f),
+  vec2(-0.3750f, 0.2500f),
+  vec2(-0.5000f, 0.0000f),
+  vec2( 0.4375f,-0.2500f),
+  vec2( 0.3750f, 0.4375f),
+  vec2(-0.4375f,-0.5000f),
+};
+
+void main() {
+  vec2 coord = vec2(p_src_coord0_x, p_src_coord0_y) + vec2(p_src_coord1_x - p_src_coord0_x, p_src_coord1_y - p_src_coord0_y) * i_pos;
+
+  ivec2 cint = ivec2(coord);
+  vec2 cfrac = fract(coord) - 0.5f;
+
+  uint pos_index = c_samples - 2u;
+
+  o_color = vec4(0.0f);
+
+  for (uint i = 0; i < c_samples; i++) {
+    vec2 sample_pos = sample_positions[pos_index + i];
+
+    ivec2 coffset = ivec2(greaterThan(cfrac - sample_pos, vec2(0.5f)));
+    o_color += texelFetch(s_image_ms, ivec3(cint + coffset, gl_Layer), int(i));
+  }
+  o_color = o_color / float(c_samples);
+}


### PR DESCRIPTION
Improves #4895 when using MSAA in Source.

HL2 frequently resolves a 2048x1536 screenshot into a 1024x1024 image which is then used for refraction when rendering glass.

The game does these resolves (using StretchRect) quite frequently and unfortunately a lot of them are redundant.
![image](https://github.com/user-attachments/assets/1156342a-043b-4098-a4f0-b21de43247c1)

Current DXVK master would first resolve the original texture to a temporary image and then blit that to the actual target texture.
While that's actually what the D3D9 docs suggest happens behind the scenes, it's a bit slow:
> Note that use of the extra surface involved in using StretchRect to downsample a Multisample Rendertarget will result in a performance hit.

This PR changes it so the blit and resolve are done in one step rather than in two. It improves performance in the HL2 main menu at 4k Max settings with 8x MSAA from 240 fps to 265 fps.

Besides that, the PR also forbids creating a lockable texture with more than 1 sample. This matches what I've seen in tests done on Windows.

In the future I'd like to get rid of the resolve step in `LockImage` but for now we still need it because of the GDI-based presentation fallback.