### PR TITLE
[dxvk] Disable descriptor buffer on older Nvidia

### DIFF
--- a/src/dxvk/dxvk_device_info.h
+++ b/src/dxvk/dxvk_device_info.h
@@ -316,6 +316,8 @@ namespace dxvk {
 
     DxvkDeviceQueueMapping                m_queueMapping = { };
 
+    bool                                  m_hasMeshShader = false;
+
     std::vector<const VkExtensionProperties*> m_extensionList;
 
     std::vector<VkQueueFamilyProperties2> m_queuesAvailable;


### PR DESCRIPTION
Apparently this is not really an option when there's 40% perf regressions.

Fixes #5043.