### PR TITLE
Display whether device is 11on12 or 9on12 device in HUD

### DIFF
--- a/src/d3d11/d3d11_swapchain.cpp
+++ b/src/d3d11/d3d11_swapchain.cpp
@@ -699,7 +699,9 @@ namespace dxvk {
     uint32_t flHi = (featureLevel >> 12);
     uint32_t flLo = (featureLevel >> 8) & 0x7;
 
-    return str::format("D3D", apiVersion, " FL", flHi, "_", flLo);
+    bool is11On12 = m_parent->Is11on12Device();
+
+    return str::format("D3D", apiVersion, (is11On12 ? "On12" : ""), " FL", flHi, "_", flLo);
   }
 
 }

--- a/src/d3d9/d3d9_adapter.cpp
+++ b/src/d3d9/d3d9_adapter.cpp
@@ -37,6 +37,7 @@ namespace dxvk {
 
   D3D9Adapter::D3D9Adapter(
           D3D9InterfaceEx* pParent,
+    const D3D9ON12_ARGS*   p9On12Args,
           Rc<DxvkAdapter>  Adapter,
           UINT             Ordinal,
           UINT             DisplayIndex)
@@ -49,6 +50,9 @@ namespace dxvk {
     // D3D9VkFormatTable needs to be constructed after we've cached the
     // identifier info and determined the proper vendorID to be used.
     m_d3d9Formats = std::make_unique<D3D9VkFormatTable>(this, Adapter, m_parent->GetOptions());
+
+    if (p9On12Args)
+      m_9On12Args = *p9On12Args;
   }
 
 

--- a/src/d3d9/d3d9_adapter.h
+++ b/src/d3d9/d3d9_adapter.h
@@ -17,6 +17,7 @@ namespace dxvk {
 
     D3D9Adapter(
             D3D9InterfaceEx* pParent,
+      const D3D9ON12_ARGS*   p9On12Args,
             Rc<DxvkAdapter>  Adapter,
             UINT             Ordinal,
             UINT             DisplayIndex);
@@ -91,6 +92,10 @@ namespace dxvk {
       return m_d3d9Formats->GetUnsupportedFormatInfo(Format);
     }
 
+    D3D9ON12_ARGS Get9On12Args() const {
+      return m_9On12Args;
+    }
+
     bool IsExtended() const;
 
     bool IsD3D8Compatible() const;
@@ -121,6 +126,7 @@ namespace dxvk {
     uint32_t                      m_deviceId;
     std::string                   m_deviceDesc;
     std::string                   m_deviceDriver;
+    D3D9ON12_ARGS                 m_9On12Args = { };
 
     std::vector<D3DDISPLAYMODEEX>            m_modes;
     D3D9Format                               m_modeCacheFormat;

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -1272,6 +1272,10 @@ namespace dxvk {
       return DxvkCsChunkRef(chunk, &m_csChunkPool);
     }
 
+    bool Is9On12Device() const {
+      return m_d3d9On12Args.Enable9On12;
+    }
+
   private:
 
     template<bool AllowFlush = true, typename Cmd>
@@ -1691,6 +1695,7 @@ namespace dxvk {
     Direct3DState9                  m_state;
 
     D3D9VkInteropDevice             m_d3d9Interop;
+    D3D9ON12_ARGS                   m_d3d9On12Args = { };
     D3D9On12                        m_d3d9On12;
     DxvkD3D8Bridge                  m_d3d8Bridge;
 

--- a/src/d3d9/d3d9_interface.cpp
+++ b/src/d3d9/d3d9_interface.cpp
@@ -13,7 +13,7 @@ namespace dxvk {
 
   Singleton<DxvkInstance> g_dxvkInstance;
 
-  D3D9InterfaceEx::D3D9InterfaceEx(bool bExtended)
+  D3D9InterfaceEx::D3D9InterfaceEx(bool bExtended, const D3D9ON12_ARGS* pOverrideList, uint32_t OverrideCount)
     : m_instance    ( g_dxvkInstance.acquire(DxvkInstanceFlag::ClientApiIsD3D9) )
     , m_d3d8Bridge  ( this )
     , m_extended    ( bExtended ) 
@@ -47,8 +47,10 @@ namespace dxvk {
           ? m_instance->enumAdapters(0)
           : m_instance->enumAdapters(adapterOrdinal);
 
-        if (adapter != nullptr)
-          m_adapters.emplace_back(this, adapter, adapterOrdinal++, i - 1);
+        if (adapter != nullptr) {
+          const auto* d3d9On12Args = Find9On12Args(adapter, pOverrideList, OverrideCount);
+          m_adapters.emplace_back(this, d3d9On12Args, adapter, adapterOrdinal++, i - 1);
+        }
       }
     }
     else
@@ -57,8 +59,10 @@ namespace dxvk {
       const uint32_t adapterCount = m_instance->adapterCount();
       m_adapters.reserve(adapterCount);
 
-      for (uint32_t i = 0; i < adapterCount; i++)
-        m_adapters.emplace_back(this, m_instance->enumAdapters(i), i, 0);
+      for (uint32_t i = 0; i < adapterCount; i++) {
+        const auto* d3d9On12Args = Find9On12Args(m_instance->enumAdapters(i), pOverrideList, OverrideCount);
+        m_adapters.emplace_back(this, d3d9On12Args, m_instance->enumAdapters(i), i, 0);
+      }
     }
 
 #ifdef _WIN32
@@ -477,6 +481,37 @@ namespace dxvk {
       return D3DERR_INVALIDCALL;
 
     return D3D_OK;
+  }
+
+
+  const D3D9ON12_ARGS* D3D9InterfaceEx::Find9On12Args(
+    const Rc<DxvkAdapter>& Adapter,
+    const D3D9ON12_ARGS*   pOverrides,
+          uint32_t         OverrideCount) {
+    const D3D9ON12_ARGS* arg = nullptr;
+
+#ifdef _WIN32
+    for (uint32_t i = 0u; i < OverrideCount; i++) {
+      if (pOverrides[i].pD3D12Device) {
+        const auto& vk11 = Adapter->deviceProperties().vk11;
+
+        if (vk11.deviceLUIDValid) {
+          Com<ID3D12Device> device = nullptr;
+
+          if (SUCCEEDED(pOverrides[i].pD3D12Device->QueryInterface(__uuidof(ID3D12Device), reinterpret_cast<void**>(&device)))) {
+            LUID luid = device->GetAdapterLuid();
+
+            if (!std::memcmp(&luid, vk11.deviceLUID, sizeof(vk11.deviceLUID)))
+              arg = &pOverrides[i];
+          }
+        }
+      } else if (!arg) {
+        arg = &pOverrides[i];
+      }
+    }
+#endif
+
+    return arg;
   }
 
 }

--- a/src/d3d9/d3d9_interface.h
+++ b/src/d3d9/d3d9_interface.h
@@ -19,7 +19,10 @@ namespace dxvk {
 
   public:
 
-    D3D9InterfaceEx(bool bExtended);
+    D3D9InterfaceEx(
+              bool           bExtended,
+        const D3D9ON12_ARGS* pOverrideList,
+              uint32_t       OverrideCount);
 
     ~D3D9InterfaceEx();
 
@@ -159,6 +162,11 @@ namespace dxvk {
     std::vector<D3D9Adapter>      m_adapters;
 
     D3D9VkInteropInterface        m_d3d9Interop;
+
+    static const D3D9ON12_ARGS* Find9On12Args(
+      const Rc<DxvkAdapter>& Adapter,
+      const D3D9ON12_ARGS*   pOverrides,
+            uint32_t         OverrideCount);
 
   };
 

--- a/src/d3d9/d3d9_main.cpp
+++ b/src/d3d9/d3d9_main.cpp
@@ -14,11 +14,13 @@ namespace dxvk {
 
   HRESULT CreateD3D9(
           bool           Extended,
-          IDirect3D9Ex** ppDirect3D9Ex) {
+          IDirect3D9Ex** ppDirect3D9Ex,
+    const D3D9ON12_ARGS* pOverrideList,
+          uint32_t       OverrideCount) {
     if (!ppDirect3D9Ex)
       return D3DERR_INVALIDCALL;
 
-    *ppDirect3D9Ex = ref(new D3D9InterfaceEx( Extended ));
+    *ppDirect3D9Ex = ref(new D3D9InterfaceEx(Extended, pOverrideList, OverrideCount));
     return D3D_OK;
   }
 }
@@ -28,13 +30,13 @@ extern "C" {
 
   DLLEXPORT IDirect3D9* __stdcall Direct3DCreate9(UINT nSDKVersion) {
     IDirect3D9Ex* pDirect3D = nullptr;
-    dxvk::CreateD3D9(false, &pDirect3D);
+    dxvk::CreateD3D9(false, &pDirect3D, nullptr, 0);
 
     return pDirect3D;
   }
 
   DLLEXPORT HRESULT __stdcall Direct3DCreate9Ex(UINT nSDKVersion, IDirect3D9Ex** ppDirect3D9Ex) {
-    return dxvk::CreateD3D9(true, ppDirect3D9Ex);
+    return dxvk::CreateD3D9(true, ppDirect3D9Ex, nullptr, 0);
   }
 
   DLLEXPORT int __stdcall D3DPERF_BeginEvent(D3DCOLOR col, LPCWSTR wszName) {
@@ -103,12 +105,16 @@ extern "C" {
 
   DLLEXPORT IDirect3D9* __stdcall Direct3DCreate9On12(UINT sdk_version, D3D9ON12_ARGS* override_list, UINT override_entry_count) {
     dxvk::Logger::warn("Direct3DCreate9On12: 9On12 functionality is unimplemented.");
-    return Direct3DCreate9(sdk_version);
+
+    IDirect3D9Ex* pDirect3D = nullptr;
+    dxvk::CreateD3D9(false, &pDirect3D, override_list, override_entry_count);
+
+    return pDirect3D;
   }
 
   DLLEXPORT HRESULT __stdcall Direct3DCreate9On12Ex(UINT sdk_version, D3D9ON12_ARGS* override_list, UINT override_entry_count, IDirect3D9Ex** output) {
     dxvk::Logger::warn("Direct3DCreate9On12Ex: 9On12 functionality is unimplemented.");
-    return Direct3DCreate9Ex(sdk_version, output);
+    return dxvk::CreateD3D9(true, output, override_list, override_entry_count);
   }
 
 }

--- a/src/d3d9/d3d9_swapchain.cpp
+++ b/src/d3d9/d3d9_swapchain.cpp
@@ -1352,6 +1352,9 @@ namespace dxvk {
 
 
   std::string D3D9SwapChainEx::GetApiName() {
+    if (this->GetParent()->Is9On12Device())
+      return this->GetParent()->IsExtended() ? "D3D9On12Ex" : "D3D9On12";
+
     return this->GetParent()->IsD3D8Compatible() ? "D3D8" :
            this->GetParent()->IsExtended() ? "D3D9Ex" : "D3D9";
   }


### PR DESCRIPTION
Only relevant if the game actually creates a D3D9 or D3D11 swap chain rather than a D3D12 one, but A Hat In Time does just that:

![Bildschirmfoto-1013](https://github.com/user-attachments/assets/3f353be0-0ed8-4c36-b0f5-36d9b26c9b11)
