### PR TITLE
[d3d9] Fix NULL format CheckDeviceMultiSampleType behavior

### DIFF
--- a/src/d3d9/d3d9_adapter.cpp
+++ b/src/d3d9/d3d9_adapter.cpp
@@ -246,7 +246,9 @@ namespace dxvk {
       return D3DERR_INVALIDCALL;
 
     auto dst = ConvertFormatUnfixed(SurfaceFormat);
-    if (dst.FormatColor == VK_FORMAT_UNDEFINED)
+    // Wargame: European Escalation expects NULL format
+    // checks to succeed, otherwise it will crash
+    if (SurfaceFormat != D3D9Format::NULL_FORMAT && dst.FormatColor == VK_FORMAT_UNDEFINED)
       return D3DERR_NOTAVAILABLE;
 
     if (MultiSampleType != D3DMULTISAMPLE_NONE


### PR DESCRIPTION
Drafted, until I write some tests to check if that's actually true in d3d8/9 as well, since the game is using 9Ex. But the below does fix crashing when attempting to start a game in Wargame: European Escalation.

Confirmed with an apitrace the game checks:

`IDirect3D9Ex::CheckDeviceMultiSampleType(this = 0x2e3cbf0, Adapter = D3DADAPTER_DEFAULT, DeviceType = D3DDEVTYPE_HAL, SurfaceFormat = D3DFMT_NULL, Windowed = FALSE, MultiSampleType = D3DMULTISAMPLE_NONE, pQualityLevels = ?) = D3DERR_NOTAVAILABLE`

... and crashes if the above call fails.