### PR TITLE
[util] Hide Nvidia in Fallout New Vegas

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -918,9 +918,12 @@ namespace dxvk {
       { "d3d9.deviceLossOnFocusLoss",       "True" },
     }} },
     /* Fallout New Vegas - Various visual issues  *
-     * with mods such as New Vegas Reloaded       */
-    { R"(\\FalloutNV\.exe$)", {{
+     * in mod New Vegas Reloaded. Nvidia path in  *
+     * same mod use NvAPI_D3D9_StretchRectEx for  *
+     * depth buffer resolves                      */
+    { R"(\\FalloutNV(Launcher)?\.exe$)", {{
       { "d3d9.floatEmulation",            "Strict" },
+      { "d3d9.hideNvidiaGpu",               "True" },
     }} },
     /* Dungeons and Dragons: Dragonshard          *
      * Massive FPS decreases in some scenes       */


### PR DESCRIPTION
The Nvidia path in the New Vegas Reloaded mod depends on `NvAPI_D3D9_StretchRectEx` being implemented in nvapi for depth buffer resolves.
Previously it took a different path because `RESZ` was exposed on Nvidia. This is no longer the case because we match what the native drivers expose now.

Closes #5134