### PR TITLE
[dxvk] Disable descriptor buffer on AMDVLK on RDNA2 and older

### DIFF
--- a/src/dxvk/dxvk_device_info.h
+++ b/src/dxvk/dxvk_device_info.h
@@ -317,6 +317,7 @@ namespace dxvk {
     DxvkDeviceQueueMapping                m_queueMapping = { };
 
     bool                                  m_hasMeshShader = false;
+    bool                                  m_hasFmask = false;
 
     std::vector<const VkExtensionProperties*> m_extensionList;
 


### PR DESCRIPTION
So yeah apparently amdvlk just goes -90% perf with this in Half-Life 2. Thanks to @Blisto91 for spotting this.