### PR TITLE
[d3d9] Add more known unsupported formats

### DIFF
--- a/src/d3d9/d3d9_format.cpp
+++ b/src/d3d9/d3d9_format.cpp
@@ -343,7 +343,7 @@ namespace dxvk {
 
       case D3D9Format::A1: return {}; // Unsupported
 
-      case D3D9Format::A2B10G10R10_XR_BIAS: return {}; // Unsupported
+      case D3D9Format::A2B10G10R10_XR_BIAS: return {}; // Unsupported (everywhere)
 
       case D3D9Format::BINARYBUFFER: return {
         VK_FORMAT_R8_UINT,
@@ -423,9 +423,28 @@ namespace dxvk {
 
       case D3D9Format::RAWZ: return {}; // Unsupported
 
-      case D3D9Format::R16:  return {}; // Unsupported
+      // EXT1, FXT1, GXT1 and HXT1 are checked for support
+      // by D3D9 SAGE engine games (e.g. Command & Conquer 3)
 
-      case D3D9Format::AL16: return {}; // Unsupported
+      case D3D9Format::EXT1: return {}; // Unsupported (everywhere)
+
+      case D3D9Format::FXT1: return {}; // Unsupported (everywhere)
+
+      case D3D9Format::GXT1: return {}; // Unsupported (everywhere)
+
+      case D3D9Format::HXT1: return {}; // Unsupported (everywhere)
+
+      // AL16 and R16 FOURCCs are often checked for support by
+      // various D3D8 and early D3D9 games. AR16 and L16 (FOURCC)
+      // are also checked for support, but to a lesser extent.
+
+      case D3D9Format::AL16: return {}; // Unsupported (everywhere)
+
+      case D3D9Format::AR16: return {}; // Unsupported (everywhere)
+
+      case D3D9Format::R16:  return {}; // Unsupported (everywhere)
+
+      case D3D9Format::L16_FOURCC:  return {}; // Unsupported (everywhere)
 
       default:
         Logger::warn(str::format("ConvertFormat: Unknown format encountered: ", Format));

--- a/src/d3d9/d3d9_format.h
+++ b/src/d3d9/d3d9_format.h
@@ -114,13 +114,15 @@ namespace dxvk {
     R2VB = MAKEFOURCC('R', '2', 'V', 'B'),
     COPM = MAKEFOURCC('C', 'O', 'P', 'M'),
     SSAA = MAKEFOURCC('S', 'S', 'A', 'A'),
-    AL16 = MAKEFOURCC('A', 'L', '1', '6'),
-    R16  = MAKEFOURCC(' ', 'R', '1', '6'),
 
     EXT1 = MAKEFOURCC('E', 'X', 'T', '1'),
     FXT1 = MAKEFOURCC('F', 'X', 'T', '1'),
     GXT1 = MAKEFOURCC('G', 'X', 'T', '1'),
     HXT1 = MAKEFOURCC('H', 'X', 'T', '1'),
+    AL16 = MAKEFOURCC('A', 'L', '1', '6'),
+    AR16 = MAKEFOURCC('A', 'R', '1', '6'),
+    R16  = MAKEFOURCC(' ', 'R', '1', '6'),
+    L16_FOURCC = MAKEFOURCC(' ', 'L', '1', '6'),
   };
 
   inline D3D9Format EnumerateFormat(D3DFORMAT format) {


### PR DESCRIPTION
Silences "ConvertFormat: Unknown format encountered:" log spam in some games that like to call `CheckDeviceFormat` a lot... even during rendering (don't ask). The warnings are a bit pointless for these formats anyway, since we know that they exist and are unsupported.

WineD3D, for some reason, allows OffscreenPlainSurface creation for `AL16` and `R16`, but I've checked both mordern and olden drivers and haven't found any indication that support was a thing even back in the day, in either d3d8 or 9, at least not on mid-2000s/Windows XP timescales. My suspicion is that perhaps at least some of these are remnants from even earlier d3d times, from the land of Mord... I mean ddraw, where the shadows lie.