### PR TITLE
[d3d9] Texture creation cleanup + missing D3D9Ex texture creation validations

### DIFF
--- a/src/d3d9/d3d9_common_texture.cpp
+++ b/src/d3d9/d3d9_common_texture.cpp
@@ -45,22 +45,29 @@ namespace dxvk {
 
     const bool createImage = m_desc.Pool != D3DPOOL_SYSTEMMEM && m_desc.Pool != D3DPOOL_SCRATCH && m_desc.Format != D3D9Format::NULL_FORMAT;
     if (createImage) {
-      bool plainSurface = m_type == D3DRTYPE_SURFACE &&
-                          !(m_desc.Usage & (D3DUSAGE_RENDERTARGET | D3DUSAGE_DEPTHSTENCIL));
+      m_image = CreatePrimaryImage(ResourceType, pSharedHandle);
 
-      try {
-        m_image = CreatePrimaryImage(ResourceType, plainSurface, pSharedHandle);
+      if (unlikely(m_image == nullptr && (m_desc.Usage & D3DUSAGE_AUTOGENMIPMAP))) {
+        // AUTOGENMIPMAP is supposed to be treated like a hint according to the docs.
+        // So if creating an image with it fails, create one without it.
+        m_desc.Usage &= ~D3DUSAGE_AUTOGENMIPMAP;
+        m_desc.MipLevels = 1;
+        m_image = CreatePrimaryImage(ResourceType, pSharedHandle);
       }
-      catch (const DxvkError& e) {
-        // D3DUSAGE_AUTOGENMIPMAP and offscreen plain is mutually exclusive
-        // so we can combine their retry this way.
-        if (m_desc.Usage & D3DUSAGE_AUTOGENMIPMAP || plainSurface) {
-          m_desc.Usage &= ~D3DUSAGE_AUTOGENMIPMAP;
-          m_desc.MipLevels = 1;
-          m_image = CreatePrimaryImage(ResourceType, false, pSharedHandle);
-        }
-        else
-          throw e;
+
+      if (unlikely(m_image == nullptr)) {
+        throw DxvkError(str::format(
+          "D3D9: Cannot create texture:",
+          "\n  Type:    0x", std::hex, ResourceType, std::dec,
+          "\n  Format:  ", m_desc.Format,
+          "\n  Extent:  ", m_desc.Width,
+                      "x", m_desc.Height,
+                      "x", m_desc.Depth,
+          "\n  Samples: ", m_desc.MultiSample,
+          "\n  Layers:  ", m_desc.ArraySize,
+          "\n  Levels:  ", m_desc.MipLevels,
+          "\n  Usage:   0x", std::hex, m_desc.Usage, std::dec,
+          "\n  Pool:    0x", std::hex, m_desc.Pool, std::dec));
       }
 
       if (pSharedHandle && *pSharedHandle == nullptr) {
@@ -333,7 +340,7 @@ namespace dxvk {
   }
 
 
-  Rc<DxvkImage> D3D9CommonTexture::CreatePrimaryImage(D3DRESOURCETYPE ResourceType, bool TryOffscreenRT, HANDLE* pSharedHandle) const {
+  Rc<DxvkImage> D3D9CommonTexture::CreatePrimaryImage(D3DRESOURCETYPE ResourceType, HANDLE* pSharedHandle) const {
     DxvkImageCreateInfo imageInfo;
     imageInfo.type            = GetImageTypeFromResourceType(ResourceType);
     imageInfo.format          = m_mapping.ConversionFormatInfo.FormatColor != VK_FORMAT_UNDEFINED
@@ -371,6 +378,7 @@ namespace dxvk {
     if (m_mapping.ConversionFormatInfo.FormatType != D3D9ConversionFormat_None) {
       imageInfo.usage  |= VK_IMAGE_USAGE_STORAGE_BIT;
       imageInfo.stages |= VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT;
+      imageInfo.access |= VK_ACCESS_SHADER_WRITE_BIT;
       imageInfo.shared = true;
     }
 
@@ -401,7 +409,7 @@ namespace dxvk {
       imageInfo.usage |= VK_IMAGE_USAGE_SAMPLED_BIT;
 
     // Are we an RT, need to gen mips or an offscreen plain surface?
-    if (isRT || isAutoGen || TryOffscreenRT) {
+    if (isRT || isAutoGen) {
       imageInfo.usage  |= VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
       imageInfo.stages |= VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
       imageInfo.access |= VK_ACCESS_COLOR_ATTACHMENT_READ_BIT
@@ -434,20 +442,8 @@ namespace dxvk {
       imageInfo.layout = OptimizeLayout(imageInfo.usage);
 
     // Check if we can actually create the image
-    if (!CheckImageSupport(&imageInfo, imageInfo.tiling)) {
-      throw DxvkError(str::format(
-        "D3D9: Cannot create texture:",
-        "\n  Type:    0x", std::hex, ResourceType, std::dec,
-        "\n  Format:  ", m_desc.Format,
-        "\n  Extent:  ", m_desc.Width,
-                    "x", m_desc.Height,
-                    "x", m_desc.Depth,
-        "\n  Samples: ", m_desc.MultiSample,
-        "\n  Layers:  ", m_desc.ArraySize,
-        "\n  Levels:  ", m_desc.MipLevels,
-        "\n  Usage:   0x", std::hex, m_desc.Usage, std::dec,
-        "\n  Pool:    0x", std::hex, m_desc.Pool, std::dec));
-    }
+    if (!CheckImageSupport(&imageInfo, imageInfo.tiling))
+      return nullptr;
 
     return m_device->GetDXVKDevice()->createImage(imageInfo, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
   }

--- a/src/d3d9/d3d9_common_texture.h
+++ b/src/d3d9/d3d9_common_texture.h
@@ -531,7 +531,7 @@ namespace dxvk {
 
     D3D9VkInteropTexture          m_d3d9Interop;
 
-    Rc<DxvkImage> CreatePrimaryImage(D3DRESOURCETYPE ResourceType, bool TryOffscreenRT, HANDLE* pSharedHandle) const;
+    Rc<DxvkImage> CreatePrimaryImage(D3DRESOURCETYPE ResourceType, HANDLE* pSharedHandle) const;
 
     Rc<DxvkImage> CreateResolveImage() const;
 

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -4179,11 +4179,18 @@ namespace dxvk {
     if (unlikely(MultiSample > D3DMULTISAMPLE_16_SAMPLES))
       return D3DERR_INVALIDCALL;
 
-    uint32_t sampleCount = std::max<uint32_t>(MultiSample, 1u);
+    // The new Create functions added in 9Ex only accept the new USAGE flags added with 9Ex.
+    // Yes, it actually fails when explicitly passing D3DUSAGE_RENDERTARGET.
+    if (unlikely(Usage & ~(D3DUSAGE_RESTRICTED_CONTENT | D3DUSAGE_RESTRICT_SHARED_RESOURCE | D3DUSAGE_RESTRICT_SHARED_RESOURCE_DRIVER)))
+      return D3DERR_INVALIDCALL;
 
-    // Check if this is a power of two and
-    // return D3DERR_NOTAVAILABLE on failure
-    if (sampleCount & (sampleCount - 1))
+    if (unlikely((Usage & (D3DUSAGE_RESTRICT_SHARED_RESOURCE | D3DUSAGE_RESTRICT_SHARED_RESOURCE_DRIVER)) != 0
+      && pSharedHandle == nullptr))
+      return D3DERR_INVALIDCALL;
+
+    // Check if the sample count is valid and supported and
+    // specifically return D3DERR_NOTAVAILABLE on failure.
+    if (FAILED(DecodeMultiSampleType(m_dxvkDevice, MultiSample, MultisampleQuality, nullptr)))
       return D3DERR_NOTAVAILABLE;
 
     D3D9_COMMON_TEXTURE_DESC desc;
@@ -4231,6 +4238,14 @@ namespace dxvk {
     InitReturnPtr(ppSurface);
 
     if (unlikely(ppSurface == nullptr))
+      return D3DERR_INVALIDCALL;
+
+    // The new Create functions added in 9Ex only accept the new USAGE flags added with 9Ex.
+    if (unlikely(Usage & ~(D3DUSAGE_RESTRICTED_CONTENT | D3DUSAGE_RESTRICT_SHARED_RESOURCE | D3DUSAGE_RESTRICT_SHARED_RESOURCE_DRIVER)))
+      return D3DERR_INVALIDCALL;
+
+    if (unlikely((Usage & (D3DUSAGE_RESTRICT_SHARED_RESOURCE | D3DUSAGE_RESTRICT_SHARED_RESOURCE_DRIVER)) != 0
+      && pSharedHandle == nullptr))
       return D3DERR_INVALIDCALL;
 
     D3D9_COMMON_TEXTURE_DESC desc;
@@ -4301,6 +4316,15 @@ namespace dxvk {
     InitReturnPtr(ppSurface);
 
     if (unlikely(ppSurface == nullptr))
+      return D3DERR_INVALIDCALL;
+
+    // The new Create functions added in 9Ex only accept the new USAGE flags added with 9Ex.
+    // Yes, it actually fails when explicitly passing D3DUSAGE_DEPTHSTENCIL.
+    if (unlikely(Usage & ~(D3DUSAGE_RESTRICTED_CONTENT | D3DUSAGE_RESTRICT_SHARED_RESOURCE | D3DUSAGE_RESTRICT_SHARED_RESOURCE_DRIVER)))
+      return D3DERR_INVALIDCALL;
+
+    if (unlikely((Usage & (D3DUSAGE_RESTRICT_SHARED_RESOURCE | D3DUSAGE_RESTRICT_SHARED_RESOURCE_DRIVER)) != 0
+      && pSharedHandle == nullptr))
       return D3DERR_INVALIDCALL;
 
     D3D9_COMMON_TEXTURE_DESC desc;

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -1545,7 +1545,9 @@ namespace dxvk {
         cClearValue = clearValue
       ] (DxvkContext* ctx) {
         DxvkImageUsageInfo usage = { };
-        usage.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
+        usage.usage  = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
+        usage.stages = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+        usage.access = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
 
         ctx->ensureImageCompatibility(cImage, usage);
 

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -1329,7 +1329,7 @@ namespace dxvk {
     // Copies would only work if the extents match. (ie. no stretching)
     bool stretch = srcCopyExtent != dstCopyExtent;
 
-    bool dstHasRTUsage = (dstTextureInfo->Desc()->Usage & (D3DUSAGE_RENDERTARGET | D3DUSAGE_DEPTHSTENCIL)) != 0;
+    bool dstHasAttachmentUsage = (dstTextureInfo->Desc()->Usage & (D3DUSAGE_RENDERTARGET | D3DUSAGE_DEPTHSTENCIL)) != 0;
     bool dstIsSurface = dstTextureInfo->GetType() == D3DRTYPE_SURFACE;
     if (stretch) {
       if (unlikely(pSourceSurface == pDestSurface))
@@ -1341,17 +1341,17 @@ namespace dxvk {
       // The docs say that stretching is only allowed if the destination is either a render target surface or a render target texture.
       // However in practice, using an offscreen plain surface in D3DPOOL_DEFAULT as the destination works fine.
       // Using a texture without USAGE_RENDERTARGET as destination however does not.
-      if (unlikely(!dstIsSurface && !dstHasRTUsage))
+      if (unlikely(!dstIsSurface && !dstHasAttachmentUsage))
         return D3DERR_INVALIDCALL;
     } else {
       bool srcIsSurface = srcTextureInfo->GetType() == D3DRTYPE_SURFACE;
-      bool srcHasRTUsage = (srcTextureInfo->Desc()->Usage & (D3DUSAGE_RENDERTARGET | D3DUSAGE_DEPTHSTENCIL)) != 0;
+      bool srcHasAttachmentUsage = (srcTextureInfo->Desc()->Usage & (D3DUSAGE_RENDERTARGET | D3DUSAGE_DEPTHSTENCIL)) != 0;
       // Non-stretching copies are only allowed if:
       // - the destination is either a render target surface or a render target texture
       // - both destination and source are depth stencil surfaces
       // - both destination and source are offscreen plain surfaces.
       // The only way to get a surface with resource type D3DRTYPE_SURFACE without USAGE_RT or USAGE_DS is CreateOffscreenPlainSurface.
-      if (unlikely((!dstHasRTUsage && (!dstIsSurface || !srcIsSurface || srcHasRTUsage)) && !m_isD3D8Compatible))
+      if (unlikely((!dstHasAttachmentUsage && (!dstIsSurface || !srcIsSurface || srcHasAttachmentUsage)) && !m_isD3D8Compatible))
         return D3DERR_INVALIDCALL;
     }
 


### PR DESCRIPTION
Part 1 of what was originally #5092.

The validation changes are fairly straightforward.
It's particularly about the USAGE flags in the CreateXYZSurfaceEx functions that 9Ex added.
Thankfully they simply reject almost all usage flags instead of magically turning an offscreen surface
into a render target.

Besides that, it cleans up the actual image creation.
For example offscreen surfaces always got VK_IMAGE_USAGE_COLOR_ATTACHMENT
because they can be used with D3D9Device::ColorFill. That function however
uses DxvkContext::ensureImageCompatibility anyway and it's not super commonly
used with plain offscreen surfaces.