### PR TITLE
[d3d9] Cleanup of hw/sw cursor logic

### DIFF
--- a/src/d3d9/d3d9_adapter.cpp
+++ b/src/d3d9/d3d9_adapter.cpp
@@ -394,7 +394,7 @@ namespace dxvk {
                                     | D3DPRESENT_INTERVAL_FOUR
                                     | D3DPRESENT_INTERVAL_IMMEDIATE;
     // Cursor
-    pCaps->CursorCaps               = D3DCURSORCAPS_COLOR; // I do not support Cursor yet, but I don't want to say I don't support it for compatibility reasons.
+    pCaps->CursorCaps               = D3DCURSORCAPS_COLOR;
     // Dev Caps
     pCaps->DevCaps                  = D3DDEVCAPS_EXECUTESYSTEMMEMORY
                                     | D3DDEVCAPS_EXECUTEVIDEOMEMORY

--- a/src/d3d9/d3d9_cursor.h
+++ b/src/d3d9/d3d9_cursor.h
@@ -8,14 +8,14 @@ namespace dxvk {
    * \brief D3D9 Software Cursor
    */
   struct D3D9_SOFTWARE_CURSOR {
-    UINT Width  = 0;
-    UINT Height = 0;
-    UINT XHotSpot = 0;
-    UINT YHotSpot = 0;
-    int32_t X = 0;
-    int32_t Y = 0;
+    UINT Width       = 0;
+    UINT Height      = 0;
+    UINT XHotSpot    = 0;
+    UINT YHotSpot    = 0;
+    int32_t X        = 0;
+    int32_t Y        = 0;
     bool DrawCursor  = false;
-    bool ResetCursor = false;
+    bool ClearCursor = false;
   };
 
   constexpr uint32_t HardwareCursorWidth      = 32u;
@@ -49,29 +49,35 @@ namespace dxvk {
 
     BOOL ShowCursor(BOOL bShow);
 
-    HRESULT SetHardwareCursor(UINT XHotSpot, UINT YHotSpot, const CursorBitmap& bitmap);
+    void SetHardwareCursor(UINT XHotSpot, UINT YHotSpot, const CursorBitmap& bitmap);
 
-    HRESULT SetSoftwareCursor(UINT Width, UINT Height, UINT XHotSpot, UINT YHotSpot);
+    void SetSoftwareCursor(UINT XHotSpot, UINT YHotSpot, UINT Width, UINT Height);
 
     D3D9_SOFTWARE_CURSOR* GetSoftwareCursor() {
       return &m_sCursor;
     }
 
-    BOOL IsSoftwareCursor() const {
+    bool IsSoftwareCursor() const {
       return m_sCursor.Width > 0 && m_sCursor.Height > 0;
     }
 
-    BOOL IsCursorVisible() const {
-      return m_visible;
+    inline bool IsActiveSoftwareCursor() const {
+      return IsSoftwareCursor() && !m_sCursor.ClearCursor;
     }
+
+#ifdef _WIN32
+    inline bool IsHardwareCursor() const {
+      return m_hCursor != nullptr;
+    }
+#endif
 
   private:
 
-    BOOL                  m_visible   = FALSE;
+    BOOL                  m_visible = FALSE;
     D3D9_SOFTWARE_CURSOR  m_sCursor;
 
 #ifdef _WIN32
-    HCURSOR               m_hCursor   = nullptr;
+    HCURSOR               m_hCursor = nullptr;
 #endif
 
   };


### PR DESCRIPTION
While looking at some cursor related problems, I took the liberty to clean up a lot of our cursor code to:
- fix broken sub 32x32 cursor bitmap size use (thankfully nobody is resorting to them, but now they'll be handled with software cursors in fullscreen, as was the intention in d3d9)
- make use of helper methods for state tracking so that hw/sw specific stuff is more obvious
- handle sw/hw cursor transitions within the same frame (there used to be a one-frame lag between the two, but now we consider the sw cursor as inactive once it has been queued for hiding on the next call to Present())
- better corner case handling, so that we have potentially less issues with apps dual using win32 and d3d cursors

Did a bit of testing and it seems to be behaving itself properly.