### PR TITLE
[d3d8/9] Assorted fixes and nits

### DIFF
--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -5777,10 +5777,17 @@ namespace dxvk {
       availableTextureMemory += memoryProp.memoryHeaps[i].size;
 
     constexpr VkDeviceSize Megabytes = 1024 * 1024;
+    // Windows will typically "reserve" some amount of video memory,
+    // presumably for back buffers, which gets subtracted from the
+    // reported size, e.g. in case of 4 GB it will report a total of
+    // 4286578687 available bytes. The reserved amount varies depending
+    // on the number of back buffers and the back buffer resolution,
+    // however 8 MB has been generally observed for 1080p.
+    constexpr VkDeviceSize ReservedMemory = 8 * Megabytes;
 
     // The value returned is a 32-bit value, so we need to clamp it.
     VkDeviceSize maxMemory = (VkDeviceSize(m_d3d9Options.maxAvailableMemory) * Megabytes) - 1;
-    availableTextureMemory = std::min(availableTextureMemory, maxMemory);
+    availableTextureMemory = std::min(availableTextureMemory, maxMemory) - ReservedMemory;
 
     return int64_t(availableTextureMemory);
   }

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -3994,7 +3994,8 @@ namespace dxvk {
 
     if (!std::exchange(s_errorShown, true))
       Logger::warn("D3D9DeviceEx::DrawRectPatch: Stub");
-    return D3DERR_INVALIDCALL;
+
+    return D3D_OK;
   }
 
 
@@ -4006,7 +4007,8 @@ namespace dxvk {
 
     if (!std::exchange(s_errorShown, true))
       Logger::warn("D3D9DeviceEx::DrawTriPatch: Stub");
-    return D3DERR_INVALIDCALL;
+
+    return D3D_OK;
   }
 
 
@@ -4015,6 +4017,7 @@ namespace dxvk {
 
     if (!std::exchange(s_errorShown, true))
       Logger::warn("D3D9DeviceEx::DeletePatch: Stub");
+
     return D3DERR_INVALIDCALL;
   }
 
@@ -4058,19 +4061,31 @@ namespace dxvk {
           D3DCOMPOSERECTSOP       Operation,
           int                     Xoffset,
           int                     Yoffset) {
-    Logger::warn("D3D9DeviceEx::ComposeRects: Stub");
+    static bool s_errorShown = false;
+
+    if (!std::exchange(s_errorShown, true))
+      Logger::warn("D3D9DeviceEx::ComposeRects: Stub");
+
     return D3D_OK;
   }
 
 
   HRESULT STDMETHODCALLTYPE D3D9DeviceEx::GetGPUThreadPriority(INT* pPriority) {
-    Logger::warn("D3D9DeviceEx::GetGPUThreadPriority: Stub");
+    static bool s_errorShown = false;
+
+    if (!std::exchange(s_errorShown, true))
+      Logger::warn("D3D9DeviceEx::GetGPUThreadPriority: Stub");
+
     return D3D_OK;
   }
 
 
   HRESULT STDMETHODCALLTYPE D3D9DeviceEx::SetGPUThreadPriority(INT Priority) {
-    Logger::warn("D3D9DeviceEx::SetGPUThreadPriority: Stub");
+    static bool s_errorShown = false;
+
+    if (!std::exchange(s_errorShown, true))
+      Logger::warn("D3D9DeviceEx::SetGPUThreadPriority: Stub");
+
     return D3D_OK;
   }
 
@@ -4084,7 +4099,11 @@ namespace dxvk {
 
 
   HRESULT STDMETHODCALLTYPE D3D9DeviceEx::CheckResourceResidency(IDirect3DResource9** pResourceArray, UINT32 NumResources) {
-    Logger::warn("D3D9DeviceEx::CheckResourceResidency: Stub");
+    static bool s_errorShown = false;
+
+    if (!std::exchange(s_errorShown, true))
+      Logger::warn("D3D9DeviceEx::CheckResourceResidency: Stub");
+
     return D3D_OK;
   }
 

--- a/src/d3d9/d3d9_swapchain.cpp
+++ b/src/d3d9/d3d9_swapchain.cpp
@@ -504,7 +504,7 @@ namespace dxvk {
     // Assume there's 20 lines in a vBlank.
     constexpr uint32_t vBlankLineCount = 20;
 
-    if (pRasterStatus == nullptr)
+    if (unlikely(pRasterStatus == nullptr))
       return D3DERR_INVALIDCALL;
 
     D3DDISPLAYMODEEX mode;
@@ -532,7 +532,7 @@ namespace dxvk {
 
   
   HRESULT STDMETHODCALLTYPE D3D9SwapChainEx::GetDisplayMode(D3DDISPLAYMODE* pMode) {
-    if (pMode == nullptr)
+    if (unlikely(pMode == nullptr))
       return D3DERR_INVALIDCALL;
 
     *pMode = D3DDISPLAYMODE();
@@ -554,7 +554,7 @@ namespace dxvk {
 
 
   HRESULT STDMETHODCALLTYPE D3D9SwapChainEx::GetPresentParameters(D3DPRESENT_PARAMETERS* pPresentationParameters) {
-    if (pPresentationParameters == nullptr)
+    if (unlikely(pPresentationParameters == nullptr))
       return D3DERR_INVALIDCALL;
 
     *pPresentationParameters = m_presentParams;
@@ -564,19 +564,35 @@ namespace dxvk {
 
 
   HRESULT STDMETHODCALLTYPE D3D9SwapChainEx::GetLastPresentCount(UINT* pLastPresentCount) {
-    Logger::warn("D3D9SwapChainEx::GetLastPresentCount: Stub");
+    static bool s_errorShown = false;
+
+    if (!std::exchange(s_errorShown, true))
+      Logger::warn("D3D9SwapChainEx::GetLastPresentCount: Stub");
+
+    if (likely(pLastPresentCount != nullptr))
+      *pLastPresentCount = 0;
+
     return D3D_OK;
   }
 
 
   HRESULT STDMETHODCALLTYPE D3D9SwapChainEx::GetPresentStats(D3DPRESENTSTATS* pPresentationStatistics) {
-    Logger::warn("D3D9SwapChainEx::GetPresentStats: Stub");
+    static bool s_errorShown = false;
+
+    if (!std::exchange(s_errorShown, true))
+      Logger::warn("D3D9SwapChainEx::GetPresentStats: Stub");
+
+    if (likely(pPresentationStatistics != nullptr)) {
+      D3DPRESENTSTATS presentationStatistics = { };
+      *pPresentationStatistics = presentationStatistics;
+    }
+
     return D3D_OK;
   }
 
 
   HRESULT STDMETHODCALLTYPE D3D9SwapChainEx::GetDisplayModeEx(D3DDISPLAYMODEEX* pMode, D3DDISPLAYROTATION* pRotation) {
-    if (pMode == nullptr && pRotation == nullptr)
+    if (unlikely(pMode == nullptr && pRotation == nullptr))
       return D3DERR_INVALIDCALL;
 
     if (pRotation != nullptr)

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -23,32 +23,32 @@ namespace dxvk {
     /* D3D12 GAMES (vkd3d-proton with dxvk dxgi)  */
     /**********************************************/
 
-    /* Diablo 4 - Will complain about missing  *
-     * GPU unless dxgi Id match actual GPU Id. *
-     * Bugs out on some multi-gpu systems.     */
+    /* Diablo 4 - Will complain about missing     *
+     * GPU unless dxgi Id match actual GPU Id.    *
+     * Bugs out on some multi-gpu systems.        */
     { R"(\\Diablo IV\.exe$)", {{
-      { "dxgi.hideNvidiaGpu",               "False" },
-      { "dxvk.hideIntegratedGraphics",      "True"  },
+      { "dxgi.hideNvidiaGpu",              "False" },
+      { "dxvk.hideIntegratedGraphics",      "True" },
     }} },
-    /* Ratchet & Clank: Rift Apart - does not allow
-     * enabling ray tracing if it sees an AMD GPU. */
+    /* Ratchet & Clank: Rift Apart - does not allow *
+     * enabling ray tracing if it sees an AMD GPU.  */
     { R"(\\RiftApart\.exe$)", {{
-      { "dxgi.hideNvidiaGpu",               "False" },
+      { "dxgi.hideNvidiaGpu",              "False" },
     }} },
-    /* Persona 3 Reload - disables vsync by default and
-     * runs into severe frame latency issues on Deck. */
+    /* Persona 3 Reload - disables vsync by default and *
+     * runs into severe frame latency issues on Deck.   */
     { R"(\\P3R\.exe$)", {{
-      { "dxgi.syncInterval",                "1" },
+      { "dxgi.syncInterval",                   "1" },
     }} },
     /* World of Warcraft                           *
      * Bugs out on some multi-gpu systems.         */
     { R"(\\Wow(Classic)?\.exe$)", {{
-      { "dxvk.hideIntegratedGraphics",      "True"  },
+      { "dxvk.hideIntegratedGraphics",      "True" },
     }} },
     /* Bright Memory - Will choose other vendors   *
      * over Intel even if Intel is the only dGPU   */
     { R"(\\BrightMemory_EP1-Win64-Shipping\.exe$)", {{
-      { "dxvk.hideIntegratedGraphics",      "True"  },
+      { "dxvk.hideIntegratedGraphics",      "True" },
     }} },
     /* AC Shadows: Uses composition swapchain to   *
      * check for HDR support                       */
@@ -60,8 +60,8 @@ namespace dxvk {
     /* D3D11 GAMES                                */
     /**********************************************/
 
-    /* Batman Arkham Knight - doesn't like intel vendor id
-      (refuses to boot if vendor isn't 0x10de or 0x1002)  */
+    /* Batman Arkham Knight - doesn't like intel vendor id *
+     *(refuses to boot if vendor isn't 0x10de or 0x1002)   */
     { R"(\\BatmanAK\.exe$)", {{
       { "dxgi.hideIntelGpu",                "True" },
     }} },
@@ -78,7 +78,7 @@ namespace dxvk {
     { R"(\\EliteDangerous64\.exe$)", {{
       { "dxgi.customVendorId",              "10de" },
     }} },
-     /* EVE Online: Needs this to expose D3D12     *
+    /* EVE Online: Needs this to expose D3D12     *
      * otherwise D3D12 option on launcher is      *
      * greyed out                                 */
     { R"(\\evelauncher\.exe$)", {{
@@ -87,7 +87,7 @@ namespace dxvk {
     /* The Evil Within: Submits command lists     *
      * multiple times                             */
     { R"(\\EvilWithin(Demo)?\.exe$)", {{
-      { "d3d11.cachedDynamicResources",     "vi"   },
+      { "d3d11.cachedDynamicResources",       "vi" },
     }} },
     /* Far Cry 3: Assumes clear(0.5) on an UNORM  *
      * format to result in 128 on AMD and 127 on  *
@@ -95,30 +95,30 @@ namespace dxvk {
      * match the clear behaviour of D3D11.        *
      * Intel needs to match the AMD result        */
     { R"(\\(farcry3|fc3_blooddragon)_d3d11\.exe$)", {{
-      { "dxgi.hideNvidiaGpu",               "False" },
+      { "dxgi.hideNvidiaGpu",              "False" },
       { "dxgi.hideIntelGpu",                "True" },
     }} },
     /* Far Cry 4 and Primal: Same as Far Cry 3    */
     { R"(\\(FarCry4|FCPrimal)\.exe$)", {{
-      { "dxgi.hideNvidiaGpu",               "False" },
+      { "dxgi.hideNvidiaGpu",              "False" },
       { "dxgi.hideIntelGpu",                "True" },
     }} },
     /* Frostpunk: Renders one frame with D3D9     *
      * after creating the DXGI swap chain         */
     { R"(\\Frostpunk\.exe$)", {{
       { "dxgi.deferSurfaceCreation",        "True" },
-      { "d3d11.cachedDynamicResources",     "c" },
+      { "d3d11.cachedDynamicResources",        "c" },
     }} },
-    /* Nioh: Apparently the same as the Atelier games  */
+    /* Nioh: Apparently the same as the Atelier games */
     { R"(\\nioh\.exe$)", {{
       { "d3d9.deferSurfaceCreation",        "True" },
     }} },
     /* Anno 1800: Poor performance without this   */
     { R"(\\Anno1800\.exe$)", {{
-      { "d3d11.cachedDynamicResources",     "c"    },
+      { "d3d11.cachedDynamicResources",        "c" },
     }} },
     /* Fifa '19+: Binds typed buffer SRV to shader *
-     * that expects raw/structured buffer SRV     */
+     * that expects raw/structured buffer SRV      */
     { R"(\\FIFA(19|[2-9][0-9])(_demo)?\.exe$)", {{
       { "dxvk.useRawSsbo",                  "True" },
     }} },
@@ -132,15 +132,15 @@ namespace dxvk {
     }} },
     /* Call of Duty WW2                           */
     { R"(\\s2_sp64_ship\.exe$)", {{
-      { "dxgi.hideNvidiaGpu",               "False" },
+      { "dxgi.hideNvidiaGpu",              "False" },
     }} },
     /* Need for Speed 2015                        */
     { R"(\\NFS16\.exe$)", {{
-      { "dxgi.hideNvidiaGpu",               "False" },
+      { "dxgi.hideNvidiaGpu",              "False" },
     }} },
     /* Mass Effect Andromeda                      */
     { R"(\\MassEffectAndromeda\.exe$)", {{
-      { "dxgi.hideNvidiaGpu",               "False" },
+      { "dxgi.hideNvidiaGpu",              "False" },
     }} },
     /* Mirror`s Edge Catalyst: Crashes on AMD     */
     { R"(\\MirrorsEdgeCatalyst(Trial)?\.exe$)", {{
@@ -152,12 +152,12 @@ namespace dxvk {
     }} },
     /* NieR Replicant                             */
     { R"(\\NieR Replicant ver\.1\.22474487139\.exe)", {{
-      { "d3d11.cachedDynamicResources",     "vi"   },
+      { "d3d11.cachedDynamicResources",       "vi" },
     }} },
-    /* Hitman 2 - requires AGS library      */
+    /* Hitman 2 - requires AGS library            */
     { R"(\\HITMAN2\.exe$)", {{
       { "dxgi.customVendorId",              "10de" },
-      { "d3d11.cachedDynamicResources",     "c"    },
+      { "d3d11.cachedDynamicResources",        "c" },
     }} },
     /* Modern Warfare Remastered                  */
     { R"(\\h1(_[ms]p64_ship|-mod)\.exe$)", {{
@@ -177,14 +177,14 @@ namespace dxvk {
      * vendor IDs. Cached dynamic buffers help      *
      * massively in CPU bound game parts            */
     { R"(\\Crysis3\.exe$)", {{
-      { "dxgi.hideNvidiaGpu",               "False" },
-      { "d3d11.cachedDynamicResources",     "a"    },
+      { "dxgi.hideNvidiaGpu",              "False" },
+      { "d3d11.cachedDynamicResources",        "a" },
     }} },
-    /* Crysis 3 Remastered                          *
-     * Cached dynamic buffers help massively        *
-     * in CPU bound game parts                      */
+    /* Crysis 3 Remastered                        *
+     * Cached dynamic buffers help massively      *
+     * in CPU bound game parts                    */
     { R"(\\Crysis3Remastered\.exe$)", {{
-      { "d3d11.cachedDynamicResources",     "a"    },
+      { "d3d11.cachedDynamicResources",        "a" },
     }} },
     /* Atelier series - games try to render video *
      * with a D3D9 swap chain over the DXGI swap  *
@@ -228,33 +228,33 @@ namespace dxvk {
     /* Darksiders Warmastered - apparently reads  *
      * from write-only mapped buffers             */
     { R"(\\darksiders1\.exe$)", {{
-      { "d3d11.cachedDynamicResources",     "a"    },
+      { "d3d11.cachedDynamicResources",        "a" },
     }} },
     /* Monster Hunter World                       */
     { R"(\\MonsterHunterWorld\.exe$)", {{
-      { "d3d11.cachedDynamicResources",     "a"    },
+      { "d3d11.cachedDynamicResources",        "a" },
     }} },
     /* Kingdome Come: Deliverance                 */
     { R"(\\KingdomCome\.exe$)", {{
-      { "d3d11.cachedDynamicResources",     "a"    },
+      { "d3d11.cachedDynamicResources",        "a" },
     }} },
     /* Homefront: The Revolution                  */
     { R"(\\Homefront2_Release\.exe$)", {{
-      { "d3d11.cachedDynamicResources",     "a"    },
+      { "d3d11.cachedDynamicResources",        "a" },
     }} },
     /* Sniper Ghost Warrior Contracts             */
     { R"(\\SGWContracts\.exe$)", {{
-      { "d3d11.cachedDynamicResources",     "a"    },
+      { "d3d11.cachedDynamicResources",        "a" },
     }} },
     /* Armored Warfare             */
     { R"(\\armoredwarfare\.exe$)", {{
-      { "d3d11.cachedDynamicResources",     "c"    },
+      { "d3d11.cachedDynamicResources",        "c" },
     }} },
     /* Shadow of the Tomb Raider - invariant      *
      * position breaks character rendering on NV  */
     { R"(\\SOTTR\.exe$)", {{
-      { "d3d11.invariantPosition",          "False" },
-      { "d3d11.floatControls",              "False" },
+      { "d3d11.invariantPosition",         "False" },
+      { "d3d11.floatControls",             "False" },
     }} },
     /* Nioh 2                                     */
     { R"(\\nioh2\.exe$)", {{
@@ -263,21 +263,21 @@ namespace dxvk {
     /* Crazy Machines 3 - crashes on long device  *
      * descriptions                               */
     { R"(\\cm3\.exe$)", {{
-      { "dxgi.customDeviceDesc",            "DXVK Adapter" },
+      { "dxgi.customDeviceDesc",    "DXVK Adapter" },
     }} },
     /* World of Final Fantasy: Broken and useless *
      * use of 4x MSAA throughout the renderer     */
     { R"(\\WOFF\.exe$)", {{
       { "d3d11.disableMsaa",                "True" },
     }} },
-     /* Mary Skelter 2 - Broken MSAA              */
+    /* Mary Skelter 2 - Broken MSAA               */
     { R"(\\MarySkelter2\.exe$)", {{
       { "d3d11.disableMsaa",                "True" },
     }} },
     /* Final Fantasy XIV: Uses lots of HVV and    *
      * also reads some uncached memory.           */
     { R"(\\ffxiv_dx11\.exe$)", {{
-      { "d3d11.cachedDynamicResources",     "vi"   },
+      { "d3d11.cachedDynamicResources",       "vi" },
     }} },
     /* Final Fantasy XV: VXAO does thousands of   *
      * draw calls with the same UAV bound         */
@@ -288,16 +288,16 @@ namespace dxvk {
      * barrier stuff, needs nvapi for DLSS        */
     { R"(\\GoW\.exe$)", {{
       { "d3d11.relaxedBarriers",            "True" },
-      { "dxgi.hideNvidiaGpu",               "False" },
-      { "dxgi.maxFrameLatency",             "1"    },
+      { "dxgi.hideNvidiaGpu",              "False" },
+      { "dxgi.maxFrameLatency",                "1" },
     }} },
     /* AoE 2 DE - runs poorly for some users      */
     { R"(\\AoE2DE_s\.exe$)", {{
-      { "d3d11.cachedDynamicResources",     "a"    },
+      { "d3d11.cachedDynamicResources",        "a" },
     }} },
     /* Assassin's Creed 3 and 4                   */
     { R"(\\ac(3|4bf)[sm]p\.exe$)", {{
-      { "d3d11.cachedDynamicResources",     "a"    },
+      { "d3d11.cachedDynamicResources",        "a" },
     }} },
     /* Stranger of Paradise - FF Origin           */
     { R"(\\SOPFFO\.exe$)", {{
@@ -309,16 +309,16 @@ namespace dxvk {
     }} },
     /* A Way Out: fix for stuttering and low fps  */
     { R"(\\AWayOut(_friend)?\.exe$)", {{
-      { "dxgi.maxFrameLatency",             "1" },
+      { "dxgi.maxFrameLatency",                "1" },
     }} },
-    /* Garden Warfare 2
-       Won't start on amd Id without atiadlxx     */
+    /* Garden Warfare 2                           *
+     * Won't start on amd Id without atiadlxx     */
     { R"(\\GW2\.Main_Win64_Retail\.exe$)", {{
-      { "dxgi.customVendorId",              "10de"   },
+      { "dxgi.customVendorId",              "10de" },
     }} },
     /* DayZ */
     { R"(\\DayZ_x64\.exe$)", {{
-      { "d3d11.cachedDynamicResources",     "cr" },
+      { "d3d11.cachedDynamicResources",       "cr" },
     }} },
     /* Stray - writes to the same UAV every draw, *
      * presumably for culling, which doesn't play *
@@ -334,91 +334,89 @@ namespace dxvk {
     /* Shantae and the Pirate's Curse             *
      * Game speeds up above 60 fps                */
     { R"(\\ShantaeCurse\.exe$)", {{
-      { "dxgi.maxFrameRate",                "60" },
+      { "dxgi.maxFrameRate",                  "60" },
     }} },
     /* Mighty Switch Force! Collection            *
      * Games speed up above 60 fps                */
     { R"(\\MSFC\.exe$)", {{
-      { "dxgi.maxFrameRate",                "60" },
+      { "dxgi.maxFrameRate",                  "60" },
     }} },
     /* Battlefield: Bad Company 2                 *
      * Gets rid of black flickering               */
     { R"(\\BFBC2Game\.exe$)", {{
-      { "d3d11.floatControls",              "False" },
+      { "d3d11.floatControls",             "False" },
     }} },
     /* Sonic Frontiers - flickering shadows and   *
      * vegetation when GPU-bound                  */
     { R"(\\SonicFrontiers\.exe$)", {{
-      { "dxgi.maxFrameLatency",             "1" },
+      { "dxgi.maxFrameLatency",                "1" },
     }} },
     /* SpellForce 3 Reforced & expansions         *
      * Greatly improves CPU bound performance     */
     { R"(\\SF3ClientFinal\.exe$)", {{
-      { "d3d11.cachedDynamicResources",     "v" },
+      { "d3d11.cachedDynamicResources",        "v" },
     }} },
     /* Tom Clancy's Ghost Recon Breakpoint        */
     { R"(\\GRB\.exe$)", {{
-      { "dxgi.hideNvidiaGpu",               "False" },
+      { "dxgi.hideNvidiaGpu",              "False" },
     }} },
     /* GTA V performance issues                   */
     { R"(\\GTA5\.exe$)", {{
-      { "d3d11.cachedDynamicResources",     "vi"   },
+      { "d3d11.cachedDynamicResources",       "vi" },
     }} },
     /* Crash Bandicoot N. Sane Trilogy            *
      * Work around some vsync funkiness           */
     { R"(\\CrashBandicootNSaneTrilogy\.exe$)", {{
-      { "dxgi.syncInterval",                "1"   },
+      { "dxgi.syncInterval",                   "1" },
     }} },
-    /* Fallout 76
-     * Game tries to be too "smart" and changes sync
-     * interval based on performance (in fullscreen)
-     * or tries to match (or ratio below) 60fps
-     * (in windowed).
-     *
-     * Ends up getting in a loop where it will switch
-     * and start stuttering, or get stuck at targeting
-     * 30Hz in fullscreen.
-     * Windowed mode being locked to 60fps as well is
-     * pretty suboptimal...
-     */
+    /* Fallout 76                                      *
+     * Game tries to be too "smart" and changes sync   *
+     * interval based on performance (in fullscreen)   *
+     * or tries to match (or ratio below) 60fps        *
+     * (in windowed).                                  *
+     * Ends up getting in a loop where it will switch  *
+     * and start stuttering, or get stuck at targeting *
+     * 30Hz in fullscreen.                             *
+     * Windowed mode being locked to 60fps as well is  *
+     * pretty suboptimal...                            */
     { R"(\\Fallout76\.exe$)", {{
-      { "dxgi.syncInterval",                "1" },
+      { "dxgi.syncInterval",                   "1" },
     }} },
     /* Bladestorm Nightmare                       *
      * Game speed increases when above 60 fps in  *
      * the tavern area                            */
     { R"(\\BLADESTORM Nightmare\\Launch_(EA|JP)\.exe$)", {{
-      { "dxgi.maxFrameRate",                "60"  },
+      { "dxgi.maxFrameRate",                  "60" },
     }} },
     /* Vindictus d3d11 CPU bound perf, and work   *
      * around the game not properly initializing  *
      * some of its constant buffers after discard */
     { R"(\\Vindictus(_x64)?\.exe$)", {{
-      { "d3d11.cachedDynamicResources",     "cr"   },
+      { "d3d11.cachedDynamicResources",       "cr" },
       { "dxvk.zeroMappedMemory",            "True" },
     }} },
     /* Riders Republic - Statically linked AMDAGS */
     { R"(\\RidersRepublic(_BE)?\.exe$)", {{
-      { "dxgi.hideAmdGpu",                "True"   },
+      { "dxgi.hideAmdGpu",                  "True" },
     }} },
     /* Kenshi                                     *
      * Helps CPU bound performance                */
     { R"(\\kenshi_x64\.exe$)", {{
-      { "d3d11.cachedDynamicResources",     "v"    },
+      { "d3d11.cachedDynamicResources",        "v" },
     }} },
     /* Granblue Relink: Spams pixel shader UAVs   *
      * and assumes that AMD GPUs do not expose    *
      * native command lists for AGS usage         */
     { R"(\\granblue_fantasy_relink\.exe$)", {{
-      { "d3d11.relaxedGraphicsBarriers",    "True"  },
-      { "d3d11.exposeDriverCommandLists",   "False" },
-      { "dxgi.hideNvidiaGpu",               "False" },
+      { "d3d11.relaxedGraphicsBarriers",    "True" },
+      { "d3d11.exposeDriverCommandLists",  "False" },
+      { "dxgi.hideNvidiaGpu",              "False" },
     }} },
     /* Crysis 1/Warhead - Game bug in d3d10 makes *
      * it select lowest supported refresh rate    */
     { R"(\\Crysis(64)?\.exe$)", {{
-      { "d3d9.maxFrameRate",              "-1"      },
-      { "dxgi.maxFrameRate",              "-1"      },
+      { "d3d9.maxFrameRate",                  "-1" },
+      { "dxgi.maxFrameRate",                  "-1" },
     }} },
     /* EDF6 - possible race condition?            */
     { R"(\\EDF6\.exe$)", {{
@@ -427,40 +425,40 @@ namespace dxvk {
     /* Kena: Bridge of Spirits: intel water       *
      * flickering issues                          */
     { R"(\\Kena-Win64-Shipping\.exe$)", {{
-      { "dxgi.hideIntelGpu",                 "True" },
+      { "dxgi.hideIntelGpu",                "True" },
     }} },
     /* GTA Definitive Edition trilogy             *
      * Static ags crash with HDR support          */
     { R"(\\(LibertyCity|ViceCity|SanAndreas)\.exe$)", {{
       { "dxgi.enableUe4Workarounds",        "True" },
     }} },
-    /* Warcraft 3 Reforged                         *
-     * Bugs out on some multi-gpu systems.         */
+    /* Warcraft 3 Reforged                        *
+     * Bugs out on some multi-gpu systems.        */
     { R"(\\x86_64\\Warcraft III\.exe$)", {{
-      { "dxvk.hideIntegratedGraphics",      "True"  },
+      { "dxvk.hideIntegratedGraphics",      "True" },
     }} },
-    /* Earth Defense Force 5                       */
+    /* Earth Defense Force 5                      */
     { R"(\\EDF5\.exe$)", {{
-      { "dxgi.tearFree",                    "False" },
-      { "dxgi.syncInterval",                "1"     },
+      { "dxgi.tearFree",                   "False" },
+      { "dxgi.syncInterval",                   "1" },
     }} },
-    /* The Hurricane of the Varstray               *
-     * Too fast above 60fps                        */
+    /* The Hurricane of the Varstray              *
+     * Too fast above 60fps                       */
     { R"(\\Varstray_steam(_demo)?\.exe$)", {{
-      { "dxgi.maxFrameRate",                "60" },
+      { "dxgi.maxFrameRate",                  "60" },
     }} },
     /* Watch Dogs 2 - ships broken compute shaders *
      * with no barriers when they are needed       */
     { R"(\\WatchDogs2\.exe$)", {{
       { "d3d11.forceComputeUavBarriers",    "True" },
     }} },
-    /* Rocketbirds 2: Ignores row pitch for mapped *
-     * images, corrupting intro video              */
+    /* Rocketbirds 2: Ignores row pitch for       *
+     * mapped images, corrupting intro video      */
     { R"(\\Rocketbirds 2\\Game\.exe$)", {{
       { "d3d11.disableDirectImageMapping",  "True" },
     }} },
-    /* LEGO City Undercover                        *
-     * Fixes graphical corruption on cutscenes     */
+    /* LEGO City Undercover                       *
+     * Fixes graphical corruption on cutscenes    */
     { R"(\\LEGOLCUR_DX11\.exe$)", {{
       { "d3d11.disableDirectImageMapping",  "True" },
     }} },
@@ -476,7 +474,7 @@ namespace dxvk {
 
     /* A Hat in Time                              */
     { R"(\\HatinTimeGame\.exe$)", {{
-      { "d3d9.strictPow",                   "False" },
+      { "d3d9.strictPow",                  "False" },
       { "d3d9.lenientClear",                "True" },
     }} },
     /* Anarchy Online                             */
@@ -487,78 +485,78 @@ namespace dxvk {
     { R"(\\Borderlands\.exe$)", {{
       { "d3d9.lenientClear",                "True" },
     }} },
-    /* Borderlands 2                               *
-     * Missing lava in Vault of the Warrior        *
-     * without Strict floats                       */
+    /* Borderlands 2                              *
+     * Missing lava in Vault of the Warrior       *
+     * without Strict floats                      */
     { R"(\\Borderlands2\.exe$)", {{
       { "d3d9.lenientClear",                "True" },
-      { "d3d9.supportDFFormats",            "False" },
-      { "d3d9.floatEmulation",              "Strict" },
+      { "d3d9.supportDFFormats",           "False" },
+      { "d3d9.floatEmulation",            "Strict" },
     }} },
-    /* Borderlands: The Pre-Sequel                  */
+    /* Borderlands: The Pre-Sequel                */
     { R"(\\BorderlandsPreSequel\.exe$)", {{
       { "d3d9.lenientClear",                "True" },
-      { "d3d9.supportDFFormats",            "False" },
+      { "d3d9.supportDFFormats",           "False" },
     }} },
     /* Gothic 3                                   */
     { R"(\\Gothic(3|3Final| III Forsaken Gods)\.exe$)", {{
-      { "d3d9.supportDFFormats",            "False" },
+      { "d3d9.supportDFFormats",           "False" },
     }} },
     /* Sonic Adventure 2                          */
     { R"(\\Sonic Adventure 2\\(launcher|sonic2app)\.exe$)", {{
-      { "d3d9.floatEmulation",              "Strict" },
-      { "d3d9.maxFrameRate",                "60" },
+      { "d3d9.floatEmulation",            "Strict" },
+      { "d3d9.maxFrameRate",                  "60" },
     }} },
-    /* The Sims 2,
-       Body Shop,
-       The Sims Life Stories,
-       The Sims Pet Stories,
-       and The Sims Castaway Stories             */
+    /* The Sims 2,                                *
+     * Body Shop,                                 *
+     * The Sims Life Stories,                     *
+     * The Sims Pet Stories,                      *
+     * and The Sims Castaway Stories              */
     { R"(\\(Sims2.*|TS2BodyShop|SimsLS|SimsPS|SimsCS)"
       R"(|The Sims 2 Content Manager|TS2HomeCrafterPlus)\.exe$)", {{
       { "d3d9.customVendorId",              "10de" },
       { "d3d9.customDeviceId",              "0091" },
-      { "d3d9.customDeviceDesc",            "GeForce 7800 GTX" },
+      { "d3d9.customDeviceDesc", "GeForce 7800 GTX" },
       { "d3d9.disableA8RT",                 "True" },
-      { "d3d9.supportX4R4G4B4",             "False" },
+      { "d3d9.supportX4R4G4B4",            "False" },
       { "d3d9.maxAvailableMemory",          "2048" },
       { "d3d9.memoryTrackTest",             "True" },
       { "d3d9.cachedDynamicBuffers",        "True" },
     }} },
-    /* Dead Space uses the a NULL render target instead
-       of a 1x1 one if DF24 is NOT supported
-       Mouse and physics issues above 60 FPS
-       Built-in Vsync Locks the game to 30 FPS    */
+    /* Dead Space                                 *
+     * Uses the a NULL render target instead      *
+     * of a 1x1 one if DF24 is NOT supported      *
+     * Mouse and physics issues above 60 FPS      *
+     * Built-in Vsync Locks the game to 30 FPS    */
     { R"(\\Dead Space\.exe$)", {{
-      { "d3d9.supportDFFormats",                 "False" },
-      { "d3d9.maxFrameRate",                     "60" },
-      { "d3d9.presentInterval",                  "1" },
+      { "d3d9.supportDFFormats",           "False" },
+      { "d3d9.maxFrameRate",                  "60" },
+      { "d3d9.presentInterval",                "1" },
     }} },
-    /* Dead Space 2
-       Physics issues above 60 FPS
-       Built-in Vsync Locks the game to 30 FPS
-    */
+    /* Dead Space 2                               *
+     * Physics issues above 60 FPS                *
+     * Built-in Vsync Locks the game to 30 FPS    */
     { R"(\\deadspace2\.exe$)", {{
-      { "d3d9.maxFrameRate",                     "60" },
-      { "d3d9.presentInterval",                  "1" },
+      { "d3d9.maxFrameRate",                  "60" },
+      { "d3d9.presentInterval",                "1" },
     }} },
     /* Halo CE/HaloPC                             */
     { R"(\\halo(ce)?\.exe$)", {{
-      // Game enables minor decal layering fixes
-      // specifically when it detects AMD.
-      // Avoids chip being detected as unsupported
-      // when on intel. Avoids possible path towards
-      // invalid texture addressing methods.
+    /* Game enables minor decal layering fixes     *
+     * specifically when it detects AMD.           *
+     * Avoids chip being detected as unsupported   *
+     * when on intel. Avoids possible path towards *
+     * invalid texture addressing methods.         */
       { "d3d9.customVendorId",              "1002" },
-      // Avoids card not recognized error.
-      // Keeps game's rendering methods consistent
-      // for optimal compatibility.
+    /* Avoids card not recognized error.          *
+     * Keeps game's rendering methods             *
+     * consistent for optimal compatibility.      */
       { "d3d9.customDeviceId",              "4172" },
-      // The game uses incorrect sampler types in
-      // the shaders for glass rendering which
-      // breaks it on native + us if we don't
-      // spec-constantly chose the sampler type
-      // automagically.
+    /* The game uses incorrect sampler types in   *
+     * the shaders for glass rendering which      *
+     * breaks it on native + us if we don't       *
+     * spec-constantly chose the sampler type     *
+     * automagically.                             */
       { "d3d9.forceSamplerTypeSpecConstants", "True" },
     }} },
     /* Counter Strike: Global Offensive
@@ -585,18 +583,18 @@ namespace dxvk {
     { R"(\\Neptunia\.exe$)", {{
       { "d3d9.forceAspectRatio",            "16:9" },
     }} },
-    /* GTA IV (NVAPI)                             */
-    /* Also thinks we're always on Intel          *
-     * and will report/use bad amounts of VRAM
-     * if we report more than 128 MB of VRAM.
-     * Disabling support for DF texture formats
-     * makes the game use a better looking render
-     * path for mirrors.
+    /* GTA IV (NVAPI)                             *
+     * Also thinks we're always on Intel          *
+     * and will report/use bad amounts of VRAM    *
+     * if we report more than 128 MB of VRAM.     *
+     * Disabling support for DF texture formats   *
+     * makes the game use a better looking render *
+     * path for mirrors.                          *
      * Also runs into issues after alt-tabbing.   */
     { R"(\\(GTAIV|EFLC)\.exe$)", {{
       { "d3d9.hideNvidiaGpu",               "True" },
-      { "dxgi.maxDeviceMemory",             "128" },
-      { "d3d9.supportDFFormats",            "False" },
+      { "dxgi.maxDeviceMemory",              "128" },
+      { "d3d9.supportDFFormats",           "False" },
       { "d3d9.deviceLossOnFocusLoss",       "True" },
     }} },
     /* Battlefield 2 & Battlefield 2142           *
@@ -606,7 +604,7 @@ namespace dxvk {
      * around.                                    */
     { R"(\\(BF2|BF2142|PRBF2)\.exe$)", {{
       { "d3d9.deviceLossOnFocusLoss",       "True" },
-      { "d3d9.countLosableResources",       "False"},
+      { "d3d9.countLosableResources",      "False" },
     }} },
     /* SpellForce 2 Series                        */
     { R"(\\SpellForce2.*\.exe$)", {{
@@ -619,398 +617,384 @@ namespace dxvk {
      * Legend flickers with next gen content option. */
     { R"(\\(trl|tra|tru)\.exe$)", {{
       { "d3d9.cachedDynamicBuffers",        "True" },
-      { "d3d9.maxFrameRate",                "60" },
+      { "d3d9.maxFrameRate",                  "60" },
     }} },
-    /* Everquest                                 */
+    /* Everquest                                  */
     { R"(\\eqgame\.exe$)", {{
       { "d3d9.cachedDynamicBuffers",        "True" },
     }} },
-    /* Dark Messiah of Might & Magic             */
+    /* Dark Messiah of Might & Magic              */
     { R"(\\mm\.exe$)", {{
       { "d3d9.deferSurfaceCreation",        "True" },
       { "d3d9.memoryTrackTest",             "True" },
     }} },
-    /* Mafia 2                                   */
+    /* Mafia 2                                    */
     { R"(\\mafia2\.exe$)", {{
       { "d3d9.customVendorId",              "10de" },
       { "d3d9.customDeviceId",              "0402" },
     }} },
-    /* Warhammer: Online                         *
-     * Overly bright ground textures on Nvidia   */
+    /* Warhammer: Online                          *
+     * Overly bright ground textures on Nvidia    */
     { R"(\\(WAR(-64)?|WARTEST(-64)?)\.exe$)", {{
       { "d3d9.hideNvidiaGpu",               "True" },
     }} },
-    /* Dragon Nest                               */
+    /* Dragon Nest                                */
     { R"(\\DragonNest_x64\.exe$)", {{
       { "d3d9.memoryTrackTest",             "True" },
     }} },
-    /* Dal Segno                                 */
+    /* Dal Segno                                  */
     { R"(\\DST\.exe$)", {{
       { "d3d9.deferSurfaceCreation",        "True" },
     }} },
-    /* Kohan II                                  */
+    /* Kohan II                                   */
     { R"(\\k2\.exe$)", {{
       { "d3d9.memoryTrackTest",             "True" },
     }} },
-    /* Time Leap Paradise SUPER LIVE             */
+    /* Time Leap Paradise SUPER LIVE              */
     { R"(\\tlpsl\.exe$)", {{
       { "d3d9.deferSurfaceCreation",        "True" },
     }} },
-    /* Ninja Gaiden Sigma 1/2                    */
+    /* Ninja Gaiden Sigma 1/2                     */
     { R"(\\NINJA GAIDEN SIGMA(2)?\.exe$)", {{
       { "d3d9.deferSurfaceCreation",        "True" },
     }} },
-    /* Demon Stone breaks at frame rates > 60fps */
+    /* Demon Stone breaks at frame rates > 60fps  */
     { R"(\\Demonstone\.exe$)", {{
-      { "d3d9.maxFrameRate",                "60" },
+      { "d3d9.maxFrameRate",                  "60" },
     }} },
-    /* Far Cry 1 has worse water rendering when it detects AMD GPUs */
+    /* Far Cry 1                                  *
+     * Has worse water rendering on AMD GPUs      */
     { R"(\\FarCry\.exe$)", {{
       { "d3d9.hideAmdGpu",                  "True" },
     }} },
-    /* Sine Mora EX */
+    /* Sine Mora EX                               */
     { R"(\\SineMoraEX\.exe$)", {{
-      { "d3d9.maxFrameRate",                "60" },
+      { "d3d9.maxFrameRate",                  "60" },
     }} },
-    /* Red Orchestra 2                           */
+    /* Red Orchestra 2                            */
     { R"(\\ROGame\.exe$)", {{
-      { "d3d9.floatEmulation",              "Strict" },
+      { "d3d9.floatEmulation",            "Strict" },
     }} },
-    /* Dark Souls II                            */
+    /* Dark Souls II                              */
     { R"(\\DarkSoulsII\.exe$)", {{
-      { "d3d9.floatEmulation",              "Strict" },
+      { "d3d9.floatEmulation",            "Strict" },
     }} },
-    /* Dogfight 1942                            */
+    /* Dogfight 1942                              */
     { R"(\\Dogfight1942\.exe$)", {{
-      { "d3d9.floatEmulation",              "Strict" },
+      { "d3d9.floatEmulation",            "Strict" },
     }} },
-    /* Bayonetta                                */
+    /* Bayonetta                                  */
     { R"(\\Bayonetta\.exe$)", {{
-      { "d3d9.floatEmulation",              "Strict" },
+      { "d3d9.floatEmulation",            "Strict" },
     }} },
-    /* Rayman Origins                           */
+    /* Rayman Origins                             */
     { R"(\\Rayman Origins\.exe$)", {{
-      { "d3d9.floatEmulation",              "Strict" },
+      { "d3d9.floatEmulation",            "Strict" },
     }} },
-    /* Guilty Gear Xrd -Relevator-              */
+    /* Guilty Gear Xrd -Relevator-                */
     { R"(\\GuiltyGearXrd\.exe$)", {{
-      { "d3d9.floatEmulation",              "Strict" },
+      { "d3d9.floatEmulation",            "Strict" },
     }} },
-    /* Richard Burns Rally                      */
+    /* Richard Burns Rally                        */
     { R"(\\RichardBurnsRally_SSE\.exe$)", {{
-      { "d3d9.floatEmulation",              "Strict" },
+      { "d3d9.floatEmulation",            "Strict" },
     }} },
-    /* BlazBlue Centralfiction                  */
+    /* BlazBlue Centralfiction                    */
     { R"(\\BBCF\.exe$)", {{
-      { "d3d9.floatEmulation",              "Strict" },
-      { "d3d9.textureMemory",               "0"   },
+      { "d3d9.floatEmulation",            "Strict" },
+      { "d3d9.textureMemory",                  "0" },
     }} },
-    /* Limbo                                    */
+    /* Limbo                                      */
     { R"(\\limbo\.exe$)", {{
-      { "d3d9.maxFrameRate",                "60" },
+      { "d3d9.maxFrameRate",                  "60" },
     }} },
-    /* Escape from Tarkov launcher
-       Work around partial presentation issues  */
+    /* Escape from Tarkov launcher                *
+     * Work around partial presentation issues    */
     { R"(\\BsgLauncher\.exe$)", {{
-      { "d3d9.shaderModel",                 "1" },
+      { "d3d9.shaderModel",                    "1" },
     }} },
-    /* Star Wars The Force Unleashed 2          *
-     * Black particles because it tries to bind *
-     * a 2D texture for a shader that           *
-     * declares a 3d texture.                   */
+    /* Star Wars The Force Unleashed 2            *
+     * Black particles because it tries to bind   *
+     * a 2D texture for a shader that             *
+     * declares a 3d texture.                     */
     { R"(\\SWTFU2\.exe$)", {{
-      { "d3d9.forceSamplerTypeSpecConstants",  "True" },
+      { "d3d9.forceSamplerTypeSpecConstants", "True" },
     }} },
-    /* Majesty 2 (Collection)                   *
-     * Crashes on UMA without a memory limit,   *
-     * since the game(s) will allocate all      *
-     * available VRAM on startup.               */
-    { R"(\\Majesty2\.exe$)", {{
-      { "d3d9.memoryTrackTest",             "True" },
-      { "d3d9.maxAvailableMemory",          "2048" },
-    }} },
-    /* Myst V End of Ages                       *
-     * Resolution change crash and cached       *
-     * dynamic buffers for performance reasons  */
+    /* Myst V End of Ages                         *
+     * Resolution change crash and cached         *
+     * dynamic buffers for performance reasons    */
     { R"(\\eoa\.exe$)", {{
       { "d3d9.cachedDynamicBuffers",        "True" },
-      { "d3d9.countLosableResources",       "False" },
+      { "d3d9.countLosableResources",      "False" },
     }} },
     /* Supreme Commander & Forged Alliance Forever */
     { R"(\\(SupremeCommander|ForgedAlliance)\.exe$)", {{
-      { "d3d9.floatEmulation",              "Strict" },
+      { "d3d9.floatEmulation",            "Strict" },
     }} },
-    /* Bionic Commando
-       Physics break at high fps               */
+    /* Bionic Commando                            *
+     * Physics break at high fps                  */
     { R"(\\bionic_commando\.exe$)", {{
-      { "d3d9.maxFrameRate",                "60" },
+      { "d3d9.maxFrameRate",                  "60" },
     }} },
-    /* Beyond Good And Evil                     *
-     * UI breaks at high fps                     */
+    /* Beyond Good And Evil                       *
+     * UI breaks at high fps                      */
     { R"(\\BGE\.exe$)", {{
-      { "d3d9.maxFrameRate",                "60" },
+      { "d3d9.maxFrameRate",                  "60" },
     }} },
-    /* King Of Fighters XIII                     *
-     * In-game speed increases on high FPS       */
+    /* King Of Fighters XIII                      *
+     * In-game speed increases on high FPS        */
     { R"(\\kof(xiii|13_win32_Release)\.exe$)", {{
-      { "d3d9.maxFrameRate",                "60" },
+      { "d3d9.maxFrameRate",                  "60" },
     }} },
-    /* YS Origin                                *
-     * Helps very bad frametimes in some areas  */
+    /* YS Origin                                  *
+     * Helps very bad frametimes in some areas    */
     { R"(\\yso_win\.exe$)", {{
-      { "d3d9.maxFrameLatency",             "1" },
+      { "d3d9.maxFrameLatency",                "1" },
     }} },
-    /* Saints Row 2 - Prevents unmap crash      */
+    /* Saints Row 2 - Prevents unmap crash        */
     { R"(\\SR2_pc\.exe$)", {{
-      { "d3d9.textureMemory",               "0" },
+      { "d3d9.textureMemory",                  "0" },
     }} },
-    /* Witcher 1: Very long loading times       */
+    /* Witcher 1: Very long loading times         */
     { R"(\\witcher\.exe$)", {{
       { "d3d9.cachedDynamicBuffers",        "True" },
     }} },
-    /* Guitar Hero World Tour                   *
-     * Very prone to address space crashes      */
+    /* Guitar Hero World Tour                     *
+     * Very prone to address space crashes        */
     { R"(\\(GHWT|GHWT_Definitive)\.exe$)", {{
-      { "d3d9.textureMemory",               "16" },
-      { "d3d9.allowDirectBufferMapping",    "False" },
+      { "d3d9.textureMemory",                 "16" },
+      { "d3d9.allowDirectBufferMapping",   "False" },
     }} },
-    /* Heroes of Annihilated Empires            *
-     * Has issues with texture rendering and    *
-     * video memory detection otherwise.        */
-    { R"(\\Heroes (o|O)f Annihilated Empires.*\\engine\.exe$)", {{
-      { "d3d9.memoryTrackTest",             "True" },
-      { "d3d9.maxAvailableMemory",          "2048" },
-    }} },
-    /* The Ship (2004)                          */
+    /* The Ship (2004)                            */
     { R"(\\ship\.exe$)", {{
       { "d3d9.memoryTrackTest",             "True" },
     }} },
-    /* SiN Episodes Emergence                   */
+    /* SiN Episodes Emergence                     */
     { R"(\\SinEpisodes\.exe$)", {{
       { "d3d9.memoryTrackTest",             "True" },
     }} },
-    /* Hammer World Editor                      */
+    /* Hammer World Editor                        */
     { R"(\\(hammer(plusplus)?|mallet|wc)\.exe$)", {{
       { "d3d9.cachedDynamicBuffers",        "True" },
     }} },
-    /* Dragon Age Origins                       *
-     * Keeps unmapping the same 3 1MB buffers   *
-     * thousands of times when you alt-tab out  *
-     * Causing it to crash OOM                  */
+    /* Dragon Age Origins                         *
+     * Keeps unmapping the same 3 1MB buffers     *
+     * thousands of times when you alt-tab out    *
+     * Causing it to crash OOM                    */
     { R"(\\DAOrigins\.exe$)" , {{
-      { "d3d9.allowDirectBufferMapping",    "False" },
+      { "d3d9.allowDirectBufferMapping",   "False" },
     }} },
-    /* Sonic & All-Stars Racing Transformed    *
-     * Helps performance when Resizable BAR    *
-     * is enabled                              */
+    /* Sonic & All-Stars Racing Transformed       *
+     * Helps performance when Resizable BAR       *
+     * is enabled                                 */
     { R"(\\ASN_App_PcDx9_Final\.exe$)", {{
       { "d3d9.cachedDynamicBuffers",        "True" },
     }} },
-    /* Final Fantasy XIV - Direct3D 9 mode     *
-     * Can crash with unmapping                */
+    /* Final Fantasy XIV - Direct3D 9 mode        *
+     * Can crash with unmapping                   */
     { R"(\\ffxiv\.exe$)", {{
-      { "d3d9.textureMemory",               "0"   },
+      { "d3d9.textureMemory",                  "0" },
     }} },
-    /* Alien Rage                              *
-     * GTX 295 & disable Hack to fix shadows   */
+    /* Alien Rage                                 *
+     * GTX 295 & disable Hack to fix shadows      */
     { R"(\\(ShippingPC-AFEARGame|ARageMP)\.exe$)", {{
       { "d3d9.customVendorId",              "10de" },
       { "d3d9.customDeviceId",              "05E0" },
-      { "dxgi.hideNvidiaGpu",               "False" },
+      { "dxgi.hideNvidiaGpu",              "False" },
     }} },
-    /* Battle Fantasia Revised Edition         *
-     * Speedup above 60fps                     */
+    /* Battle Fantasia Revised Edition            *
+     * Speedup above 60fps                        */
     { R"(\\bf10\.exe$)", {{
-      { "d3d9.maxFrameRate",                "60" },
+      { "d3d9.maxFrameRate",                  "60" },
     }} },
-    /* Codename Panzers Phase One/Two          *
-     * Main menu won't render after intros     *
-     * and CPU bound performance               */
+    /* Codename Panzers Phase One/Two             *
+     * Main menu won't render after intros        *
+     * and CPU bound performance                  */
     { R"(\\(PANZERS|PANZERS_Phase_2)\.exe$)", {{
       { "d3d9.deferSurfaceCreation",        "True" },
       { "d3d9.cachedDynamicBuffers",        "True" },
     }} },
-    /* DC Universe Online                      *
-     * Freezes after alt tabbing               */
+    /* DC Universe Online                         *
+     * Freezes after alt tabbing                  */
     { R"(\\DCGAME\.EXE$)", {{
       { "d3d9.deviceLossOnFocusLoss",       "True" },
     }} },
-    /* Halo Online                             *
-     * Black textures                          */
+    /* Halo Online                                *
+     * Black textures                             */
     { R"(\\eldorado\.exe$)", {{
-      { "d3d9.floatEmulation",              "Strict"   },
-      { "d3d9.allowDirectBufferMapping",    "False" },
+      { "d3d9.floatEmulation",            "Strict" },
+      { "d3d9.allowDirectBufferMapping",   "False" },
     }} },
-    /* Injustice: Gods Among Us                *
-     * Locks a buffer that's still in use      */
+    /* Injustice: Gods Among Us                   *
+     * Locks a buffer that's still in use         */
     { R"(\\injustice\.exe$)", {{
-      { "d3d9.allowDirectBufferMapping",    "False" },
+      { "d3d9.allowDirectBufferMapping",   "False" },
     }} },
-    /* STEINS;GATE ELITE                       */
+    /* STEINS;GATE ELITE                          */
     { R"(\\SG_ELITE\\Game\.exe$)", {{
-      { "d3d9.maxFrameRate",                "60" },
+      { "d3d9.maxFrameRate",                  "60" },
     }} },
-    /* The Incredibles                         */
+    /* The Incredibles                            */
     { R"(\\IncPC\.exe$)", {{
-      { "d3d9.maxFrameRate",                "59" },
+      { "d3d9.maxFrameRate",                  "59" },
     }} },
-    /* Conflict Vietnam                        */
+    /* Conflict Vietnam                           */
     { R"(\\Vietnam\.exe$)", {{
-      { "d3d9.maxFrameRate",                "60" },
+      { "d3d9.maxFrameRate",                  "60" },
     }} },
-    /* Project: Snowblind                      */
+    /* Project: Snowblind                         */
     { R"(\\Snowblind\.(SP|MP|exe)$)", {{
-      { "d3d9.maxFrameRate",                "60" },
+      { "d3d9.maxFrameRate",                  "60" },
     }} },
-    /* Aviary Attorney                         */
+    /* Aviary Attorney                            */
     { R"(\\Aviary Attorney\\nw\.exe$)", {{
-      { "d3d9.maxFrameRate",                "60" },
+      { "d3d9.maxFrameRate",                  "60" },
     }} },
-    /* Drakensang: The Dark Eye                */
+    /* Drakensang: The Dark Eye                   */
     { R"(\\drakensang\.exe$)", {{
       { "d3d9.deferSurfaceCreation",        "True" },
     }} },
-    /* Age of Empires 2 - janky frame timing   */
+    /* Age of Empires 2 - janky frame timing      */
     { R"(\\AoK HD\.exe$)", {{
-      { "d3d9.maxFrameLatency",             "1" },
+      { "d3d9.maxFrameLatency",                "1" },
     }} },
-    /* Battlestations Midway                   */
+    /* Battlestations Midway                      */
     { R"(\\Battlestationsmidway\.exe$)", {{
-      { "d3d9.cachedDynamicBuffers",     "True" },
+      { "d3d9.cachedDynamicBuffers",        "True" },
     }} },
-    /* SkyDrift                                 *
-     * Works around alt tab OOM crash           */
+    /* SkyDrift                                   *
+     * Works around alt tab OOM crash             */
     { R"(\\SkyDrift\.exe$)" , {{
-      { "d3d9.allowDirectBufferMapping",    "False" },
+      { "d3d9.allowDirectBufferMapping",   "False" },
     }} },
-     /* Assassin's Creed 2                      *
-     *  Helps alt tab crash on Linux            */
+    /* Assassin's Creed 2                         *
+     * Helps alt tab crash on Linux               */
     { R"(\\AssassinsCreedIIGame\.exe$)" , {{
       { "d3d9.deviceLossOnFocusLoss",       "True" },
     }} },
-    /* Sonic CD                                */
+    /* Sonic CD                                   */
     { R"(\\soniccd\.exe$)", {{
-      { "d3d9.maxFrameRate",                "60" },
+      { "d3d9.maxFrameRate",                  "60" },
     }} },
-    /* UK Truck Simulator 1                    */
+    /* UK Truck Simulator 1                       */
     { R"(\\UK Truck Simulator\\bin\\win_x86\\game\.exe$)", {{
-      { "d3d9.floatEmulation",              "Strict" },
+      { "d3d9.floatEmulation",            "Strict" },
     }} },
-    /* d3d9 Supreme Ruler games              *
-     * Leaks a StateBlock leading                *
-     * to Reset calls failing                    */
+    /* d3d9 Supreme Ruler game series             *
+     * Leaks a state block leading                *
+     * to Reset calls failing                     */
     { R"(\\SupremeRuler(Ultimate|GreatWar|1936|CW)\.exe$)", {{
-      { "d3d9.countLosableResources",       "False" },
+      { "d3d9.countLosableResources",      "False" },
     }} },
-    /* Operation Flashpoint: Red River           *
-     * Flickering issues                         */
+    /* Operation Flashpoint: Red River            *
+     * Flickering issues                          */
     { R"(\\RedRiver\.exe$)", {{
-      { "d3d9.floatEmulation",              "Strict" },
+      { "d3d9.floatEmulation",            "Strict" },
     }} },
-    /* Dark Void - Crashes above 60fps in places */
+    /* Dark Void - Crashes above 60fps in places  */
     { R"(\\ShippingPC-SkyGame\.exe$)", {{
-      { "d3d9.maxFrameRate",                "60" },
+      { "d3d9.maxFrameRate",                  "60" },
     }} },
-    /* 9th Dawn II                               *
-     * OpenGL game that also spins up d3d9       *
-     * Black screens without config              */
+    /* 9th Dawn II                                *
+     * OpenGL game that also spins up d3d9        *
+     * Black screens without config               */
     { R"(\\ninthdawnii\.exe$)", {{
       { "d3d9.deferSurfaceCreation",        "True" },
     }} },
-    /* Delta Force: Xtreme 1 & 2 - Performance   */
+    /* Delta Force: Xtreme 1 & 2 - Performance    */
     { R"(\\(DFX|dfx2)\.exe$)", {{
       { "d3d9.cachedDynamicBuffers",        "True" },
     }} },
-    /* Prototype                                 *
-     * Incorrect shadows on AMD & Intel.         *
-     * AA 4x can not be selected above 2GB vram  */
+    /* Prototype                                  *
+     * Incorrect shadows on AMD & Intel.          *
+     * AA 4x can not be selected above 2GB vram   */
     { R"(\\prototypef\.exe$)", {{
       { "d3d9.hideAmdGpu",                  "True" },
       { "dxgi.maxDeviceMemory",             "2047" },
     }} },
-    /* STAR WARS: The Force Unleashed            *
-     * Prevents black screen on each alt-tab     */
+    /* STAR WARS: The Force Unleashed             *
+     * Prevents black screen on each alt-tab      */
     { R"(\\SWTFU\.exe$)", {{
       { "d3d9.deviceLossOnFocusLoss",       "True" },
     }} },
-    /* Fallout New Vegas - Various visual issues *
-     * with mods such as New Vegas Reloaded      */
+    /* Fallout New Vegas - Various visual issues  *
+     * with mods such as New Vegas Reloaded       */
     { R"(\\FalloutNV\.exe$)", {{
-      { "d3d9.floatEmulation",              "Strict" },
+      { "d3d9.floatEmulation",            "Strict" },
     }} },
-    /* Dungeons and Dragons: Dragonshard         *
-     * Massive FPS decreases in some scenes      */
+    /* Dungeons and Dragons: Dragonshard          *
+     * Massive FPS decreases in some scenes       */
     { R"(\\Dragonshard\.exe$)", {{
       { "d3d9.cachedDynamicBuffers",        "True" },
     }} },
-    /* Battle for Middle-earth 2 and expansion   *
-     * Slowdowns in certain scenarios            */
+    /* Battle for Middle-earth 2 and expansion    *
+     * Slowdowns in certain scenarios             */
     { R"(\\(The Battle for Middle-earth( \(tm\))? II( Demo)?)"
       R"(|The Lord of the Rings, The Rise of the Witch-king)\\game\.dat$)", {{
       { "d3d9.cachedDynamicBuffers",        "True" },
     }} },
-    /* WRC4 - Audio breaks above 60fps           */
+    /* WRC4 - Audio breaks above 60fps            */
     { R"(\\WRC4\.exe$)", {{
-      { "d3d9.maxFrameRate",                "60" },
+      { "d3d9.maxFrameRate",                  "60" },
     }} },
-    /* Splinter Cell Conviction                  *
-     * Unsupported GPU complaint                 */
+    /* Splinter Cell Conviction                   *
+     * Unsupported GPU complaint                  */
     { R"(\\conviction_game\.exe$)", {{
       { "dxgi.customVendorId",              "10de" },
       { "dxgi.customDeviceId",              "05e0" },
-      { "dxgi.customDeviceDesc",            "GeForce GTX 295" },
+      { "dxgi.customDeviceDesc", "GeForce GTX 295" },
     }} },
-    /* Resident Evil: Operation Raccoon City     */
+    /* Resident Evil: Operation Raccoon City      */
     { R"(\\RaccoonCity\.exe$)", {{
-      { "d3d9.textureMemory",               "0" },
+      { "d3d9.textureMemory",                  "0" },
     }} },
-    /* APB: Reloaded                               *
-     * Fixes frametime jumps when shooting         */
+    /* APB: Reloaded                              *
+     * Fixes frametime jumps when shooting        */
     { R"(\\APB\.exe$)", {{
       { "d3d9.cachedDynamicBuffers",        "True" },
     }} },
-    /* Battle Mages - helps CPU bound perf         */
+    /* Battle Mages - helps CPU bound perf        */
     { R"(\\Battle Mages\\mages\.exe$)", {{
       { "d3d9.cachedDynamicBuffers",        "True" },
     }} },
-    /* Prince of Persia (2008) - Can get stuck     *
-     * during loading at very high fps             */
+    /* Prince of Persia (2008) - Can get stuck    *
+     * during loading at very high fps            */
     { R"(\\Prince( of Persia|OfPersia_Launcher)\.exe$)", {{
       { "d3d9.maxFrameRate",                 "240" },
     }} },
-    /* F.E.A.R 1 & expansions                      *
-     * Graphics glitches at very high fps          */
+    /* F.E.A.R 1 & expansions                     *
+     * Graphics glitches at very high fps         */
     { R"(\\FEAR(MP|XP|XP2)?\.exe$)", {{
       { "d3d9.maxFrameRate",                 "360" },
     }} },
-    /* Secret World Legends - d3d9 mode only sees  *
-     * 512MB vram locking higher graphics presets  */
+    /* Secret World Legends - d3d9 mode only sees *
+     * 512MB vram locking higher graphics presets */
     { R"(\\SecretWorldLegends\.exe$)", {{
-      { "d3d9.memoryTrackTest",              "True" },
+      { "d3d9.memoryTrackTest",             "True" },
     }} },
-    /* Far Cry 2:                                  *
-     * Set cached dynamic buffers to True to       *
-     * improve perf on all hardware.               */
+    /* Far Cry 2:                                 *
+     * Set cached dynamic buffers to True to      *
+     * improve perf on all hardware.              */
     { R"(\\(FarCry2|farcry2game)\.exe$)", {{
       { "d3d9.cachedDynamicBuffers",        "True" },
     }} },
-    /* Dark Sector - Crashes in places             */
+    /* Dark Sector - Crashes in places            */
     { R"(\\DS\.exe$)", {{
-      { "d3d9.textureMemory",                "0" },
+      { "d3d9.textureMemory",                  "0" },
     }} },
-    /* Arcana Heart 3 Love Max + Xtend version     *
-     * Game speed is too fast above 60 fps         */
+    /* Arcana Heart 3 Love Max + Xtend version    *
+     * Game speed is too fast above 60 fps        */
     { R"(\\(AH3LM|AALib)\.exe$)", {{
-      { "d3d9.maxFrameRate",                "60" },
+      { "d3d9.maxFrameRate",                  "60" },
     }} },
-    /* May Payne 3 - Visual issues on some drivers *
-     * such as ANV (and amdvlk when set to True)   */
+    /* May Payne 3 - Visual issues on drivers     *
+     * such as ANV (and amdvlk when set to True)  */
     { R"(\\MaxPayne3\.exe$)", {{
-      { "d3d9.floatEmulation",              "Strict" },
+      { "d3d9.floatEmulation",            "Strict" },
     }} },
-    /* Star Wars Empire at War & expansion         *
-     * In base game the AA option dissapears at    *
-     * 2075MB vram and above                       */
+    /* Star Wars Empire at War & expansion        *
+     * In base game the AA option dissapears at   *
+     * 2075MB vram and above                      */
     { R"(\\(StarWarsG|sweaw|swfoc)\.exe$)", {{
       { "d3d9.maxAvailableMemory",          "2048" },
       { "d3d9.memoryTrackTest",             "True" },
@@ -1042,15 +1026,15 @@ namespace dxvk {
     }} },
     /* Thumper - Fixes missing track              */
     { R"(\\THUMPER_dx9\.exe$)", {{
-      { "d3d9.floatEmulation",              "Strict" },
+      { "d3d9.floatEmulation",            "Strict" },
     }} },
     /* Red Orchestra: Ostfront 41-45 - Blinks,    *
      * freeze, crash or goes Windowed on alt-tab  */
     { R"(\\RedOrchestra\.exe$)", {{
       { "d3d9.deviceLossOnFocusLoss",       "True" },
-      { "d3d9.countLosableResources",       "False" },
+      { "d3d9.countLosableResources",      "False" },
     }} },
-    /* Pirate Huner - Prevents crash              */
+    /* Pirate Hunter - Prevents crash             */
     { R"(\\PH\.exe$)", {{
       { "d3d9.memoryTrackTest",             "True" },
       { "d3d9.maxAvailableMemory",          "2048" },
@@ -1060,7 +1044,7 @@ namespace dxvk {
     { R"(\\BEA\.exe$)", {{
       { "d3d9.customVendorId",              "10de" },
       { "d3d9.customDeviceId",              "0330" },
-      { "d3d9.customDeviceDesc",            "NVIDIA GeForce FX 5900 Ultra" },
+      { "d3d9.customDeviceDesc", "NVIDIA GeForce FX 5900 Ultra" },
     }} },
     /* Astebreed - Will crash on any graphical    *
      * options or preset changes otherwise. Also, *
@@ -1092,55 +1076,55 @@ namespace dxvk {
 
     /* Duke Nukem Forever (2001)                  */
     { R"(\\DukeForever\.exe$)", {{
-      { "d3d9.maxFrameRate",                "60"   },
+      { "d3d9.maxFrameRate",                  "60" },
     }} },
-    /* Anito: Defend a Land Enraged              */
+    /* Anito: Defend a Land Enraged               */
     { R"(\\Anito\.exe$)", {{
       { "d3d9.memoryTrackTest",             "True" },
       { "d3d9.maxAvailableMemory",          "1024" },
     }} },
-    /* Red Faction                               *
-     * Fixes crashing when starting a new game   */
+    /* Red Faction                                *
+     * Fixes crashing when starting a new game    */
     { R"(\\RF\.exe$)", {{
       { "d3d9.allowDirectBufferMapping",   "False" },
     }} },
-    /* Commandos 3                               *
-     * The game doesn't use NOOVERWRITE properly *
-     * and reads from actively modified buffers, *
-     * which causes graphical glitches at times  */
+    /* Commandos 3                                *
+     * The game doesn't use NOOVERWRITE properly  *
+     * and reads from actively modified buffers,  *
+     * which causes graphical glitches at times   */
     { R"(\\Commandos3\.exe$)", {{
       { "d3d9.allowDirectBufferMapping",   "False" },
     }} },
-    /* Motor City Online                         */
+    /* Motor City Online                          */
     { R"(\\MCity_d\.exe$)", {{
       { "d3d9.cachedDynamicBuffers",        "True" },
       { "d3d8.batching",                    "True" },
     }} },
-    /* Railroad Tycoon 3                         */
+    /* Railroad Tycoon 3                          */
     { R"(\\RT3\.exe$)", {{
       { "d3d9.maxFrameRate",                  "60" },
     }} },
-    /* Pure Pinball 2.0 REDUX                    *
-     * This game reads from undeclared vs inputs *
-     * but somehow works on native. Let's just   *
-     * change its declaration to make them work. */
+    /* Pure Pinball 2.0 REDUX                     *
+     * This game reads from undeclared vs inputs  *
+     * but somehow works on native. Let's just    *
+     * change its declaration to make them work.  */
     { R"(\\Pure Pinball 2\.0 REDUX\.exe$)", {{
       { "d3d8.forceVsDecl",  "0:2,4:2,7:4,9:1,8:1" },
     }} },
-    /* Need for Speed III: Hot Pursuit           *
-       (with the "Modern Patch")                 */
+    /* Need for Speed III: Hot Pursuit            *
+     * (with the "Modern Patch")                  */
     { R"(\\nfs3\.exe$)", {{
       { "d3d9.cachedDynamicBuffers",        "True" },
       { "d3d8.batching",                    "True" },
     }} },
     /* Need for Speed: High Stakes / Road         *
-       Challenge (with the "Modern Patch") -      *
-       Won't actually render anything in game     *
-       without a memory limit in place            */
+     * Challenge (with the "Modern Patch") -      *
+     * Won't actually render anything in game     *
+     * without a memory limit in place            */
     { R"(\\nfs4\.exe$)", {{
       { "d3d9.cachedDynamicBuffers",        "True" },
       { "d3d9.memoryTrackTest",             "True" },
-      { "d3d9.maxAvailableMemory",           "256" },
+      { "d3d9.maxAvailableMemory",          "1024" },
       { "d3d8.batching",                    "True" },
     }} },
     /* Need for Speed: Hot Pursuit 2              */
@@ -1151,12 +1135,12 @@ namespace dxvk {
     { R"(\\igi2\.exe$)", {{
       { "d3d9.cachedDynamicBuffers",        "True" },
     }} },
-    /* Treasure Planet: Battle at Procyon        *
-     * Declares v5 as color but shader uses v6   */
+    /* Treasure Planet: Battle at Procyon         *
+     * Declares v5 as color but shader uses v6    */
     { R"(\\TP_Win32\.exe$)", {{
       { "d3d8.forceVsDecl",      "0:2,3:2,6:4,7:1" },
     }} },
-    /* Scrapland (Remastered)                   */
+    /* Scrapland (Remastered)                     */
     { R"(\\Scrap\.exe$)", {{
       { "d3d9.deferSurfaceCreation",        "True" },
     }} },
@@ -1169,7 +1153,7 @@ namespace dxvk {
      * while loading the main menu otherwise      */
     { R"(\\Soldiers\.exe$)", {{
       { "d3d9.memoryTrackTest",             "True" },
-      { "d3d9.maxAvailableMemory",          "512"  },
+      { "d3d9.maxAvailableMemory",           "512" },
     }} },
     /* Cossacks II: Napoleonic Wars &             *
      * Battle for Europe                          */
@@ -1266,13 +1250,13 @@ namespace dxvk {
     { R"(\\SFC3\.exe$)", {{
       { "d3d9.countLosableResources",      "False" },
     }} },
-    /* GTR - FIA GT Racing Game                   *                  
+    /* GTR - FIA GT Racing Game                   *
      * Vram complaint & restricted resolutions    *
      * Performance                                */
     { R"(\\GTR (- FIA GT Rac(e)?ing Game|Demo)\\(GTR(Demo)?|(3D)?Config)\.exe$)", {{
-      { "d3d9.maxAvailableMemory",         "1024" },
-      { "d3d9.memoryTrackTest",            "True" },
-      { "d3d9.cachedDynamicBuffers",       "True" },
+      { "d3d9.maxAvailableMemory",          "1024" },
+      { "d3d9.memoryTrackTest",             "True" },
+      { "d3d9.cachedDynamicBuffers",        "True" },
     }} },
   };
 
@@ -1280,8 +1264,8 @@ namespace dxvk {
   const static ProfileList g_deckProfiles = {
     /* Fallout 4: Defaults to 45 FPS on OLED, but also breaks above 60 FPS */
     { R"(\\Fallout4\.exe$)", {{
-      { "dxgi.syncInterval",                "1" },
-      { "dxgi.maxFrameRate",                "60" },
+      { "dxgi.syncInterval",                   "1" },
+      { "dxgi.maxFrameRate",                  "60" },
     }} },
   };
 

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -1258,6 +1258,13 @@ namespace dxvk {
       { "d3d9.memoryTrackTest",             "True" },
       { "d3d9.cachedDynamicBuffers",        "True" },
     }} },
+    /* Comanche 4 - Only enables the FSAA option  *
+     * if it detects a device ID of 0x025x.       */
+     { R"(\\c4(lan)?\.exe$)", {{
+      { "d3d9.customVendorId",              "10de" },
+      { "d3d9.customDeviceId",              "0250" },
+      { "d3d9.customDeviceDesc", "NVIDIA GeForce4 Ti 4600" },
+    }} },
   };
 
 


### PR DESCRIPTION
Noticed a distinct difference between dxvk and native d3d9 when looking at several traces, namely `GetAvailableTextureMem()` consistently reports lower numbers on native (this is for newly created devices). The exact delta varies between 2 MB and 8 MB depending on chosen resolution, so I can only assume it's memory reserved for back buffer use or other internal (Windows) purposes.

This PR might help us get rid of the caps for some games currently using a 2048 limit, but that needs further testing.

Other than that, I've taken the liberty to attempt a somewhat (more) consistent formatting/alignment of the config.cpp profiles. The only actual change in there besides formatting/alignment is that I've bumped the memory limit for NFS4 to 1024 MB, to account for potential modding, since the game will actually get in trouble close to 2048 MB.