### PR TITLE
[d3d9] Only use readonly depth layout if necessary

### DIFF
--- a/src/d3d9/d3d9_common_texture.cpp
+++ b/src/d3d9/d3d9_common_texture.cpp
@@ -714,6 +714,11 @@ namespace dxvk {
       m_sampleView.Srgb = CreateView(AllLayers, Lod,
         VK_IMAGE_USAGE_SAMPLED_BIT, VK_IMAGE_LAYOUT_UNDEFINED, true);
     }
+
+    if (IsDepthStencil() && GetType() != D3DRTYPE_SURFACE) {
+      m_sampleView.DepthReadOnly = CreateView(AllLayers, Lod,
+        VK_IMAGE_USAGE_SAMPLED_BIT, VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_STENCIL_ATTACHMENT_OPTIMAL, false);
+    }
   }
 
 

--- a/src/d3d9/d3d9_common_texture.h
+++ b/src/d3d9/d3d9_common_texture.h
@@ -64,6 +64,7 @@ namespace dxvk {
 
     Rc<DxvkImageView> Color;
     Rc<DxvkImageView> Srgb;
+    Rc<DxvkImageView> DepthReadOnly;
   };
 
   template <typename T>
@@ -351,6 +352,10 @@ namespace dxvk {
 
     const Rc<DxvkImageView>& GetSampleView(bool srgb) const {
       return m_sampleView.Pick(srgb && IsSrgbCompatible());
+    }
+
+    const Rc<DxvkImageView>& GetDepthReadOnlySampleView() const {
+      return m_sampleView.DepthReadOnly;
     }
 
     Rc<DxvkImageView> CreateView(


### PR DESCRIPTION
In current master, we use `LAYOUT_DEPTH_READONLY` views every time writing the depth buffer is disabled. This causes unnecessary layout transitions. It also doesn't really have any advantages because we never use this layout when also sampling the depth buffer.

The PR changes it so we always use the read-write layout unless the depth texture is also bound for sampling and depth write is disabled. I'm not sure if the extra complexity is worth it compared to just resorting to FEEDBACK_LOOP_LAYOUT when the depth texture is bound for depth testing and sampling. Let me know, what you think.

Either way, not using DEPTH_READONLY for depth attachments significantly reduces the number of render passes in Half Life 2. One random hallway in one of my apitraces goes from 17 render passes down to just 10. The City 17 main menu scene goes from 51 render passes down to just 28.

Hopefully helps a bit for #4895