### PR TITLE
FF Ubershader hotfix

### DIFF
--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -3921,7 +3921,7 @@ namespace dxvk {
 
       UpdateTextureTypeMismatchesForShader(newShader, newShaderMasks.samplerMask, 0);
 
-      bool dirty = m_specInfo.set<D3D9SpecConstantId::SpecFFTextureStageCount>(0u);
+      bool dirty = m_specInfo.set<D3D9SpecConstantId::SpecFFLastActiveTextureStage>(0u);
       dirty |= m_specInfo.set<D3D9SpecConstantId::SpecFFGlobalSpecularEnabled>(0u);
       constexpr uint32_t perTextureStageSpecConsts = static_cast<uint32_t>(D3D9SpecConstantId::SpecFFTextureStage1ColorOp) - static_cast<uint32_t>(D3D9SpecConstantId::SpecFFTextureStage0ColorOp);
       for (uint32_t i = 0; i < 4; i++) {
@@ -8353,8 +8353,8 @@ namespace dxvk {
 
       // Spec constants...
       uint32_t activeTextureStageCount;
-      for (activeTextureStageCount = 1; activeTextureStageCount <= caps::TextureStageCount; activeTextureStageCount++) {
-        auto& stage = key.Stages[activeTextureStageCount - 1].Contents;
+      for (activeTextureStageCount = 0; activeTextureStageCount < caps::TextureStageCount; activeTextureStageCount++) {
+        auto& stage = key.Stages[activeTextureStageCount].Contents;
         if (stage.ColorOp == D3DTOP_DISABLE)
           break;
       }
@@ -8363,7 +8363,8 @@ namespace dxvk {
         return (arg & 0b111u) | ((arg & 0b110000u) >> 1u);
       };
 
-      bool dirty = m_specInfo.set<D3D9SpecConstantId::SpecFFTextureStageCount>(std::max(activeTextureStageCount, 1u) - 1u /* Subtract 1 to make it fit 3 bits */);
+      uint32_t lastActiveTextureStage = std::max(activeTextureStageCount, 1u) - 1u; // Subtract 1 to make it fit 3 bits
+      bool dirty = m_specInfo.set<D3D9SpecConstantId::SpecFFLastActiveTextureStage>(lastActiveTextureStage);
       dirty |= m_specInfo.set<D3D9SpecConstantId::SpecFFGlobalSpecularEnabled>(key.Stages[0].Contents.GlobalSpecularEnable);
       constexpr uint32_t perTextureStageSpecConsts = static_cast<uint32_t>(D3D9SpecConstantId::SpecFFTextureStage1ColorOp) - static_cast<uint32_t>(D3D9SpecConstantId::SpecFFTextureStage0ColorOp);
       for (uint32_t i = 0; i < 4; i++) {

--- a/src/d3d9/d3d9_spec_constants.h
+++ b/src/d3d9/d3d9_spec_constants.h
@@ -28,7 +28,7 @@ namespace dxvk {
     SpecPixelShaderBools,   // 16 bools                       | Bits: 16
 
     SpecSamplerFetch4,      // 1 bit for 16 PS samplers       | Bits: 16
-    SpecFFTextureStageCount, // Range: 1 -> 8 | Bits: 3
+    SpecFFLastActiveTextureStage, // Range: 1 -> 8            | Bits: 3
 
     SpecSamplerDrefClamp,   // 1 bit for 21 VS + PS samplers  | Bits: 21
     SpecClipPlaneCount,     // 3 bits for 6 clip planes       | Bits : 3
@@ -105,7 +105,7 @@ namespace dxvk {
       { 3, 16, 16 }, // PixelShaderBools
 
       { 4, 0,  16 }, // SamplerFetch4
-      { 4, 16,  3 }, // FFTextureStageCount
+      { 4, 16,  3 }, // FFLastActiveTextureStage
 
       { 5, 0, 21 },  // SamplerDrefClamp
       { 5, 21, 3 },  // ClipPlaneCount

--- a/src/d3d9/shaders/d3d9_fixed_function_common.glsl
+++ b/src/d3d9/shaders/d3d9_fixed_function_common.glsl
@@ -68,7 +68,7 @@ const uint SpecPixelFogMode = 8;
 const uint SpecVertexShaderBools = 9;
 const uint SpecPixelShaderBools = 10;
 const uint SpecSamplerFetch4 = 11;
-const uint SpecFFTextureStageCount = 12;
+const uint SpecFFLastActiveTextureStage = 12;
 const uint SpecSamplerDrefClamp = 13;
 const uint SpecClipPlaneCount = 14;
 const uint SpecPointMode = 15;
@@ -128,7 +128,7 @@ BitfieldPosition SpecConstLayout[SpecConstantCount] = {
     { 3, 16, 16 }, // PixelShaderBools
 
     { 4, 0,  16 }, // SamplerFetch4
-    { 4, 16,  3 }, // FFTextureStageCount
+    { 4, 16,  3 }, // FFLastActiveTextureStage
 
     { 5, 0, 21 },  // SamplerDrefClamp
     { 5, 21, 3 },  // ClipPlaneCount

--- a/src/d3d9/shaders/d3d9_fixed_function_frag.frag
+++ b/src/d3d9/shaders/d3d9_fixed_function_frag.frag
@@ -562,7 +562,7 @@ struct TextureStageState {
 };
 
 TextureStageState runTextureStage(uint stage, TextureStageState state) {
-    if (specUint(SpecFFTextureStageCount) <= stage) {
+    if (stage > specUint(SpecFFLastActiveTextureStage)) {
         return state;
     }
 

--- a/src/d3d9/shaders/d3d9_fixed_function_frag.frag
+++ b/src/d3d9/shaders/d3d9_fixed_function_frag.frag
@@ -386,6 +386,11 @@ TextureStageArgumentValues readArgValues(uint stage, const TextureStageArguments
     return argVals;
 }
 
+uint repackArg(uint arg) {
+    // Move the flags by 1 bit. 0x18 = 0b11000
+    return (arg & ~0x18) | ((arg & 0x18) << 1u);
+}
+
 vec4 complement(vec4 val) {
     return vec4(1.0) - val;
 }
@@ -582,13 +587,13 @@ TextureStageState runTextureStage(uint stage, TextureStageState state) {
 
     const TextureStageArguments colorArgs = {
         usesArg0 ? colorArg0(stage) : D3DTA_CONSTANT,
-        isStageOptimized ? specUint(SpecFFTextureStage0ColorArg1 + PerTextureStageSpecConsts * stage) : colorArg1(stage),
-        isStageOptimized ? specUint(SpecFFTextureStage0ColorArg2 + PerTextureStageSpecConsts * stage) : colorArg2(stage)
+        isStageOptimized ? repackArg(specUint(SpecFFTextureStage0ColorArg1 + PerTextureStageSpecConsts * stage)) : colorArg1(stage),
+        isStageOptimized ? repackArg(specUint(SpecFFTextureStage0ColorArg2 + PerTextureStageSpecConsts * stage)) : colorArg2(stage)
     };
     const TextureStageArguments alphaArgs = {
         usesArg0 ? alphaArg0(stage) : D3DTA_CONSTANT,
-        isStageOptimized ? specUint(SpecFFTextureStage0AlphaArg1 + PerTextureStageSpecConsts * stage) : alphaArg1(stage),
-        isStageOptimized ? specUint(SpecFFTextureStage0AlphaArg2 + PerTextureStageSpecConsts * stage) : alphaArg2(stage)
+        isStageOptimized ? repackArg(specUint(SpecFFTextureStage0AlphaArg1 + PerTextureStageSpecConsts * stage)) : alphaArg1(stage),
+        isStageOptimized ? repackArg(specUint(SpecFFTextureStage0AlphaArg2 + PerTextureStageSpecConsts * stage)) : alphaArg2(stage)
     };
 
     vec4 textureVal = vec4(0.0);


### PR DESCRIPTION
Little mistake that happened when refactoring the way spec constants are accessed in the FF shaders.
I forgot that I repack the texture stage arguments before putting it into the spec constants to save 1 bit each.
This fixes the Sims 2 bug that @Blisto91 found.

The PR also changes the code that is used to count the number of active texture stages to make that less confusing.
