### PR TITLE
[d3d9] Only fail on DISCARD|READONLY locks of D3DPOOL_DEFAULT resources

### DIFF
--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -4799,7 +4799,10 @@ namespace dxvk {
     if (unlikely(pResource->GetLocked(Subresource)))
       return D3DERR_INVALIDCALL;
 
-    if (unlikely((Flags & (D3DLOCK_DISCARD | D3DLOCK_READONLY)) == (D3DLOCK_DISCARD | D3DLOCK_READONLY)))
+    auto& desc = *(pResource->Desc());
+
+    if (unlikely((Flags & (D3DLOCK_DISCARD | D3DLOCK_READONLY)) == (D3DLOCK_DISCARD | D3DLOCK_READONLY)
+               && desc.Pool == D3DPOOL_DEFAULT))
       return D3DERR_INVALIDCALL;
 
     // We only ever wait for textures that were used with GetRenderTargetData or GetFrontBufferData anyway.
@@ -4812,8 +4815,6 @@ namespace dxvk {
     // Tests show that D3D9 drivers ignore DISCARD when the device is lost.
     if (unlikely(m_deviceLostState != D3D9DeviceLostState::Ok))
       Flags &= ~D3DLOCK_DISCARD;
-
-    auto& desc = *(pResource->Desc());
 
     if (unlikely(!desc.IsLockable))
       return D3DERR_INVALIDCALL;


### PR DESCRIPTION
Should fix #5080. @Blisto91 would appreciate it if you can confirm this when you get the time.

Wrote a test and it looks like the restriction only applies to D3DPOOL_DEFAULT resources. Turok (2008) was trying to lock some D3DPOOL_SYSTEMMEM textures and that was causing issues.