### PR TITLE
[d3d9] Preparation for the FF Ubershader

### DIFF
--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -8941,7 +8941,7 @@ namespace dxvk {
 
   void D3D9DeviceEx::UpdatePixelShaderSamplerSpec(uint32_t types, uint32_t projections, uint32_t fetch4) {
     bool dirty  = m_specInfo.set<SpecSamplerType>(types);
-         dirty |= m_specInfo.set<SpecProjectionType>(projections);
+         dirty |= m_specInfo.set<SpecProjected>(projections);
          dirty |= m_specInfo.set<SpecFetch4>(fetch4);
 
     if (dirty)

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -190,6 +190,8 @@ namespace dxvk {
     m_flags.set(D3D9DeviceFlag::DirtyPointScale);
 
     m_flags.set(D3D9DeviceFlag::DirtySpecializationEntries);
+
+    m_specInfo.set<SpecDrefScaling, uint32_t>(m_d3d9Options.drefScaling);
   }
 
 

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -8941,8 +8941,8 @@ namespace dxvk {
 
   void D3D9DeviceEx::UpdatePixelShaderSamplerSpec(uint32_t types, uint32_t projections, uint32_t fetch4) {
     bool dirty  = m_specInfo.set<SpecSamplerType>(types);
-         dirty |= m_specInfo.set<SpecProjected>(projections);
-         dirty |= m_specInfo.set<SpecFetch4>(fetch4);
+         dirty |= m_specInfo.set<SpecSamplerProjected>(projections);
+         dirty |= m_specInfo.set<SpecSamplerFetch4>(fetch4);
 
     if (dirty)
       m_flags.set(D3D9DeviceFlag::DirtySpecializationEntries);
@@ -8952,7 +8952,7 @@ namespace dxvk {
   void D3D9DeviceEx::UpdateCommonSamplerSpec(uint32_t nullMask, uint32_t depthMask, uint32_t drefMask) {
     bool dirty  = m_specInfo.set<SpecSamplerDepthMode>(depthMask);
          dirty |= m_specInfo.set<SpecSamplerNull>(nullMask);
-         dirty |= m_specInfo.set<SpecDrefClamp>(drefMask);
+         dirty |= m_specInfo.set<SpecSamplerDrefClamp>(drefMask);
 
     if (dirty)
       m_flags.set(D3D9DeviceFlag::DirtySpecializationEntries);

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -1479,8 +1479,8 @@ namespace dxvk {
     void UpdateAlphaTestSpec(VkCompareOp alphaOp, uint32_t precision);
     void UpdateVertexBoolSpec(uint32_t value);
     void UpdatePixelBoolSpec(uint32_t value);
-    void UpdatePixelShaderSamplerSpec(uint32_t types, uint32_t projections, uint32_t fetch4);
-    void UpdateCommonSamplerSpec(uint32_t boundMask, uint32_t depthMask, uint32_t drefMask);
+    void UpdatePixelShaderSamplerSpec(uint32_t types, uint32_t fetch4);
+    void UpdateCommonSamplerSpec(uint32_t boundMask, uint32_t depthMask, uint32_t drefMask, uint32_t projections);
     void UpdatePointModeSpec(uint32_t mode);
     void UpdateFogModeSpec(bool fogEnabled, D3DFOGMODE vertexFogMode, D3DFOGMODE pixelFogMode);
 

--- a/src/d3d9/d3d9_fixed_function.cpp
+++ b/src/d3d9/d3d9_fixed_function.cpp
@@ -2594,7 +2594,6 @@ namespace dxvk {
       pDevice->GetOptions());
 
     m_shader = compiler.compile();
-    m_isgn   = compiler.isgn();
 
     Dump(pDevice, Key, name);
 
@@ -2616,7 +2615,6 @@ namespace dxvk {
       pDevice->GetOptions());
 
     m_shader = compiler.compile();
-    m_isgn   = compiler.isgn();
 
     Dump(pDevice, Key, name);
 

--- a/src/d3d9/d3d9_fixed_function.h
+++ b/src/d3d9/d3d9_fixed_function.h
@@ -143,7 +143,7 @@ namespace dxvk {
 
         uint32_t VertexBlendMode    : 2;
         uint32_t VertexBlendIndexed : 1;
-        uint32_t VertexBlendCount   : 3;
+        uint32_t VertexBlendCount   : 2;
 
         uint32_t VertexClipping     : 1;
 

--- a/src/d3d9/d3d9_fixed_function.h
+++ b/src/d3d9/d3d9_fixed_function.h
@@ -50,12 +50,7 @@ namespace dxvk {
 
     bool    invariantPosition;
     bool    forceSampleRateShading;
-    int32_t drefScaling;
   };
-
-  constexpr float GetDrefScaleFactor(int32_t bitDepth) {
-    return 1.0f / (float(1 << bitDepth) - 1.0f);
-  }
 
   constexpr uint32_t GetGlobalSamplerSetIndex() {
     // arbitrary, but must not conflict with bindings

--- a/src/d3d9/d3d9_fixed_function.h
+++ b/src/d3d9/d3d9_fixed_function.h
@@ -114,12 +114,12 @@ namespace dxvk {
       struct {
         uint32_t TexcoordIndices : 24;
 
-        uint32_t HasPositionT : 1;
+        uint32_t VertexHasPositionT : 1;
 
-        uint32_t HasColor0 : 1; // Diffuse
-        uint32_t HasColor1 : 1; // Specular
+        uint32_t VertexHasColor0 : 1; // Diffuse
+        uint32_t VertexHasColor1 : 1; // Specular
 
-        uint32_t HasPointSize : 1;
+        uint32_t VertexHasPointSize : 1;
 
         uint32_t UseLighting : 1;
 
@@ -139,7 +139,7 @@ namespace dxvk {
         uint32_t LightCount : 4;
 
         uint32_t TexcoordDeclMask : 24;
-        uint32_t HasFog : 1;
+        uint32_t VertexHasFog : 1;
 
         uint32_t VertexBlendMode    : 2;
         uint32_t VertexBlendIndexed : 1;

--- a/src/d3d9/d3d9_fixed_function.h
+++ b/src/d3d9/d3d9_fixed_function.h
@@ -254,8 +254,6 @@ namespace dxvk {
 
     Rc<DxvkShader> m_shader;
 
-    DxsoIsgn       m_isgn;
-
   };
 
 

--- a/src/d3d9/d3d9_fixed_function.h
+++ b/src/d3d9/d3d9_fixed_function.h
@@ -146,8 +146,6 @@ namespace dxvk {
         uint32_t VertexBlendCount   : 2;
 
         uint32_t VertexClipping     : 1;
-
-        uint32_t Projected : 8;
       } Contents;
 
       uint32_t Primitive[5];

--- a/src/d3d9/d3d9_spec_constants.h
+++ b/src/d3d9/d3d9_spec_constants.h
@@ -15,7 +15,8 @@ namespace dxvk {
 
     SpecSamplerDepthMode,   // 1 bit for 21 VS + PS samplers  | Bits: 21
     SpecAlphaCompareOp,     // Range: 0 -> 7                  | Bits: 3
-    SpecSamplerProjected,   // 1 bit for 6 PS 1.x samplers    | Bits: 6
+    SpecSamplerProjected,   // 1 bit for 6 PS 1.x samplers    | Bits: 8
+                            // (1 bit for 8 FF texture stages)
 
     SpecSamplerNull,        // 1 bit for 21 samplers          | Bits: 21
     SpecAlphaPrecisionBits, // Range: 0 -> 8 or 0xF           | Bits: 4
@@ -58,7 +59,7 @@ namespace dxvk {
 
       { 1, 0,  21 }, // SamplerDepthMode
       { 1, 21, 3 },  // AlphaCompareOp
-      { 1, 24, 6 },  // SamplerProjected
+      { 1, 24, 8 },  // SamplerProjected
 
       { 2, 0,  21 }, // SamplerNull
       { 2, 21, 4 },  // AlphaPrecisionBits

--- a/src/d3d9/d3d9_spec_constants.h
+++ b/src/d3d9/d3d9_spec_constants.h
@@ -15,7 +15,7 @@ namespace dxvk {
 
     SpecSamplerDepthMode,   // 1 bit for 21 VS + PS samplers  | Bits: 21
     SpecAlphaCompareOp,     // Range: 0 -> 7                  | Bits: 3
-    SpecProjected,          // 1 bit for 6 PS 1.x samplers    | Bits: 6
+    SpecSamplerProjected,   // 1 bit for 6 PS 1.x samplers    | Bits: 6
 
     SpecSamplerNull,        // 1 bit for 21 samplers          | Bits: 21
     SpecAlphaPrecisionBits, // Range: 0 -> 8 or 0xF           | Bits: 4
@@ -26,9 +26,9 @@ namespace dxvk {
     SpecVertexShaderBools,  // 16 bools                       | Bits: 16
     SpecPixelShaderBools,   // 16 bools                       | Bits: 16
 
-    SpecFetch4,             // 1 bit for 16 PS samplers       | Bits: 16
+    SpecSamplerFetch4,      // 1 bit for 16 PS samplers       | Bits: 16
 
-    SpecDrefClamp,          // 1 bit for 21 VS + PS samplers  | Bits: 21
+    SpecSamplerDrefClamp,   // 1 bit for 21 VS + PS samplers  | Bits: 21
     SpecClipPlaneCount,     // 3 bits for 6 clip planes       | Bits : 3
     SpecPointMode,          // Range: 0 -> 3                  | Bits: 2
 
@@ -57,7 +57,7 @@ namespace dxvk {
 
       { 1, 0,  21 }, // SamplerDepthMode
       { 1, 21, 3 },  // AlphaCompareOp
-      { 1, 24, 6 },  // Projected
+      { 1, 24, 6 },  // SamplerProjected
 
       { 2, 0,  21 }, // SamplerNull
       { 2, 21, 4 },  // AlphaPrecisionBits
@@ -68,9 +68,9 @@ namespace dxvk {
       { 3, 0,  16 }, // VertexShaderBools
       { 3, 16, 16 }, // PixelShaderBools
 
-      { 4, 0,  16 }, // Fetch4
+      { 4, 0,  16 }, // SamplerFetch4
 
-      { 5, 0, 21 },  // DrefClamp
+      { 5, 0, 21 },  // SamplerDrefClamp
       { 5, 21, 3 },  // ClipPlaneCount
       { 5, 24, 2 },  // PointMode
     }};

--- a/src/d3d9/d3d9_spec_constants.h
+++ b/src/d3d9/d3d9_spec_constants.h
@@ -31,6 +31,7 @@ namespace dxvk {
     SpecSamplerDrefClamp,   // 1 bit for 21 VS + PS samplers  | Bits: 21
     SpecClipPlaneCount,     // 3 bits for 6 clip planes       | Bits : 3
     SpecPointMode,          // Range: 0 -> 3                  | Bits: 2
+    SpecDrefScaling,        // Range: 0-31 | Bits: 5
 
     SpecConstantCount,
   };
@@ -73,6 +74,7 @@ namespace dxvk {
       { 5, 0, 21 },  // SamplerDrefClamp
       { 5, 21, 3 },  // ClipPlaneCount
       { 5, 24, 2 },  // PointMode
+      { 5, 26, 5 },  // DrefScaling
     }};
 
     template <D3D9SpecConstantId Id, typename T>

--- a/src/d3d9/d3d9_spec_constants.h
+++ b/src/d3d9/d3d9_spec_constants.h
@@ -15,14 +15,13 @@ namespace dxvk {
 
     SpecSamplerDepthMode,   // 1 bit for 21 VS + PS samplers  | Bits: 21
     SpecAlphaCompareOp,     // Range: 0 -> 7                  | Bits: 3
-    SpecPointMode,          // Range: 0 -> 3                  | Bits: 2
-    SpecVertexFogMode,      // Range: 0 -> 3                  | Bits: 2
-    SpecPixelFogMode,       // Range: 0 -> 3                  | Bits: 2
-    SpecFogEnabled,         // Range: 0 -> 1                  | Bits: 1
+    SpecProjected,          // 1 bit for 6 PS 1.x samplers    | Bits: 6
 
     SpecSamplerNull,        // 1 bit for 21 samplers          | Bits: 21
-    SpecProjectionType,     // 1 bit for 6 PS 1.x samplers    | Bits: 6
     SpecAlphaPrecisionBits, // Range: 0 -> 8 or 0xF           | Bits: 4
+    SpecFogEnabled,         // Range: 0 -> 1                  | Bits: 1
+    SpecVertexFogMode,      // Range: 0 -> 3                  | Bits: 2
+    SpecPixelFogMode,       // Range: 0 -> 3                  | Bits: 2
 
     SpecVertexShaderBools,  // 16 bools                       | Bits: 16
     SpecPixelShaderBools,   // 16 bools                       | Bits: 16
@@ -31,6 +30,7 @@ namespace dxvk {
 
     SpecDrefClamp,          // 1 bit for 21 VS + PS samplers  | Bits: 21
     SpecClipPlaneCount,     // 3 bits for 6 clip planes       | Bits : 3
+    SpecPointMode,          // Range: 0 -> 3                  | Bits: 2
 
     SpecConstantCount,
   };
@@ -46,6 +46,7 @@ namespace dxvk {
   };
 
   struct D3D9SpecializationInfo {
+    // Spec const word 0 determines whether the other spec constants are used rather than the spec const UBO
     static constexpr uint32_t MaxSpecDwords = 6;
 
     static constexpr uint32_t MaxUBODwords  = 5;
@@ -56,14 +57,13 @@ namespace dxvk {
 
       { 1, 0,  21 }, // SamplerDepthMode
       { 1, 21, 3 },  // AlphaCompareOp
-      { 1, 24, 2 },  // PointMode
-      { 1, 26, 2 },  // VertexFogMode
-      { 1, 28, 2 },  // PixelFogMode
-      { 1, 30, 1 },  // FogEnabled
+      { 1, 24, 6 },  // Projected
 
       { 2, 0,  21 }, // SamplerNull
-      { 2, 21, 6 },  // ProjectionType
-      { 2, 27, 4 },  // AlphaPrecisionBits
+      { 2, 21, 4 },  // AlphaPrecisionBits
+      { 2, 25, 1 },  // FogEnabled
+      { 2, 26, 2 },  // VertexFogMode
+      { 2, 28, 2 },  // PixelFogMode
 
       { 3, 0,  16 }, // VertexShaderBools
       { 3, 16, 16 }, // PixelShaderBools
@@ -72,6 +72,7 @@ namespace dxvk {
 
       { 5, 0, 21 },  // DrefClamp
       { 5, 21, 3 },  // ClipPlaneCount
+      { 5, 24, 2 },  // PointMode
     }};
 
     template <D3D9SpecConstantId Id, typename T>

--- a/src/dxso/dxso_compiler.cpp
+++ b/src/dxso/dxso_compiler.cpp
@@ -2812,6 +2812,7 @@ void DxsoCompiler::emitControlFlowGenericLoop(
 
       // The projection (/.w) happens before this...
       // Of course it does...
+      // TexBem/TexBemL only exist in PS<=1.3
       texcoordVar.id  = DoProjection(texcoordVar, true);
       auto values     = emitBem(ctx, texcoordVar, n);
       for (uint32_t i = 0; i < 2; i++)
@@ -2912,7 +2913,7 @@ void DxsoCompiler::emitControlFlowGenericLoop(
       }
 
       // We already handled this for TexBem(L)
-      if (m_programInfo.majorVersion() < 2 && samplerType != SamplerTypeTextureCube && opcode != DxsoOpcode::TexBem && opcode != DxsoOpcode::TexBemL) {
+      if (m_programInfo.majorVersion() < 2 && m_programInfo.minorVersion() < 4 && samplerType != SamplerTypeTextureCube && opcode != DxsoOpcode::TexBem && opcode != DxsoOpcode::TexBemL) {
         texcoordVar.id = DoProjection(texcoordVar, true);
       }
 

--- a/src/dxso/dxso_compiler.cpp
+++ b/src/dxso/dxso_compiler.cpp
@@ -2740,7 +2740,7 @@ void DxsoCompiler::emitControlFlowGenericLoop(
       uint32_t projResult = m_module.opVectorTimesScalar(texcoord_t, coord.id, projScalar);
 
       if (switchProjRes) {
-        uint32_t shouldProj = m_spec.get(m_module, m_specUbo, SpecProjected, samplerIdx, 1);
+        uint32_t shouldProj = m_spec.get(m_module, m_specUbo, SpecSamplerProjected, samplerIdx, 1);
         shouldProj = m_module.opINotEqual(bool_t, shouldProj, m_module.constu32(0));
 
         uint32_t bvec4_t = m_module.defVectorType(bool_t, 4);
@@ -2932,7 +2932,7 @@ void DxsoCompiler::emitControlFlowGenericLoop(
         }
 
         // Clamp Dref to [0..1] for D32F emulating UNORM textures 
-        uint32_t clampDref = m_spec.get(m_module, m_specUbo, SpecDrefClamp, samplerIdx, 1);
+        uint32_t clampDref = m_spec.get(m_module, m_specUbo, SpecSamplerDrefClamp, samplerIdx, 1);
         clampDref = m_module.opINotEqual(bool_t, clampDref, m_module.constu32(0));
         uint32_t clampedDref = m_module.opFClamp(fType, reference, m_module.constf32(0.0f), m_module.constf32(1.0f));
         reference = m_module.opSelect(fType, clampDref, clampedDref, reference);
@@ -2940,7 +2940,7 @@ void DxsoCompiler::emitControlFlowGenericLoop(
 
       uint32_t fetch4 = 0;
       if (m_programInfo.type() == DxsoProgramType::PixelShader && samplerType != SamplerTypeTexture3D) {
-        fetch4 = m_spec.get(m_module, m_specUbo, SpecFetch4, samplerIdx, 1);
+        fetch4 = m_spec.get(m_module, m_specUbo, SpecSamplerFetch4, samplerIdx, 1);
 
         fetch4 = m_module.opINotEqual(bool_t, fetch4, m_module.constu32(0));
 

--- a/src/dxso/dxso_compiler.cpp
+++ b/src/dxso/dxso_compiler.cpp
@@ -2740,7 +2740,7 @@ void DxsoCompiler::emitControlFlowGenericLoop(
       uint32_t projResult = m_module.opVectorTimesScalar(texcoord_t, coord.id, projScalar);
 
       if (switchProjRes) {
-        uint32_t shouldProj = m_spec.get(m_module, m_specUbo, SpecProjectionType, samplerIdx, 1);
+        uint32_t shouldProj = m_spec.get(m_module, m_specUbo, SpecProjected, samplerIdx, 1);
         shouldProj = m_module.opINotEqual(bool_t, shouldProj, m_module.constu32(0));
 
         uint32_t bvec4_t = m_module.defVectorType(bool_t, 4);

--- a/src/dxso/dxso_options.cpp
+++ b/src/dxso/dxso_options.cpp
@@ -30,7 +30,6 @@ namespace dxvk {
     robustness2Supported = devFeatures.extRobustness2.robustBufferAccess2;
 
     sincosEmulation     = device->getShaderCompileOptions().flags.test(DxvkShaderCompileFlag::LowerSinCos);
-    drefScaling         = options.drefScaling;
   }
 
 }

--- a/src/dxso/dxso_options.h
+++ b/src/dxso/dxso_options.h
@@ -44,12 +44,6 @@ namespace dxvk {
 
     /// Whether or not we need to use custom sincos
     bool sincosEmulation = false;
-
-    /// Whether runtime to apply Dref scaling for depth textures of specified bit depth
-    /// (24: D24S8, 16: D16, 0: Disabled). This allows compatability with games
-    /// that expect a different depth test range, which was typically a D3D8 quirk on
-    /// early NVIDIA hardware.
-    int32_t drefScaling = 0;
   };
 
 }

--- a/src/dxso/dxso_util.cpp
+++ b/src/dxso/dxso_util.cpp
@@ -5,15 +5,33 @@
 namespace dxvk {
 
   dxvk::mutex                  g_linkerSlotMutex;
-  uint32_t                     g_linkerSlotCount = 0;
-  std::array<DxsoSemantic, 32> g_linkerSlots;
+  uint32_t                     g_linkerSlotCount = 12;
+  std::array<DxsoSemantic, 32> g_linkerSlots = {
+    {
+      {DxsoUsage::Normal,   0},
+      {DxsoUsage::Texcoord,   0},
+      {DxsoUsage::Texcoord,   1},
+      {DxsoUsage::Texcoord,   2},
+      {DxsoUsage::Texcoord,   3},
+      {DxsoUsage::Texcoord,   4},
+      {DxsoUsage::Texcoord,   5},
+      {DxsoUsage::Texcoord,   6},
+      {DxsoUsage::Texcoord,   7},
+
+      {DxsoUsage::Color,      0},
+      {DxsoUsage::Color,      1},
+
+      {DxsoUsage::Fog,        0},
+    }};
+  // We set fixed locations for the outputs that fixed function vertex shaders
+  // can produce so the uber shader doesn't need to be patched at runtime.
 
   uint32_t RegisterLinkerSlot(DxsoSemantic semantic) {
     // Lock, because games could be trying
     // to make multiple shaders at a time.
     std::lock_guard<dxvk::mutex> lock(g_linkerSlotMutex);
 
-    // Need to chose a slot that maps nicely and similarly
+    // Need to choose a slot that maps nicely and similarly
     // between vertex and pixel shaders
 
     // Find or map a slot.


### PR DESCRIPTION
# VS<-> FS linking

DXVK uses a global hashmap that assigns an index to a semantic (Usage + Index). To make the programmable + fixed function combination work, we prepopulate that with the semantics that fixed function actually exports.

Besides that, programmable shaders with shader model <3 also emit all outputs that fixed function fragment shaders might use. This is to avoid requiring shader patching for missing outputs in the backend (and thus breaking GPL) when combining programmable VS + FF ubershader FS.

# Use spec constants instead of FF shader key state

Current master has a bunch of spec constants that are used by SM1 shaders for which we generate different SPIR-V shaders when it comes to fixed function.

We need those spec constants for the ubershaders anyway so the PR also changes the generated FF SPIR-V shaders to use the spec constants instead.

# Small cleanup

Besides that there's some minor cleanup and some naming improvements.