### PR TITLE
[util] Add configs for GTR - FIA GT Racing Game

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -1253,6 +1253,14 @@ namespace dxvk {
     { R"(\\SFC3\.exe$)", {{
       { "d3d9.countLosableResources",      "False" },
     }} },
+    /* GTR - FIA GT Racing Game                   *                  
+     * Vram complaint & restricted resolutions    *
+     * Performance                                */
+    { R"(\\GTR (- FIA GT Rac(e)?ing Game|Demo)\\(GTR(Demo)?|(3D)?Config)\.exe$)", {{
+      { "d3d9.maxAvailableMemory",         "1024" },
+      { "d3d9.memoryTrackTest",            "True" },
+      { "d3d9.cachedDynamicBuffers",       "True" },
+    }} },
   };
 
 


### PR DESCRIPTION
Otherwise the games config tool will complain about vram unless we restrict it and also wont allow up to 1080p if set too high. Also helps CPU performance.