### PR TITLE
v.2.6.x Backport: [util] Enable dummy composition for Anno 117

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -55,6 +55,10 @@ namespace dxvk {
     { R"(\\ACShadows\.exe$)", {{
       { "dxgi.enableDummyCompositionSwapchain", "True" }
     }} },
+    /* Anno 117: Uses composition swapchain        */
+    { R"(\\Anno117\.exe$)", {{
+      { "dxgi.enableDummyCompositionSwapchain", "True" }
+    }} },
 
     /**********************************************/
     /* D3D11 GAMES                                */


### PR DESCRIPTION
Backport of #5188 for v2.6.x branch.