### PR TITLE
[dxvk] Error out at build time if AVX is enabled

### DIFF
--- a/src/util/util_bit.h
+++ b/src/util/util_bit.h
@@ -12,6 +12,9 @@
 
 #ifdef DXVK_ARCH_X86
   #ifndef _MSC_VER
+    #if defined(_WIN32) && (defined(__AVX__) || defined(__AVX2__))
+      #error "AVX-enabled builds not supported due to stack alignment issues."
+    #endif
     #if defined(__WINE__) && defined(__clang__)
       #pragma push_macro("_WIN32")
       #undef _WIN32


### PR DESCRIPTION
@WinterSnowfall made the good point that we should at least give users a warning when using unsupported build flags.

AVX is a no-no because it GCC will generate code that requires 32-byte stack alignment, but we're never going to get more than 16 (or 4 on 32-bit builds). Native builds and MSVC *should* be unaffected, but it's not tested.