### PR TITLE
[dxvk] Support average resolve in blit shader

### DIFF
--- a/src/dxvk/dxvk_meta_blit.cpp
+++ b/src/dxvk/dxvk_meta_blit.cpp
@@ -33,7 +33,7 @@ namespace dxvk {
           VkFormat              viewFormat,
           VkSampleCountFlagBits srcSamples,
           VkSampleCountFlagBits dstSamples,
-          VkFilter              filter) {
+          DxvkMetaBlitResolveMode resolveMode) {
     std::lock_guard<dxvk::mutex> lock(m_mutex);
 
     DxvkMetaBlitPipelineKey key;
@@ -43,7 +43,7 @@ namespace dxvk {
     key.dstSamples = dstSamples;
 
     if (srcSamples != VK_SAMPLE_COUNT_1_BIT)
-      key.pointFilter = filter == VK_FILTER_NEAREST;
+      key.resolveMode = resolveMode;
 
     auto entry = m_pipelines.find(key);
     if (entry != m_pipelines.end())
@@ -67,9 +67,10 @@ namespace dxvk {
     const DxvkMetaBlitPipelineKey&    key) const {
     util::DxvkBuiltInGraphicsState state = { };
 
-    std::array<VkSpecializationMapEntry, 2u> specMap = {{
+    std::array<VkSpecializationMapEntry, 3u> specMap = {{
       { 0u, offsetof(DxvkMetaBlitPipelineKey, srcSamples),  sizeof(VkSampleCountFlagBits) },
-      { 1u, offsetof(DxvkMetaBlitPipelineKey, pointFilter), sizeof(VkBool32) },
+      { 1u, offsetof(DxvkMetaBlitPipelineKey, dstSamples),  sizeof(VkSampleCountFlagBits) },
+      { 2u, offsetof(DxvkMetaBlitPipelineKey, resolveMode), sizeof(DxvkMetaBlitResolveMode) },
     }};
 
     VkSpecializationInfo specInfo = { };

--- a/src/dxvk/dxvk_meta_blit.h
+++ b/src/dxvk/dxvk_meta_blit.h
@@ -26,6 +26,15 @@ namespace dxvk {
     uint32_t           layerCount;
     uint32_t           sampler;
   };
+
+  /**
+   * \brief Resolve mode for multisampled blits
+   */
+  enum class DxvkMetaBlitResolveMode : uint32_t {
+    FilterNearest     = 0u,
+    FilterLinear      = 1u,
+    ResolveAverage    = 2u,
+  };
   
   /**
    * \brief Blit pipeline key
@@ -39,14 +48,14 @@ namespace dxvk {
     VkFormat              viewFormat;
     VkSampleCountFlagBits srcSamples;
     VkSampleCountFlagBits dstSamples;
-    VkBool32              pointFilter;
+    DxvkMetaBlitResolveMode resolveMode;
     
     bool eq(const DxvkMetaBlitPipelineKey& other) const {
       return this->viewType     == other.viewType
           && this->viewFormat   == other.viewFormat
           && this->srcSamples   == other.srcSamples
           && this->dstSamples   == other.dstSamples
-          && this->pointFilter  == other.pointFilter;
+          && this->resolveMode  == other.resolveMode;
     }
     
     size_t hash() const {
@@ -55,7 +64,7 @@ namespace dxvk {
       result.add(uint32_t(this->viewFormat));
       result.add(uint32_t(this->srcSamples));
       result.add(uint32_t(this->dstSamples));
-      result.add(uint32_t(this->pointFilter));
+      result.add(uint32_t(this->resolveMode));
       return result;
     }
   };
@@ -95,7 +104,7 @@ namespace dxvk {
      * \param [in] viewFormat Image view format
      * \param [in] srcSamples Source sample count
      * \param [in] dstSamples Target sample count
-     * \param [in] filter What type of filter to use
+     * \param [in] resolveMode The resolve mode to use
      * \returns The blit pipeline
      */
     DxvkMetaBlitPipeline getPipeline(
@@ -103,7 +112,7 @@ namespace dxvk {
             VkFormat              viewFormat,
             VkSampleCountFlagBits srcSamples,
             VkSampleCountFlagBits dstSamples,
-            VkFilter              filter);
+            DxvkMetaBlitResolveMode resolveMode);
     
   private:
 


### PR DESCRIPTION
Fixes #5107, #5074. Needs some testing that it doesn't regress Source Engine again.

TLDR if there is no stretching happening, just do a normal shader-based resolve. WoW hits the blit path here for... some reason (presumably view swizzles), but this also allows the resolve to work properly in scenarios where the regular resolve functions wouldn't work, e.g. if the image gets mirrored at the same time.