### PR TITLE
[util] Enable d3d9.hideNvidiaGpu for Perilous Warp

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -1079,6 +1079,13 @@ namespace dxvk {
     { R"(\\(DLSteamEdition|dlords)\.exe$)", {{
       { "d3d9.textureMemory",                  "0" },
     }} },
+    /* Perilous Warp - Nvidia path depends on     *
+     * unimplemented NvAPI_D3D9_StretchRectEx.    *
+     * Without it screen effects such as blood    *
+     * splatter are bugged.                       */
+    { R"(\\Perilous Warp\\system(64)?\\game\.exe$)", {{
+      { "d3d9.hideNvidiaGpu",               "True" },
+    }} },
 
     /**********************************************/
     /* D3D8 GAMES                                 */


### PR DESCRIPTION
Quick cherry as it works around a regression