### PR TITLE
[d3d9] Add feedback loop usage to RT image view

### DIFF
--- a/src/d3d9/d3d9_common_texture.cpp
+++ b/src/d3d9/d3d9_common_texture.cpp
@@ -649,7 +649,7 @@ namespace dxvk {
   Rc<DxvkImageView> D3D9CommonTexture::CreateView(
           UINT                   Layer,
           UINT                   Lod,
-          VkImageUsageFlagBits   UsageFlags,
+          VkImageUsageFlags      UsageFlags,
           VkImageLayout          Layout,
           bool                   Srgb) {
     DxvkImageViewKey viewInfo;

--- a/src/d3d9/d3d9_common_texture.h
+++ b/src/d3d9/d3d9_common_texture.h
@@ -360,7 +360,7 @@ namespace dxvk {
     Rc<DxvkImageView> CreateView(
             UINT                   Layer,
             UINT                   Lod,
-            VkImageUsageFlagBits   UsageFlags,
+            VkImageUsageFlags      UsageFlags,
             VkImageLayout          Layout,
             bool                   Srgb);
     D3D9SubresourceBitset& GetUploadBitmask() { return m_needsUpload; }

--- a/src/d3d9/d3d9_subresource.h
+++ b/src/d3d9/d3d9_subresource.h
@@ -84,8 +84,13 @@ namespace dxvk {
         // that have GENERAL (or FEEDBACK_LOOP) as their layout.
         // Because of that, we don't need to pay special attention here
         // to whether the image was transitioned because of a feedback loop.
+
+        VkImageUsageFlags usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
+        if (m_texture->GetImage()->info().usage & VK_IMAGE_USAGE_ATTACHMENT_FEEDBACK_LOOP_BIT_EXT)
+          usage |= VK_IMAGE_USAGE_ATTACHMENT_FEEDBACK_LOOP_BIT_EXT | VK_IMAGE_USAGE_SAMPLED_BIT;
+
         view = m_texture->CreateView(m_face, m_mipLevel,
-          VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT,
+          usage,
           VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
           Srgb && m_isSrgbCompatible);
       }

--- a/src/dxvk/dxvk_memory.h
+++ b/src/dxvk/dxvk_memory.h
@@ -334,7 +334,7 @@ namespace dxvk {
     /// View type
     VkImageViewType viewType = VK_IMAGE_VIEW_TYPE_MAX_ENUM;
     /// View usage flags
-    VkImageUsageFlagBits usage = VkImageUsageFlagBits(0u);
+    VkImageUsageFlags usage = VkImageUsageFlags(0u);
     /// View format
     VkFormat format = VK_FORMAT_UNDEFINED;
     /// Image layout that the view will be used as


### PR DESCRIPTION
> err:   VUID-VkRenderingAttachmentInfo-imageView-10780: 
err:   vkCmdBeginRendering(): pRenderingInfo->pColorAttachments[0].imageLayout is VK_IMAGE_LAYOUT_ATTACHMENT_FEEDBACK_LOOP_OPTIMAL_EXT, but image view usage is VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT.
err:   The Vulkan spec states: If feedback loop is enabled for the attachment identified by imageView, then imageView must have been created with a usage value including VK_IMAGE_USAGE_ATTACHMENT_FEEDBACK_LOOP_BIT_EXT, either VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT or VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT, and either VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT or VK_IMAGE_USAGE_SAMPLED_BIT (https://docs.vulkan.org/spec/latest/chapters/renderpass.html#VUID-VkRenderingAttachmentInfo-imageView-10780)