### PR TITLE
Fix usage of copyFeature

### DIFF
--- a/src/dxvk/dxvk_device_info.cpp
+++ b/src/dxvk/dxvk_device_info.cpp
@@ -343,8 +343,8 @@ namespace dxvk {
 
       copyFeature(deviceInfo->pNext, nullptr, &m_featuresSupported.core);
 
-      #define HANDLE_CORE(name) copyFeature(&deviceInfo->pNext, nullptr, &m_featuresSupported.name)
-      #define HANDLE_EXT(name) copyFeature(&deviceInfo->pNext, &m_extensionsSupported.name, &m_featuresSupported.name)
+      #define HANDLE_CORE(name) copyFeature(deviceInfo->pNext, nullptr, &m_featuresSupported.name)
+      #define HANDLE_EXT(name) copyFeature(deviceInfo->pNext, &m_extensionsSupported.name, &m_featuresSupported.name)
 
       CORE_VERSIONS
       EXTENSIONS_WITH_FEATURES


### PR DESCRIPTION
Usage of `copyFeature` is inconsistent in `initSupportedFeatures` when `deviceInfo` is provided. This happens in D3D11on12 scenarios where the device is reused. `copyFeature`'s signature is `const void*` not `const void**` as the ref to `deviceInfo->pNext` suggests. The first `copyFeature` succeeds because the usage is correct. The `CORE_VERSIONS` define crashes immediately.

Found testing on Windows with the  https://github.com/microsoft/directx-graphics-samples/tree/master/Samples/Desktop/D3D12VariableRateShading sample. It uses D3D11on12 and crashes in the `D3D11On12CreateDevice` call.