### PR TITLE
[d3d9] Dirty FF shaders when changing texture transform flags

### DIFF
--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -4644,6 +4644,9 @@ namespace dxvk {
           m_textureSlotTracking.projected &= ~(1 << Stage);
           if (Value & D3DTTFF_PROJECTED)
             m_textureSlotTracking.projected |= 1 << Stage;
+
+          m_flags.set(D3D9DeviceFlag::DirtyFFVertexShader);
+          m_flags.set(D3D9DeviceFlag::DirtyFFPixelShader);
           break;
 
         case DXVK_TSS_BUMPENVMAT00:


### PR DESCRIPTION
I mistakenly thought that the dirtying here was just about the projected flag.
That's wrong of course.