### PR TITLE
[util] Add a frame rate cap for Psi-Ops

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -1074,6 +1074,11 @@ namespace dxvk {
     { R"(\\AN2\.dat$)", {{
       { "d3d9.modeCountCompatibility",      "True" },
     }} },
+    /* Psi-Ops: The Mindgate Conspiracy           *
+     * Broken input and physics above 60 fps      */
+    { R"(\\PsiOps\.exe$)", {{
+      { "d3d9.maxFrameRate",                  "60" },
+    }} },
 
     /**********************************************/
     /* D3D8 GAMES                                 */


### PR DESCRIPTION
The game has a built-in V-Sync option at least, however that won't do much on high refresh rate displays.