### PR TITLE
D3D9 Fixed function ubershader

### DIFF
--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -48,6 +48,7 @@ namespace dxvk {
     , m_dxvkDevice         ( dxvkDevice )
     , m_memoryAllocator    ( )
     , m_shaderAllocator    ( )
+    , m_ffModules          ( this )
     , m_shaderModules      ( new D3D9ShaderModuleSet )
     , m_stagingBuffer      ( dxvkDevice, StagingBufferSize )
     , m_stagingBufferFence ( new sync::Fence() )
@@ -184,7 +185,6 @@ namespace dxvk {
     m_flags.set(D3D9DeviceFlag::DirtyFFPixelShader);
     m_flags.set(D3D9DeviceFlag::DirtyFFViewport);
     m_flags.set(D3D9DeviceFlag::DirtyFFPixelData);
-    m_flags.set(D3D9DeviceFlag::DirtyProgVertexShader);
     m_flags.set(D3D9DeviceFlag::DirtySharedPixelShaderData);
     m_flags.set(D3D9DeviceFlag::DirtyDepthBounds);
     m_flags.set(D3D9DeviceFlag::DirtyPointScale);
@@ -192,6 +192,8 @@ namespace dxvk {
     m_flags.set(D3D9DeviceFlag::DirtySpecializationEntries);
 
     m_specInfo.set<SpecDrefScaling, uint32_t>(m_d3d9Options.drefScaling);
+
+    BindFFUbershader<DxsoProgramType::VertexShader>();
   }
 
 
@@ -3417,7 +3419,20 @@ namespace dxvk {
     if (dirtyFFShader)
       m_flags.set(D3D9DeviceFlag::DirtyFFVertexShader);
 
+    const bool wasUsingProgrammableVS = UseProgrammableVS();
+
     m_state.vertexDecl = decl;
+
+    const bool usesProgrammableVS = UseProgrammableVS();
+
+    if (unlikely(usesProgrammableVS != wasUsingProgrammableVS)) {
+      if (usesProgrammableVS) {
+        BindShader<DxsoProgramType::VertexShader>(GetCommonShader(m_state.vertexShader));
+      } else {
+        m_flags.set(D3D9DeviceFlag::DirtyFFVertexShader);
+        BindFFUbershader<DxsoProgramType::VertexShader>();
+      }
+    }
 
     m_flags.set(D3D9DeviceFlag::DirtyInputLayout);
 
@@ -3536,15 +3551,19 @@ namespace dxvk {
         || newShader->GetMeta().maxConstIndexB > oldShader->GetMeta().maxConstIndexB;
     }
 
+    const bool wasUsingProgrammableVS = UseProgrammableVS();
+
     m_state.vertexShader = shader;
 
-    if (shader != nullptr) {
-      m_flags.clr(D3D9DeviceFlag::DirtyProgVertexShader);
-      m_flags.set(D3D9DeviceFlag::DirtyFFVertexShader);
+    const bool usesProgrammableVS = UseProgrammableVS();
 
+    if (usesProgrammableVS) {
       BindShader<DxsoProgramTypes::VertexShader>(GetCommonShader(shader));
 
       UpdateTextureTypeMismatchesForShader(newShader, VSShaderMasks().samplerMask, FirstVSSamplerSlot);
+    } else if (wasUsingProgrammableVS) {
+      m_flags.set(D3D9DeviceFlag::DirtyFFVertexShader);
+      BindFFUbershader<DxsoProgramType::VertexShader>();
     }
 
     m_flags.set(D3D9DeviceFlag::DirtyInputLayout);
@@ -7537,12 +7556,6 @@ namespace dxvk {
     UpdatePointMode(PrimitiveType == D3DPT_POINTLIST);
 
     if (likely(UseProgrammableVS())) {
-      if (unlikely(m_flags.test(D3D9DeviceFlag::DirtyProgVertexShader))) {
-        m_flags.set(D3D9DeviceFlag::DirtyInputLayout);
-
-        BindShader<DxsoProgramType::VertexShader>(
-          GetCommonShader(m_state.vertexShader));
-      }
       UploadConstants<DxsoProgramTypes::VertexShader>();
 
       if (likely(!CanSWVP())) {
@@ -7742,6 +7755,17 @@ namespace dxvk {
     ] (DxvkContext* ctx) mutable {
       constexpr VkShaderStageFlagBits stage = GetShaderStage(ShaderStage);
       ctx->bindShader<stage>(std::move(cShader));
+    });
+  }
+
+
+  template <DxsoProgramType ShaderStage>
+  void D3D9DeviceEx::BindFFUbershader() {
+    EmitCs([
+     &cShaders = m_ffModules
+    ](DxvkContext* ctx) {
+      auto shader = cShaders.GetVSUbershaderModule();
+      ctx->bindShader<VK_SHADER_STAGE_VERTEX_BIT>(shader.GetShader());
     });
   }
 
@@ -8020,14 +8044,77 @@ namespace dxvk {
   }
 
 
-  void D3D9DeviceEx::UpdateFixedFunctionVS() {
-    // Shader...
-    bool hasPositionT = m_state.vertexDecl != nullptr && m_state.vertexDecl->TestFlag(D3D9VertexDeclFlag::HasPositionT);
-    bool hasBlendWeight    = m_state.vertexDecl != nullptr && m_state.vertexDecl->TestFlag(D3D9VertexDeclFlag::HasBlendWeight);
-    bool hasBlendIndices   = m_state.vertexDecl != nullptr && m_state.vertexDecl->TestFlag(D3D9VertexDeclFlag::HasBlendIndices);
+  D3D9FFShaderKeyVS D3D9DeviceEx::BuildFFKeyVS(D3D9FF_VertexBlendMode vertexBlendMode, bool indexedVertexBlend) const {
+    D3D9FFShaderKeyVS key;
+    key.Data.Contents.VertexHasPositionT = m_state.vertexDecl != nullptr && m_state.vertexDecl->TestFlag(D3D9VertexDeclFlag::HasPositionT);
+    key.Data.Contents.VertexHasColor0    = m_state.vertexDecl != nullptr && m_state.vertexDecl->TestFlag(D3D9VertexDeclFlag::HasColor0);
+    key.Data.Contents.VertexHasColor1    = m_state.vertexDecl != nullptr && m_state.vertexDecl->TestFlag(D3D9VertexDeclFlag::HasColor1);
+    key.Data.Contents.VertexHasPointSize = m_state.vertexDecl != nullptr && m_state.vertexDecl->TestFlag(D3D9VertexDeclFlag::HasPointSize);
+    key.Data.Contents.VertexHasFog       = m_state.vertexDecl != nullptr && m_state.vertexDecl->TestFlag(D3D9VertexDeclFlag::HasFog);
+
+    bool lighting    = m_state.renderStates[D3DRS_LIGHTING] != 0 && !key.Data.Contents.VertexHasPositionT;
+    bool colorVertex = m_state.renderStates[D3DRS_COLORVERTEX] != 0;
+    uint32_t mask    = (lighting && colorVertex)
+                     ? (key.Data.Contents.VertexHasColor0 ? D3DMCS_COLOR1 : D3DMCS_MATERIAL)
+                     | (key.Data.Contents.VertexHasColor1 ? D3DMCS_COLOR2 : D3DMCS_MATERIAL)
+                     : 0;
+
+    key.Data.Contents.UseLighting      = lighting;
+    key.Data.Contents.NormalizeNormals = m_state.renderStates[D3DRS_NORMALIZENORMALS];
+    key.Data.Contents.LocalViewer      = m_state.renderStates[D3DRS_LOCALVIEWER] && lighting;
+
+    key.Data.Contents.RangeFog         = m_state.renderStates[D3DRS_RANGEFOGENABLE];
+
+    key.Data.Contents.DiffuseSource    = m_state.renderStates[D3DRS_DIFFUSEMATERIALSOURCE]  & mask;
+    key.Data.Contents.AmbientSource    = m_state.renderStates[D3DRS_AMBIENTMATERIALSOURCE]  & mask;
+    key.Data.Contents.SpecularSource   = m_state.renderStates[D3DRS_SPECULARMATERIALSOURCE] & mask;
+    key.Data.Contents.EmissiveSource   = m_state.renderStates[D3DRS_EMISSIVEMATERIALSOURCE] & mask;
+
+    uint32_t lightCount = 0;
+
+    if (key.Data.Contents.UseLighting) {
+      for (uint32_t i = 0; i < caps::MaxEnabledLights; i++) {
+        if (m_state.enabledLightIndices[i] != std::numeric_limits<uint32_t>::max())
+          lightCount++;
+      }
+    }
+
+    key.Data.Contents.LightCount = lightCount;
+
+    for (uint32_t i = 0; i < caps::MaxTextureBlendStages; i++) {
+      uint32_t transformFlags = m_state.textureStages[i][DXVK_TSS_TEXTURETRANSFORMFLAGS] & ~(D3DTTFF_PROJECTED);
+      uint32_t index          = m_state.textureStages[i][DXVK_TSS_TEXCOORDINDEX];
+      uint32_t indexFlags     = (index & TCIMask) >> TCIOffset;
+
+      transformFlags &= 0b111;
+      index          &= 0b111;
+
+      key.Data.Contents.TransformFlags  |= transformFlags << (i * 3);
+      key.Data.Contents.TexcoordFlags   |= indexFlags     << (i * 3);
+      key.Data.Contents.TexcoordIndices |= index          << (i * 3);
+    }
+
+    key.Data.Contents.VertexTexcoordDeclMask = m_state.vertexDecl != nullptr ? m_state.vertexDecl->GetTexcoordMask() : 0;
+
+    key.Data.Contents.VertexBlendMode  = uint32_t(vertexBlendMode);
+
+    if (vertexBlendMode == D3D9FF_VertexBlendMode_Normal) {
+      key.Data.Contents.VertexBlendIndexed = indexedVertexBlend;
+      key.Data.Contents.VertexBlendCount   = m_state.renderStates[D3DRS_VERTEXBLEND] & 0xff;
+    }
+
+    key.Data.Contents.VertexClipping = m_state.renderStates[D3DRS_CLIPPLANEENABLE] != 0;
+
+    return key;
+  }
+
+
+   void D3D9DeviceEx::UpdateFixedFunctionVS() {
+    bool hasPositionT    = m_state.vertexDecl != nullptr && m_state.vertexDecl->TestFlag(D3D9VertexDeclFlag::HasPositionT);
+    bool hasBlendWeight  = m_state.vertexDecl != nullptr && m_state.vertexDecl->TestFlag(D3D9VertexDeclFlag::HasBlendWeight);
+    bool hasBlendIndices = m_state.vertexDecl != nullptr && m_state.vertexDecl->TestFlag(D3D9VertexDeclFlag::HasBlendIndices);
 
     bool indexedVertexBlend = hasBlendIndices && m_state.renderStates[D3DRS_INDEXEDVERTEXBLENDENABLE];
-
     D3D9FF_VertexBlendMode vertexBlendMode = D3D9FF_VertexBlendMode_Disabled;
 
     if (m_state.renderStates[D3DRS_VERTEXBLEND] != D3DVBF_DISABLE && !hasPositionT) {
@@ -8043,74 +8130,16 @@ namespace dxvk {
         vertexBlendMode = D3D9FF_VertexBlendMode_Disabled;
     }
 
-    if (unlikely(hasPositionT && m_state.vertexShader != nullptr && !m_flags.test(D3D9DeviceFlag::DirtyProgVertexShader))) {
-      m_flags.set(D3D9DeviceFlag::DirtyInputLayout);
-      m_flags.set(D3D9DeviceFlag::DirtyFFVertexShader);
-      m_flags.set(D3D9DeviceFlag::DirtyProgVertexShader);
-    }
+    // Shader...
+    const bool useUbershader = m_d3d9Options.ffUbershaderVS;
 
-    if (m_flags.test(D3D9DeviceFlag::DirtyFFVertexShader)) {
+    if (useUbershader && m_flags.test(D3D9DeviceFlag::DirtyFFVertexShader)) {
+      m_flags.clr(D3D9DeviceFlag::DirtyFFVertexShader);
+      m_flags.set(D3D9DeviceFlag::DirtyFFVertexData);
+    } else if (m_flags.test(D3D9DeviceFlag::DirtyFFVertexShader)) {
       m_flags.clr(D3D9DeviceFlag::DirtyFFVertexShader);
 
-      D3D9FFShaderKeyVS key;
-      key.Data.Contents.VertexHasPositionT = hasPositionT;
-      key.Data.Contents.VertexHasColor0    = m_state.vertexDecl != nullptr && m_state.vertexDecl->TestFlag(D3D9VertexDeclFlag::HasColor0);
-      key.Data.Contents.VertexHasColor1    = m_state.vertexDecl != nullptr && m_state.vertexDecl->TestFlag(D3D9VertexDeclFlag::HasColor1);
-      key.Data.Contents.VertexHasPointSize = m_state.vertexDecl != nullptr && m_state.vertexDecl->TestFlag(D3D9VertexDeclFlag::HasPointSize);
-      key.Data.Contents.VertexHasFog       = m_state.vertexDecl != nullptr && m_state.vertexDecl->TestFlag(D3D9VertexDeclFlag::HasFog);
-
-      bool lighting    = m_state.renderStates[D3DRS_LIGHTING] != 0 && !key.Data.Contents.VertexHasPositionT;
-      bool colorVertex = m_state.renderStates[D3DRS_COLORVERTEX] != 0;
-      uint32_t mask    = (lighting && colorVertex)
-                       ? (key.Data.Contents.VertexHasColor0 ? D3DMCS_COLOR1 : D3DMCS_MATERIAL)
-                       | (key.Data.Contents.VertexHasColor1 ? D3DMCS_COLOR2 : D3DMCS_MATERIAL)
-                       : 0;
-
-      key.Data.Contents.UseLighting      = lighting;
-      key.Data.Contents.NormalizeNormals = m_state.renderStates[D3DRS_NORMALIZENORMALS];
-      key.Data.Contents.LocalViewer      = m_state.renderStates[D3DRS_LOCALVIEWER] && lighting;
-
-      key.Data.Contents.RangeFog         = m_state.renderStates[D3DRS_RANGEFOGENABLE];
-
-      key.Data.Contents.DiffuseSource    = m_state.renderStates[D3DRS_DIFFUSEMATERIALSOURCE]  & mask;
-      key.Data.Contents.AmbientSource    = m_state.renderStates[D3DRS_AMBIENTMATERIALSOURCE]  & mask;
-      key.Data.Contents.SpecularSource   = m_state.renderStates[D3DRS_SPECULARMATERIALSOURCE] & mask;
-      key.Data.Contents.EmissiveSource   = m_state.renderStates[D3DRS_EMISSIVEMATERIALSOURCE] & mask;
-
-      uint32_t lightCount = 0;
-
-      if (key.Data.Contents.UseLighting) {
-        for (uint32_t i = 0; i < caps::MaxEnabledLights; i++) {
-          if (m_state.enabledLightIndices[i] != std::numeric_limits<uint32_t>::max())
-            lightCount++;
-        }
-      }
-
-      key.Data.Contents.LightCount = lightCount;
-
-      for (uint32_t i = 0; i < caps::MaxTextureBlendStages; i++) {
-        uint32_t transformFlags = m_state.textureStages[i][DXVK_TSS_TEXTURETRANSFORMFLAGS] & ~(D3DTTFF_PROJECTED);
-        uint32_t index          = m_state.textureStages[i][DXVK_TSS_TEXCOORDINDEX];
-        uint32_t indexFlags     = (index & TCIMask) >> TCIOffset;
-
-        transformFlags &= 0b111;
-        index          &= 0b111;
-
-        key.Data.Contents.TransformFlags  |= transformFlags << (i * 3);
-        key.Data.Contents.TexcoordFlags   |= indexFlags     << (i * 3);
-        key.Data.Contents.TexcoordIndices |= index          << (i * 3);
-      }
-
-      key.Data.Contents.VertexTexcoordDeclMask = m_state.vertexDecl != nullptr ? m_state.vertexDecl->GetTexcoordMask() : 0;
-
-      key.Data.Contents.VertexBlendMode    = uint32_t(vertexBlendMode);
-
-      if (vertexBlendMode == D3D9FF_VertexBlendMode_Normal) {
-        key.Data.Contents.VertexBlendIndexed = indexedVertexBlend;
-        key.Data.Contents.VertexBlendCount   = m_state.renderStates[D3DRS_VERTEXBLEND] & 0xff;
-      }
-
-      key.Data.Contents.VertexClipping = m_state.renderStates[D3DRS_CLIPPLANEENABLE] != 0;
+      D3D9FFShaderKeyVS key = BuildFFKeyVS(vertexBlendMode, indexedVertexBlend);
 
       EmitCs([
         this,
@@ -8122,6 +8151,7 @@ namespace dxvk {
       });
     }
 
+    // Viewport...
     if (hasPositionT && (m_flags.test(D3D9DeviceFlag::DirtyFFViewport) || m_ffZTest != IsZTestEnabled())) {
       m_flags.clr(D3D9DeviceFlag::DirtyFFViewport);
       m_flags.set(D3D9DeviceFlag::DirtyFFVertexData);
@@ -8185,6 +8215,9 @@ namespace dxvk {
 
       data->Material = m_state.material;
       data->TweenFactor = bit::cast<float>(m_state.renderStates[D3DRS_TWEENFACTOR]);
+      if (useUbershader) {
+        data->Key = BuildFFKeyVS(vertexBlendMode, indexedVertexBlend).Data;
+      }
     }
 
     if (m_flags.test(D3D9DeviceFlag::DirtyFFVertexBlend) && vertexBlendMode == D3D9FF_VertexBlendMode_Normal) {

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -8101,7 +8101,7 @@ namespace dxvk {
         key.Data.Contents.TexcoordIndices |= index          << (i * 3);
       }
 
-      key.Data.Contents.TexcoordDeclMask = m_state.vertexDecl != nullptr ? m_state.vertexDecl->GetTexcoordMask() : 0;
+      key.Data.Contents.VertexTexcoordDeclMask = m_state.vertexDecl != nullptr ? m_state.vertexDecl->GetTexcoordMask() : 0;
 
       key.Data.Contents.VertexBlendMode    = uint32_t(vertexBlendMode);
 

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -8246,8 +8246,6 @@ namespace dxvk {
             break;
         }
 
-        stage.TextureBound = m_state.textures[idx] != nullptr ? 1 : 0;
-
         stage.ColorOp = data[DXVK_TSS_COLOROP];
         stage.AlphaOp = data[DXVK_TSS_ALPHAOP];
 
@@ -8259,17 +8257,7 @@ namespace dxvk {
         stage.AlphaArg1 = data[DXVK_TSS_ALPHAARG1];
         stage.AlphaArg2 = data[DXVK_TSS_ALPHAARG2];
 
-        const uint32_t samplerOffset = idx * 2;
-        stage.Type         = (m_textureSlotTracking.textureType >> samplerOffset) & 0xffu;
         stage.ResultIsTemp = data[DXVK_TSS_RESULTARG] == D3DTA_TEMP;
-
-        uint32_t ttff  = data[DXVK_TSS_TEXTURETRANSFORMFLAGS];
-        uint32_t count = ttff & ~D3DTTFF_PROJECTED;
-
-        stage.Projected      = (ttff & D3DTTFF_PROJECTED) ? 1      : 0;
-        stage.ProjectedCount = (ttff & D3DTTFF_PROJECTED) ? count  : 0;
-
-        stage.SampleDref = (m_textureSlotTracking.depth & (1 << idx)) != 0;
       }
 
       auto& stage0 = key.Stages[0].Contents;

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -1487,6 +1487,7 @@ namespace dxvk {
     void UpdateFogModeSpec(bool fogEnabled, D3DFOGMODE vertexFogMode, D3DFOGMODE pixelFogMode);
 
     D3D9FFShaderKeyVS BuildFFKeyVS(D3D9FF_VertexBlendMode vertexBlendMode, bool indexedVertexBlend) const;
+    D3D9FFShaderKeyFS BuildFFKeyFS() const;
 
     void BindSpecConstants();
 

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -80,7 +80,6 @@ namespace dxvk {
     DirtyFFPixelShader,
     DirtyFFViewport,
     DirtyFFPixelData,
-    DirtyProgVertexShader,
     DirtySharedPixelShaderData,
     ValidSampleMask,
     DirtyDepthBounds,
@@ -1091,7 +1090,10 @@ namespace dxvk {
 
     template <DxsoProgramType ShaderStage>
     void BindShader(
-      const D3D9CommonShader*                 pShaderModule);
+    const D3D9CommonShader*                 pShaderModule);
+
+    template <DxsoProgramType ShaderStage>
+    void BindFFUbershader();
 
     void BindInputLayout();
 
@@ -1483,6 +1485,8 @@ namespace dxvk {
     void UpdateCommonSamplerSpec(uint32_t boundMask, uint32_t depthMask, uint32_t drefMask, uint32_t projections);
     void UpdatePointModeSpec(uint32_t mode);
     void UpdateFogModeSpec(bool fogEnabled, D3DFOGMODE vertexFogMode, D3DFOGMODE pixelFogMode);
+
+    D3D9FFShaderKeyVS BuildFFKeyVS(D3D9FF_VertexBlendMode vertexBlendMode, bool indexedVertexBlend) const;
 
     void BindSpecConstants();
 

--- a/src/d3d9/d3d9_fixed_function.cpp
+++ b/src/d3d9/d3d9_fixed_function.cpp
@@ -14,6 +14,7 @@
 #include <cfloat>
 
 #include <d3d9_fixed_function_vert.h>
+#include <d3d9_fixed_function_frag.h>
 
 namespace dxvk {
 
@@ -2730,64 +2731,148 @@ namespace dxvk {
 
 
   D3D9FFShader::D3D9FFShader(
-          D3D9DeviceEx*         pDevice) {
+          D3D9DeviceEx*         pDevice,
+          DxsoProgramType       ProgramType) {
 
-    std::array<DxvkBindingInfo, 4> bindings;
+    bool isVS = ProgramType == DxsoProgramType::VertexShader;
 
-    SpirvCodeBuffer codeBuffer = SpirvCodeBuffer(sizeof(d3d9_fixed_function_vert) / sizeof(uint32_t), d3d9_fixed_function_vert);
+    if (isVS) {
+      std::array<DxvkBindingInfo, 4> bindings;
 
-    constexpr uint32_t specConstantBufferBindingId = getSpecConstantBufferSlot();
-    auto& specConstantBufferBinding = bindings[0];
-    specConstantBufferBinding.set = 0u;
-    specConstantBufferBinding.binding        = specConstantBufferBindingId;
-    specConstantBufferBinding.resourceIndex  = specConstantBufferBindingId;
-    specConstantBufferBinding.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
-    specConstantBufferBinding.access = VK_ACCESS_UNIFORM_READ_BIT;
-    specConstantBufferBinding.flags.set(DxvkDescriptorFlag::UniformBuffer);
+      SpirvCodeBuffer codeBuffer = SpirvCodeBuffer(sizeof(d3d9_fixed_function_vert) / sizeof(uint32_t), d3d9_fixed_function_vert);
 
-    constexpr uint32_t fixedFunctionDataBindingId = computeResourceSlotId(
-      DxsoProgramType::VertexShader, DxsoBindingType::ConstantBuffer,
-      DxsoConstantBuffers::VSFixedFunction);
-    auto& fixedFunctionDataBinding = bindings[1];
-    fixedFunctionDataBinding.set             = 0u;
-    fixedFunctionDataBinding.binding         = fixedFunctionDataBindingId;
-    fixedFunctionDataBinding.resourceIndex   = fixedFunctionDataBindingId;
-    fixedFunctionDataBinding.descriptorType  = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
-    fixedFunctionDataBinding.access          = VK_ACCESS_UNIFORM_READ_BIT;
-    fixedFunctionDataBinding.flags.set(DxvkDescriptorFlag::UniformBuffer);
+      constexpr uint32_t specConstantBufferBindingId = getSpecConstantBufferSlot();
+      auto& specConstantBufferBinding = bindings[0];
+      specConstantBufferBinding.set = 0u;
+      specConstantBufferBinding.binding        = specConstantBufferBindingId;
+      specConstantBufferBinding.resourceIndex  = specConstantBufferBindingId;
+      specConstantBufferBinding.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+      specConstantBufferBinding.access = VK_ACCESS_UNIFORM_READ_BIT;
+      specConstantBufferBinding.flags.set(DxvkDescriptorFlag::UniformBuffer);
 
-    constexpr uint32_t vertexBlendBindingId = computeResourceSlotId(
-      DxsoProgramType::VertexShader, DxsoBindingType::ConstantBuffer,
-      DxsoConstantBuffers::VSVertexBlendData);
-    auto& vertexBlendBinding = bindings[2];
-    vertexBlendBinding.set             = 0u;
-    vertexBlendBinding.binding         = vertexBlendBindingId;
-    vertexBlendBinding.resourceIndex   = vertexBlendBindingId;
-    vertexBlendBinding.descriptorType  = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
-    vertexBlendBinding.access          = VK_ACCESS_SHADER_READ_BIT;
-    vertexBlendBinding.flags.set(DxvkDescriptorFlag::UniformBuffer);
+      constexpr uint32_t fixedFunctionDataBindingId = computeResourceSlotId(
+        DxsoProgramType::VertexShader, DxsoBindingType::ConstantBuffer,
+        DxsoConstantBuffers::VSFixedFunction);
+      auto& fixedFunctionDataBinding = bindings[1];
+      fixedFunctionDataBinding.set             = 0u;
+      fixedFunctionDataBinding.binding         = fixedFunctionDataBindingId;
+      fixedFunctionDataBinding.resourceIndex   = fixedFunctionDataBindingId;
+      fixedFunctionDataBinding.descriptorType  = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+      fixedFunctionDataBinding.access          = VK_ACCESS_UNIFORM_READ_BIT;
+      fixedFunctionDataBinding.flags.set(DxvkDescriptorFlag::UniformBuffer);
 
-    constexpr uint32_t clipPlanesBindingId = computeResourceSlotId(
-      DxsoProgramType::VertexShader, DxsoBindingType::ConstantBuffer,
-      DxsoConstantBuffers::VSClipPlanes);
-    auto& clipPlanesBinding = bindings[3];
-    clipPlanesBinding.set             = 0u;
-    clipPlanesBinding.binding         = clipPlanesBindingId;
-    clipPlanesBinding.resourceIndex   = clipPlanesBindingId;
-    clipPlanesBinding.descriptorType  = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
-    clipPlanesBinding.access          = VK_ACCESS_UNIFORM_READ_BIT;
-    clipPlanesBinding.flags.set(DxvkDescriptorFlag::UniformBuffer);
+      constexpr uint32_t vertexBlendBindingId = computeResourceSlotId(
+        DxsoProgramType::VertexShader, DxsoBindingType::ConstantBuffer,
+        DxsoConstantBuffers::VSVertexBlendData);
+      auto& vertexBlendBinding = bindings[2];
+      vertexBlendBinding.set             = 0u;
+      vertexBlendBinding.binding         = vertexBlendBindingId;
+      vertexBlendBinding.resourceIndex   = vertexBlendBindingId;
+      vertexBlendBinding.descriptorType  = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+      vertexBlendBinding.access          = VK_ACCESS_SHADER_READ_BIT;
+      vertexBlendBinding.flags.set(DxvkDescriptorFlag::UniformBuffer);
 
-    DxvkSpirvShaderCreateInfo info;
-    info.bindingCount = bindings.size();
-    info.bindings = bindings.data();
-    info.flatShadingInputs = 0;
-    info.sharedPushData = DxvkPushDataBlock(0u, sizeof(D3D9RenderStateInfo), 4u, 0u);
-    info.localPushData = DxvkPushDataBlock();
-    info.samplerHeap = DxvkShaderBinding();
-    info.debugName = "FF VS";
+      constexpr uint32_t clipPlanesBindingId = computeResourceSlotId(
+        DxsoProgramType::VertexShader, DxsoBindingType::ConstantBuffer,
+        DxsoConstantBuffers::VSClipPlanes);
+      auto& clipPlanesBinding = bindings[3];
+      clipPlanesBinding.set             = 0u;
+      clipPlanesBinding.binding         = clipPlanesBindingId;
+      clipPlanesBinding.resourceIndex   = clipPlanesBindingId;
+      clipPlanesBinding.descriptorType  = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+      clipPlanesBinding.access          = VK_ACCESS_UNIFORM_READ_BIT;
+      clipPlanesBinding.flags.set(DxvkDescriptorFlag::UniformBuffer);
 
-    m_shader = new DxvkSpirvShader(info, std::move(codeBuffer));
+      DxvkSpirvShaderCreateInfo info;
+      info.bindingCount = bindings.size();
+      info.bindings = bindings.data();
+      info.flatShadingInputs = 0;
+      info.sharedPushData = DxvkPushDataBlock(0u, sizeof(D3D9RenderStateInfo), 4u, 0u);
+      info.localPushData = DxvkPushDataBlock();
+      info.samplerHeap = DxvkShaderBinding();
+      info.debugName = "FF VS";
+
+      m_shader = new DxvkSpirvShader(info, std::move(codeBuffer));
+    } else {
+      std::vector<DxvkBindingInfo> bindings;
+
+      SpirvCodeBuffer codeBuffer = SpirvCodeBuffer(sizeof(d3d9_fixed_function_frag) / sizeof(uint32_t), d3d9_fixed_function_frag);
+
+      constexpr uint32_t specConstantBufferBindingId = getSpecConstantBufferSlot();
+      auto& specConstantBufferBinding = bindings.emplace_back();
+      specConstantBufferBinding.set = 0u;
+      specConstantBufferBinding.binding        = specConstantBufferBindingId;
+      specConstantBufferBinding.resourceIndex  = specConstantBufferBindingId;
+      specConstantBufferBinding.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+      specConstantBufferBinding.access = VK_ACCESS_UNIFORM_READ_BIT;
+      specConstantBufferBinding.flags.set(DxvkDescriptorFlag::UniformBuffer);
+
+      constexpr uint32_t fixedFunctionDataBindingId = computeResourceSlotId(
+        DxsoProgramType::PixelShader, DxsoBindingType::ConstantBuffer,
+        DxsoConstantBuffers::PSFixedFunction);
+      auto& fixedFunctionDataBinding = bindings.emplace_back();
+      fixedFunctionDataBinding.set             = 0u;
+      fixedFunctionDataBinding.binding         = fixedFunctionDataBindingId;
+      fixedFunctionDataBinding.resourceIndex   = fixedFunctionDataBindingId;
+      fixedFunctionDataBinding.descriptorType  = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+      fixedFunctionDataBinding.access          = VK_ACCESS_UNIFORM_READ_BIT;
+      fixedFunctionDataBinding.flags.set(DxvkDescriptorFlag::UniformBuffer);
+
+      constexpr uint32_t sharedDataBindingId = computeResourceSlotId(
+        DxsoProgramType::PixelShader, DxsoBindingType::ConstantBuffer,
+        DxsoConstantBuffers::PSShared);
+      auto& sharedDataBinding = bindings.emplace_back();
+      sharedDataBinding.set             = 0u;
+      sharedDataBinding.binding         = sharedDataBindingId;
+      sharedDataBinding.resourceIndex   = sharedDataBindingId;
+      sharedDataBinding.descriptorType  = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+      sharedDataBinding.access          = VK_ACCESS_SHADER_READ_BIT;
+      sharedDataBinding.flags.set(DxvkDescriptorFlag::UniformBuffer);
+
+      constexpr uint32_t textureBindingId = computeResourceSlotId(
+        DxsoProgramType::PixelShader,
+        DxsoBindingType::Image,
+        0);
+      auto& textureBinding = bindings.emplace_back();
+      textureBinding.set             = 0u;
+      textureBinding.binding         = textureBindingId;
+      textureBinding.resourceIndex   = textureBindingId;
+      textureBinding.descriptorType  = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
+      textureBinding.access       = VK_ACCESS_SHADER_READ_BIT;
+      textureBinding.descriptorCount = caps::TextureStageCount;
+
+      for (uint32_t i = 0; i < caps::TextureStageCount; i++) {
+        uint32_t samplerBindingId = computeResourceSlotId(
+          DxsoProgramType::PixelShader,
+          DxsoBindingType::Image,
+          i);
+
+        auto& samplerBinding = bindings.emplace_back();
+        samplerBinding.resourceIndex   = samplerBindingId;
+        samplerBinding.descriptorType  = VK_DESCRIPTOR_TYPE_SAMPLER;
+        samplerBinding.blockOffset     = GetPushSamplerOffset(i);
+        samplerBinding.flags.set(DxvkDescriptorFlag::PushData);
+        bindings.push_back(samplerBinding);
+      }
+
+      uint32_t flatShadingMask = (1u << RegisterLinkerSlot(DxsoSemantic{ DxsoUsage::Color, 0 }))
+        | (1u << RegisterLinkerSlot(DxsoSemantic{ DxsoUsage::Color, 1 }));
+
+      uint32_t samplerCount = caps::TextureStageCount;
+      uint32_t samplerDwordCount = (samplerCount + 1u) / 2u;
+
+      DxvkSpirvShaderCreateInfo info;
+      info.bindingCount = bindings.size();
+      info.bindings = bindings.data();
+      info.flatShadingInputs = flatShadingMask;
+      info.sharedPushData = DxvkPushDataBlock(0u, sizeof(D3D9RenderStateInfo), 4u, 0u);
+      info.localPushData = DxvkPushDataBlock(VK_SHADER_STAGE_FRAGMENT_BIT, GetPushSamplerOffset(0u),
+        samplerDwordCount * sizeof(uint32_t), sizeof(uint32_t), (1u << samplerDwordCount) - 1u);
+      info.samplerHeap = DxvkShaderBinding(VK_SHADER_STAGE_FRAGMENT_BIT, 1u, 0u);
+      info.debugName = "FF FS";
+
+      m_shader = new DxvkSpirvShader(info, std::move(codeBuffer));
+    }
 
     pDevice->GetDXVKDevice()->registerShader(m_shader);
   }
@@ -2808,7 +2893,8 @@ namespace dxvk {
 
 
   D3D9FFShaderModuleSet::D3D9FFShaderModuleSet(D3D9DeviceEx* pDevice)
-    : m_vsUbershader(pDevice) {}
+    : m_vsUbershader(pDevice, DxsoProgramType::VertexShader)
+    , m_fsUbershader(pDevice, DxsoProgramType::PixelShader) {}
 
 
   D3D9FFShader D3D9FFShaderModuleSet::GetShaderModule(

--- a/src/d3d9/d3d9_fixed_function.cpp
+++ b/src/d3d9/d3d9_fixed_function.cpp
@@ -1183,7 +1183,7 @@ namespace dxvk {
     for (uint32_t i = 0; i < caps::TextureStageCount; i++) {
       uint32_t inputIndex = (m_vsKey.Data.Contents.TexcoordIndices     >> (i * 3)) & 0b111;
       uint32_t inputFlags = (m_vsKey.Data.Contents.TexcoordFlags       >> (i * 3)) & 0b111;
-      uint32_t texcoordCount = (m_vsKey.Data.Contents.TexcoordDeclMask >> (inputIndex * 3)) & 0b111;
+      uint32_t texcoordCount = (m_vsKey.Data.Contents.VertexTexcoordDeclMask >> (inputIndex * 3)) & 0b111;
 
       uint32_t transformed;
 

--- a/src/d3d9/d3d9_fixed_function.h
+++ b/src/d3d9/d3d9_fixed_function.h
@@ -113,45 +113,6 @@ namespace dxvk {
 
   constexpr uint32_t TextureArgCount = 3;
 
-  struct D3D9FFShaderStage {
-    union {
-      struct {
-        uint32_t     ColorOp   : 5;
-        uint32_t     ColorArg0 : 6;
-        uint32_t     ColorArg1 : 6;
-        uint32_t     ColorArg2 : 6;
-
-        uint32_t     AlphaOp   : 5;
-        uint32_t     AlphaArg0 : 6;
-        uint32_t     AlphaArg1 : 6;
-        uint32_t     AlphaArg2 : 6;
-
-        uint32_t     ResultIsTemp : 1;
-
-        // Included in here, read from Stage 0 for packing reasons
-        // Affects all stages.
-        uint32_t     GlobalSpecularEnable : 1;
-      } Contents;
-
-      uint32_t Primitive[2];
-    };
-  };
-
-  struct D3D9FFShaderKeyFS {
-    D3D9FFShaderKeyFS() {
-      // memcmp safety
-      std::memset(Stages, 0, sizeof(Stages));
-
-      // Normalize this. DISABLE != 0.
-      for (uint32_t i = 0; i < caps::TextureStageCount; i++) {
-        Stages[i].Contents.ColorOp = D3DTOP_DISABLE;
-        Stages[i].Contents.AlphaOp = D3DTOP_DISABLE;
-      }
-    }
-
-    D3D9FFShaderStage Stages[caps::TextureStageCount];
-  };
-
   struct D3D9FFShaderKeyHash {
     size_t operator () (const D3D9FFShaderKeyVS& key) const;
     size_t operator () (const D3D9FFShaderKeyFS& key) const;
@@ -180,7 +141,8 @@ namespace dxvk {
       const D3D9FFShaderKeyFS&    Key);
 
     D3D9FFShader(
-            D3D9DeviceEx*         pDevice);
+            D3D9DeviceEx*         pDevice,
+            DxsoProgramType       ProgramType);
 
     template <typename T>
     void Dump(D3D9DeviceEx* pDevice, const T& Key, const std::string& Name);
@@ -216,6 +178,10 @@ namespace dxvk {
       return m_vsUbershader;
     }
 
+    const D3D9FFShader& GetFSUbershaderModule() const {
+      return m_fsUbershader;
+    }
+
     UINT GetVSCount() const {
       return m_vsModules.size();
     }
@@ -237,6 +203,7 @@ namespace dxvk {
       D3D9FFShaderKeyHash, D3D9FFShaderKeyEq> m_fsModules;
 
     D3D9FFShader m_vsUbershader;
+    D3D9FFShader m_fsUbershader;
 
   };
 

--- a/src/d3d9/d3d9_fixed_function.h
+++ b/src/d3d9/d3d9_fixed_function.h
@@ -138,7 +138,7 @@ namespace dxvk {
 
         uint32_t LightCount : 4;
 
-        uint32_t TexcoordDeclMask : 24;
+        uint32_t VertexTexcoordDeclMask : 24;
         uint32_t VertexHasFog : 1;
 
         uint32_t VertexBlendMode    : 2;

--- a/src/d3d9/d3d9_fixed_function.h
+++ b/src/d3d9/d3d9_fixed_function.h
@@ -176,14 +176,7 @@ namespace dxvk {
         uint32_t     AlphaArg1 : 6;
         uint32_t     AlphaArg2 : 6;
 
-        uint32_t     Type         : 2;
         uint32_t     ResultIsTemp : 1;
-        uint32_t     Projected    : 1;
-
-        uint32_t     ProjectedCount : 3;
-        uint32_t     SampleDref     : 1;
-
-        uint32_t     TextureBound : 1;
 
         // Included in here, read from Stage 0 for packing reasons
         // Affects all stages.

--- a/src/d3d9/d3d9_fixed_function.h
+++ b/src/d3d9/d3d9_fixed_function.h
@@ -4,6 +4,8 @@
 
 #include "d3d9_caps.h"
 
+#include "d3d9_state.h"
+
 #include "../dxvk/dxvk_shader.h"
 
 #include "../dxso/dxso_isgn.h"
@@ -109,58 +111,6 @@ namespace dxvk {
     D3D9FF_VertexBlendMode_Tween,
   };
 
-  struct D3D9FFShaderKeyVSData {
-    union {
-      struct {
-        uint32_t TexcoordIndices : 24;
-
-        uint32_t VertexHasPositionT : 1;
-
-        uint32_t VertexHasColor0 : 1; // Diffuse
-        uint32_t VertexHasColor1 : 1; // Specular
-
-        uint32_t VertexHasPointSize : 1;
-
-        uint32_t UseLighting : 1;
-
-        uint32_t NormalizeNormals : 1;
-        uint32_t LocalViewer : 1;
-        uint32_t RangeFog : 1;
-
-        uint32_t TexcoordFlags : 24;
-
-        uint32_t DiffuseSource : 2;
-        uint32_t AmbientSource : 2;
-        uint32_t SpecularSource : 2;
-        uint32_t EmissiveSource : 2;
-
-        uint32_t TransformFlags : 24;
-
-        uint32_t LightCount : 4;
-
-        uint32_t VertexTexcoordDeclMask : 24;
-        uint32_t VertexHasFog : 1;
-
-        uint32_t VertexBlendMode    : 2;
-        uint32_t VertexBlendIndexed : 1;
-        uint32_t VertexBlendCount   : 2;
-
-        uint32_t VertexClipping     : 1;
-      } Contents;
-
-      uint32_t Primitive[5];
-    };
-  };
-
-  struct D3D9FFShaderKeyVS {
-    D3D9FFShaderKeyVS() {
-      // memcmp safety
-      std::memset(&Data, 0, sizeof(Data));
-    }
-
-    D3D9FFShaderKeyVSData Data;
-  };
-
   constexpr uint32_t TextureArgCount = 3;
 
   struct D3D9FFShaderStage {
@@ -229,6 +179,9 @@ namespace dxvk {
             D3D9DeviceEx*         pDevice,
       const D3D9FFShaderKeyFS&    Key);
 
+    D3D9FFShader(
+            D3D9DeviceEx*         pDevice);
+
     template <typename T>
     void Dump(D3D9DeviceEx* pDevice, const T& Key, const std::string& Name);
 
@@ -247,6 +200,10 @@ namespace dxvk {
 
   public:
 
+    D3D9FFShaderModuleSet() = delete;
+
+    explicit D3D9FFShaderModuleSet(D3D9DeviceEx* pDevice);
+
     D3D9FFShader GetShaderModule(
             D3D9DeviceEx*         pDevice,
       const D3D9FFShaderKeyVS&    ShaderKey);
@@ -254,6 +211,10 @@ namespace dxvk {
     D3D9FFShader GetShaderModule(
             D3D9DeviceEx*         pDevice,
       const D3D9FFShaderKeyFS&    ShaderKey);
+
+    const D3D9FFShader& GetVSUbershaderModule() const {
+      return m_vsUbershader;
+    }
 
     UINT GetVSCount() const {
       return m_vsModules.size();
@@ -274,6 +235,8 @@ namespace dxvk {
       D3D9FFShaderKeyFS,
       D3D9FFShader,
       D3D9FFShaderKeyHash, D3D9FFShaderKeyEq> m_fsModules;
+
+    D3D9FFShader m_vsUbershader;
 
   };
 

--- a/src/d3d9/d3d9_options.cpp
+++ b/src/d3d9/d3d9_options.cpp
@@ -76,6 +76,7 @@ namespace dxvk {
     this->countLosableResources         = config.getOption<bool>        ("d3d9.countLosableResources",         true);
     this->reproducibleCommandStream     = config.getOption<bool>        ("d3d9.reproducibleCommandStream",     false);
     this->extraFrontbuffer              = config.getOption<bool>        ("d3d9.extraFrontbuffer",              false);
+    this->ffUbershaderVS                = config.getOption<bool>        ("d3d9.ffUbershaderVS",                false);
 
     // D3D8 options
     this->drefScaling                   = config.getOption<int32_t>     ("d3d8.scaleDref",                     0);

--- a/src/d3d9/d3d9_options.cpp
+++ b/src/d3d9/d3d9_options.cpp
@@ -76,8 +76,8 @@ namespace dxvk {
     this->countLosableResources         = config.getOption<bool>        ("d3d9.countLosableResources",         true);
     this->reproducibleCommandStream     = config.getOption<bool>        ("d3d9.reproducibleCommandStream",     false);
     this->extraFrontbuffer              = config.getOption<bool>        ("d3d9.extraFrontbuffer",              false);
-    this->ffUbershaderVS                = config.getOption<bool>        ("d3d9.ffUbershaderVS",                false);
-    this->ffUbershaderFS                = config.getOption<bool>        ("d3d9.ffUbershaderFS",                false);
+    this->ffUbershaderVS                = config.getOption<bool>        ("d3d9.ffUbershaderVS",                true);
+    this->ffUbershaderFS                = config.getOption<bool>        ("d3d9.ffUbershaderFS",                true);
 
     // D3D8 options
     this->drefScaling                   = config.getOption<int32_t>     ("d3d8.scaleDref",                     0);

--- a/src/d3d9/d3d9_options.cpp
+++ b/src/d3d9/d3d9_options.cpp
@@ -77,6 +77,7 @@ namespace dxvk {
     this->reproducibleCommandStream     = config.getOption<bool>        ("d3d9.reproducibleCommandStream",     false);
     this->extraFrontbuffer              = config.getOption<bool>        ("d3d9.extraFrontbuffer",              false);
     this->ffUbershaderVS                = config.getOption<bool>        ("d3d9.ffUbershaderVS",                false);
+    this->ffUbershaderFS                = config.getOption<bool>        ("d3d9.ffUbershaderFS",                false);
 
     // D3D8 options
     this->drefScaling                   = config.getOption<int32_t>     ("d3d8.scaleDref",                     0);

--- a/src/d3d9/d3d9_options.h
+++ b/src/d3d9/d3d9_options.h
@@ -167,6 +167,9 @@ namespace dxvk {
 
     /// Add an extra front buffer to make GetFrontBufferData() work correctly when the swapchain only has a single buffer
     bool extraFrontbuffer;
+
+    /// Use the uber shader for fixed function vertex shaders.
+    bool ffUbershaderVS;
   };
 
 }

--- a/src/d3d9/d3d9_options.h
+++ b/src/d3d9/d3d9_options.h
@@ -170,6 +170,9 @@ namespace dxvk {
 
     /// Use the uber shader for fixed function vertex shaders.
     bool ffUbershaderVS;
+
+    /// Use the uber shader for fixed function fragment shaders.
+    bool ffUbershaderFS;
   };
 
 }

--- a/src/d3d9/d3d9_spec_constants.h
+++ b/src/d3d9/d3d9_spec_constants.h
@@ -28,11 +28,46 @@ namespace dxvk {
     SpecPixelShaderBools,   // 16 bools                       | Bits: 16
 
     SpecSamplerFetch4,      // 1 bit for 16 PS samplers       | Bits: 16
+    SpecFFTextureStageCount, // Range: 1 -> 8 | Bits: 3
 
     SpecSamplerDrefClamp,   // 1 bit for 21 VS + PS samplers  | Bits: 21
     SpecClipPlaneCount,     // 3 bits for 6 clip planes       | Bits : 3
     SpecPointMode,          // Range: 0 -> 3                  | Bits: 2
     SpecDrefScaling,        // Range: 0-31 | Bits: 5
+
+    SpecFFGlobalSpecularEnabled,  // Bool                     | Bits: 1
+
+    SpecFFTextureStage0ColorOp,   // Range: 1 -> 26           | Bits: 5
+    SpecFFTextureStage0ColorArg1, // Range: 0 -> 6 + 2 flags  | Bits: 5
+    SpecFFTextureStage0ColorArg2, // Range: 0 -> 6 + 2 flags  | Bits: 5
+    SpecFFTextureStage0AlphaOp,   // Range: 1 -> 26           | Bits: 5
+    SpecFFTextureStage0AlphaArg1, // Range: 0 -> 6 + 2 flags  | Bits: 5
+    SpecFFTextureStage0AlphaArg2, // Range: 0 -> 6 + 2 flags  | Bits: 5
+    SpecFFTextureStage0ResultIsTemp, // Bool                  | Bits: 1
+
+    SpecFFTextureStage1ColorOp,   // Range: 1 -> 26           | Bits: 5
+    SpecFFTextureStage1ColorArg1, // Range: 0 -> 6 + 2 flags  | Bits: 5
+    SpecFFTextureStage1ColorArg2, // Range: 0 -> 6 + 2 flags  | Bits: 5
+    SpecFFTextureStage1AlphaOp,   // Range: 1 -> 26           | Bits: 5
+    SpecFFTextureStage1AlphaArg1, // Range: 0 -> 6 + 2 flags  | Bits: 5
+    SpecFFTextureStage1AlphaArg2, // Range: 0 -> 6 + 2 flags  | Bits: 5
+    SpecFFTextureStage1ResultIsTemp, // Bool                  | Bits: 1
+
+    SpecFFTextureStage2ColorOp,   // Range: 1 -> 26           | Bits: 5
+    SpecFFTextureStage2ColorArg1, // Range: 0 -> 6 + 2 flags  | Bits: 5
+    SpecFFTextureStage2ColorArg2, // Range: 0 -> 6 + 2 flags  | Bits: 5
+    SpecFFTextureStage2AlphaOp,   // Range: 1 -> 26           | Bits: 5
+    SpecFFTextureStage2AlphaArg1, // Range: 0 -> 6 + 2 flags  | Bits: 5
+    SpecFFTextureStage2AlphaArg2, // Range: 0 -> 6 + 2 flags  | Bits: 5
+    SpecFFTextureStage2ResultIsTemp, // Bool                  | Bits: 1
+
+    SpecFFTextureStage3ColorOp,   // Range: 1 -> 26           | Bits: 5
+    SpecFFTextureStage3ColorArg1, // Range: 0 -> 6 + 2 flags  | Bits: 5
+    SpecFFTextureStage3ColorArg2, // Range: 0 -> 6 + 2 flags  | Bits: 5
+    SpecFFTextureStage3AlphaOp,   // Range: 1 -> 26           | Bits: 5
+    SpecFFTextureStage3AlphaArg1, // Range: 0 -> 6 + 2 flags  | Bits: 5
+    SpecFFTextureStage3AlphaArg2, // Range: 0 -> 6 + 2 flags  | Bits: 5
+    SpecFFTextureStage3ResultIsTemp, // Bool                  | Bits: 1
 
     SpecConstantCount,
   };
@@ -49,10 +84,9 @@ namespace dxvk {
 
   struct D3D9SpecializationInfo {
     // Spec const word 0 determines whether the other spec constants are used rather than the spec const UBO
-    static constexpr uint32_t MaxSpecDwords = 6;
+    static constexpr uint32_t MaxSpecDwords = 10;
 
-    static constexpr uint32_t MaxUBODwords  = 5;
-    static constexpr size_t UBOSize = MaxUBODwords * sizeof(uint32_t);
+    static constexpr size_t UBOSize = MaxSpecDwords * sizeof(uint32_t);
 
     static constexpr std::array<BitfieldPosition, SpecConstantCount> Layout{{
       { 0, 0, 32 },  // SamplerType
@@ -71,11 +105,48 @@ namespace dxvk {
       { 3, 16, 16 }, // PixelShaderBools
 
       { 4, 0,  16 }, // SamplerFetch4
+      { 4, 16,  3 }, // FFTextureStageCount
 
       { 5, 0, 21 },  // SamplerDrefClamp
       { 5, 21, 3 },  // ClipPlaneCount
       { 5, 24, 2 },  // PointMode
       { 5, 26, 5 },  // DrefScaling
+
+      { 6, 31, 1 },  // FFGlobalSpecularEnabled.
+      // Packed with Texture stage 0 but placed here out of order so every texture stage
+      // has the same number of entries in the Layout array.
+
+      { 6,  0, 5 },  // FFTextureStage0ColorOp
+      { 6,  5, 5 },  // FFTextureStage0ColorArg1
+      { 6, 10, 5 },  // FFTextureStage0ColorArg2
+      { 6, 15, 5 },  // FFTextureStage0AlphaOp
+      { 6, 20, 5 },  // FFTextureStage0AlphaArg1
+      { 6, 25, 5 },  // FFTextureStage0AlphaArg2
+      { 6, 30, 1 },  // FFTextureStage0ResultIsTemp
+
+      { 7,  0, 5 },  // FFTextureStage1ColorOp
+      { 7,  5, 5 },  // FFTextureStage1ColorArg1
+      { 7, 10, 5 },  // FFTextureStage1ColorArg2
+      { 7, 15, 5 },  // FFTextureStage1AlphaOp
+      { 7, 20, 5 },  // FFTextureStage1AlphaArg1
+      { 7, 25, 5 },  // FFTextureStage1AlphaArg2
+      { 7, 30, 1 },  // FFTextureStage1ResultIsTemp
+
+      { 8,  0, 5 },  // FFTextureStage2ColorOp
+      { 8,  5, 5 },  // FFTextureStage2ColorArg1
+      { 8, 10, 5 },  // FFTextureStage2ColorArg2
+      { 8, 15, 5 },  // FFTextureStage2AlphaOp
+      { 8, 20, 5 },  // FFTextureStage2AlphaArg1
+      { 8, 25, 5 },  // FFTextureStage2AlphaArg2
+      { 8, 30, 1 },  // FFTextureStage2ResultIsTemp
+
+      { 9,  0, 5 },  // FFTextureStage3ColorOp
+      { 9,  5, 5 },  // FFTextureStage3ColorArg1
+      { 9, 10, 5 },  // FFTextureStage3ColorArg2
+      { 9, 15, 5 },  // FFTextureStage3AlphaOp
+      { 9, 20, 5 },  // FFTextureStage3AlphaArg1
+      { 9, 25, 5 },  // FFTextureStage3AlphaArg2
+      { 9, 30, 1 },  // FFTextureStage3ResultIsTemp
     }};
 
     template <D3D9SpecConstantId Id, typename T>
@@ -92,9 +163,29 @@ namespace dxvk {
       return true;
     }
 
+    template <typename T>
+    bool set(const D3D9SpecConstantId id, const T& value) {
+      const uint32_t x = uint32_t(value);
+      if (get(id) == x)
+        return false;
+
+      const auto& layout = Layout[id];
+
+      data[layout.dwordOffset] &= ~layout.mask();
+      data[layout.dwordOffset] |= (x << layout.bitOffset) & layout.mask();
+
+      return true;
+    }
+
     template <D3D9SpecConstantId Id>
     uint32_t get() const {
       constexpr auto& layout = Layout[Id];
+
+      return (data[layout.dwordOffset] & layout.mask()) >> layout.bitOffset;
+    }
+
+    uint32_t get(const D3D9SpecConstantId id) const {
+      const auto& layout = Layout[id];
 
       return (data[layout.dwordOffset] & layout.mask()) >> layout.bitOffset;
     }

--- a/src/d3d9/d3d9_state.h
+++ b/src/d3d9/d3d9_state.h
@@ -109,6 +109,57 @@ namespace dxvk {
     float Phi;
   };
 
+  struct D3D9FFShaderKeyVSData {
+    union {
+      struct {
+        uint32_t TexcoordIndices : 24;
+
+        uint32_t VertexHasPositionT : 1;
+
+        uint32_t VertexHasColor0 : 1; // Diffuse
+        uint32_t VertexHasColor1 : 1; // Specular
+
+        uint32_t VertexHasPointSize : 1;
+
+        uint32_t UseLighting : 1;
+
+        uint32_t NormalizeNormals : 1;
+        uint32_t LocalViewer : 1;
+        uint32_t RangeFog : 1;
+
+        uint32_t TexcoordFlags : 24;
+
+        uint32_t DiffuseSource : 2;
+        uint32_t AmbientSource : 2;
+        uint32_t SpecularSource : 2;
+        uint32_t EmissiveSource : 2;
+
+        uint32_t TransformFlags : 24;
+
+        uint32_t LightCount : 4;
+
+        uint32_t VertexTexcoordDeclMask : 24;
+        uint32_t VertexHasFog : 1;
+
+        uint32_t VertexBlendMode    : 2;
+        uint32_t VertexBlendIndexed : 1;
+        uint32_t VertexBlendCount   : 2;
+
+        uint32_t VertexClipping     : 1;
+      } Contents;
+
+      uint32_t Primitive[5];
+    };
+  };
+
+  struct D3D9FFShaderKeyVS {
+    D3D9FFShaderKeyVS() {
+      // memcmp safety
+      std::memset(&Data, 0, sizeof(Data));
+    }
+
+    D3D9FFShaderKeyVSData Data;
+  };
 
   struct D3D9FixedFunctionVS {
     Matrix4 WorldView;
@@ -124,6 +175,8 @@ namespace dxvk {
     std::array<D3D9Light, caps::MaxEnabledLights> Lights;
     D3DMATERIAL9 Material;
     float TweenFactor;
+
+    D3D9FFShaderKeyVSData Key;
   };
 
 

--- a/src/d3d9/d3d9_state.h
+++ b/src/d3d9/d3d9_state.h
@@ -190,8 +190,48 @@ namespace dxvk {
   };
 
 
+  struct D3D9FFShaderStage {
+    union {
+      struct {
+        uint32_t     ColorOp   : 5;
+        uint32_t     ColorArg0 : 6;
+        uint32_t     ColorArg1 : 6;
+        uint32_t     ColorArg2 : 6;
+
+        uint32_t     AlphaOp   : 5;
+        uint32_t     AlphaArg0 : 6;
+        uint32_t     AlphaArg1 : 6;
+        uint32_t     AlphaArg2 : 6;
+
+        uint32_t     ResultIsTemp : 1;
+
+        // Included in here, read from Stage 0 for packing reasons
+        // Affects all stages.
+        uint32_t     GlobalSpecularEnable : 1;
+      } Contents;
+
+      uint32_t Primitive[2];
+    };
+  };
+
+  struct D3D9FFShaderKeyFS {
+    D3D9FFShaderKeyFS() {
+      // memcmp safety
+      std::memset(Stages, 0, sizeof(Stages));
+
+      // Normalize this. DISABLE != 0.
+      for (uint32_t i = 0; i < caps::TextureStageCount; i++) {
+        Stages[i].Contents.ColorOp = D3DTOP_DISABLE;
+        Stages[i].Contents.AlphaOp = D3DTOP_DISABLE;
+      }
+    }
+
+    D3D9FFShaderStage Stages[caps::TextureStageCount];
+  };
+
   struct D3D9FixedFunctionPS {
     Vector4 textureFactor;
+    D3D9FFShaderKeyFS Key;
   };
 
   enum D3D9SharedPSStages {

--- a/src/d3d9/meson.build
+++ b/src/d3d9/meson.build
@@ -7,7 +7,8 @@ d3d9_shaders = files([
   'shaders/d3d9_convert_a2w10v10u10.comp',
   'shaders/d3d9_convert_w11v11u10.comp',
   'shaders/d3d9_convert_nv12.comp',
-  'shaders/d3d9_convert_yv12.comp'
+  'shaders/d3d9_convert_yv12.comp',
+  'shaders/d3d9_fixed_function_vert.vert'
 ])
 
 d3d9_src = [

--- a/src/d3d9/meson.build
+++ b/src/d3d9/meson.build
@@ -8,7 +8,8 @@ d3d9_shaders = files([
   'shaders/d3d9_convert_w11v11u10.comp',
   'shaders/d3d9_convert_nv12.comp',
   'shaders/d3d9_convert_yv12.comp',
-  'shaders/d3d9_fixed_function_vert.vert'
+  'shaders/d3d9_fixed_function_vert.vert',
+  'shaders/d3d9_fixed_function_frag.frag'
 ])
 
 d3d9_src = [

--- a/src/d3d9/shaders/d3d9_fixed_function_common.glsl
+++ b/src/d3d9/shaders/d3d9_fixed_function_common.glsl
@@ -68,41 +68,11 @@ const uint SpecPixelFogMode = 8;
 const uint SpecVertexShaderBools = 9;
 const uint SpecPixelShaderBools = 10;
 const uint SpecSamplerFetch4 = 11;
-const uint SpecFFTextureStageCount = 12;
-const uint SpecSamplerDrefClamp = 13;
-const uint SpecClipPlaneCount = 14;
-const uint SpecPointMode = 15;
-const uint SpecDrefScaling = 16;
-const uint SpecFFGlobalSpecularEnabled = 17;
-const uint SpecFFTextureStage0ColorOp = 18;
-const uint SpecFFTextureStage0ColorArg1 = 19;
-const uint SpecFFTextureStage0ColorArg2 = 20;
-const uint SpecFFTextureStage0AlphaOp = 21;
-const uint SpecFFTextureStage0AlphaArg1 = 22;
-const uint SpecFFTextureStage0AlphaArg2 = 23;
-const uint SpecFFTextureStage0ResultIsTemp = 24;
-const uint SpecFFTextureStage1ColorOp = 25;
-const uint SpecFFTextureStage1ColorArg1 = 26;
-const uint SpecFFTextureStage1ColorArg2 = 27;
-const uint SpecFFTextureStage1AlphaOp = 28;
-const uint SpecFFTextureStage1AlphaArg1 = 29;
-const uint SpecFFTextureStage1AlphaArg2 = 30;
-const uint SpecFFTextureStage1ResultIsTemp = 31;
-const uint SpecFFTextureStage2ColorOp = 32;
-const uint SpecFFTextureStage2ColorArg1 = 33;
-const uint SpecFFTextureStage2ColorArg2 = 34;
-const uint SpecFFTextureStage2AlphaOp = 35;
-const uint SpecFFTextureStage2AlphaArg1 = 36;
-const uint SpecFFTextureStage2AlphaArg2 = 37;
-const uint SpecFFTextureStage2ResultIsTemp = 38;
-const uint SpecFFTextureStage3ColorOp = 39;
-const uint SpecFFTextureStage3ColorArg1 = 40;
-const uint SpecFFTextureStage3ColorArg2 = 41;
-const uint SpecFFTextureStage3AlphaOp = 42;
-const uint SpecFFTextureStage3AlphaArg1 = 43;
-const uint SpecFFTextureStage3AlphaArg2 = 44;
-const uint SpecFFTextureStage3ResultIsTemp = 45;
-const uint SpecConstantCount = 46;
+const uint SpecSamplerDrefClamp = 12;
+const uint SpecClipPlaneCount = 13;
+const uint SpecPointMode = 14;
+const uint SpecDrefScaling = 15;
+const uint SpecConstantCount = 16;
 
 struct BitfieldPosition {
     uint dwordOffset;
@@ -128,46 +98,11 @@ BitfieldPosition SpecConstLayout[SpecConstantCount] = {
     { 3, 16, 16 }, // PixelShaderBools
 
     { 4, 0,  16 }, // SamplerFetch4
-    { 4, 16,  3 }, // FFTextureStageCount
 
     { 5, 0, 21 },  // SamplerDrefClamp
     { 5, 21, 3 },  // ClipPlaneCount
     { 5, 24, 2 },  // PointMode
     { 5, 26, 5 },  // DrefScaling
-
-    { 6, 31, 1 },  // FFGlobalSpecularEnabled.
-
-    { 6,  0, 5 },  // FFTextureStage0ColorOp
-    { 6,  5, 5 },  // FFTextureStage0ColorArg1
-    { 6, 10, 5 },  // FFTextureStage0ColorArg2
-    { 6, 15, 5 },  // FFTextureStage0AlphaOp
-    { 6, 20, 5 },  // FFTextureStage0AlphaArg1
-    { 6, 25, 5 },  // FFTextureStage0AlphaArg2
-    { 6, 30, 1 },  // FFTextureStage0ResultIsTemp
-
-    { 7,  0, 5 },  // FFTextureStage1ColorOp
-    { 7,  5, 5 },  // FFTextureStage1ColorArg1
-    { 7, 10, 5 },  // FFTextureStage1ColorArg2
-    { 7, 15, 5 },  // FFTextureStage1AlphaOp
-    { 7, 20, 5 },  // FFTextureStage1AlphaArg1
-    { 7, 25, 5 },  // FFTextureStage1AlphaArg2
-    { 7, 30, 1 },  // FFTextureStage1ResultIsTemp
-
-    { 8,  0, 5 },  // FFTextureStage2ColorOp
-    { 8,  5, 5 },  // FFTextureStage2ColorArg1
-    { 8, 10, 5 },  // FFTextureStage2ColorArg2
-    { 8, 15, 5 },  // FFTextureStage2AlphaOp
-    { 8, 20, 5 },  // FFTextureStage2AlphaArg1
-    { 8, 25, 5 },  // FFTextureStage2AlphaArg2
-    { 8, 30, 1 },  // FFTextureStage2ResultIsTemp
-
-    { 9,  0, 5 },  // FFTextureStage3ColorOp
-    { 9,  5, 5 },  // FFTextureStage3ColorArg1
-    { 9, 10, 5 },  // FFTextureStage3ColorArg2
-    { 9, 15, 5 },  // FFTextureStage3AlphaOp
-    { 9, 20, 5 },  // FFTextureStage3AlphaArg1
-    { 9, 25, 5 },  // FFTextureStage3AlphaArg2
-    { 9, 30, 1 },  // FFTextureStage3ResultIsTemp
 };
 
 bool specIsOptimized() {

--- a/src/d3d9/shaders/d3d9_fixed_function_common.glsl
+++ b/src/d3d9/shaders/d3d9_fixed_function_common.glsl
@@ -1,0 +1,232 @@
+const float FloatMaxValue = 340282346638528859811704183484516925440.0;
+
+const uint TextureStageCount = 8;
+
+#define D3DFOGMODE uint
+const uint D3DFOG_NONE   = 0;
+const uint D3DFOG_EXP    = 1;
+const uint D3DFOG_EXP2   = 2;
+const uint D3DFOG_LINEAR = 3;
+
+struct D3D9RenderStateInfo {
+    float fogColor[3];
+    float fogScale;
+    float fogEnd;
+    float fogDensity;
+
+    uint alphaRef;
+
+    float pointSize;
+    float pointSizeMin;
+    float pointSizeMax;
+    float pointScaleA;
+    float pointScaleB;
+    float pointScaleC;
+};
+
+
+// Thanks SPIRV-Cross
+spirv_instruction(set = "GLSL.std.450", id = 79) float spvNMin(float, float);
+spirv_instruction(set = "GLSL.std.450", id = 79) vec2 spvNMin(vec2, vec2);
+spirv_instruction(set = "GLSL.std.450", id = 79) vec3 spvNMin(vec3, vec3);
+spirv_instruction(set = "GLSL.std.450", id = 79) vec4 spvNMin(vec4, vec4);
+spirv_instruction(set = "GLSL.std.450", id = 81) float spvNClamp(float, float, float);
+spirv_instruction(set = "GLSL.std.450", id = 81) vec2 spvNClamp(vec2, vec2, vec2);
+spirv_instruction(set = "GLSL.std.450", id = 81) vec3 spvNClamp(vec3, vec3, vec3);
+spirv_instruction(set = "GLSL.std.450", id = 81) vec4 spvNClamp(vec4, vec4, vec4);
+
+
+// Dynamic "spec constants"
+// Binding has to match with getSpecConstantBufferSlot in dxso_util.h
+layout(set = 0, binding = 31, scalar) uniform SpecConsts {
+    uint dynamicSpecConstDword[13];
+};
+
+layout (constant_id = 0) const uint SpecConstDword0 = 0;
+layout (constant_id = 1) const uint SpecConstDword1 = 0;
+layout (constant_id = 2) const uint SpecConstDword2 = 0;
+layout (constant_id = 3) const uint SpecConstDword3 = 0;
+layout (constant_id = 4) const uint SpecConstDword4 = 0;
+layout (constant_id = 5) const uint SpecConstDword5 = 0;
+layout (constant_id = 6) const uint SpecConstDword6 = 0;
+layout (constant_id = 7) const uint SpecConstDword7 = 0;
+layout (constant_id = 8) const uint SpecConstDword8 = 0;
+layout (constant_id = 9) const uint SpecConstDword9 = 0;
+layout (constant_id = 10) const uint SpecConstDword10 = 0;
+layout (constant_id = 11) const uint SpecConstDword11 = 0;
+layout (constant_id = 12) const uint SpecConstDword12 = 0;
+
+const uint SpecSamplerType = 0;
+const uint SpecSamplerDepthMode = 1;
+const uint SpecAlphaCompareOp = 2;
+const uint SpecSamplerProjected = 3;
+const uint SpecSamplerNull = 4;
+const uint SpecAlphaPrecisionBits = 5;
+const uint SpecFogEnabled = 6;
+const uint SpecVertexFogMode = 7;
+const uint SpecPixelFogMode = 8;
+const uint SpecVertexShaderBools = 9;
+const uint SpecPixelShaderBools = 10;
+const uint SpecSamplerFetch4 = 11;
+const uint SpecFFTextureStageCount = 12;
+const uint SpecSamplerDrefClamp = 13;
+const uint SpecClipPlaneCount = 14;
+const uint SpecPointMode = 15;
+const uint SpecDrefScaling = 16;
+const uint SpecFFGlobalSpecularEnabled = 17;
+const uint SpecFFTextureStage0ColorOp = 18;
+const uint SpecFFTextureStage0ColorArg1 = 19;
+const uint SpecFFTextureStage0ColorArg2 = 20;
+const uint SpecFFTextureStage0AlphaOp = 21;
+const uint SpecFFTextureStage0AlphaArg1 = 22;
+const uint SpecFFTextureStage0AlphaArg2 = 23;
+const uint SpecFFTextureStage0ResultIsTemp = 24;
+const uint SpecFFTextureStage1ColorOp = 25;
+const uint SpecFFTextureStage1ColorArg1 = 26;
+const uint SpecFFTextureStage1ColorArg2 = 27;
+const uint SpecFFTextureStage1AlphaOp = 28;
+const uint SpecFFTextureStage1AlphaArg1 = 29;
+const uint SpecFFTextureStage1AlphaArg2 = 30;
+const uint SpecFFTextureStage1ResultIsTemp = 31;
+const uint SpecFFTextureStage2ColorOp = 32;
+const uint SpecFFTextureStage2ColorArg1 = 33;
+const uint SpecFFTextureStage2ColorArg2 = 34;
+const uint SpecFFTextureStage2AlphaOp = 35;
+const uint SpecFFTextureStage2AlphaArg1 = 36;
+const uint SpecFFTextureStage2AlphaArg2 = 37;
+const uint SpecFFTextureStage2ResultIsTemp = 38;
+const uint SpecFFTextureStage3ColorOp = 39;
+const uint SpecFFTextureStage3ColorArg1 = 40;
+const uint SpecFFTextureStage3ColorArg2 = 41;
+const uint SpecFFTextureStage3AlphaOp = 42;
+const uint SpecFFTextureStage3AlphaArg1 = 43;
+const uint SpecFFTextureStage3AlphaArg2 = 44;
+const uint SpecFFTextureStage3ResultIsTemp = 45;
+const uint SpecConstantCount = 46;
+
+struct BitfieldPosition {
+    uint dwordOffset;
+    uint bitOffset;
+    uint sizeInBits;
+};
+
+// Needs to match d3d9_spec_constants.h
+BitfieldPosition SpecConstLayout[SpecConstantCount] = {
+    { 0, 0, 32 },  // SamplerType
+
+    { 1, 0,  21 }, // SamplerDepthMode
+    { 1, 21, 3 },  // AlphaCompareOp
+    { 1, 24, 8 },  // SamplerProjected
+
+    { 2, 0,  21 }, // SamplerNull
+    { 2, 21, 4 },  // AlphaPrecisionBits
+    { 2, 25, 1 },  // FogEnabled
+    { 2, 26, 2 },  // VertexFogMode
+    { 2, 28, 2 },  // PixelFogMode
+
+    { 3, 0,  16 }, // VertexShaderBools
+    { 3, 16, 16 }, // PixelShaderBools
+
+    { 4, 0,  16 }, // SamplerFetch4
+    { 4, 16,  3 }, // FFTextureStageCount
+
+    { 5, 0, 21 },  // SamplerDrefClamp
+    { 5, 21, 3 },  // ClipPlaneCount
+    { 5, 24, 2 },  // PointMode
+    { 5, 26, 5 },  // DrefScaling
+
+    { 6, 31, 1 },  // FFGlobalSpecularEnabled.
+
+    { 6,  0, 5 },  // FFTextureStage0ColorOp
+    { 6,  5, 5 },  // FFTextureStage0ColorArg1
+    { 6, 10, 5 },  // FFTextureStage0ColorArg2
+    { 6, 15, 5 },  // FFTextureStage0AlphaOp
+    { 6, 20, 5 },  // FFTextureStage0AlphaArg1
+    { 6, 25, 5 },  // FFTextureStage0AlphaArg2
+    { 6, 30, 1 },  // FFTextureStage0ResultIsTemp
+
+    { 7,  0, 5 },  // FFTextureStage1ColorOp
+    { 7,  5, 5 },  // FFTextureStage1ColorArg1
+    { 7, 10, 5 },  // FFTextureStage1ColorArg2
+    { 7, 15, 5 },  // FFTextureStage1AlphaOp
+    { 7, 20, 5 },  // FFTextureStage1AlphaArg1
+    { 7, 25, 5 },  // FFTextureStage1AlphaArg2
+    { 7, 30, 1 },  // FFTextureStage1ResultIsTemp
+
+    { 8,  0, 5 },  // FFTextureStage2ColorOp
+    { 8,  5, 5 },  // FFTextureStage2ColorArg1
+    { 8, 10, 5 },  // FFTextureStage2ColorArg2
+    { 8, 15, 5 },  // FFTextureStage2AlphaOp
+    { 8, 20, 5 },  // FFTextureStage2AlphaArg1
+    { 8, 25, 5 },  // FFTextureStage2AlphaArg2
+    { 8, 30, 1 },  // FFTextureStage2ResultIsTemp
+
+    { 9,  0, 5 },  // FFTextureStage3ColorOp
+    { 9,  5, 5 },  // FFTextureStage3ColorArg1
+    { 9, 10, 5 },  // FFTextureStage3ColorArg2
+    { 9, 15, 5 },  // FFTextureStage3AlphaOp
+    { 9, 20, 5 },  // FFTextureStage3AlphaArg1
+    { 9, 25, 5 },  // FFTextureStage3AlphaArg2
+    { 9, 30, 1 },  // FFTextureStage3ResultIsTemp
+};
+
+bool specIsOptimized() {
+    return SpecConstDword12 != 0u;
+}
+
+uint specDword(uint index) {
+    if (!specIsOptimized()) {
+        return dynamicSpecConstDword[index];
+    }
+
+    switch (index) {
+        case 0u:
+            return SpecConstDword0;
+        case 1u:
+            return SpecConstDword1;
+        case 2u:
+            return SpecConstDword2;
+        case 3u:
+            return SpecConstDword3;
+        case 4u:
+            return SpecConstDword4;
+        case 5u:
+            return SpecConstDword5;
+        case 6u:
+            return SpecConstDword6;
+        case 7u:
+            return SpecConstDword7;
+        case 8u:
+            return SpecConstDword8;
+        case 9u:
+            return SpecConstDword9;
+        case 10u:
+            return SpecConstDword10;
+        case 11u:
+            return SpecConstDword11;
+        case 12u:
+            return SpecConstDword12;
+        default:
+            return 0u;
+    }
+}
+
+uint specUint(uint specConstIdx, uint bitOffset, uint bits) {
+    BitfieldPosition pos = SpecConstLayout[specConstIdx];
+    uint dword = specDword(pos.dwordOffset);
+    return bitfieldExtract(dword, int(pos.bitOffset + bitOffset), int(bits));
+}
+
+uint specUint(uint specConstIdx) {
+    BitfieldPosition pos = SpecConstLayout[specConstIdx];
+    uint dword = specDword(pos.dwordOffset);
+    return bitfieldExtract(dword, int(pos.bitOffset), int(pos.sizeInBits));
+}
+
+bool specBool(uint specConstIdx, uint bitOffset) {
+    return specUint(specConstIdx, bitOffset, 1u) != 0u;
+}
+
+bool specBool(uint specConstIdx) {
+    return specUint(specConstIdx) != 0u;
+}

--- a/src/d3d9/shaders/d3d9_fixed_function_common.glsl
+++ b/src/d3d9/shaders/d3d9_fixed_function_common.glsl
@@ -68,11 +68,41 @@ const uint SpecPixelFogMode = 8;
 const uint SpecVertexShaderBools = 9;
 const uint SpecPixelShaderBools = 10;
 const uint SpecSamplerFetch4 = 11;
-const uint SpecSamplerDrefClamp = 12;
-const uint SpecClipPlaneCount = 13;
-const uint SpecPointMode = 14;
-const uint SpecDrefScaling = 15;
-const uint SpecConstantCount = 16;
+const uint SpecFFTextureStageCount = 12;
+const uint SpecSamplerDrefClamp = 13;
+const uint SpecClipPlaneCount = 14;
+const uint SpecPointMode = 15;
+const uint SpecDrefScaling = 16;
+const uint SpecFFGlobalSpecularEnabled = 17;
+const uint SpecFFTextureStage0ColorOp = 18;
+const uint SpecFFTextureStage0ColorArg1 = 19;
+const uint SpecFFTextureStage0ColorArg2 = 20;
+const uint SpecFFTextureStage0AlphaOp = 21;
+const uint SpecFFTextureStage0AlphaArg1 = 22;
+const uint SpecFFTextureStage0AlphaArg2 = 23;
+const uint SpecFFTextureStage0ResultIsTemp = 24;
+const uint SpecFFTextureStage1ColorOp = 25;
+const uint SpecFFTextureStage1ColorArg1 = 26;
+const uint SpecFFTextureStage1ColorArg2 = 27;
+const uint SpecFFTextureStage1AlphaOp = 28;
+const uint SpecFFTextureStage1AlphaArg1 = 29;
+const uint SpecFFTextureStage1AlphaArg2 = 30;
+const uint SpecFFTextureStage1ResultIsTemp = 31;
+const uint SpecFFTextureStage2ColorOp = 32;
+const uint SpecFFTextureStage2ColorArg1 = 33;
+const uint SpecFFTextureStage2ColorArg2 = 34;
+const uint SpecFFTextureStage2AlphaOp = 35;
+const uint SpecFFTextureStage2AlphaArg1 = 36;
+const uint SpecFFTextureStage2AlphaArg2 = 37;
+const uint SpecFFTextureStage2ResultIsTemp = 38;
+const uint SpecFFTextureStage3ColorOp = 39;
+const uint SpecFFTextureStage3ColorArg1 = 40;
+const uint SpecFFTextureStage3ColorArg2 = 41;
+const uint SpecFFTextureStage3AlphaOp = 42;
+const uint SpecFFTextureStage3AlphaArg1 = 43;
+const uint SpecFFTextureStage3AlphaArg2 = 44;
+const uint SpecFFTextureStage3ResultIsTemp = 45;
+const uint SpecConstantCount = 46;
 
 struct BitfieldPosition {
     uint dwordOffset;
@@ -98,11 +128,46 @@ BitfieldPosition SpecConstLayout[SpecConstantCount] = {
     { 3, 16, 16 }, // PixelShaderBools
 
     { 4, 0,  16 }, // SamplerFetch4
+    { 4, 16,  3 }, // FFTextureStageCount
 
     { 5, 0, 21 },  // SamplerDrefClamp
     { 5, 21, 3 },  // ClipPlaneCount
     { 5, 24, 2 },  // PointMode
     { 5, 26, 5 },  // DrefScaling
+
+    { 6, 31, 1 },  // FFGlobalSpecularEnabled.
+
+    { 6,  0, 5 },  // FFTextureStage0ColorOp
+    { 6,  5, 5 },  // FFTextureStage0ColorArg1
+    { 6, 10, 5 },  // FFTextureStage0ColorArg2
+    { 6, 15, 5 },  // FFTextureStage0AlphaOp
+    { 6, 20, 5 },  // FFTextureStage0AlphaArg1
+    { 6, 25, 5 },  // FFTextureStage0AlphaArg2
+    { 6, 30, 1 },  // FFTextureStage0ResultIsTemp
+
+    { 7,  0, 5 },  // FFTextureStage1ColorOp
+    { 7,  5, 5 },  // FFTextureStage1ColorArg1
+    { 7, 10, 5 },  // FFTextureStage1ColorArg2
+    { 7, 15, 5 },  // FFTextureStage1AlphaOp
+    { 7, 20, 5 },  // FFTextureStage1AlphaArg1
+    { 7, 25, 5 },  // FFTextureStage1AlphaArg2
+    { 7, 30, 1 },  // FFTextureStage1ResultIsTemp
+
+    { 8,  0, 5 },  // FFTextureStage2ColorOp
+    { 8,  5, 5 },  // FFTextureStage2ColorArg1
+    { 8, 10, 5 },  // FFTextureStage2ColorArg2
+    { 8, 15, 5 },  // FFTextureStage2AlphaOp
+    { 8, 20, 5 },  // FFTextureStage2AlphaArg1
+    { 8, 25, 5 },  // FFTextureStage2AlphaArg2
+    { 8, 30, 1 },  // FFTextureStage2ResultIsTemp
+
+    { 9,  0, 5 },  // FFTextureStage3ColorOp
+    { 9,  5, 5 },  // FFTextureStage3ColorArg1
+    { 9, 10, 5 },  // FFTextureStage3ColorArg2
+    { 9, 15, 5 },  // FFTextureStage3AlphaOp
+    { 9, 20, 5 },  // FFTextureStage3AlphaArg1
+    { 9, 25, 5 },  // FFTextureStage3AlphaArg2
+    { 9, 30, 1 },  // FFTextureStage3ResultIsTemp
 };
 
 bool specIsOptimized() {

--- a/src/d3d9/shaders/d3d9_fixed_function_frag.frag
+++ b/src/d3d9/shaders/d3d9_fixed_function_frag.frag
@@ -1,0 +1,685 @@
+#version 450
+#extension GL_GOOGLE_include_directive : enable
+#extension GL_EXT_scalar_block_layout : require
+#extension GL_EXT_spirv_intrinsics : require
+#extension GL_EXT_demote_to_helper_invocation : require
+#extension GL_ARB_derivative_control : require
+#extension GL_EXT_control_flow_attributes : require
+#extension GL_EXT_nonuniform_qualifier : require
+
+
+// The locations need to match with RegisterLinkerSlot in dxso_util.cpp
+layout(location = 0) in vec4 in_Normal;
+layout(location = 1) in vec4 in_Texcoord0;
+layout(location = 2) in vec4 in_Texcoord1;
+layout(location = 3) in vec4 in_Texcoord2;
+layout(location = 4) in vec4 in_Texcoord3;
+layout(location = 5) in vec4 in_Texcoord4;
+layout(location = 6) in vec4 in_Texcoord5;
+layout(location = 7) in vec4 in_Texcoord6;
+layout(location = 8) in vec4 in_Texcoord7;
+layout(location = 9) in vec4 in_Color0;
+layout(location = 10) in vec4 in_Color1;
+layout(location = 11) in float in_Fog;
+
+layout(location = 0) out vec4 out_Color0;
+
+
+const uint SpecConstOptimizedTextureStageCount = 4;
+const uint TextureArgCount = 3;
+const uint MaxSharedPushDataSize = 64;
+
+#include "d3d9_fixed_function_common.glsl"
+
+struct D3D9FFTextureStage {
+    uint Primitive[2];
+};
+
+struct D3D9FixedFunctionPS {
+    vec4 textureFactor;
+    D3D9FFTextureStage Stages[8];
+};
+
+struct D3D9SharedPSStage {
+    float Constant[4];
+    float BumpEnvMat[2][2];
+    float BumpEnvLScale;
+    float BumpEnvLOffset;
+    float Padding[2];
+};
+
+struct D3D9SharedPS {
+    D3D9SharedPSStage Stages[TextureStageCount];
+};
+
+const uint D3DTOP_DISABLE                   = 1;
+const uint D3DTOP_SELECTARG1                = 2;
+const uint D3DTOP_SELECTARG2                = 3;
+const uint D3DTOP_MODULATE                  = 4;
+const uint D3DTOP_MODULATE2X                = 5;
+const uint D3DTOP_MODULATE4X                = 6;
+const uint D3DTOP_ADD                       = 7;
+const uint D3DTOP_ADDSIGNED                 = 8;
+const uint D3DTOP_ADDSIGNED2X               = 9;
+const uint D3DTOP_SUBTRACT                  = 10;
+const uint D3DTOP_ADDSMOOTH                 = 11;
+const uint D3DTOP_BLENDDIFFUSEALPHA         = 12;
+const uint D3DTOP_BLENDTEXTUREALPHA         = 13;
+const uint D3DTOP_BLENDFACTORALPHA          = 14;
+const uint D3DTOP_BLENDTEXTUREALPHAPM       = 15;
+const uint D3DTOP_BLENDCURRENTALPHA         = 16;
+const uint D3DTOP_PREMODULATE               = 17;
+const uint D3DTOP_MODULATEALPHA_ADDCOLOR    = 18;
+const uint D3DTOP_MODULATECOLOR_ADDALPHA    = 19;
+const uint D3DTOP_MODULATEINVALPHA_ADDCOLOR = 20;
+const uint D3DTOP_MODULATEINVCOLOR_ADDALPHA = 21;
+const uint D3DTOP_BUMPENVMAP                = 22;
+const uint D3DTOP_BUMPENVMAPLUMINANCE       = 23;
+const uint D3DTOP_DOTPRODUCT3               = 24;
+const uint D3DTOP_MULTIPLYADD               = 25;
+const uint D3DTOP_LERP                      = 26;
+
+const uint D3DTA_SELECTMASK     = 0x0000000f;
+const uint D3DTA_DIFFUSE        = 0x00000000;
+const uint D3DTA_CURRENT        = 0x00000001;
+const uint D3DTA_TEXTURE        = 0x00000002;
+const uint D3DTA_TFACTOR        = 0x00000003;
+const uint D3DTA_SPECULAR       = 0x00000004;
+const uint D3DTA_TEMP           = 0x00000005;
+const uint D3DTA_CONSTANT       = 0x00000006;
+const uint D3DTA_COMPLEMENT     = 0x00000010;
+const uint D3DTA_ALPHAREPLICATE = 0x00000020;
+
+const uint D3DRTYPE_SURFACE       = 1;
+const uint D3DRTYPE_VOLUME        = 2;
+const uint D3DRTYPE_TEXTURE       = 3;
+const uint D3DRTYPE_VOLUMETEXTURE = 4;
+const uint D3DRTYPE_CUBETEXTURE   = 5;
+const uint D3DRTYPE_VERTEXBUFFER  = 6;
+const uint D3DRTYPE_INDEXBUFFER   = 7;
+
+const uint VK_COMPARE_OP_NEVER            = 0;
+const uint VK_COMPARE_OP_LESS             = 1;
+const uint VK_COMPARE_OP_EQUAL            = 2;
+const uint VK_COMPARE_OP_LESS_OR_EQUAL    = 3;
+const uint VK_COMPARE_OP_GREATER          = 4;
+const uint VK_COMPARE_OP_NOT_EQUAL        = 5;
+const uint VK_COMPARE_OP_GREATER_OR_EQUAL = 6;
+const uint VK_COMPARE_OP_ALWAYS           = 7;
+
+
+// Bindings have to match with computeResourceSlotId in dxso_util.h
+// computeResourceSlotId(
+//     DxsoProgramType::PixelShader,
+//     DxsoBindingType::ConstantBuffer,
+//     DxsoConstantBuffers::PSFixedFunction
+// ) = 11
+layout(set = 0, binding = 11, scalar, row_major) uniform ShaderData {
+    D3D9FixedFunctionPS data;
+};
+
+// Bindings have to match with computeResourceSlotId in dxso_util.h
+// computeResourceSlotId(
+//     DxsoProgramType::PixelShader,
+//     DxsoBindingType::ConstantBuffer,
+//     DxsoConstantBuffers::PSShared
+// ) = 12
+layout(set = 0, binding = 12, scalar, row_major) uniform SharedData {
+    D3D9SharedPS sharedData;
+};
+
+layout(push_constant, scalar, row_major) uniform RenderStates {
+    D3D9RenderStateInfo rs;
+
+    layout(offset = MaxSharedPushDataSize) uint packedSamplerIndices[TextureStageCount / 2];
+};
+
+layout(set = 0, binding = 13) uniform texture2D t2d[TextureStageCount];
+layout(set = 0, binding = 13) uniform textureCube tcube[TextureStageCount];
+layout(set = 0, binding = 13) uniform texture3D t3d[TextureStageCount];
+
+layout(set = 1, binding = 0) uniform sampler sampler_heap[];
+
+
+// Functions to extract information from the packed texture stages
+uint colorOp(uint stageIndex) {
+    return bitfieldExtract(data.Stages[stageIndex].Primitive[0], 0, 5);
+}
+uint colorArg0(uint stageIndex) {
+    return bitfieldExtract(data.Stages[stageIndex].Primitive[0], 5, 6);
+}
+uint colorArg1(uint stageIndex) {
+    return bitfieldExtract(data.Stages[stageIndex].Primitive[0], 11, 6);
+}
+uint colorArg2(uint stageIndex) {
+    return bitfieldExtract(data.Stages[stageIndex].Primitive[0], 17, 6);
+}
+
+uint alphaOp(uint stageIndex) {
+    return bitfieldExtract(data.Stages[stageIndex].Primitive[0], 23, 5);
+}
+uint alphaArg0(uint stageIndex) {
+    return bitfieldExtract(data.Stages[stageIndex].Primitive[1], 0, 6);
+}
+uint alphaArg1(uint stageIndex) {
+    return bitfieldExtract(data.Stages[stageIndex].Primitive[1], 6, 6);
+}
+uint alphaArg2(uint stageIndex) {
+    return bitfieldExtract(data.Stages[stageIndex].Primitive[1], 12, 6);
+}
+
+bool resultIsTemp(uint stageIndex) {
+    return bitfieldExtract(data.Stages[stageIndex].Primitive[1], 18, 1) != 0;
+}
+bool globalSpecularEnabled() {
+    return bitfieldExtract(data.Stages[0].Primitive[1], 19, 1) != 0;
+}
+
+
+vec4 calculateFog(vec4 vPos, vec4 oColor) {
+    vec3 fogColor = vec3(rs.fogColor[0], rs.fogColor[1], rs.fogColor[2]);
+    float fogScale = rs.fogScale;
+    float fogEnd = rs.fogEnd;
+    float fogDensity = rs.fogDensity;
+    D3DFOGMODE fogMode = specUint(SpecPixelFogMode);
+    bool fogEnabled = specBool(SpecFogEnabled);
+    if (!fogEnabled) {
+        return oColor;
+    }
+
+    float w = vPos.w;
+    float z = vPos.z;
+    float depth = z * (1.0 / w);
+    float fogFactor;
+    switch (fogMode) {
+        case D3DFOG_NONE:
+            fogFactor = in_Fog;
+            break;
+
+        // (end - d) / (end - start)
+        case D3DFOG_LINEAR:
+            fogFactor = fogEnd - depth;
+            fogFactor = fogFactor * fogScale;
+            fogFactor = spvNClamp(fogFactor, 0.0, 1.0);
+            break;
+
+        // 1 / (e^[d * density])^2
+        case D3DFOG_EXP2:
+        // 1 / (e^[d * density])
+        case D3DFOG_EXP:
+            fogFactor = depth * fogDensity;
+
+            if (fogMode == D3DFOG_EXP2)
+                fogFactor *= fogFactor;
+
+            // Provides the rcp.
+            fogFactor = -fogFactor;
+            fogFactor = exp(fogFactor);
+            break;
+    }
+
+    vec4 color = oColor;
+    vec3 color3 = color.rgb;
+    vec3 fogFact3 = vec3(fogFactor);
+    vec3 lerpedFrog = mix(fogColor, color3, fogFact3);
+    return vec4(lerpedFrog.r, lerpedFrog.g, lerpedFrog.b, color.a);
+}
+
+
+// [D3D8] Scale Dref to [0..(2^N - 1)] for D24S8 and D16 if Dref scaling is enabled
+float adjustDref(float reference, uint samplerIndex) {
+    uint drefScaleFactor = specUint(SpecDrefScaling);
+    if (drefScaleFactor != 0) {
+        float maxDref = 1.0 / (float(1 << drefScaleFactor) - 1.0);
+        reference *= maxDref;
+    }
+    if (specBool(SpecSamplerDrefClamp, samplerIndex)) {
+        reference = clamp(reference, 0.0, 1.0);
+    }
+    return reference;
+}
+
+
+vec4 calculateBumpmapCoords(uint stage, vec4 baseCoords, vec4 previousStageTextureVal) {
+    uint previousStage = stage - 1;
+
+    vec4 coords = baseCoords;
+    [[unroll]]
+    for (uint i = 0; i < 2; i++) {
+        float tc_m_n = coords[i];
+        vec2 bm = vec2(sharedData.Stages[previousStage].BumpEnvMat[i][0], sharedData.Stages[previousStage].BumpEnvMat[i][1]);
+        vec2 t = previousStageTextureVal.xy;
+        float result = tc_m_n + dot(bm, t);
+        coords[i] = result;
+    }
+    return coords;
+}
+
+
+uint loadSamplerHeapIndex(uint samplerBindingIndex) {
+    uint packedSamplerIndex = packedSamplerIndices[samplerBindingIndex / 2u];
+    return bitfieldExtract(packedSamplerIndex, 16 * (int(samplerBindingIndex) & 1), 16);
+}
+
+
+vec4 sampleTexture(uint stage, vec4 texcoord, vec4 previousStageTextureVal) {
+    if (specBool(SpecSamplerProjected, stage)) {
+        texcoord /= texcoord.w;
+    }
+
+    uint previousStageColorOp = 0;
+    if (stage > 0) {
+        previousStageColorOp = colorOp(stage - 1);
+    }
+
+    if (stage != 0 && (
+        previousStageColorOp == D3DTOP_BUMPENVMAP
+        || previousStageColorOp == D3DTOP_BUMPENVMAPLUMINANCE)) {
+        texcoord = calculateBumpmapCoords(stage, texcoord, previousStageTextureVal);
+    }
+
+    vec4 texVal;
+    uint textureType = D3DRTYPE_TEXTURE + specUint(SpecSamplerType, 2u * stage, 2u);
+    switch (textureType) {
+        case D3DRTYPE_TEXTURE:
+            if (specBool(SpecSamplerDepthMode, stage)) {
+                texcoord.z = adjustDref(texcoord.z, stage);
+                texVal = texture(sampler2DShadow(t2d[stage], sampler_heap[loadSamplerHeapIndex(stage)]), texcoord.xyz).xxxx;
+            } else {
+                texVal = texture(sampler2D(t2d[stage], sampler_heap[loadSamplerHeapIndex(stage)]), texcoord.xy);
+            }
+            break;
+        case D3DRTYPE_CUBETEXTURE:
+            if (specBool(SpecSamplerDepthMode, stage)) {
+                texcoord.w = adjustDref(texcoord.w, stage);
+                texVal = texture(samplerCubeShadow(tcube[stage], sampler_heap[loadSamplerHeapIndex(stage)]), texcoord).xxxx;
+            } else {
+                texVal = texture(samplerCube(tcube[stage], sampler_heap[loadSamplerHeapIndex(stage)]), texcoord.xyz);
+            }
+            break;
+        case D3DRTYPE_VOLUMETEXTURE:
+            texVal = texture(sampler3D(t3d[stage], sampler_heap[loadSamplerHeapIndex(stage)]), texcoord.xyz);
+            break;
+        default:
+            // This should never happen unless there's a major bug in the API implementation.
+            // Produce a value that's obviously wrong to make it obvious when it somehow does happen.
+            texVal = vec4(999.9);
+            break;
+    }
+
+    if (stage != 0 && previousStageColorOp == D3DTOP_BUMPENVMAPLUMINANCE) {
+        float lScale = sharedData.Stages[stage - 1].BumpEnvLScale;
+        float lOffset = sharedData.Stages[stage - 1].BumpEnvLOffset;
+        float scale = texVal.z;
+        scale *= lScale;
+        scale += lOffset;
+        scale = clamp(scale, 0.0, 1.0);
+        texVal *= scale;
+    }
+
+    return texVal;
+}
+
+
+vec4 readArgValue(uint stage, uint arg, vec4 current, vec4 temp, vec4 textureVal) {
+    vec4 reg = vec4(1.0);
+    switch (arg & D3DTA_SELECTMASK) {
+        case D3DTA_CONSTANT:
+            reg = vec4(
+                sharedData.Stages[stage].Constant[0],
+                sharedData.Stages[stage].Constant[1],
+                sharedData.Stages[stage].Constant[2],
+                sharedData.Stages[stage].Constant[3]
+            );
+            break;
+        case D3DTA_CURRENT:
+            reg = current;
+            break;
+        case D3DTA_DIFFUSE:
+            reg = in_Color0;
+            break;
+        case D3DTA_SPECULAR:
+            reg = in_Color1;
+            break;
+        case D3DTA_TEMP:
+            reg = temp;
+            break;
+        case D3DTA_TEXTURE:
+            reg = textureVal;
+            break;
+        case D3DTA_TFACTOR:
+            reg = data.textureFactor;
+            break;
+    }
+
+    // reg = 1 - reg
+    if ((arg & D3DTA_COMPLEMENT) != 0)
+        reg = vec4(1.0) - reg;
+
+    // reg = reg.wwww
+    if ((arg & D3DTA_ALPHAREPLICATE) != 0)
+        reg = reg.aaaa;
+
+    return reg;
+}
+
+struct TextureStageArguments {
+    uint arg0;
+    uint arg1;
+    uint arg2;
+};
+
+struct TextureStageArgumentValues {
+    vec4 arg0;
+    vec4 arg1;
+    vec4 arg2;
+};
+
+TextureStageArgumentValues readArgValues(uint stage, const TextureStageArguments args, vec4 current, vec4 temp, vec4 textureVal) {
+    TextureStageArgumentValues argVals;
+    argVals.arg0 = readArgValue(stage, args.arg0, current, temp, textureVal);
+    argVals.arg1 = readArgValue(stage, args.arg1, current, temp, textureVal);
+    argVals.arg2 = readArgValue(stage, args.arg2, current, temp, textureVal);
+    return argVals;
+}
+
+vec4 complement(vec4 val) {
+    return vec4(1.0) - val;
+}
+
+vec4 saturate(vec4 val) {
+    return clamp(val, vec4(0.0), vec4(1.0));
+}
+
+vec4 calculateTextureStage(uint op, vec4 dst, const TextureStageArgumentValues arg, vec4 current, vec4 textureVal) {
+    switch (op) {
+        case D3DTOP_SELECTARG1:
+            return arg.arg1;
+
+        case D3DTOP_SELECTARG2:
+            return arg.arg2;
+
+        case D3DTOP_MODULATE4X:
+            return arg.arg1 * arg.arg2 * 4.0;
+
+        case D3DTOP_MODULATE2X:
+            return arg.arg1 * arg.arg2 * 2.0;
+
+        case D3DTOP_MODULATE:
+            return arg.arg1 * arg.arg2;
+
+        case D3DTOP_ADDSIGNED2X:
+            return saturate(2.0 * (arg.arg1 + (arg.arg2 - vec4(0.5))));
+
+        case D3DTOP_ADDSIGNED:
+            return saturate(arg.arg1 + (arg.arg2 - vec4(0.5)));
+
+        case D3DTOP_ADD:
+            return saturate(arg.arg1 + arg.arg2);
+
+        case D3DTOP_SUBTRACT:
+            return saturate(arg.arg1 - arg.arg2);
+
+        case D3DTOP_ADDSMOOTH:
+            return fma(complement(arg.arg1), arg.arg2, arg.arg1);
+
+        case D3DTOP_BLENDDIFFUSEALPHA:
+            return mix(arg.arg2, arg.arg1, in_Color0.aaaa);
+
+        case D3DTOP_BLENDTEXTUREALPHA:
+            return mix(arg.arg2, arg.arg1, textureVal.aaaa);
+
+        case D3DTOP_BLENDFACTORALPHA:
+            return mix(arg.arg2, arg.arg1, data.textureFactor.aaaa);
+
+        case D3DTOP_BLENDTEXTUREALPHAPM:
+            return saturate(fma(arg.arg2, complement(textureVal.aaaa), arg.arg1));
+
+        case D3DTOP_BLENDCURRENTALPHA:
+            return mix(arg.arg2, arg.arg1, current.aaaa);
+
+        case D3DTOP_PREMODULATE:
+            return dst; // Not implemented
+
+        case D3DTOP_MODULATEALPHA_ADDCOLOR:
+            return saturate(fma(arg.arg1.aaaa, arg.arg2, arg.arg1));
+
+        case D3DTOP_MODULATECOLOR_ADDALPHA:
+            return saturate(fma(arg.arg1, arg.arg2, arg.arg1.aaaa));
+
+        case D3DTOP_MODULATEINVALPHA_ADDCOLOR:
+            return saturate(fma(complement(arg.arg1.aaaa), arg.arg2, arg.arg1));
+
+        case D3DTOP_MODULATEINVCOLOR_ADDALPHA:
+            return saturate(fma(complement(arg.arg1), arg.arg2, arg.arg1.aaaa));
+
+        case D3DTOP_BUMPENVMAPLUMINANCE:
+        case D3DTOP_BUMPENVMAP:
+            // Load texture for the next stage...
+            return dst;
+
+        case D3DTOP_DOTPRODUCT3:
+            return saturate(vec4(dot(arg.arg1.rgb - vec3(0.5), arg.arg2.rgb - vec3(0.5)) * 4.0));
+
+        case D3DTOP_MULTIPLYADD:
+            return saturate(fma(arg.arg1, arg.arg2, arg.arg0));
+
+        case D3DTOP_LERP:
+            return mix(arg.arg2, arg.arg1, arg.arg0);
+
+        default:
+            // Unhandled texture op!
+            return dst;
+
+    }
+
+    return vec4(0.0);
+}
+
+
+void alphaTest() {
+    uint alphaFunc = specUint(SpecAlphaCompareOp);
+    uint alphaPrecision = specUint(SpecAlphaPrecisionBits);
+    uint alphaRefInitial = rs.alphaRef;
+    float alphaRef;
+    float alpha = out_Color0.a;
+
+    if (alphaFunc == VK_COMPARE_OP_ALWAYS) {
+        return;
+    }
+
+    // Check if the given bit precision is supported
+    bool useIntPrecision = alphaPrecision <= 8;
+    if (useIntPrecision) {
+        // Adjust alpha ref to the given range
+        uint alphaRefInt = (alphaRefInitial << alphaPrecision) | (alphaRefInitial >> (8 - alphaPrecision));
+
+        // Convert alpha ref to float since we'll do the comparison based on that
+        alphaRef = float(alphaRefInt);
+
+        // Adjust alpha to the given range and round
+        float alphaFactor = float((256u << alphaPrecision) - 1u);
+
+        alpha = round(alpha * alphaFactor);
+    } else {
+        alphaRef = float(alphaRefInitial) / 255.0;
+    }
+
+    bool atestResult;
+    switch (alphaFunc) {
+        case VK_COMPARE_OP_NEVER:
+            atestResult = false;
+            break;
+
+        case VK_COMPARE_OP_LESS:
+            atestResult = alpha < alphaRef;
+            break;
+
+        case VK_COMPARE_OP_EQUAL:
+            atestResult = alpha == alphaRef;
+            break;
+
+        case VK_COMPARE_OP_LESS_OR_EQUAL:
+            atestResult = alpha <= alphaRef;
+            break;
+
+        case VK_COMPARE_OP_GREATER:
+            atestResult = alpha > alphaRef;
+            break;
+
+        case VK_COMPARE_OP_NOT_EQUAL:
+            atestResult = alpha != alphaRef;
+            break;
+
+        case VK_COMPARE_OP_GREATER_OR_EQUAL:
+            atestResult = alpha >= alphaRef;
+            break;
+
+        default:
+        case VK_COMPARE_OP_ALWAYS:
+            atestResult = true;
+            break;
+    }
+
+    bool atestDiscard = !atestResult;
+    if (atestDiscard) {
+        demote;
+    }
+}
+
+struct TextureStageState {
+    vec4 current;
+    vec4 temp;
+    vec4 previousStageTextureVal;
+};
+
+TextureStageState runTextureStage(uint stage, TextureStageState state) {
+    const uint colorOp = colorOp(stage);
+
+    // This cancels all subsequent stages.
+    if (colorOp == D3DTOP_DISABLE)
+        return state;
+
+    const bool resultIsTemp = resultIsTemp(stage);
+    vec4 dst = resultIsTemp ? state.temp : state.current;
+
+    const uint alphaOp = alphaOp(stage);
+
+    const bool usesArg0 = colorOp == D3DTOP_LERP
+        || colorOp == D3DTOP_MULTIPLYADD
+        || alphaOp == D3DTOP_LERP
+        || alphaOp == D3DTOP_MULTIPLYADD;
+
+    const TextureStageArguments colorArgs = {
+        usesArg0 ? colorArg0(stage) : D3DTA_CONSTANT,
+        colorArg1(stage),
+        colorArg2(stage)
+    };
+    const TextureStageArguments alphaArgs = {
+        usesArg0 ? alphaArg0(stage) : D3DTA_CONSTANT,
+        alphaArg1(stage),
+        alphaArg2(stage)
+    };
+
+    vec4 textureVal = vec4(0.0);
+    bool usesTexture = colorArgs.arg0 == D3DTA_TEXTURE
+        || colorArgs.arg1 == D3DTA_TEXTURE
+        || colorArgs.arg2 == D3DTA_TEXTURE
+        || alphaArgs.arg0 == D3DTA_TEXTURE
+        || alphaArgs.arg1 == D3DTA_TEXTURE
+        || alphaArgs.arg2 == D3DTA_TEXTURE;
+
+    if (usesTexture) {
+        // We need to replace TEXCOORD inputs with gl_PointCoord
+        // if D3DRS_POINTSPRITEENABLE is set.
+        const uint pointMode = specUint(SpecPointMode);
+        const bool isSprite = bitfieldExtract(pointMode, 1, 1) == 1u;
+
+        vec4 texCoord;
+        if (isSprite) {
+            texCoord = vec4(gl_PointCoord, 0.0, 0.0);
+        } else {
+            switch (stage) {
+                case 0: texCoord = in_Texcoord0; break;
+                case 1: texCoord = in_Texcoord1; break;
+                case 2: texCoord = in_Texcoord2; break;
+                case 3: texCoord = in_Texcoord3; break;
+                case 4: texCoord = in_Texcoord4; break;
+                case 5: texCoord = in_Texcoord5; break;
+                case 6: texCoord = in_Texcoord6; break;
+                case 7: texCoord = in_Texcoord7; break;
+            }
+        }
+        const vec4 unboundTextureConst = vec4(0.0, 0.0, 0.0, 1.0);
+        textureVal = !specBool(SpecSamplerNull, stage) ? sampleTexture(stage, texCoord, state.previousStageTextureVal) : unboundTextureConst;
+    }
+
+    // Fast path if alpha/color path is identical.
+    // D3DTOP_DOTPRODUCT3 also has special quirky behaviour here.
+    const bool fastPath = colorOp == alphaOp && colorArgs == alphaArgs;
+    if (fastPath || colorOp == D3DTOP_DOTPRODUCT3) {
+        TextureStageArgumentValues colorArgVals = readArgValues(stage, colorArgs, state.current, state.temp, textureVal);
+        dst = calculateTextureStage(colorOp, dst, colorArgVals, state.current, textureVal);
+    } else {
+        vec4 colorResult = dst;
+        vec4 alphaResult = dst;
+
+        TextureStageArgumentValues colorArgVals = readArgValues(stage, colorArgs, state.current, state.temp, textureVal);
+        colorResult = calculateTextureStage(colorOp, dst, colorArgVals, state.current, textureVal);
+
+        if (alphaOp != D3DTOP_DISABLE) {
+            TextureStageArgumentValues alphaArgVals = readArgValues(stage, alphaArgs, state.current, state.temp, textureVal);
+            alphaResult = calculateTextureStage(alphaOp, dst, alphaArgVals, state.current, textureVal);
+        }
+
+        dst.xyz = colorResult.xyz;
+
+        // src0.x, src0.y, src0.z src1.w
+        if (alphaOp != D3DTOP_DISABLE) {
+            dst.a = alphaResult.a;
+        }
+    }
+
+    if (resultIsTemp) {
+        state.temp = dst;
+    } else {
+        state.current = dst;
+    }
+    state.previousStageTextureVal = textureVal;
+
+    return state;
+}
+
+void main() {
+    // in_Color0 is diffuse
+    // in_Color1 is specular
+
+    TextureStageState state;
+    // Current starts of as equal to diffuse.
+    state.current = in_Color0;
+    // Temp starts off as equal to vec4(0)
+    state.temp = vec4(0.0);
+    state.previousStageTextureVal = vec4(0.0);
+
+    // If we turn this into a loop, performance becomes very poor on the proprietary Nvidia driver
+    // because it fails to unroll it.
+    state = runTextureStage(0, state);
+    state = runTextureStage(1, state);
+    state = runTextureStage(2, state);
+    state = runTextureStage(3, state);
+    state = runTextureStage(4, state);
+    state = runTextureStage(5, state);
+    state = runTextureStage(6, state);
+    state = runTextureStage(7, state);
+
+    if (globalSpecularEnabled()) {
+        vec4 specular = in_Color1 * vec4(1.0, 1.0, 1.0, 0.0);
+        state.current += specular;
+    }
+
+    state.current = calculateFog(gl_FragCoord, state.current);
+
+    out_Color0 = state.current;
+
+    alphaTest();
+}

--- a/src/d3d9/shaders/d3d9_fixed_function_vert.vert
+++ b/src/d3d9/shaders/d3d9_fixed_function_vert.vert
@@ -1,0 +1,705 @@
+#version 450
+#extension GL_GOOGLE_include_directive : enable
+#extension GL_EXT_scalar_block_layout : require
+#extension GL_EXT_spirv_intrinsics : require
+
+layout(location = 0) in vec4 in_Position0;
+layout(location = 1) in vec4 in_Normal0;
+layout(location = 2) in vec4 in_Position1;
+layout(location = 3) in vec4 in_Normal1;
+layout(location = 4) in vec4 in_Texcoord0;
+layout(location = 5) in vec4 in_Texcoord1;
+layout(location = 6) in vec4 in_Texcoord2;
+layout(location = 7) in vec4 in_Texcoord3;
+layout(location = 8) in vec4 in_Texcoord4;
+layout(location = 9) in vec4 in_Texcoord5;
+layout(location = 10) in vec4 in_Texcoord6;
+layout(location = 11) in vec4 in_Texcoord7;
+layout(location = 12) in vec4 in_Color0;
+layout(location = 13) in vec4 in_Color1;
+layout(location = 14) in float in_Fog;
+layout(location = 15) in float in_PointSize;
+layout(location = 16) in vec4 in_BlendWeight;
+layout(location = 17) in vec4 in_BlendIndices;
+
+
+// The locations need to match with RegisterLinkerSlot in dxso_util.cpp
+precise gl_Position;
+const uint MaxClipPlaneCount = 6;
+out float gl_ClipDistance[MaxClipPlaneCount];
+layout(location = 0) out vec4 out_Normal;
+layout(location = 1) out vec4 out_Texcoord0;
+layout(location = 2) out vec4 out_Texcoord1;
+layout(location = 3) out vec4 out_Texcoord2;
+layout(location = 4) out vec4 out_Texcoord3;
+layout(location = 5) out vec4 out_Texcoord4;
+layout(location = 6) out vec4 out_Texcoord5;
+layout(location = 7) out vec4 out_Texcoord6;
+layout(location = 8) out vec4 out_Texcoord7;
+layout(location = 9) out vec4 out_Color0;
+layout(location = 10) out vec4 out_Color1;
+layout(location = 11) out float out_Fog;
+
+
+#include "d3d9_fixed_function_common.glsl"
+
+const uint MaxEnabledLights = 8;
+
+struct D3D9ViewportInfo {
+    vec4 inverseOffset;
+    vec4 inverseExtent;
+};
+
+#define D3DLIGHTTYPE uint
+const uint D3DLIGHT_POINT       = 1;
+const uint D3DLIGHT_SPOT        = 2;
+const uint D3DLIGHT_DIRECTIONAL = 3;
+
+struct D3D9Light {
+    vec4 Diffuse;
+    vec4 Specular;
+    vec4 Ambient;
+
+    vec4 Position;
+    vec4 Direction;
+
+    D3DLIGHTTYPE Type;
+    float Range;
+    float Falloff;
+    float Attenuation0;
+    float Attenuation1;
+    float Attenuation2;
+    float Theta;
+    float Phi;
+};
+
+#define D3DCOLORVALUE vec4
+
+struct D3DMATERIAL9 {
+    D3DCOLORVALUE   Diffuse;
+    D3DCOLORVALUE   Ambient;
+    D3DCOLORVALUE   Specular;
+    D3DCOLORVALUE   Emissive;
+    float           Power;
+};
+
+struct D3D9FixedFunctionVS {
+    mat4 WorldView;
+    mat4 NormalMatrix;
+    mat4 InverseView;
+    mat4 Projection;
+
+    mat4 TexcoordMatrices[TextureStageCount];
+
+    D3D9ViewportInfo ViewportInfo;
+
+    vec4 GlobalAmbient;
+    D3D9Light Lights[MaxEnabledLights];
+    D3DMATERIAL9 Material;
+    float TweenFactor;
+
+    uint KeyPrimitives[4];
+};
+
+#define D3D9FF_VertexBlendMode uint
+const uint D3D9FF_VertexBlendMode_Disabled = 0;
+const uint D3D9FF_VertexBlendMode_Normal   = 1;
+const uint D3D9FF_VertexBlendMode_Tween    = 2;
+
+#define D3DMATERIALCOLORSOURCE uint
+const uint D3DMCS_MATERIAL = 0;
+const uint D3DMCS_COLOR1   = 1;
+const uint D3DMCS_COLOR2   = 2;
+
+#define D3DTEXTURETRANSFORMFLAGS uint
+const uint D3DTTFF_DISABLE   = 0;
+const uint D3DTTFF_COUNT1    = 1;
+const uint D3DTTFF_COUNT2    = 2;
+const uint D3DTTFF_COUNT3    = 3;
+const uint D3DTTFF_COUNT4    = 4;
+const uint D3DTTFF_PROJECTED = 256;
+
+const uint DXVK_TSS_TCI_PASSTHRU                    = 0x00000000;
+const uint DXVK_TSS_TCI_CAMERASPACENORMAL           = 0x00010000;
+const uint DXVK_TSS_TCI_CAMERASPACEPOSITION         = 0x00020000;
+const uint DXVK_TSS_TCI_CAMERASPACEREFLECTIONVECTOR = 0x00030000;
+const uint DXVK_TSS_TCI_SPHEREMAP                   = 0x00040000;
+
+const uint TCIOffset = 16;
+const uint TCIMask = (7 << TCIOffset);
+
+
+// Bindings have to match with computeResourceSlotId in dxso_util.h
+// computeResourceSlotId(
+//     DxsoProgramType::VertexShader,
+//     DxsoBindingType::ConstantBuffer,
+//     DxsoConstantBuffers::VSFixedFunction
+// ) = 4
+layout(set = 0, binding = 4, scalar, row_major) uniform ShaderData {
+    D3D9FixedFunctionVS data;
+};
+
+layout(push_constant, scalar, row_major) uniform RenderStates {
+    D3D9RenderStateInfo rs;
+};
+
+// Bindings have to match with computeResourceSlotId in dxso_util.h
+// computeResourceSlotId(
+//     DxsoProgramType::VertexShader,
+//     DxsoBindingType::ConstantBuffer,
+//     DxsoConstantBuffers::VSVertexBlendData
+// ) = 5
+layout(set = 0, binding = 5, std140, row_major) readonly buffer VertexBlendData {
+    mat4 WorldViewArray[];
+};
+
+
+// Bindings have to match with computeResourceSlotId in dxso_util.h
+// computeResourceSlotId(
+//     DxsoProgramType::VertexShader,
+//     DxsoBindingType::ConstantBuffer,
+//     DxsoConstantBuffers::VSClipPlanes
+// ) = 3
+layout(set = 0, binding = 3, std140) uniform ClipPlanes {
+    vec4 clipPlanes[MaxClipPlaneCount];
+};
+
+
+// Functions to extract information from the packed VS key
+// See D3D9FFShaderKeyVSData in d3d9_shader_types.h
+// Please, dearest compiler, inline all of this.
+uint texcoordIndices() {
+    return bitfieldExtract(data.KeyPrimitives[0], 0, 24);
+}
+bool vertexHasPositionT() {
+    return bitfieldExtract(data.KeyPrimitives[0], 24, 1) != 0;
+}
+bool vertexHasColor0() {
+    return bitfieldExtract(data.KeyPrimitives[0], 25, 1) != 0;
+}
+bool vertexHasColor1() {
+    return bitfieldExtract(data.KeyPrimitives[0], 26, 1) != 0;
+}
+bool vertexHasPointSize() {
+    return bitfieldExtract(data.KeyPrimitives[0], 27, 1) != 0;
+}
+bool useLighting() {
+    return bitfieldExtract(data.KeyPrimitives[0], 28, 1) != 0;
+}
+bool normalizeNormals() {
+    return bitfieldExtract(data.KeyPrimitives[0], 29, 1) != 0;
+}
+bool localViewer() {
+    return bitfieldExtract(data.KeyPrimitives[0], 30, 1) != 0;
+}
+bool rangeFog() {
+    return bitfieldExtract(data.KeyPrimitives[0], 31, 1) != 0;
+}
+
+uint texcoordFlags() {
+    return bitfieldExtract(data.KeyPrimitives[1], 0, 24);
+}
+uint diffuseSource() {
+    return bitfieldExtract(data.KeyPrimitives[1], 24, 2);
+}
+uint ambientSource() {
+    return bitfieldExtract(data.KeyPrimitives[1], 26, 2);
+}
+uint specularSource() {
+    return bitfieldExtract(data.KeyPrimitives[1], 28, 2);
+}
+uint emissiveSource() {
+    return bitfieldExtract(data.KeyPrimitives[1], 30, 2);
+}
+
+uint transformFlags() {
+    return bitfieldExtract(data.KeyPrimitives[2], 0, 24);
+}
+uint lightCount() {
+    return bitfieldExtract(data.KeyPrimitives[2], 24, 4);
+}
+
+uint vertexTexcoordDeclMask() {
+    return bitfieldExtract(data.KeyPrimitives[3], 0, 24);
+}
+bool vertexHasFog() {
+    return bitfieldExtract(data.KeyPrimitives[3], 24, 1) != 0;
+}
+D3D9FF_VertexBlendMode blendMode() {
+    return bitfieldExtract(data.KeyPrimitives[3], 25, 2);
+}
+bool vertexBlendIndexed() {
+    return bitfieldExtract(data.KeyPrimitives[3], 27, 1) != 0;
+}
+uint vertexBlendCount() {
+    return bitfieldExtract(data.KeyPrimitives[3], 28, 2);
+}
+bool vertexClipping() {
+    return bitfieldExtract(data.KeyPrimitives[3], 30, 1) != 0;
+}
+
+
+float calculateFog(vec4 vPos, vec4 oColor) {
+    vec4 color1 = vertexHasColor1() ? in_Color1 : vec4(0.0);
+
+    vec4 specular = color1;
+    bool hasSpecular = vertexHasColor1();
+
+    vec3 fogColor = vec3(rs.fogColor[0], rs.fogColor[1], rs.fogColor[2]);
+    float fogScale = rs.fogScale;
+    float fogEnd = rs.fogEnd;
+    float fogDensity = rs.fogDensity;
+    D3DFOGMODE fogMode = specUint(SpecVertexFogMode);
+    bool fogEnabled = specBool(SpecFogEnabled);
+    if (!fogEnabled) {
+        return 0.0;
+    }
+
+    float w = vPos.w;
+    float z = vPos.z;
+    float depth;
+    if (rangeFog()) {
+        vec3 pos3 = vPos.xyz;
+        depth = length(pos3);
+    } else {
+        depth = vertexHasFog() ? in_Fog : abs(z);
+    }
+    float fogFactor;
+    if (vertexHasPositionT()) {
+        fogFactor = hasSpecular ? specular.w : 1.0;
+    } else {
+        switch (fogMode) {
+            case D3DFOG_NONE:
+                if (hasSpecular)
+                    fogFactor = specular.w;
+                else
+                    fogFactor = 1.0;
+                break;
+
+            // (end - d) / (end - start)
+            case D3DFOG_LINEAR:
+                fogFactor = fogEnd - depth;
+                fogFactor = fogFactor * fogScale;
+                fogFactor = spvNClamp(fogFactor, 0.0, 1.0);
+                break;
+
+            // 1 / (e^[d * density])^2
+            case D3DFOG_EXP2:
+            // 1 / (e^[d * density])
+            case D3DFOG_EXP:
+                fogFactor = depth * fogDensity;
+
+                if (fogMode == D3DFOG_EXP2)
+                    fogFactor *= fogFactor;
+
+                // Provides the rcp.
+                fogFactor = -fogFactor;
+                fogFactor = exp(fogFactor);
+                break;
+        }
+    }
+
+    return fogFactor;
+}
+
+
+float calculatePointSize(vec4 vtx) {
+    float value = vertexHasPointSize() ? in_PointSize : rs.pointSize;
+    uint pointMode = specUint(SpecPointMode);
+    bool isScale = bitfieldExtract(pointMode, 0, 1) != 0;
+    float scaleC = rs.pointScaleC;
+    float scaleB = rs.pointScaleB;
+    float scaleA = rs.pointScaleA;
+
+    vec3 vtx3 = vtx.xyz;
+
+    float DeSqr = dot(vtx3, vtx3);
+    float De    = sqrt(DeSqr);
+    float scaleValue = scaleC * DeSqr;
+    scaleValue = fma(scaleB, De, scaleValue);
+    scaleValue += scaleA;
+    scaleValue = sqrt(scaleValue);
+    scaleValue = value / scaleValue;
+
+    value = isScale ? scaleValue : value;
+
+    float pointSizeMin = rs.pointSizeMin;
+    float pointSizeMax = rs.pointSizeMax;
+
+    return clamp(value, pointSizeMin, pointSizeMax);
+}
+
+
+void emitVsClipping(vec4 vtx) {
+    vec4 worldPos = data.InverseView * vtx;
+
+    // Always consider clip planes enabled when doing GPL by forcing 6 for the quick value.
+    uint clipPlaneCount = specUint(SpecClipPlaneCount);
+
+    // Compute clip distances
+    for (uint i = 0; i < MaxClipPlaneCount; i++) {
+        vec4 clipPlane = clipPlanes[i];
+        float dist = dot(worldPos, clipPlane);
+        bool clipPlaneEnabled = i < clipPlaneCount;
+        float value = clipPlaneEnabled ? dist : 0.0;
+        gl_ClipDistance[i] = value;
+    }
+}
+
+
+vec4 pickMaterialSource(uint source, vec4 material) {
+    if (source == D3DMCS_MATERIAL)
+        return material;
+    else if (source == D3DMCS_COLOR1)
+        return vertexHasColor0() ? in_Color0 : vec4(1.0);
+    else
+        return vertexHasColor1() ? in_Color1 : vec4(0.0);
+}
+
+
+void main() {
+    vec4 vtx = in_Position0;
+    gl_Position = in_Position0;
+    vec3 normal = in_Normal0.xyz;
+
+    if (blendMode() == D3D9FF_VertexBlendMode_Tween) {
+        vec4 vtx1 = in_Position1;
+        vec3 normal1 = in_Normal1.xyz;
+        vtx = mix(vtx, vtx1, data.TweenFactor);
+        normal = mix(normal, normal1, data.TweenFactor);
+    }
+
+    if (!vertexHasPositionT()) {
+        if (blendMode() == D3D9FF_VertexBlendMode_Normal) {
+            float blendWeightRemaining = 1.0;
+            vec4 vtxSum = vec4(0.0);
+            vec3 nrmSum = vec3(0.0);
+
+            for (uint i = 0; i <= vertexBlendCount(); i++) {
+                uint arrayIndex;
+                if (vertexBlendIndexed()) {
+                    arrayIndex = uint(round(in_BlendIndices[i]));
+                } else {
+                    arrayIndex = i;
+                }
+                mat4 worldView = WorldViewArray[arrayIndex];
+
+                mat3 nrmMtx;
+                for (uint j = 0; j < 3; j++) {
+                    nrmMtx[j] = worldView[j].xyz;
+                }
+
+                vec4 vtxResult = vtx * worldView;
+                vec3 nrmResult = normal * nrmMtx;
+
+                float weight;
+                if (i != vertexBlendCount()) {
+                    weight = in_BlendWeight[i];
+                    blendWeightRemaining -= weight;
+                } else {
+                    weight = blendWeightRemaining;
+                }
+
+                vec4 weightVec4 = vec4(weight, weight, weight, weight);
+
+                vtxSum = fma(vtxResult, weightVec4, vtxSum);
+                nrmSum = fma(nrmResult, weightVec4.xyz, nrmSum);
+            }
+
+            vtx = vtxSum;
+            normal = nrmSum;
+        } else {
+            vtx = vtx * data.WorldView;
+
+            mat3 nrmMtx = mat3(data.NormalMatrix);
+
+            normal = nrmMtx * normal;
+        }
+
+        // Some games rely on normals not being normal.
+        if (normalizeNormals()) {
+            bool isZeroNormal = all(equal(normal, vec3(0.0, 0.0, 0.0)));
+            normal = isZeroNormal ? normal : normalize(normal);
+        }
+
+        gl_Position = vtx * data.Projection;
+    } else {
+        gl_Position *= data.ViewportInfo.inverseExtent;
+        gl_Position += data.ViewportInfo.inverseOffset;
+
+        // We still need to account for perspective correction here...
+
+        float w = gl_Position.w;
+        float rhw = w == 0.0 ? 1.0 : 1.0 / w;
+        gl_Position.xyz *= rhw;
+        gl_Position.w = rhw;
+    }
+
+    vec4 outNrm = vec4(normal, 1.0);
+    out_Normal = outNrm;
+
+    vec4 texCoords[TextureStageCount];
+    texCoords[0] = in_Texcoord0;
+    texCoords[1] = in_Texcoord1;
+    texCoords[2] = in_Texcoord2;
+    texCoords[3] = in_Texcoord3;
+    texCoords[4] = in_Texcoord4;
+    texCoords[5] = in_Texcoord5;
+    texCoords[6] = in_Texcoord6;
+    texCoords[7] = in_Texcoord7;
+
+    vec4 transformedTexCoords[TextureStageCount];
+
+    for (uint i = 0; i < TextureStageCount; i++) {
+        // 0b111 = 7
+        uint inputIndex = (texcoordIndices() >> (i * 3)) & 7;
+        uint inputFlags = (texcoordFlags() >> (i * 3)) & 7;
+        uint texcoordCount = (vertexTexcoordDeclMask() >> (inputIndex * 3)) & 7;
+
+        vec4 transformed;
+
+        uint flags = (transformFlags() >> (i * 3)) & 7;
+
+        // Passing 0xffffffff results in it getting clamped to the dimensions of the texture coords and getting treated as PROJECTED
+        // but D3D9 does not apply the transformation matrix.
+        bool applyTransform = flags > D3DTTFF_COUNT1 && flags <= D3DTTFF_COUNT4;
+
+        uint count = min(flags, 4u);
+
+        // A projection component index of 4 means we won't do projection
+        uint projIndex = count != 0 ? count - 1 : 4;
+
+        switch (inputFlags) {
+            default:
+            case (DXVK_TSS_TCI_PASSTHRU >> TCIOffset):
+                transformed = texCoords[inputIndex & 0xFF];
+
+                if (texcoordCount < 4) {
+                    // Vulkan sets the w component to 1.0 if that's not provided by the vertex buffer, D3D9 expects 0 here
+                    transformed.w = 0.0;
+                }
+
+                if (applyTransform && !vertexHasPositionT()) {
+                    /*This doesn't happen every time and I cannot figure out the difference between when it does and doesn't.
+                    Keep it disabled for now, it's more likely that games rely on the zero texcoord than the weird 1 here.
+                    if (texcoordCount <= 1) {
+                      // y gets padded to 1 for some reason
+                      transformed.y = 1.0;
+                    }*/
+
+                    if (texcoordCount >= 1 && texcoordCount < 4) {
+                        // The first component after the last one thats backed by a vertex buffer gets padded to 1 for some reason.
+                        uint idx = texcoordCount;
+                        transformed[idx] = 1.0;
+                    }
+                } else if (texcoordCount != 0 && !applyTransform) {
+                    // COUNT0, COUNT1, COUNT > 4 => take count from vertex decl if that's not zero
+                    count = texcoordCount;
+                }
+
+                projIndex = count != 0 ? count - 1 : 4;
+                break;
+
+            case (DXVK_TSS_TCI_CAMERASPACENORMAL >> TCIOffset):
+                transformed = outNrm;
+                if (!applyTransform) {
+                    count = 3;
+                    projIndex = 4;
+                }
+                break;
+
+            case (DXVK_TSS_TCI_CAMERASPACEPOSITION >> TCIOffset):
+                transformed = vtx;
+                if (!applyTransform) {
+                    count = 3;
+                    projIndex = 4;
+                }
+                break;
+
+            case (DXVK_TSS_TCI_CAMERASPACEREFLECTIONVECTOR >> TCIOffset): {
+                vec3 vtx3 = vtx.xyz;
+                vtx3 = normalize(vtx3);
+
+                vec3 reflection = reflect(vtx3, normal);
+                transformed = vec4(reflection, 1.0);
+                if (!applyTransform) {
+                    count = 3;
+                    projIndex = 4;
+                }
+                break;
+            }
+
+            case (DXVK_TSS_TCI_SPHEREMAP >> TCIOffset): {
+                vec3 vtx3 = vtx.xyz;
+                vtx3 = normalize(vtx3);
+
+                vec3 reflection = reflect(vtx3, normal);
+                float m = length(reflection + vec3(0.0, 0.0, 1.0)) * 2.0;
+
+                transformed = vec4(
+                    reflection.x / m + 0.5,
+                    reflection.y / m + 0.5,
+                    0.0,
+                    1.0
+                );
+                break;
+            }
+        }
+
+        if (applyTransform && !vertexHasPositionT()) {
+            transformed = transformed * data.TexcoordMatrices[i];
+        }
+
+        // TODO: Shouldn't projected be checked per texture stage?
+        if (specUint(SpecSamplerProjected) != 0u && projIndex < 4) {
+            // The projection idx is always based on the flags, even when the input mode is not DXVK_TSS_TCI_PASSTHRU.
+            float projValue = transformed[projIndex];
+
+            // The w component is only used for projection or unused, so always insert the component that's supposed to be divided by there.
+            // The fragment shader will then decide whether to project or not.
+            transformed.w = projValue;
+        }
+
+        // TODO: Shouldn't projected be checked per texture stage?
+        uint totalComponents = (specUint(SpecSamplerProjected) != 0u && projIndex < 4) ? 3 : 4;
+        for (uint j = count; j < totalComponents; j++) {
+            // Discard the components that exceed the specified D3DTTFF_COUNT
+            transformed[j] = 0.0;
+        }
+
+        transformedTexCoords[i] = transformed;
+    }
+
+    out_Texcoord0 = transformedTexCoords[0];
+    out_Texcoord1 = transformedTexCoords[1];
+    out_Texcoord2 = transformedTexCoords[2];
+    out_Texcoord3 = transformedTexCoords[3];
+    out_Texcoord4 = transformedTexCoords[4];
+    out_Texcoord5 = transformedTexCoords[5];
+    out_Texcoord6 = transformedTexCoords[6];
+    out_Texcoord7 = transformedTexCoords[7];
+
+    if (useLighting()) {
+        vec4 diffuseValue = vec4(0.0);
+        vec4 specularValue = vec4(0.0);
+        vec4 ambientValue = vec4(0.0);
+
+        for (uint i = 0; i < lightCount(); i++) {
+            D3D9Light light = data.Lights[i];
+
+            vec4 diffuse = light.Diffuse;
+            vec4 specular = light.Specular;
+            vec4 ambient = light.Ambient;
+            vec3 position = light.Position.xyz;
+            vec3 direction = light.Direction.xyz;
+            uint type = light.Type;
+            float range = light.Range;
+            float falloff = light.Falloff;
+            float atten0 = light.Attenuation0;
+            float atten1 = light.Attenuation1;
+            float atten2 = light.Attenuation2;
+            float theta = light.Theta;
+            float phi = light.Phi;
+
+            bool isSpot = type == D3DLIGHT_SPOT;
+            bool isDirectional = type == D3DLIGHT_DIRECTIONAL;
+
+            bvec3 isDirectional3 = bvec3(isDirectional);
+
+            vec3 vtx3 = vtx.xyz;
+
+            vec3 delta = position - vtx3;
+            float d = length(delta);
+            vec3 hitDir = -direction;
+                 hitDir = mix(delta, hitDir, isDirectional3);
+                 hitDir = normalize(hitDir);
+
+            float atten = fma(d, atten2, atten1);
+                  atten = fma(d, atten, atten0);
+                  atten = 1.0 / atten;
+                  atten = spvNMin(atten, FloatMaxValue);
+
+                  atten = d > range ? 0.0 : atten;
+                  atten = isDirectional ? 1.0 : atten;
+
+            // Spot Lighting
+            {
+                float rho = dot(-hitDir, direction);
+                float spotAtten = rho - phi;
+                      spotAtten = spotAtten / (theta - phi);
+                      spotAtten = pow(spotAtten, falloff);
+
+                bool insideThetaAndPhi = rho <= theta;
+                bool insidePhi = rho > phi;
+                     spotAtten = insidePhi ? spotAtten : 0.0;
+                     spotAtten = insideThetaAndPhi ? spotAtten : 1.0;
+                     spotAtten = clamp(spotAtten, 0.0, 1.0);
+
+                     spotAtten = atten * spotAtten;
+                     atten     = isSpot ? spotAtten : atten;
+            }
+
+            float hitDot = dot(normal, hitDir);
+                  hitDot = clamp(hitDot, 0.0, 1.0);
+
+            float diffuseness = hitDot * atten;
+
+            vec3 mid;
+            if (localViewer()) {
+                mid = normalize(vtx3);
+                mid = hitDir - mid;
+            } else {
+                mid = hitDir - vec3(0.0, 0.0, 1.0);
+            }
+
+            mid = normalize(mid);
+
+            float midDot = dot(normal, mid);
+                  midDot = clamp(midDot, 0.0, 1.0);
+            bool doSpec = midDot > 0.0;
+                 doSpec = doSpec && hitDot > 0.0;
+
+            float specularness = pow(midDot, data.Material.Power);
+                  specularness *= atten;
+                  specularness = doSpec ? specularness : 0.0;
+
+            vec4 lightAmbient  = ambient * atten;
+            vec4 lightDiffuse  = diffuse * diffuseness;
+            vec4 lightSpecular = specular * specularness;
+
+            ambientValue  += lightAmbient;
+            diffuseValue  += lightDiffuse;
+            specularValue += lightSpecular;
+        }
+
+        vec4 matDiffuse  = pickMaterialSource(diffuseSource(), data.Material.Diffuse);
+        vec4 matAmbient  = pickMaterialSource(ambientSource(), data.Material.Ambient);
+        vec4 matEmissive = pickMaterialSource(emissiveSource(), data.Material.Emissive);
+        vec4 matSpecular = pickMaterialSource(specularSource(), data.Material.Specular);
+
+        vec4 finalColor0 = fma(matAmbient, data.GlobalAmbient, matEmissive);
+             finalColor0 = fma(matAmbient, ambientValue, finalColor0);
+             finalColor0 = fma(matDiffuse, diffuseValue, finalColor0);
+             finalColor0.a = matDiffuse.a;
+
+        vec4 finalColor1 = matSpecular * specularValue;
+
+        // Saturate
+        finalColor0 = clamp(finalColor0, vec4(0.0), vec4(1.0));
+
+        finalColor1 = clamp(finalColor1, vec4(0.0), vec4(1.0));
+
+        out_Color0 = finalColor0;
+        out_Color1 = finalColor1;
+    } else {
+        out_Color0 = vertexHasColor0() ? in_Color0 : vec4(1.0);
+        out_Color1 = vertexHasColor1() ? in_Color1 : vec4(0.0);
+    }
+
+    out_Fog = calculateFog(vtx, vec4(0.0));
+
+    gl_PointSize = calculatePointSize(vtx);
+
+    // We statically declare 6 clip planes, so we always need to write values.
+    emitVsClipping(vtx);
+}

--- a/src/dxvk/dxvk_shader_spirv.cpp
+++ b/src/dxvk/dxvk_shader_spirv.cpp
@@ -36,7 +36,9 @@ namespace dxvk {
         info.samplerHeap.getBinding()));
     }
 
-    if (m_debugName.empty())
+    if (!info.debugName.empty())
+      m_debugName = info.debugName;
+    else if (m_debugName.empty())
       m_debugName = std::to_string(getCookie());
 
     m_code = SpirvCompressedBuffer(code);

--- a/src/dxvk/dxvk_shader_spirv.h
+++ b/src/dxvk/dxvk_shader_spirv.h
@@ -24,6 +24,8 @@ namespace dxvk {
     int32_t xfbRasterizedStream = 0;
     /// Tess control patch vertex count
     uint32_t patchVertexCount = 0;
+    /// Manually assigned debug name
+    std::string debugName;
   };
 
 


### PR DESCRIPTION
This creates a single shader that handles the D3D9 fixed function vertex stage and another one that handles the fixed function pixel stage.

This initial PR keeps the old FF code generator around. The ubershaders are enabled by default but can be disabled using `d3d9.ffUbershaderVS=False` and `d3d9.ffUbershaderFS=False` respectively.
The long term plan is to get rid of the FF code generator.

To get performance up to par with the generated shaders (mostly), we have to optimize the fragment shader using spec constants. That works like this:
The D3D9 fixed function pixel pipeline stage consists of 8 texture stages. Each of those has both a color operation with 3 arguments and an alpha operation with 3 arguments. The arguments decide which value to use and the operation decides what to do with it. For good performance we need to turn most of those into specialization constants.
At first this seemed like a huge problem because we also store a bunch of other information for each texture stage like: the texture type, whether it's a depth ("shadow") sampler and whether it's projected. Thankfully we already had spec constants for those because shader model 1 shaders need those three bits of data too. So the first step was to shrink each texture stage by making it reuse the existing spec constants (9bd9cb2bf92201b9232d83f678e868e1da564b0c). Those changes are done for the generated shaders too, so the PR changes those as well.
On top of that we can ignore putting argument 0 into the spec constant because that's only used very rarely. (yes, argument 0 is the rarely used one, not 1 or 2. D3D9...). If a game uses one of the two operations that use argument 0, that will just get loaded from a buffer.
Besides that, the arguments could be repacked into 5 instead of 6 bits because they only contain values from 0 to 7 and 2 flags.
With those changes one texture stage takes up 31 bits. So one uint32_t specialization constant can cover one texture stage.
The DXVK backend is configured to support 12 specialization constants right now and in current master the D3D9 frontend uses 6 of those.
I went with optimizing the first 4 texture stages. This covers almost all draws in the games I've tested.
In Star Wars Republic Commando I saw a 95% rate of draws that only use 4 texture stages and dont use argument 0 for either color or alpha. In UT2004 it was even 99%.
Besides that, I also managed to squeeze in the number of active texture stages into one of the existing spec constant dwords. That allows the shader to optimize away all stages past that.
In most cases this should hopefully yield shaders that are basically what we manually generated before. I looked into a few shaders with RGP captures and this was indeed the case as far as I can tell.

Vertex shaders get no such optimization treatment because games from 2004 only have tiny amounts of geometry anyway.

Performance in Star Wars Republic Commando on the Steam Deck is about 0-10% worse than the generated shaders (difficult to test because the framerate varies a little even on a static scene).
It completely fixes any shader compilation stutter for fixed function shaders so it also makes Unreal Tournament 2004 (and other UE2 games presumably) finally playable. UT2004 in particular has a combinatorics problem with FF vertex shaders on master. The compiled output for fully optimized fragment shaders is practically the same as on master with some very minor exceptions that require the compiler to have better knowledge of the vertex shader (which we don't bother optimizing).

The ubershaders pass all Wine tests that master passes.