### PR TITLE
[d3d9] Relax UpdateTexture size validations for single mip textures

### DIFF
--- a/src/d3d9/d3d9_format.h
+++ b/src/d3d9/d3d9_format.h
@@ -114,6 +114,7 @@ namespace dxvk {
     R2VB = MAKEFOURCC('R', '2', 'V', 'B'),
     COPM = MAKEFOURCC('C', 'O', 'P', 'M'),
     SSAA = MAKEFOURCC('S', 'S', 'A', 'A'),
+    NVCS = MAKEFOURCC('N', 'V', 'C', 'S'),
     NVHS = MAKEFOURCC('N', 'V', 'H', 'S'),
     NVHU = MAKEFOURCC('N', 'V', 'H', 'U'),
 

--- a/src/d3d9/d3d9_names.cpp
+++ b/src/d3d9/d3d9_names.cpp
@@ -107,6 +107,7 @@ namespace dxvk {
       ENUM_NAME(D3D9Format::R2VB);
       ENUM_NAME(D3D9Format::COPM);
       ENUM_NAME(D3D9Format::SSAA);
+      ENUM_NAME(D3D9Format::NVCS);
       ENUM_NAME(D3D9Format::NVHS);
       ENUM_NAME(D3D9Format::NVHU);
 


### PR DESCRIPTION
Fixes the failed texture update part of #5182 . I've written some tests and ran them against Windows XP and it looks like there's no size validation done on UpdateTexture with textures using only a single mip. Messing around with anything but matching sizes on textures with multiple mips is causing outright crashes, so current behavior seems fine on that part (or better than native, in fact). I've simply skipped the validations on both src and dst textures having a single mip, which seems to make the game happy.

Needs a bit more testing.