### PR TITLE
[util] disable d3d9.textureMemory for Dungeon Lords

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -1063,6 +1063,10 @@ namespace dxvk {
       { "d3d9.countLosableResources",      "False" },
       { "d3d9.maxFrameRate",                  "60" },
     }} },
+    /* Dungeon Lords - Crash when saving game     */
+    { R"(\\(DLSteamEdition|dlords)\.exe$)", {{
+      { "d3d9.textureMemory",                  "0" },
+    }} },
 
     /**********************************************/
     /* D3D8 GAMES                                 */


### PR DESCRIPTION
closes #5048