### PR TITLE
Add missing ID3DDestructionNotifier support in DXGI

### DIFF
--- a/src/dxgi/dxgi_adapter.cpp
+++ b/src/dxgi/dxgi_adapter.cpp
@@ -64,7 +64,8 @@ namespace dxvk {
     m_adapter (adapter),
     m_interop (this),
     m_index   (index),
-    m_desc    (GetAdapterDesc()) {
+    m_desc    (GetAdapterDesc()),
+    m_destructionNotifier(this) {
     
   }
   
@@ -101,6 +102,11 @@ namespace dxvk {
 
     if (riid == __uuidof(IDXGIVkInteropAdapter)) {
       *ppvObject = ref(&m_interop);
+      return S_OK;
+    }
+
+    if (riid == __uuidof(ID3DDestructionNotifier)) {
+      *ppvObject = ref(&m_destructionNotifier);
       return S_OK;
     }
     

--- a/src/dxgi/dxgi_adapter.h
+++ b/src/dxgi/dxgi_adapter.h
@@ -124,6 +124,8 @@ namespace dxvk {
     std::unordered_map<DWORD, HANDLE> m_eventMap;
     dxvk::thread                      m_eventThread;
 
+    D3DDestructionNotifier m_destructionNotifier;
+
     DXGI_ADAPTER_DESC3 GetAdapterDesc() const;
 
     void runEventThread();

--- a/src/dxgi/dxgi_factory.cpp
+++ b/src/dxgi/dxgi_factory.cpp
@@ -84,7 +84,8 @@ namespace dxvk {
     m_options         (m_instance->config()),
     m_monitorInfo     (this, m_options),
     m_flags           (Flags),
-    m_monitorFallback (false) {
+    m_monitorFallback (false),
+    m_destructionNotifier(this) {
     // Be robust against situations where some monitors are not
     // associated with any adapter. This can happen if device
     // filter options are used.
@@ -163,6 +164,11 @@ namespace dxvk {
 
     if (riid == __uuidof(IDXGIVkMonitorInfo)) {
       *ppvObject = ref(&m_monitorInfo);
+      return S_OK;
+    }
+
+    if (riid == __uuidof(ID3DDestructionNotifier)) {
+      *ppvObject = ref(&m_destructionNotifier);
       return S_OK;
     }
     

--- a/src/dxgi/dxgi_factory.h
+++ b/src/dxgi/dxgi_factory.h
@@ -199,6 +199,8 @@ namespace dxvk {
     DxgiMonitorInfo  m_monitorInfo;
     UINT             m_flags;
     BOOL             m_monitorFallback;
+
+    D3DDestructionNotifier m_destructionNotifier;
       
 
     HRESULT STDMETHODCALLTYPE CreateSwapChainBase(

--- a/src/dxgi/dxgi_output.cpp
+++ b/src/dxgi/dxgi_output.cpp
@@ -27,7 +27,8 @@ namespace dxvk {
   : m_factory     ( factory ),
     m_adapter     ( adapter ),
     m_monitorInfo ( factory->GetMonitorInfo() ),
-    m_monitor     ( monitor ) {
+    m_monitor     ( monitor ),
+    m_destructionNotifier(this) {
     CacheMonitorData();
   }
   
@@ -53,6 +54,11 @@ namespace dxvk {
      || riid == __uuidof(IDXGIOutput5)
      || riid == __uuidof(IDXGIOutput6)) {
       *ppvObject = ref(this);
+      return S_OK;
+    }
+
+    if (riid == __uuidof(ID3DDestructionNotifier)) {
+      *ppvObject = ref(&m_destructionNotifier);
       return S_OK;
     }
     

--- a/src/dxgi/dxgi_output.h
+++ b/src/dxgi/dxgi_output.h
@@ -136,6 +136,8 @@ namespace dxvk {
 
     wsi::WsiDisplayMetadata m_metadata = {};
 
+    D3DDestructionNotifier m_destructionNotifier;
+
     static void FilterModesByDesc(
             std::vector<DXGI_MODE_DESC1>& Modes,
       const DXGI_MODE_DESC1&              TargetMode);


### PR DESCRIPTION
Adds `ID3DDestructionNotifier` support to:

* `DxgiAdapter`
* `DxgiFactory`
* `DxgiOutput`

A quick test on Windows reveals that these objects support `ID3DDestructionNotifier`. It seems that anything with private data support also has `ID3DDestructionNotifier` support, so maybe it'd make sense to move all of this into `DxgiObject` instead.