### PR TITLE
[util] Fix black screen on return from the A.I.M. options window

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -1226,6 +1226,12 @@ namespace dxvk {
     { R"(\\bin\\trainz\.exe$)", {{
       { "d3d9.deviceLossOnFocusLoss",       "True" },
     }} },
+    /* A.I.M.: Artificial Intelligence Machine    *
+     * Fixes black screen after the options       *
+     * window is closed or on alt-tab             */
+     { R"(\\AIM\.exe$)", {{
+      { "d3d9.deviceLossOnFocusLoss",       "True" },
+    }} },
   };
 
 


### PR DESCRIPTION
A.I.M.: Artificial Intelligence Machine uses an external configuration window which is opened once the (d3d8) main menu option is selected. The added config option prevents a black screen on return to the main menu from the options window or simply by alt-tabbing back and forth in-game.