### PR TITLE
[d3d11] Slience video related log spam in Overcooked AYCE

### DIFF
--- a/src/d3d11/d3d11_device.cpp
+++ b/src/d3d11/d3d11_device.cpp
@@ -2815,7 +2815,11 @@ namespace dxvk {
     const D3D11_VIDEO_DECODER_DESC*                     pVideoDesc,
     const D3D11_VIDEO_DECODER_CONFIG*                   pConfig,
           ID3D11VideoDecoder**                          ppDecoder) {
-    Logger::err("D3D11VideoDevice::CreateVideoDecoder: Stub");
+    static bool s_errorShown = false;
+
+    if (!std::exchange(s_errorShown, true))
+      Logger::warn("D3D11VideoDevice::CreateVideoDecoder: Stub");
+
     return E_NOTIMPL;
   }
 
@@ -2838,7 +2842,7 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE D3D11VideoDevice::CreateAuthenticatedChannel(
           D3D11_AUTHENTICATED_CHANNEL_TYPE              ChannelType,
           ID3D11AuthenticatedChannel**                  ppAuthenticatedChannel) {
-    Logger::err("D3D11VideoDevice::CreateAuthenticatedChannel: Stub");
+    Logger::warn("D3D11VideoDevice::CreateAuthenticatedChannel: Stub");
     return E_NOTIMPL;
   }
 
@@ -2848,7 +2852,7 @@ namespace dxvk {
     const GUID*                                         pDecoderProfile,
     const GUID*                                         pKeyExchangeType,
           ID3D11CryptoSession**                         ppCryptoSession) {
-    Logger::err("D3D11VideoDevice::CreateCryptoSession: Stub");
+    Logger::warn("D3D11VideoDevice::CreateCryptoSession: Stub");
     return E_NOTIMPL;
   }
 
@@ -2857,7 +2861,11 @@ namespace dxvk {
           ID3D11Resource*                               pResource,
     const D3D11_VIDEO_DECODER_OUTPUT_VIEW_DESC*         pDesc,
           ID3D11VideoDecoderOutputView**                ppVDOVView) {
-    Logger::err("D3D11VideoDevice::CreateVideoDecoderOutputView: Stub");
+    static bool s_errorShown = false;
+
+    if (!std::exchange(s_errorShown, true))
+      Logger::warn("D3D11VideoDevice::CreateVideoDecoderOutputView: Stub");
+
     return E_NOTIMPL;
   }
 
@@ -2906,7 +2914,11 @@ namespace dxvk {
 
 
   UINT STDMETHODCALLTYPE D3D11VideoDevice::GetVideoDecoderProfileCount() {
-    Logger::err("D3D11VideoDevice::GetVideoDecoderProfileCount: Stub");
+    static bool s_errorShown = false;
+
+    if (!std::exchange(s_errorShown, true))
+      Logger::warn("D3D11VideoDevice::GetVideoDecoderProfileCount: Stub");
+
     return 0;
   }
 
@@ -2914,7 +2926,11 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE D3D11VideoDevice::GetVideoDecoderProfile(
           UINT                                          Index,
           GUID*                                         pDecoderProfile) {
-    Logger::err("D3D11VideoDevice::GetVideoDecoderProfile: Stub");
+    static bool s_errorShown = false;
+
+    if (!std::exchange(s_errorShown, true))
+      Logger::warn("D3D11VideoDevice::GetVideoDecoderProfile: Stub");
+
     return E_NOTIMPL;
   }
 
@@ -2923,7 +2939,11 @@ namespace dxvk {
     const GUID*                                         pDecoderProfile,
           DXGI_FORMAT                                   Format,
           BOOL*                                         pSupported) {
-    Logger::err("D3D11VideoDevice::CheckVideoDecoderFormat: Stub");
+    static bool s_errorShown = false;
+
+    if (!std::exchange(s_errorShown, true))
+      Logger::warn("D3D11VideoDevice::CheckVideoDecoderFormat: Stub");
+
     return E_NOTIMPL;
   }
 
@@ -2931,8 +2951,17 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE D3D11VideoDevice::GetVideoDecoderConfigCount(
     const D3D11_VIDEO_DECODER_DESC*                     pDesc,
           UINT*                                         pCount) {
-    Logger::err("D3D11VideoDevice::GetVideoDecoderConfigCount: Stub");
-    return E_NOTIMPL;
+    static bool s_errorShown = false;
+
+    if (!std::exchange(s_errorShown, true))
+      Logger::warn("D3D11VideoDevice::GetVideoDecoderConfigCount: Stub");
+
+    if (!pCount)
+      return E_INVALIDARG;
+
+    *pCount = 0;
+
+    return S_OK;
   }
 
 
@@ -2940,7 +2969,11 @@ namespace dxvk {
     const D3D11_VIDEO_DECODER_DESC*                     pDesc,
           UINT                                          Index,
           D3D11_VIDEO_DECODER_CONFIG*                   pConfig) {
-    Logger::err("D3D11VideoDevice::GetVideoDecoderConfig: Stub");
+    static bool s_errorShown = false;
+
+    if (!std::exchange(s_errorShown, true))
+      Logger::warn("D3D11VideoDevice::GetVideoDecoderConfig: Stub");
+
     return E_NOTIMPL;
   }
 
@@ -2949,7 +2982,11 @@ namespace dxvk {
     const GUID*                                         pCryptoType,
     const GUID*                                         pDecoderProfile,
           D3D11_VIDEO_CONTENT_PROTECTION_CAPS*          pCaps) {
-    Logger::err("D3D11VideoDevice::GetContentProtectionCaps: Stub");
+    static bool s_errorShown = false;
+
+    if (!std::exchange(s_errorShown, true))
+      Logger::warn("D3D11VideoDevice::GetContentProtectionCaps: Stub");
+
     return E_NOTIMPL;
   }
 
@@ -2959,7 +2996,11 @@ namespace dxvk {
     const GUID*                                         pDecoderProfile,
           UINT                                          Index,
           GUID*                                         pKeyExchangeType) {
-    Logger::err("D3D11VideoDevice::CheckCryptoKeyExchange: Stub");
+    static bool s_errorShown = false;
+
+    if (!std::exchange(s_errorShown, true))
+      Logger::warn("D3D11VideoDevice::CheckCryptoKeyExchange: Stub");
+
     return E_NOTIMPL;
   }
 
@@ -2977,8 +3018,6 @@ namespace dxvk {
     const IUnknown*                                     pData) {
     return m_container->SetPrivateDataInterface(Name, pData);
   }
-
-
 
 
   D3D11ReflexDevice::D3D11ReflexDevice(

--- a/src/d3d11/d3d11_video.cpp
+++ b/src/d3d11/d3d11_video.cpp
@@ -56,7 +56,7 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE D3D11VideoProcessorEnumerator::CheckVideoProcessorFormat(
           DXGI_FORMAT             Format,
           UINT*                   pFlags) {
-    Logger::err(str::format("D3D11VideoProcessorEnumerator::CheckVideoProcessorFormat: stub, format ", Format));
+    Logger::warn(str::format("D3D11VideoProcessorEnumerator::CheckVideoProcessorFormat: stub, format ", Format));
 
     if (!pFlags)
       return E_INVALIDARG;
@@ -68,7 +68,10 @@ namespace dxvk {
 
   HRESULT STDMETHODCALLTYPE D3D11VideoProcessorEnumerator::GetVideoProcessorCaps(
           D3D11_VIDEO_PROCESSOR_CAPS* pCaps) {
-    Logger::err("D3D11VideoProcessorEnumerator::GetVideoProcessorCaps: semi-stub");
+    static bool s_errorShown = false;
+
+    if (!std::exchange(s_errorShown, true))
+      Logger::warn("D3D11VideoProcessorEnumerator::GetVideoProcessorCaps: semi-stub");
 
     if (!pCaps)
       return E_INVALIDARG;
@@ -84,7 +87,11 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE D3D11VideoProcessorEnumerator::GetVideoProcessorRateConversionCaps(
           UINT                    TypeIndex,
           D3D11_VIDEO_PROCESSOR_RATE_CONVERSION_CAPS* pCaps) {
-    Logger::err("D3D11VideoProcessorEnumerator::GetVideoProcessorRateConversionCaps: semi-stub");
+    static bool s_errorShown = false;
+
+    if (!std::exchange(s_errorShown, true))
+      Logger::warn("D3D11VideoProcessorEnumerator::GetVideoProcessorRateConversionCaps: semi-stub");
+
     if (!pCaps || TypeIndex)
       return E_INVALIDARG;
 
@@ -104,7 +111,11 @@ namespace dxvk {
           UINT                    TypeIndex,
           UINT                    CustomRateIndex,
           D3D11_VIDEO_PROCESSOR_CUSTOM_RATE* pRate) {
-    Logger::err("D3D11VideoProcessorEnumerator::GetVideoProcessorCustomRate: Stub");
+    static bool s_errorShown = false;
+
+    if (!std::exchange(s_errorShown, true))
+      Logger::warn("D3D11VideoProcessorEnumerator::GetVideoProcessorCustomRate: Stub");
+
     return E_NOTIMPL;
   }
 
@@ -112,7 +123,11 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE D3D11VideoProcessorEnumerator::GetVideoProcessorFilterRange(
           D3D11_VIDEO_PROCESSOR_FILTER        Filter,
           D3D11_VIDEO_PROCESSOR_FILTER_RANGE* pRange) {
-    Logger::err("D3D11VideoProcessorEnumerator::GetVideoProcessorFilterRange: Stub");
+    static bool s_errorShown = false;
+
+    if (!std::exchange(s_errorShown, true))
+      Logger::warn("D3D11VideoProcessorEnumerator::GetVideoProcessorFilterRange: Stub");
+
     return E_NOTIMPL;
   }
 
@@ -493,7 +508,11 @@ namespace dxvk {
           D3D11_VIDEO_DECODER_BUFFER_TYPE Type,
           UINT*                           BufferSize,
           void**                          ppBuffer) {
-    Logger::err("D3D11VideoContext::GetDecoderBuffer: Stub");
+    static bool s_errorShown = false;
+
+    if (!std::exchange(s_errorShown, true))
+      Logger::warn("D3D11VideoContext::GetDecoderBuffer: Stub");
+
     return E_NOTIMPL;
   }
 
@@ -501,7 +520,11 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE D3D11VideoContext::ReleaseDecoderBuffer(
           ID3D11VideoDecoder*             pDecoder,
           D3D11_VIDEO_DECODER_BUFFER_TYPE Type) {
-    Logger::err("D3D11VideoContext::ReleaseDecoderBuffer: Stub");
+    static bool s_errorShown = false;
+
+    if (!std::exchange(s_errorShown, true))
+      Logger::warn("D3D11VideoContext::ReleaseDecoderBuffer: Stub");
+
     return E_NOTIMPL;
   }
 
@@ -510,14 +533,22 @@ namespace dxvk {
           ID3D11VideoDecoderOutputView*   pView,
           UINT                            KeySize,
     const void*                           pKey) {
-    Logger::err("D3D11VideoContext::DecoderBeginFrame: Stub");
+    static bool s_errorShown = false;
+
+    if (!std::exchange(s_errorShown, true))
+      Logger::warn("D3D11VideoContext::DecoderBeginFrame: Stub");
+
     return E_NOTIMPL;
   }
 
 
   HRESULT STDMETHODCALLTYPE D3D11VideoContext::DecoderEndFrame(
           ID3D11VideoDecoder*             pDecoder) {
-    Logger::err("D3D11VideoContext::DecoderEndFrame: Stub");
+    static bool s_errorShown = false;
+
+    if (!std::exchange(s_errorShown, true))
+      Logger::warn("D3D11VideoContext::DecoderEndFrame: Stub");
+
     return E_NOTIMPL;
   }
 
@@ -526,7 +557,11 @@ namespace dxvk {
           ID3D11VideoDecoder*             pDecoder,
           UINT                            BufferCount,
     const D3D11_VIDEO_DECODER_BUFFER_DESC* pBufferDescs) {
-    Logger::err("D3D11VideoContext::SubmitDecoderBuffers: Stub");
+    static bool s_errorShown = false;
+
+    if (!std::exchange(s_errorShown, true))
+      Logger::warn("D3D11VideoContext::SubmitDecoderBuffers: Stub");
+
     return E_NOTIMPL;
   }
 
@@ -534,7 +569,11 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE D3D11VideoContext::DecoderExtension(
           ID3D11VideoDecoder*             pDecoder,
     const D3D11_VIDEO_DECODER_EXTENSION*  pExtension) {
-    Logger::err("D3D11VideoContext::DecoderExtension: Stub");
+    static bool s_errorShown = false;
+
+    if (!std::exchange(s_errorShown, true))
+      Logger::warn("D3D11VideoContext::DecoderExtension: Stub");
+
     return E_NOTIMPL;
   }
 
@@ -543,6 +582,11 @@ namespace dxvk {
           ID3D11VideoProcessor*           pVideoProcessor,
           BOOL                            Enable,
     const RECT*                           pRect) {
+    static bool errorShown = false;
+
+    if (!std::exchange(errorShown, true))
+      Logger::warn("D3D11VideoContext::VideoProcessorSetOutputTargetRect: Stub.");
+
     D3D10DeviceLock lock = m_ctx->LockContext();
 
     auto state = static_cast<D3D11VideoProcessor*>(pVideoProcessor)->GetState();
@@ -550,11 +594,6 @@ namespace dxvk {
 
     if (Enable)
       state->outputTargetRect = *pRect;
-
-    static bool errorShown = false;
-
-    if (!std::exchange(errorShown, true))
-      Logger::err("D3D11VideoContext::VideoProcessorSetOutputTargetRect: Stub.");
   }
 
 
@@ -562,16 +601,16 @@ namespace dxvk {
           ID3D11VideoProcessor*           pVideoProcessor,
           BOOL                            YCbCr,
     const D3D11_VIDEO_COLOR*              pColor) {
+    static bool errorShown = false;
+
+    if (!std::exchange(errorShown, true))
+      Logger::warn("D3D11VideoContext::VideoProcessorSetOutputBackgroundColor: Stub");
+
     D3D10DeviceLock lock = m_ctx->LockContext();
 
     auto state = static_cast<D3D11VideoProcessor*>(pVideoProcessor)->GetState();
     state->outputBackgroundColorIsYCbCr = YCbCr;
     state->outputBackgroundColor = *pColor;
-
-    static bool errorShown = false;
-
-    if (!std::exchange(errorShown, true))
-      Logger::err("D3D11VideoContext::VideoProcessorSetOutputBackgroundColor: Stub");
   }
 
 
@@ -589,7 +628,10 @@ namespace dxvk {
           ID3D11VideoProcessor*           pVideoProcessor,
           D3D11_VIDEO_PROCESSOR_ALPHA_FILL_MODE AlphaFillMode,
           UINT                            StreamIndex) {
-    Logger::err("D3D11VideoContext::VideoProcessorSetOutputAlphaFillMode: Stub");
+    static bool errorShown = false;
+
+    if (!std::exchange(errorShown, true))
+      Logger::warn("D3D11VideoContext::VideoProcessorSetOutputAlphaFillMode: Stub");
   }
 
 
@@ -597,7 +639,10 @@ namespace dxvk {
           ID3D11VideoProcessor*           pVideoProcessor,
           BOOL                            Enable,
           SIZE                            Size) {
-    Logger::err("D3D11VideoContext::VideoProcessorSetOutputConstriction: Stub");
+    static bool errorShown = false;
+
+    if (!std::exchange(errorShown, true))
+      Logger::warn("D3D11VideoContext::VideoProcessorSetOutputConstriction: Stub");
   }
 
 
@@ -619,7 +664,11 @@ namespace dxvk {
     const GUID*                           pExtensionGuid,
           UINT                            DataSize,
           void*                           pData) {
-    Logger::err("D3D11VideoContext::VideoProcessorSetOutputExtension: Stub");
+    static bool errorShown = false;
+
+    if (!std::exchange(errorShown, true))
+      Logger::warn("D3D11VideoContext::VideoProcessorSetOutputExtension: Stub");
+
     return E_NOTIMPL;
   }
 
@@ -663,9 +712,9 @@ namespace dxvk {
           D3D11_VIDEO_PROCESSOR_OUTPUT_RATE Rate,
           BOOL                            Repeat,
     const DXGI_RATIONAL*                  CustomRate) {
-    Logger::err(str::format("D3D11VideoContext::VideoProcessorSetStreamOutputRate: Stub, Rate ", Rate));
+    Logger::warn(str::format("D3D11VideoContext::VideoProcessorSetStreamOutputRate: Stub, Rate ", Rate));
     if (CustomRate)
-      Logger::err(str::format("CustomRate ", CustomRate->Numerator, "/", CustomRate->Denominator));
+      Logger::warn(str::format("CustomRate ", CustomRate->Numerator, "/", CustomRate->Denominator));
   }
 
 
@@ -674,6 +723,11 @@ namespace dxvk {
           UINT                            StreamIndex,
           BOOL                            Enable,
     const RECT*                           pRect) {
+    static bool errorShown = false;
+
+    if (!std::exchange(errorShown, true))
+      Logger::warn("D3D11VideoContext::VideoProcessorSetStreamSourceRect: Stub.");
+
     D3D10DeviceLock lock = m_ctx->LockContext();
 
     auto state = static_cast<D3D11VideoProcessor*>(pVideoProcessor)->GetStreamState(StreamIndex);
@@ -685,11 +739,6 @@ namespace dxvk {
 
     if (Enable)
       state->srcRect = *pRect;
-
-    static bool errorShown = false;
-
-    if (!std::exchange(errorShown, true))
-      Logger::err("D3D11VideoContext::VideoProcessorSetStreamSourceRect: Stub.");
   }
 
 
@@ -717,7 +766,10 @@ namespace dxvk {
           UINT                            StreamIndex,
           BOOL                            Enable,
           FLOAT                           Alpha) {
-    Logger::err("D3D11VideoContext::VideoProcessorSetStreamAlpha: Stub");
+    static bool errorShown = false;
+
+    if (!std::exchange(errorShown, true))
+      Logger::warn("D3D11VideoContext::VideoProcessorSetStreamAlpha: Stub");
   }
 
 
@@ -726,7 +778,10 @@ namespace dxvk {
           UINT                            StreamIndex,
           UINT                            EntryCount,
     const UINT*                           pEntries) {
-    Logger::err("D3D11VideoContext::VideoProcessorSetStreamPalette: Stub");
+    static bool errorShown = false;
+
+    if (!std::exchange(errorShown, true))
+      Logger::warn("D3D11VideoContext::VideoProcessorSetStreamPalette: Stub");
   }
 
 
@@ -736,7 +791,10 @@ namespace dxvk {
           BOOL                            Enable,
     const DXGI_RATIONAL*                  pSrcAspectRatio,
     const DXGI_RATIONAL*                  pDstAspectRatio) {
-    Logger::err("D3D11VideoContext::VideoProcessorSetStreamPixelAspectRatio: Stub");
+    static bool errorShown = false;
+
+    if (!std::exchange(errorShown, true))
+      Logger::warn("D3D11VideoContext::VideoProcessorSetStreamPixelAspectRatio: Stub");
   }
 
 
@@ -746,7 +804,10 @@ namespace dxvk {
           BOOL                            Enable,
           FLOAT                           Lower,
           FLOAT                           Upper) {
-    Logger::err("D3D11VideoContext::VideoProcessorSetStreamLumaKey: Stub");
+    static bool errorShown = false;
+
+    if (!std::exchange(errorShown, true))
+      Logger::warn("D3D11VideoContext::VideoProcessorSetStreamLumaKey: Stub");
   }
 
 
@@ -759,7 +820,10 @@ namespace dxvk {
           BOOL                            BaseViewFrame0,
           D3D11_VIDEO_PROCESSOR_STEREO_FLIP_MODE FlipMode,
           int                             MonoOffset) {
-    Logger::err("D3D11VideoContext::VideoProcessorSetStreamStereoFormat: Stub");
+    static bool errorShown = false;
+
+    if (!std::exchange(errorShown, true))
+      Logger::warn("D3D11VideoContext::VideoProcessorSetStreamStereoFormat: Stub");
   }
 
 
@@ -784,7 +848,10 @@ namespace dxvk {
           D3D11_VIDEO_PROCESSOR_FILTER    Filter,
           BOOL                            Enable,
           int                             Level) {
-    Logger::err("D3D11VideoContext::VideoProcessorSetStreamFilter: Stub");
+    static bool errorShown = false;
+
+    if (!std::exchange(errorShown, true))
+      Logger::warn("D3D11VideoContext::VideoProcessorSetStreamFilter: Stub");
   }
 
 
@@ -794,7 +861,11 @@ namespace dxvk {
     const GUID*                           pExtensionGuid,
           UINT                            DataSize,
           void*                           pData) {
-    Logger::err("D3D11VideoContext::VideoProcessorSetStreamExtension: Stub");
+    static bool errorShown = false;
+
+    if (!std::exchange(errorShown, true))
+      Logger::warn("D3D11VideoContext::VideoProcessorSetStreamExtension: Stub");
+
     return E_NOTIMPL;
   }
 
@@ -867,7 +938,10 @@ namespace dxvk {
           ID3D11VideoProcessor*           pVideoProcessor,
           D3D11_VIDEO_PROCESSOR_ALPHA_FILL_MODE* pAlphaFillMode,
           UINT*                           pStreamIndex) {
-    Logger::err("D3D11VideoContext::VideoProcessorGetOutputAlphaFillMode: Stub");
+    static bool errorShown = false;
+
+    if (!std::exchange(errorShown, true))
+      Logger::warn("D3D11VideoContext::VideoProcessorGetOutputAlphaFillMode: Stub");
   }
 
 
@@ -875,7 +949,10 @@ namespace dxvk {
           ID3D11VideoProcessor*           pVideoProcessor,
           BOOL*                           pEnabled,
           SIZE*                           pSize) {
-    Logger::err("D3D11VideoContext::VideoProcessorGetOutputConstriction: Stub");
+    static bool errorShown = false;
+
+    if (!std::exchange(errorShown, true))
+      Logger::warn("D3D11VideoContext::VideoProcessorGetOutputConstriction: Stub");
   }
 
 
@@ -896,7 +973,11 @@ namespace dxvk {
     const GUID*                           pExtensionGuid,
           UINT                            DataSize,
           void*                           pData) {
-    Logger::err("D3D11VideoContext::VideoProcessorGetOutputExtension: Stub");
+    static bool errorShown = false;
+
+    if (!std::exchange(errorShown, true))
+      Logger::warn("D3D11VideoContext::VideoProcessorGetOutputExtension: Stub");
+
     return E_NOTIMPL;
   }
 
@@ -939,7 +1020,10 @@ namespace dxvk {
           D3D11_VIDEO_PROCESSOR_OUTPUT_RATE* pRate,
           BOOL*                           pRepeat,
           DXGI_RATIONAL*                  pCustomRate) {
-    Logger::err("D3D11VideoContext::VideoProcessorGetStreamOutputRate: Stub");
+    static bool errorShown = false;
+
+    if (!std::exchange(errorShown, true))
+      Logger::warn("D3D11VideoContext::VideoProcessorGetStreamOutputRate: Stub");
   }
 
 
@@ -988,7 +1072,10 @@ namespace dxvk {
           UINT                            StreamIndex,
           BOOL*                           pEnabled,
           FLOAT*                          pAlpha) {
-    Logger::err("D3D11VideoContext::VideoProcessorGetStreamAlpha: Stub");
+    static bool errorShown = false;
+
+    if (!std::exchange(errorShown, true))
+      Logger::warn("D3D11VideoContext::VideoProcessorGetStreamAlpha: Stub");
   }
 
 
@@ -997,7 +1084,10 @@ namespace dxvk {
           UINT                            StreamIndex,
           UINT                            EntryCount,
           UINT*                           pEntries) {
-    Logger::err("D3D11VideoContext::VideoProcessorGetStreamPalette: Stub");
+    static bool errorShown = false;
+
+    if (!std::exchange(errorShown, true))
+      Logger::warn("D3D11VideoContext::VideoProcessorGetStreamPalette: Stub");
   }
 
 
@@ -1007,7 +1097,10 @@ namespace dxvk {
           BOOL*                           pEnabled,
           DXGI_RATIONAL*                  pSrcAspectRatio,
           DXGI_RATIONAL*                  pDstAspectRatio) {
-    Logger::err("D3D11VideoContext::VideoProcessorGetStreamPixelAspectRatio: Stub");
+    static bool errorShown = false;
+
+    if (!std::exchange(errorShown, true))
+      Logger::warn("D3D11VideoContext::VideoProcessorGetStreamPixelAspectRatio: Stub");
   }
 
 
@@ -1017,7 +1110,10 @@ namespace dxvk {
           BOOL*                           pEnabled,
           FLOAT*                          pLower,
           FLOAT*                          pUpper) {
-    Logger::err("D3D11VideoContext::VideoProcessorGetStreamLumaKey: Stub");
+    static bool errorShown = false;
+
+    if (!std::exchange(errorShown, true))
+      Logger::warn("D3D11VideoContext::VideoProcessorGetStreamLumaKey: Stub");
   }
 
 
@@ -1030,7 +1126,10 @@ namespace dxvk {
           BOOL*                           pBaseViewFrame0,
           D3D11_VIDEO_PROCESSOR_STEREO_FLIP_MODE* pFlipMode,
           int*                            pMonoOffset) {
-    Logger::err("D3D11VideoContext::VideoProcessorGetStreamStereoFormat: Stub");
+    static bool errorShown = false;
+
+    if (!std::exchange(errorShown, true))
+      Logger::warn("D3D11VideoContext::VideoProcessorGetStreamStereoFormat: Stub");
   }
 
 
@@ -1055,7 +1154,10 @@ namespace dxvk {
           D3D11_VIDEO_PROCESSOR_FILTER    Filter,
           BOOL*                           pEnabled,
           int*                            pLevel) {
-    Logger::err("D3D11VideoContext::VideoProcessorGetStreamFilter: Stub");
+    static bool errorShown = false;
+
+    if (!std::exchange(errorShown, true))
+      Logger::warn("D3D11VideoContext::VideoProcessorGetStreamFilter: Stub");
   }
 
 
@@ -1065,7 +1167,11 @@ namespace dxvk {
     const GUID*                           pExtensionGuid,
           UINT                            DataSize,
           void*                           pData) {
-    Logger::err("D3D11VideoContext::VideoProcessorGetStreamExtension: Stub");
+    static bool errorShown = false;
+
+    if (!std::exchange(errorShown, true))
+      Logger::warn("D3D11VideoContext::VideoProcessorGetStreamExtension: Stub");
+
     return E_NOTIMPL;
   }
 
@@ -1170,7 +1276,7 @@ namespace dxvk {
           ID3D11CryptoSession*            pSession,
           UINT                            DataSize,
           void*                           pData) {
-    Logger::err("D3D11VideoContext::NegotiateCryptoSessionKeyExchange: Stub");
+    Logger::warn("D3D11VideoContext::NegotiateCryptoSessionKeyExchange: Stub");
     return E_NOTIMPL;
   }
 
@@ -1181,7 +1287,7 @@ namespace dxvk {
           ID3D11Texture2D*                pDstSurface,
           UINT                            IVSize,
           void*                           pIV) {
-    Logger::err("D3D11VideoContext::EncryptionBlt: Stub");
+    Logger::warn("D3D11VideoContext::EncryptionBlt: Stub");
   }
 
 
@@ -1194,7 +1300,7 @@ namespace dxvk {
     const void*                           pKey,
           UINT                            IVSize,
           void*                           pIV) {
-    Logger::err("D3D11VideoContext::DecryptionBlt: Stub");
+    Logger::warn("D3D11VideoContext::DecryptionBlt: Stub");
   }
 
 
@@ -1202,13 +1308,13 @@ namespace dxvk {
           ID3D11CryptoSession*            pSession,
           UINT                            RandomNumberSize,
           void*                           pRandomNumber) {
-    Logger::err("D3D11VideoContext::StartSessionKeyRefresh: Stub");
+    Logger::warn("D3D11VideoContext::StartSessionKeyRefresh: Stub");
   }
 
 
   void STDMETHODCALLTYPE D3D11VideoContext::FinishSessionKeyRefresh(
           ID3D11CryptoSession*            pSession) {
-    Logger::err("D3D11VideoContext::FinishSessionKeyRefresh: Stub");
+    Logger::warn("D3D11VideoContext::FinishSessionKeyRefresh: Stub");
   }
 
 
@@ -1216,7 +1322,7 @@ namespace dxvk {
           ID3D11CryptoSession*            pSession,
           UINT                            KeySize,
           void*                           pKey) {
-    Logger::err("D3D11VideoContext::GetEncryptionBltKey: Stub");
+    Logger::warn("D3D11VideoContext::GetEncryptionBltKey: Stub");
     return E_NOTIMPL;
   }
 
@@ -1225,7 +1331,7 @@ namespace dxvk {
           ID3D11AuthenticatedChannel*     pChannel,
           UINT                            DataSize,
           void*                           pData) {
-    Logger::err("D3D11VideoContext::NegotiateAuthenticatedChannelKeyExchange: Stub");
+    Logger::warn("D3D11VideoContext::NegotiateAuthenticatedChannelKeyExchange: Stub");
     return E_NOTIMPL;
   }
 
@@ -1236,7 +1342,7 @@ namespace dxvk {
     const void*                           pInput,
           UINT                            OutputSize,
           void*                           pOutput) {
-    Logger::err("D3D11VideoContext::QueryAuthenticatedChannel: Stub");
+    Logger::warn("D3D11VideoContext::QueryAuthenticatedChannel: Stub");
     return E_NOTIMPL;
   }
 
@@ -1246,7 +1352,7 @@ namespace dxvk {
           UINT                            InputSize,
     const void*                           pInput,
           D3D11_AUTHENTICATED_CONFIGURE_OUTPUT* pOutput) {
-    Logger::err("D3D11VideoContext::ConfigureAuthenticatedChannel: Stub");
+    Logger::warn("D3D11VideoContext::ConfigureAuthenticatedChannel: Stub");
     return E_NOTIMPL;
   }
 


### PR DESCRIPTION
Overcooked: All You Can Eat spams pretty much all of D3D11's video API (as observed in #5081), except the DRM/crypto stuff, so I've silenced most of the calls to prevent excessive log spam. The game works fine save for video, in any case, so none of it warrants the "error" status, thus I've also lowered the logging to "warning".

I've also subbed `GetVideoDecoderConfigCount` a bit more, to return 0, hopefully it might make it clear to some apps they shouldn't spam unsupported things like mad.