### PR TITLE
[d3d9] Fix crash in GetVulkanImageInfo for SYSMEM or NULL textures

### DIFF
--- a/src/d3d9/d3d9_interfaces.h
+++ b/src/d3d9/d3d9_interfaces.h
@@ -86,7 +86,12 @@ ID3D9VkInteropTexture : public IUnknown {
    * \param [out] pHandle The image handle
    * \param [out] pLayout Image layout
    * \param [out] pInfo Image properties
-   * \returns \c S_OK on success, or \c D3DERR_INVALIDCALL
+   * \returns \c S_OK on success
+   * \returns \c D3DERR_INVALIDCALL on failure
+   * \returns \c D3DERR_NOTFOUND if this texture does not
+   *          have a device handle, such as when the image
+   *          has \c NULL format or the image's pool is
+   *          \c D3DPOOL_SYSMEM or \c D3DPOOL_SCRATCH.
    */
   virtual HRESULT STDMETHODCALLTYPE GetVulkanImageInfo(
           VkImage*              pHandle,

--- a/src/d3d9/d3d9_interop.cpp
+++ b/src/d3d9/d3d9_interop.cpp
@@ -108,6 +108,17 @@ namespace dxvk {
           VkImageLayout*        pLayout,
           VkImageCreateInfo*    pInfo) {
     const Rc<DxvkImage> image = m_texture->GetImage();
+    
+    if (unlikely(!image)) {
+      if (pHandle != nullptr)
+        *pHandle = VK_NULL_HANDLE;
+
+      if (pLayout != nullptr)
+        *pLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+
+      return D3DERR_NOTFOUND;
+    }
+
     const DxvkImageCreateInfo& info = image->info();
     
     if (pHandle != nullptr)


### PR DESCRIPTION
If you call `GetVulkanImageInfo` on a texture that does not have a `DxvkImage`, then DXVK will immediately segfault. This usually happens for `NULL` format textures and textures in `SYSMEM` or `SCRATCH`, but all the specific cases are opaque to the user. This PR fixes that by making it fail gracefully and return `D3DERR_NOTFOUND`.