### PR TITLE
Dcomp swapchain

### DIFF
--- a/src/dxgi/dxgi_factory.cpp
+++ b/src/dxgi/dxgi_factory.cpp
@@ -521,9 +521,11 @@ namespace dxvk {
     // Make sure the back buffer size is not zero
     DXGI_SWAP_CHAIN_DESC1 desc = *pDesc;
 
-    wsi::getWindowSize(hWnd,
-      desc.Width  ? nullptr : &desc.Width,
-      desc.Height ? nullptr : &desc.Height);
+    if (hWnd) {
+      wsi::getWindowSize(hWnd,
+        desc.Width  ? nullptr : &desc.Width,
+        desc.Height ? nullptr : &desc.Height);
+    }
 
     // If necessary, set up a default set of
     // fullscreen parameters for the swap chain

--- a/src/dxgi/dxgi_swapchain.cpp
+++ b/src/dxgi/dxgi_swapchain.cpp
@@ -361,7 +361,7 @@ namespace dxvk {
     std::lock_guard<dxvk::recursive_mutex> lockWin(m_lockWindow);
     HRESULT hr = S_OK;
 
-    if (wsi::isWindow(m_window)) {
+    if (wsi::isWindow(m_window) || !m_window) {
       std::lock_guard<dxvk::mutex> lockBuf(m_lockBuffer);
       hr = m_presenter->Present(SyncInterval, PresentFlags, nullptr);
     }
@@ -420,7 +420,7 @@ namespace dxvk {
           UINT                      SwapChainFlags,
     const UINT*                     pCreationNodeMask,
           IUnknown* const*          ppPresentQueue) {
-    if (!wsi::isWindow(m_window))
+    if (m_window && !wsi::isWindow(m_window))
       return DXGI_ERROR_INVALID_CALL;
 
     constexpr UINT PreserveFlags = DXGI_SWAP_CHAIN_FLAG_FRAME_LATENCY_WAITABLE_OBJECT;
@@ -432,9 +432,11 @@ namespace dxvk {
     m_desc.Width  = Width;
     m_desc.Height = Height;
     
-    wsi::getWindowSize(m_window,
-      m_desc.Width  ? nullptr : &m_desc.Width,
-      m_desc.Height ? nullptr : &m_desc.Height);
+    if (m_window) {
+      wsi::getWindowSize(m_window,
+        m_desc.Width  ? nullptr : &m_desc.Width,
+        m_desc.Height ? nullptr : &m_desc.Height);
+    }
     
     if (BufferCount != 0)
       m_desc.BufferCount = BufferCount;


### PR DESCRIPTION
Band-aid for #5053 for now, Present as well as ResizeBuffers should just work.

At some point, we should probably test how the other methods behave since things like ResizeTarget don't seem to make much sense in the context of dcomp.

Not ideal to have a dummy window, but this should at least work with d3d12 as-is.