### PR TITLE
[d3d8/9] General and format helpers cleanup

### DIFF
--- a/src/d3d8/d3d8_batch.h
+++ b/src/d3d8/d3d8_batch.h
@@ -152,31 +152,29 @@ namespace dxvk {
       Batch* batch = &m_batches[size_t(batchedPrimType)];
       batch->PrimitiveType = batchedPrimType;
 
-      //UINT vertices = GetVertexCount8(PrimitiveType, PrimitiveCount);
-
       switch (PrimitiveType) {
         case D3DPT_POINTLIST:
           batch->Indices.resize(batch->Offset + PrimitiveCount);
-          for (UINT i = 0; i < PrimitiveCount; i++)
+          for (uint32_t i = 0; i < PrimitiveCount; i++)
             batch->Indices[batch->Offset++] = (StartVertex + i);
           break;
         case D3DPT_LINELIST:
           batch->Indices.resize(batch->Offset + PrimitiveCount * 2);
-          for (UINT i = 0; i < PrimitiveCount; i++) {
+          for (uint32_t i = 0; i < PrimitiveCount; i++) {
             batch->Indices[batch->Offset++] = (StartVertex + i * 2 + 0);
             batch->Indices[batch->Offset++] = (StartVertex + i * 2 + 1);
           }
           break;
         case D3DPT_LINESTRIP:
           batch->Indices.resize(batch->Offset + PrimitiveCount * 2);
-          for (UINT i = 0; i < PrimitiveCount; i++) {
+          for (uint32_t i = 0; i < PrimitiveCount; i++) {
             batch->Indices[batch->Offset++] = (StartVertex + i + 0);
             batch->Indices[batch->Offset++] = (StartVertex + i + 1);
           }
           break;
         case D3DPT_TRIANGLELIST:
           batch->Indices.resize(batch->Offset + PrimitiveCount * 3);
-          for (UINT i = 0; i < PrimitiveCount; i++) {
+          for (uint32_t i = 0; i < PrimitiveCount; i++) {
             batch->Indices[batch->Offset++] = (StartVertex + i * 3 + 0);
             batch->Indices[batch->Offset++] = (StartVertex + i * 3 + 1);
             batch->Indices[batch->Offset++] = (StartVertex + i * 3 + 2);
@@ -190,14 +188,14 @@ namespace dxvk {
             batch->Indices[batch->Offset + 1] = batch->Indices[batch->Offset-2];
             batch->Indices[batch->Offset += 2] = StartVertex;
           }
-          for (UINT i = 0; i < PrimitiveCount; i++) {
+          for (uint32_t i = 0; i < PrimitiveCount; i++) {
             batch->Indices[batch->Offset++] = (StartVertex + i + 0);
           }
           break;
         // 1 2 3 4 5 6 7 -> 1 2 3, 1 3 4, 1 4 5, 1 5 6, 1 6 7
         case D3DPT_TRIANGLEFAN:
           batch->Indices.resize(batch->Offset + PrimitiveCount * 3);
-          for (UINT i = 0; i < PrimitiveCount; i++) {
+          for (uint32_t i = 0; i < PrimitiveCount; i++) {
             batch->Indices[batch->Offset++] = (StartVertex + 0);
             batch->Indices[batch->Offset++] = (StartVertex + i + 1);
             batch->Indices[batch->Offset++] = (StartVertex + i + 2);

--- a/src/d3d8/d3d8_device.h
+++ b/src/d3d8/d3d8_device.h
@@ -374,7 +374,7 @@ namespace dxvk {
      * called immediately before changing any D3D9 state.
      */
     inline void StateChange() {
-      if (ShouldBatch())
+      if (unlikely(ShouldBatch()))
         m_batcher->StateChange();
     }
 

--- a/src/d3d8/d3d8_format.h
+++ b/src/d3d8/d3d8_format.h
@@ -4,7 +4,7 @@
 
 namespace dxvk {
 
-  constexpr bool isDXT(D3DFORMAT fmt) {
+  inline bool isDXTFormat(D3DFORMAT fmt) {
     return fmt == D3DFMT_DXT1
         || fmt == D3DFMT_DXT2
         || fmt == D3DFMT_DXT3
@@ -12,11 +12,7 @@ namespace dxvk {
         || fmt == D3DFMT_DXT5;
   }
 
-  constexpr bool isDXT(d3d9::D3DFORMAT fmt) {
-    return isDXT(D3DFORMAT(fmt));
-  }
-
-  constexpr bool isDepthStencilFormat(D3DFORMAT fmt) {
+  inline bool isDepthStencilFormat(D3DFORMAT fmt) {
     return fmt == D3DFMT_D16_LOCKABLE
         || fmt == D3DFMT_D16
         || fmt == D3DFMT_D32
@@ -29,7 +25,7 @@ namespace dxvk {
   // The d3d8 documentation states: Render target formats are restricted to
   // D3DFMT_X1R5G5B5, D3DFMT_R5G6B5, D3DFMT_X8R8G8B8, and D3DFMT_A8R8G8B8.
   // This limited RT format support is confirmed by age-accurate drivers.
-  constexpr bool isRenderTargetFormat(D3DFORMAT fmt) {
+  inline bool isRenderTargetFormat(D3DFORMAT fmt) {
     return fmt == D3DFMT_X1R5G5B5
         || fmt == D3DFMT_R5G6B5
         || fmt == D3DFMT_X8R8G8B8
@@ -41,7 +37,7 @@ namespace dxvk {
 
   // Some games will exhaustively query all formats in the 0-100 range,
   // so filter out some known formats which are exclusive to d3d9
-  constexpr bool isD3D9ExclusiveFormat(D3DFORMAT fmt) {
+  inline bool isD3D9ExclusiveFormat(D3DFORMAT fmt) {
     const d3d9::D3DFORMAT d3d9Fmt = d3d9::D3DFORMAT(fmt);
 
     return d3d9Fmt == d3d9::D3DFMT_A8B8G8R8            //32
@@ -69,7 +65,7 @@ namespace dxvk {
   }
 
   // Get bytes per pixel (or 4x4 block for DXT)
-  constexpr UINT getFormatStride(D3DFORMAT fmt) {
+  inline UINT getFormatStride(D3DFORMAT fmt) {
     switch (fmt) {
       default:
       case D3DFMT_UNKNOWN:
@@ -122,113 +118,8 @@ namespace dxvk {
     }
   }
 
-  constexpr uint32_t GetVertexCount8(D3DPRIMITIVETYPE type, UINT count) {
-    switch (type) {
-      default:
-      case D3DPT_TRIANGLELIST:  return count * 3;
-      case D3DPT_POINTLIST:     return count;
-      case D3DPT_LINELIST:      return count * 2;
-      case D3DPT_LINESTRIP:     return count + 1;
-      case D3DPT_TRIANGLESTRIP: return count + 2;
-      case D3DPT_TRIANGLEFAN:   return count + 2;
-    }
-  }
-
-  // Essentially the same logic as D3D9VertexDecl::SetFVF
-  constexpr UINT GetFVFStride(DWORD FVF) {
-    uint32_t texCount = 0;
-
-    uint32_t betas = 0;
-    uint8_t betaIdx = 0xFF;
-
-    UINT size = 0;
-
-    switch (FVF & D3DFVF_POSITION_MASK) {
-      case D3DFVF_XYZ:
-      case D3DFVF_XYZB1:
-      case D3DFVF_XYZB2:
-      case D3DFVF_XYZB3:
-      case D3DFVF_XYZB4:
-      case D3DFVF_XYZB5:
-        size += sizeof(float) * 3;
-
-        if ((FVF & D3DFVF_POSITION_MASK) == D3DFVF_XYZ)
-          break;
-
-        betas = (((FVF & D3DFVF_XYZB5) - D3DFVF_XYZB1) >> 1) + 1;
-        if (FVF & D3DFVF_LASTBETA_D3DCOLOR)
-          betaIdx = sizeof(D3DCOLOR);
-        else if (FVF & D3DFVF_LASTBETA_UBYTE4)
-          betaIdx = sizeof(BYTE) * 4;
-        else if ((FVF & D3DFVF_XYZB5) == D3DFVF_XYZB5)
-          betaIdx = sizeof(float);
-
-        if (betaIdx != 0xFF)
-          betas--;
-
-        if (betas > 0) {
-          if (betas <= 4)
-            size += sizeof(float) * betas;
-        }
-
-        if (betaIdx != 0xFF) {
-          size += betaIdx;
-        }
-        break;
-
-      case D3DFVF_XYZW:
-      case D3DFVF_XYZRHW:
-        size += sizeof(float) * 4;
-        break;
-
-      default:
-        break;
-    }
-
-    if (FVF & D3DFVF_NORMAL) {
-      size += sizeof(float) * 3;
-    }
-    if (FVF & D3DFVF_PSIZE) {
-      size += sizeof(float);
-    }
-    if (FVF & D3DFVF_DIFFUSE) {
-      size += sizeof(D3DCOLOR);
-    }
-    if (FVF & D3DFVF_SPECULAR) {
-      size += sizeof(D3DCOLOR);
-    }
-
-    texCount = (FVF & D3DFVF_TEXCOUNT_MASK) >> D3DFVF_TEXCOUNT_SHIFT;
-    texCount = std::min(texCount, 8u);
-
-    for (uint32_t i = 0; i < texCount; i++) {
-      switch ((FVF >> (16 + i * 2)) & 0x3) {
-        case D3DFVF_TEXTUREFORMAT1:
-          size += sizeof(float);
-          break;
-
-        case D3DFVF_TEXTUREFORMAT2:
-          size += sizeof(float) * 2;
-          break;
-
-        case D3DFVF_TEXTUREFORMAT3:
-          size += sizeof(float) * 3;
-          break;
-
-        case D3DFVF_TEXTUREFORMAT4:
-          size += sizeof(float) * 4;
-          break;
-
-        default:
-          break;
-      }
-    }
-
-    return size;
-  }
-
-  constexpr UINT getSurfaceSize(D3DFORMAT Format, UINT Width, UINT Height) {
-    if (isDXT(Format)) {
+  inline UINT getSurfaceSize(D3DFORMAT Format, UINT Width, UINT Height) {
+    if (isDXTFormat(Format)) {
       Width = ((Width + 3) >> 2);
       Height = ((Height + 3) >> 2);
     }

--- a/src/d3d8/d3d8_shader.cpp
+++ b/src/d3d8/d3d8_shader.cpp
@@ -11,7 +11,7 @@
 
 namespace dxvk {
 
-  static constexpr int D3D8_NUM_VERTEX_INPUT_REGISTERS = 17;
+  static constexpr uint32_t D3D8_NUM_VERTEX_INPUT_REGISTERS = 17;
 
   /**
    * Standard mapping of vertex input registers v0-v16 to D3D9 usages and usage indices
@@ -131,10 +131,10 @@ namespace dxvk {
     DWORD shaderInputRegisters = 0;
 
     d3d9::D3DVERTEXELEMENT9* vertexElements = pTranslatedVS.declaration;
-    unsigned int elementIdx = 0;
+    uint32_t elementIdx = 0;
 
     // These are used for pDeclaration and pFunction
-    int i = 0;
+    uint32_t i = 0;
     DWORD token;
 
     std::stringstream dbg;
@@ -236,10 +236,10 @@ namespace dxvk {
           dbg << "count=" << count << ", addr=" << addr << ", rs=" << rs;
 
           // Add a DEF instruction for each constant
-          for (DWORD j = 0; j < regCount; j += 4) {
+          for (uint32_t j = 0; j < regCount; j += 4) {
             defs.push_back(encodeInstruction(d3d9::D3DSIO_DEF));
             defs.push_back(encodeDestRegister(d3d9::D3DSPR_CONST2, addr));
-            defs.push_back(pDeclaration[i+j+0]);
+            defs.push_back(pDeclaration[i+j]);
             defs.push_back(pDeclaration[i+j+1]);
             defs.push_back(pDeclaration[i+j+2]);
             defs.push_back(pDeclaration[i+j+3]);
@@ -287,7 +287,7 @@ namespace dxvk {
       Logger::debug(str::format("VS version: ", vsMajor, ".", vsMinor));
 
       // Insert dcl instructions
-      for (int vn = 0; vn < D3D8_NUM_VERTEX_INPUT_REGISTERS; vn++) {
+      for (UINT vn = 0; vn < D3D8_NUM_VERTEX_INPUT_REGISTERS; vn++) {
 
         // If bit N is set then we need to dcl register vN
         if ((shaderInputRegisters & (1 << vn)) != 0) {

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -4181,7 +4181,8 @@ namespace dxvk {
 
     uint32_t sampleCount = std::max<uint32_t>(MultiSample, 1u);
 
-    // Check if this is a power of two...
+    // Check if this is a power of two and
+    // return D3DERR_NOTAVAILABLE on failure
     if (sampleCount & (sampleCount - 1))
       return D3DERR_NOTAVAILABLE;
 

--- a/src/d3d9/d3d9_format.cpp
+++ b/src/d3d9/d3d9_format.cpp
@@ -1,5 +1,6 @@
 #include "d3d9_format.h"
 #include "d3d9_adapter.h"
+#include "d3d9_names.h"
 
 namespace dxvk {
 

--- a/src/d3d9/d3d9_format.h
+++ b/src/d3d9/d3d9_format.h
@@ -280,4 +280,31 @@ namespace dxvk {
         || format == D3D9Format::A8R8G8B8;
   }
 
+  inline bool IsDepthFormat(D3D9Format Format) {
+    return Format == D3D9Format::D16_LOCKABLE
+        || Format == D3D9Format::D32
+        || Format == D3D9Format::D15S1
+        || Format == D3D9Format::D24S8
+        || Format == D3D9Format::D24X8
+        || Format == D3D9Format::D24X4S4
+        || Format == D3D9Format::D16
+        || Format == D3D9Format::D32F_LOCKABLE
+        || Format == D3D9Format::D24FS8
+        || Format == D3D9Format::D32_LOCKABLE
+        || Format == D3D9Format::DF16
+        || Format == D3D9Format::DF24
+        || Format == D3D9Format::INTZ;
+  }
+
+  inline bool IsDepthStencilFormat(D3D9Format Format) {
+    return IsDepthFormat(Format) || Format == D3D9Format::S8_LOCKABLE;
+  }
+
+  inline bool IsLockableDepthStencilFormat(D3D9Format Format) {
+    return Format == D3D9Format::S8_LOCKABLE
+        || Format == D3D9Format::D16_LOCKABLE
+        || Format == D3D9Format::D32_LOCKABLE
+        || Format == D3D9Format::D32F_LOCKABLE;
+  }
+
 }

--- a/src/d3d9/d3d9_mem.cpp
+++ b/src/d3d9/d3d9_mem.cpp
@@ -96,8 +96,9 @@ namespace dxvk {
   }
 
   D3D9MemoryChunk::D3D9MemoryChunk(D3D9MemoryAllocator* Allocator, uint32_t Size)
-    : m_allocator(Allocator), m_size(Size) {
-    m_mapping = CreateFileMappingA(INVALID_HANDLE_VALUE, nullptr, PAGE_READWRITE | SEC_COMMIT, 0, Size, nullptr);
+    : m_allocator ( Allocator )
+    , m_size ( Size )
+    , m_mapping ( CreateFileMappingA(INVALID_HANDLE_VALUE, nullptr, PAGE_READWRITE | SEC_COMMIT, 0, Size, nullptr) ) {
     m_freeRanges.push_back({ 0, Size });
     uint32_t mappingGranularity = Allocator->MappingGranularity();
     m_mappingRanges.resize(((Size + mappingGranularity - 1) / mappingGranularity));

--- a/src/d3d9/d3d9_mem.h
+++ b/src/d3d9/d3d9_mem.h
@@ -60,8 +60,8 @@ namespace dxvk {
       uint32_t UnmapLocked(D3D9Memory* memory);
 
       D3D9MemoryAllocator* m_allocator;
-      HANDLE m_mapping;
       uint32_t m_size;
+      HANDLE m_mapping;
       std::vector<D3D9MemoryRange> m_freeRanges;
       std::vector<D3D9MappingRange> m_mappingRanges;
   };

--- a/src/d3d9/d3d9_names.cpp
+++ b/src/d3d9/d3d9_names.cpp
@@ -99,18 +99,24 @@ namespace dxvk {
       ENUM_NAME(D3D9Format::YV12);
       ENUM_NAME(D3D9Format::OPAQUE_420);
 
+      // Not supported but exist
       ENUM_NAME(D3D9Format::AI44);
       ENUM_NAME(D3D9Format::IA44);
+      ENUM_NAME(D3D9Format::CENT);
       ENUM_NAME(D3D9Format::R2VB);
       ENUM_NAME(D3D9Format::COPM);
       ENUM_NAME(D3D9Format::SSAA);
-      ENUM_NAME(D3D9Format::AL16);
-      ENUM_NAME(D3D9Format::R16);
+      ENUM_NAME(D3D9Format::NVHS);
+      ENUM_NAME(D3D9Format::NVHU);
 
       ENUM_NAME(D3D9Format::EXT1);
       ENUM_NAME(D3D9Format::FXT1);
       ENUM_NAME(D3D9Format::GXT1);
       ENUM_NAME(D3D9Format::HXT1);
+      ENUM_NAME(D3D9Format::AL16);
+      ENUM_NAME(D3D9Format::AR16);
+      ENUM_NAME(D3D9Format::R16);
+      ENUM_NAME(D3D9Format::L16_FOURCC);
 
       ENUM_DEFAULT(e);
     }

--- a/src/d3d9/d3d9_names.h
+++ b/src/d3d9/d3d9_names.h
@@ -2,6 +2,8 @@
 
 namespace dxvk {
 
+  std::ostream& operator << (std::ostream& os, D3D9Format e);
+
   std::ostream& operator << (std::ostream& os, D3DRENDERSTATETYPE e);
 
 }

--- a/src/d3d9/d3d9_swapchain.cpp
+++ b/src/d3d9/d3d9_swapchain.cpp
@@ -998,7 +998,7 @@ namespace dxvk {
     // creating a new one to free up resources
     DestroyBackBuffers();
 
-    int frontBufferCount = (SwapWithFrontBuffer() || m_parent->GetOptions()->extraFrontbuffer) ? 1 : 0;
+    const uint32_t frontBufferCount = (SwapWithFrontBuffer() || m_parent->GetOptions()->extraFrontbuffer) ? 1 : 0;
     const uint32_t bufferCount = NumBackBuffers + frontBufferCount;
 
     m_backBuffers.reserve(bufferCount);

--- a/src/d3d9/d3d9_util.cpp
+++ b/src/d3d9/d3d9_util.cpp
@@ -289,6 +289,7 @@ namespace dxvk {
     extent.depth  = box.Back   - box.Front;
   }
 
+
   void ConvertRect(RECT rect, VkOffset3D& offset, VkExtent3D& extent) {
     offset.x = rect.left;
     offset.y = rect.top;
@@ -299,6 +300,7 @@ namespace dxvk {
     extent.depth  = 1;
   }
 
+
   void ConvertRect(RECT rect, VkOffset2D& offset, VkExtent2D& extent) {
     offset.x = rect.left;
     offset.y = rect.top;
@@ -306,6 +308,7 @@ namespace dxvk {
     extent.width  = rect.right  - rect.left;
     extent.height = rect.bottom - rect.top;
   }
+
 
   uint32_t GetDecltypeSize(D3DDECLTYPE Type) {
     switch (Type) {
@@ -352,34 +355,6 @@ namespace dxvk {
       case D3DDECLTYPE_FLOAT16_4: return 4;
       default:                    return 0;
     }
-  }
-
-
-  bool IsDepthFormat(D3D9Format Format) {
-    return Format == D3D9Format::D16_LOCKABLE
-        || Format == D3D9Format::D32
-        || Format == D3D9Format::D15S1
-        || Format == D3D9Format::D24S8
-        || Format == D3D9Format::D24X8
-        || Format == D3D9Format::D24X4S4
-        || Format == D3D9Format::D16
-        || Format == D3D9Format::D32F_LOCKABLE
-        || Format == D3D9Format::D24FS8
-        || Format == D3D9Format::D32_LOCKABLE
-        || Format == D3D9Format::DF16
-        || Format == D3D9Format::DF24
-        || Format == D3D9Format::INTZ;
-  }
-
-  bool IsDepthStencilFormat(D3D9Format Format) {
-    return IsDepthFormat(Format) || Format == D3D9Format::S8_LOCKABLE;
-  }
-
-  bool IsLockableDepthStencilFormat(D3D9Format Format) {
-    return Format == D3D9Format::S8_LOCKABLE
-        || Format == D3D9Format::D16_LOCKABLE
-        || Format == D3D9Format::D32_LOCKABLE
-        || Format == D3D9Format::D32F_LOCKABLE;
   }
 
 }

--- a/src/d3d9/d3d9_util.h
+++ b/src/d3d9/d3d9_util.h
@@ -266,13 +266,6 @@ namespace dxvk {
     return count;
   }
 
-  bool IsDepthFormat(D3D9Format Format);
-
-  bool IsDepthStencilFormat(D3D9Format Format);
-
-  bool IsLockableDepthStencilFormat(D3D9Format Format);
-
-
   inline bool IsPoolManaged(D3DPOOL Pool) {
     return Pool == D3DPOOL_MANAGED || Pool == D3DPOOL_MANAGED_EX;
   }


### PR DESCRIPTION
The initial idea was to get rid of some now dead d3d8 code (some leftovers from the initial batcher implementation, I guess) and consolidate things a bit, but I happened to spot some misplaced d3d9 format helpers too while at it.