### PR TITLE
[util] Enable d3d9.hideNvidiaGpu for Perilous Warp

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -1077,6 +1077,13 @@ namespace dxvk {
     { R"(\\TestDrive2\.exe$)", {{
       { "d3d9.deviceLossOnFocusLoss",       "True" },
     }} },
+    /* Perilous Warp - Nvidia path depends on     *
+     * unimplemented NvAPI_D3D9_StretchRectEx.    *
+     * Without it screen effects such as blood    *
+     * splatter are bugged.                       */
+    { R"(\\Perilous Warp\\system(64)?\\game\.exe$)", {{
+      { "d3d9.hideNvidiaGpu",               "True" },
+    }} },
 
     /**********************************************/
     /* D3D8 GAMES                                 */


### PR DESCRIPTION
In dxvk 2.6.2 and 2.7 changes were made so we only expose support for various bits and pieces as they are also supported in the vendors native d3d9 drivers. 
Prior to those two releases the game used its AMD rendering path on Nvidia, which worked without visual issue. Now that the game can correctly select the Nvidia path we've discovered it depends on `NvAPI_D3D9_StretchRectEx` being implemented. Without it visual effects effects such as blood splatters will appear buggy. 
It was decided that it was much simpler to revert the game back to its AMD path rather than going through with implementing the above function fully.

Edit: I was mixing issues together. This does not need a backport to v2.6.x as it only affects 2.7
Edit 2: No i am dumb. It does need a backport