### PR TITLE
[d3d9] Fix a couple of omissions

### DIFF
--- a/src/d3d9/d3d9_names.cpp
+++ b/src/d3d9/d3d9_names.cpp
@@ -33,6 +33,7 @@ namespace dxvk {
       ENUM_NAME(D3D9Format::X8L8V8U8);
       ENUM_NAME(D3D9Format::Q8W8V8U8);
       ENUM_NAME(D3D9Format::V16U16);
+      ENUM_NAME(D3D9Format::W11V11U10);
       ENUM_NAME(D3D9Format::A2W10V10U10);
       ENUM_NAME(D3D9Format::UYVY);
       ENUM_NAME(D3D9Format::R8G8_B8G8);

--- a/src/d3d9/d3d9_window.cpp
+++ b/src/d3d9/d3d9_window.cpp
@@ -133,6 +133,7 @@ namespace dxvk
     windowData.unicode = IsWindowUnicode(window);
     windowData.filter  = false;
     windowData.activateProcessed = false;
+    windowData.deactivateProcessed = false;
     windowData.proc = reinterpret_cast<WNDPROC>(
       CallCharsetFunction(
       SetWindowLongPtrW, SetWindowLongPtrA, windowData.unicode,


### PR DESCRIPTION
Two nits I stumbled into while backporting the most recent set of changes onto 1.10.3:
- an uninitialized struct member in windowData
- missing decoding of W11V11U10 for logging purposes