### PR TITLE
[util] Disable losable resource tracking for SFC3

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -1232,8 +1232,14 @@ namespace dxvk {
     /* A.I.M.: Artificial Intelligence Machine    *
      * Fixes black screen after the options       *
      * window is closed or on alt-tab             */
-     { R"(\\AIM\.exe$)", {{
+    { R"(\\AIM\.exe$)", {{
       { "d3d9.deviceLossOnFocusLoss",       "True" },
+    }} },
+    /* Star Trek: Starfleet Command III           *
+     * The GOG release ships with a D3D8 to D3D9  *
+     * wrapper that leaks several surfaces.       */
+    { R"(\\SFC3\.exe$)", {{
+      { "d3d9.countLosableResources",      "False" },
     }} },
   };
 


### PR DESCRIPTION
What the description says. The leaks happen just after the wrapper initializes a d3d9 device to run some tests (I guess?). The device reset right before game initialization fails without the below. Janky game patches be jank.