### PR TITLE
[util] Add a frame cap for HoAE

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -1103,6 +1103,12 @@ namespace dxvk {
     { R"(\\Scarface\.exe$)", {{
       { "d3d9.allowDiscard",               "False" },
     }} },
+    /* Heroes of Annihilated Empires              *
+     * Cursor and other animations play back too  *
+     * fast without a frame cap in place.         */
+    { R"(\\Heroes of Annihilated Empires.*\\engine\.exe$)", {{
+      { "d3d9.maxFrameRate",                  "60" },
+    }} },
 
     /**********************************************/
     /* D3D8 GAMES                                 */


### PR DESCRIPTION
Cursor animations are the most visibly affected, since they play back too fast to even notice at times, but other minor map animations are tied to the framerate as well, looks like.

The executable sits in a `Data` folder on the GOG version, but doesn't appear to on Steam, so I've catered to both situations.