### PR TITLE
Require some extensions and simplify legacy binding model

### DIFF
--- a/VP_DXVK_requirements.json
+++ b/VP_DXVK_requirements.json
@@ -76,6 +76,8 @@
         "dxvk_common_required": {
             "extensions": {
                 "VK_KHR_maintenance5": 1,
+                "VK_KHR_maintenance6": 1,
+                "VK_EXT_depth_clip_enable": 1
             },
             "features": {
                 "VkPhysicalDeviceFeatures": {
@@ -90,6 +92,12 @@
                 },
                 "VkPhysicalDeviceMaintenance5FeaturesKHR": {
                     "maintenance5": true
+                },
+                "VkPhysicalDeviceMaintenance6FeaturesKHR": {
+                    "maintenance6": true
+                },
+                "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+                    "depthClipEnable": true
                 }
             },
             "properties": {
@@ -101,7 +109,6 @@
         "dxvk_common_optional": {
             "extensions": {
                 "VK_KHR_load_store_op_none": 1,
-                "VK_KHR_maintenance6": 1,
                 "VK_KHR_maintenance7": 1,
                 "VK_KHR_present_id": 1,
                 "VK_KHR_present_wait": 1,
@@ -117,9 +124,6 @@
                 "VkPhysicalDeviceVulkan11Features": {
                     "shaderInt16": true,
                     "storagePushConstant16": true
-                },
-                "VkPhysicalDeviceMaintenance6FeaturesKHR": {
-                    "maintenance6": true
                 },
                 "VkPhysicalDeviceMaintenance7FeaturesKHR": {
                     "maintenance7": true
@@ -177,7 +181,6 @@
                 "VK_EXT_memory_priority": 1,
                 "VK_EXT_vertex_attribute_divisor": 1,
                 "VK_EXT_depth_bias_control": 1,
-                "VK_EXT_depth_clip_enable": 1,
                 "VK_EXT_custom_border_color": 1,
                 "VK_EXT_attachment_feedback_loop_layout": 1,
                 "VK_EXT_non_seamless_cube_map": 1
@@ -201,9 +204,6 @@
                     "leastRepresentableValueForceUnormRepresentation": true,
                     "floatRepresentation": true,
                     "depthBiasExact": true
-                },
-                "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
-                    "depthClipEnable": true
                 },
                 "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
                     "customBorderColors": true,
@@ -263,7 +263,6 @@
                 "VK_EXT_vertex_attribute_divisor": 1,
                 "VK_EXT_custom_border_color": 1,
                 "VK_EXT_depth_bias_control": 1,
-                "VK_EXT_depth_clip_enable": 1,
                 "VK_EXT_swapchain_colorspace": 1,
                 "VK_EXT_hdr_metadata": 1
             },
@@ -292,9 +291,6 @@
                     "depthBiasControl": true,
                     "leastRepresentableValueForceUnormRepresentation": true,
                     "depthBiasExact": true
-                },
-                "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
-                    "depthClipEnable": true
                 }
             }
         },

--- a/src/dxbc/dxbc_options.cpp
+++ b/src/dxbc/dxbc_options.cpp
@@ -11,12 +11,7 @@ namespace dxvk {
 
   DxbcOptions::DxbcOptions(const Rc<DxvkDevice>& device, const D3D11Options& options) {
     const Rc<DxvkAdapter> adapter = device->adapter();
-
-    const DxvkDeviceFeatures& devFeatures = device->features();
     const DxvkDeviceInfo& devInfo = device->properties();
-
-    useDepthClipWorkaround
-      = !devFeatures.extDepthClipEnable.depthClipEnable;
 
     VkFormatFeatureFlags2 r32Features
       = device->getFormatFeatures(VK_FORMAT_R32_SFLOAT).optimal

--- a/src/dxvk/dxvk_cmdlist.h
+++ b/src/dxvk/dxvk_cmdlist.h
@@ -1229,15 +1229,8 @@ namespace dxvk {
 
 
     void setDescriptorPool(
-            Rc<DxvkDescriptorPool>        pool,
-            Rc<DxvkDescriptorPoolSet>     manager) {
-      if (m_descriptorPool && m_descriptorPool != pool) {
-        m_descriptorPool->updateStats(m_statCounters);
-        m_descriptorPools.push_back({ std::move(m_descriptorPool), std::move(m_descriptorManager) });
-      }
-
-      m_descriptorPool = std::move(pool);
-      m_descriptorManager = std::move(manager);
+            Rc<DxvkDescriptorPool>        pool) {
+      m_descriptorPool = pool;
     }
 
 
@@ -1280,12 +1273,9 @@ namespace dxvk {
     small_vector<DxvkCommandSubmissionInfo, 4> m_cmdSubmissions;
     small_vector<DxvkSparseBindSubmission, 4>  m_cmdSparseBinds;
     
-    std::vector<std::pair<
-      Rc<DxvkDescriptorPool>,
-      Rc<DxvkDescriptorPoolSet>>> m_descriptorPools;
+    std::vector<Rc<DxvkDescriptorPool>> m_descriptorPools;
 
     Rc<DxvkDescriptorPool>    m_descriptorPool;
-    Rc<DxvkDescriptorPoolSet> m_descriptorManager;
     sync::SyncPoint           m_descriptorSync;
 
     Rc<DxvkResourceDescriptorHeap>  m_descriptorHeap;

--- a/src/dxvk/dxvk_compute.cpp
+++ b/src/dxvk/dxvk_compute.cpp
@@ -111,10 +111,13 @@ namespace dxvk {
     if (m_device->canUseDescriptorBuffer())
       flags.flags |= VK_PIPELINE_CREATE_2_DESCRIPTOR_BUFFER_BIT_EXT;
 
-    VkComputePipelineCreateInfo info = { VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO, &flags };
+    VkComputePipelineCreateInfo info = { VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO };
     info.stage                = *stageInfo.getStageInfos();
     info.layout               = m_layout.getLayout(DxvkPipelineLayoutType::Merged)->getPipelineLayout();
     info.basePipelineIndex    = -1;
+
+    if (flags.flags)
+      flags.pNext = std::exchange(info.pNext, &flags);
 
     VkPipeline pipeline = VK_NULL_HANDLE;
     VkResult vr = vk->vkCreateComputePipelines(vk->device(),

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -7001,15 +7001,9 @@ namespace dxvk {
       m_renderPassBarrierSrc.access |= VK_ACCESS_INDEX_READ_BIT;
 
       m_cmd->track(m_state.vi.indexBuffer.buffer(), DxvkAccess::Read);
-    } else if (m_device->features().khrMaintenance6.maintenance6) {
+    } else {
       // Bind null index buffer to read all zeroes, not too useful but well-defined
       m_cmd->cmdBindIndexBuffer2(VK_NULL_HANDLE, 0, VK_WHOLE_SIZE, m_state.vi.indexType);
-    } else {
-      // Bind dummy buffer that contains all zeroes
-      auto bufferInfo = m_common->dummyResources().bufferInfo();
-
-      m_cmd->cmdBindIndexBuffer2(bufferInfo.buffer,
-        bufferInfo.offset, bufferInfo.size, m_state.vi.indexType);
     }
   }
   

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -28,7 +28,7 @@ namespace dxvk {
 
       m_features.set(DxvkContextFeature::DescriptorBuffer);
     } else {
-      m_descriptorManager = new DxvkDescriptorPoolSet(device.ptr());
+      m_descriptorPool = new DxvkDescriptorPool(device.ptr());
     }
 
     // Init framebuffer info with default render pass in case
@@ -90,8 +90,6 @@ namespace dxvk {
 
     m_implicitResolves.cleanup(m_trackingId);
 
-    this->submitDescriptorPool(false);
-
     if (unlikely(m_features.test(DxvkContextFeature::DebugUtils))) {
       // Make sure to emit the submission reason always at the very end
       if (reason && reason->pLabelName && reason->pLabelName[0])
@@ -104,8 +102,6 @@ namespace dxvk {
 
 
   void DxvkContext::endFrame() {
-    this->submitDescriptorPool(true);
-
     m_renderPassIndex = 0u;
   }
 
@@ -6293,7 +6289,7 @@ namespace dxvk {
       constexpr bool useDescriptorTemplates = env::is32BitHostPlatform();
 
       std::array<VkDescriptorSet, DxvkDescriptorSets::SetCount> sets = { };
-      m_descriptorPool->alloc(pipelineLayout, dirtySetMask, sets.data());
+      m_descriptorPool->alloc(m_trackingId, pipelineLayout, dirtySetMask, sets.data());
 
       uint32_t descriptorCount = 0;
 
@@ -8365,10 +8361,7 @@ namespace dxvk {
     if (m_features.test(DxvkContextFeature::DescriptorBuffer)) {
       m_cmd->setDescriptorHeap(m_descriptorHeap);
     } else {
-      if (!m_descriptorPool)
-        m_descriptorPool = m_descriptorManager->getDescriptorPool();
-
-      m_cmd->setDescriptorPool(m_descriptorPool, m_descriptorManager);
+      m_cmd->setDescriptorPool(m_descriptorPool);
     }
   }
 
@@ -9380,15 +9373,6 @@ namespace dxvk {
   void DxvkContext::endActiveDebugRegions() {
     for (size_t i = 0; i < m_debugLabelStack.size(); i++)
       m_cmd->cmdEndDebugUtilsLabel(DxvkCmdBuffer::ExecBuffer);
-  }
-
-
-  void DxvkContext::submitDescriptorPool(bool endFrame) {
-    // Only relevant for the legacy descriptor model
-    if (m_descriptorPool && m_descriptorPool->shouldSubmit(endFrame)) {
-      m_descriptorPool = m_descriptorManager->getDescriptorPool();
-      m_cmd->setDescriptorPool(m_descriptorPool, m_descriptorManager);
-    }
   }
 
 }

--- a/src/dxvk/dxvk_context.h
+++ b/src/dxvk/dxvk_context.h
@@ -1374,7 +1374,6 @@ namespace dxvk {
     DxvkDescriptorState     m_descriptorState;
 
     Rc<DxvkDescriptorPool>  m_descriptorPool;
-    Rc<DxvkDescriptorPoolSet> m_descriptorManager;
 
     Rc<DxvkResourceDescriptorHeap> m_descriptorHeap;
 
@@ -2180,8 +2179,6 @@ namespace dxvk {
     void beginActiveDebugRegions();
 
     void endActiveDebugRegions();
-
-    void submitDescriptorPool(bool endFrame);
 
     template<VkPipelineBindPoint BindPoint>
     force_inline void trackUniformBufferBinding(const DxvkShaderDescriptor& binding, const DxvkBufferSlice& slice) {

--- a/src/dxvk/dxvk_device.cpp
+++ b/src/dxvk/dxvk_device.cpp
@@ -278,9 +278,12 @@ namespace dxvk {
     if (canUseDescriptorBuffer())
       pipelineFlags.flags |= VK_PIPELINE_CREATE_2_DESCRIPTOR_BUFFER_BIT_EXT;
 
-    VkComputePipelineCreateInfo pipelineInfo = { VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO, &pipelineFlags };
+    VkComputePipelineCreateInfo pipelineInfo = { VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO };
     pipelineInfo.layout = layout->getPipelineLayout();
     pipelineInfo.basePipelineIndex = -1;
+
+    if (pipelineFlags.flags)
+      pipelineFlags.pNext = std::exchange(pipelineInfo.pNext, &pipelineFlags);
 
     VkPipelineShaderStageCreateInfo& stageInfo = pipelineInfo.stage;
     stageInfo = { VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO, &moduleInfo };
@@ -423,12 +426,12 @@ namespace dxvk {
     if (state.depthFormat && (depthFormatInfo->aspectMask & VK_IMAGE_ASPECT_STENCIL_BIT))
       renderingInfo.stencilAttachmentFormat = state.depthFormat;
 
-    VkPipelineCreateFlags2CreateInfo pipelineFlags = { VK_STRUCTURE_TYPE_PIPELINE_CREATE_FLAGS_2_CREATE_INFO, &renderingInfo };
+    VkPipelineCreateFlags2CreateInfo pipelineFlags = { VK_STRUCTURE_TYPE_PIPELINE_CREATE_FLAGS_2_CREATE_INFO };
 
     if (canUseDescriptorBuffer())
       pipelineFlags.flags |= VK_PIPELINE_CREATE_2_DESCRIPTOR_BUFFER_BIT_EXT;
 
-    VkGraphicsPipelineCreateInfo pipelineInfo = { VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO, &pipelineFlags };
+    VkGraphicsPipelineCreateInfo pipelineInfo = { VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO, &renderingInfo };
     pipelineInfo.stageCount = stageInfos.size();
     pipelineInfo.pStages = stageInfos.data();
     pipelineInfo.pVertexInputState = state.viState ? state.viState : &viState;
@@ -441,6 +444,9 @@ namespace dxvk {
     pipelineInfo.pDynamicState = &dyState;
     pipelineInfo.layout = layout->getPipelineLayout();
     pipelineInfo.basePipelineIndex = -1;
+
+    if (pipelineFlags.flags)
+      pipelineFlags.pNext = std::exchange(pipelineInfo.pNext, &pipelineFlags);
 
     VkPipeline pipeline = VK_NULL_HANDLE;
 

--- a/src/dxvk/dxvk_device_info.cpp
+++ b/src/dxvk/dxvk_device_info.cpp
@@ -53,7 +53,6 @@ namespace dxvk {
     HANDLE_EXT(khrSwapchain);                      \
     HANDLE_EXT(khrSwapchainMutableFormat);         \
     HANDLE_EXT(khrWin32KeyedMutex);                \
-    HANDLE_EXT(nvDescriptorPoolOverallocation);    \
     HANDLE_EXT(nvLowLatency2);                     \
     HANDLE_EXT(nvRawAccessChains);                 \
     HANDLE_EXT(nvxBinaryImport);                   \
@@ -488,10 +487,6 @@ namespace dxvk {
     if (m_featuresSupported.extRobustness2.robustImageAccess2)
       m_featuresSupported.vk13.robustImageAccess = VK_FALSE;
 
-    // If descriptor buffers are used, disable legacy descriptor model extensions
-    if (m_featuresSupported.extDescriptorBuffer.descriptorBuffer)
-      m_featuresSupported.nvDescriptorPoolOverallocation.descriptorPoolOverallocation = VK_FALSE;
-
     // Vertex attribute divisor is unusable before spec version 3
     if (m_extensionsSupported.extVertexAttributeDivisor.specVersion < 3u) {
       m_featuresSupported.extVertexAttributeDivisor.vertexAttributeInstanceRateDivisor = VK_FALSE;
@@ -892,9 +887,6 @@ namespace dxvk {
 
       /* Keyed mutex support in wine */
       ENABLE_EXT(khrWin32KeyedMutex, false),
-
-      /* Descriptor pool overallocation, reduces descriptor pool spam in legacy model */
-      ENABLE_EXT_FEATURE(nvDescriptorPoolOverallocation, descriptorPoolOverallocation, false),
 
       /* Reflex support */
       ENABLE_EXT(nvLowLatency2, false),

--- a/src/dxvk/dxvk_device_info.cpp
+++ b/src/dxvk/dxvk_device_info.cpp
@@ -871,7 +871,7 @@ namespace dxvk {
 
       /* Maintenance features, relied on in various parts of the code */
       ENABLE_EXT_FEATURE(khrMaintenance5, maintenance5, true),
-      ENABLE_EXT_FEATURE(khrMaintenance6, maintenance6, false),
+      ENABLE_EXT_FEATURE(khrMaintenance6, maintenance6, true),
       ENABLE_EXT_FEATURE(khrMaintenance7, maintenance7, false),
 
       /* Dependency for graphics pipeline library */

--- a/src/dxvk/dxvk_device_info.cpp
+++ b/src/dxvk/dxvk_device_info.cpp
@@ -508,9 +508,6 @@ namespace dxvk {
     // Sanitize features with other feature dependencies
     if (!m_featuresSupported.core.features.shaderInt16)
       m_featuresSupported.vk11.storagePushConstant16 = VK_FALSE;
-
-    if (!m_featuresSupported.extDepthClipEnable.depthClipEnable)
-      m_featuresSupported.extExtendedDynamicState3.extendedDynamicState3DepthClipEnable = VK_FALSE;
   }
 
 
@@ -791,7 +788,7 @@ namespace dxvk {
       ENABLE_EXT_FEATURE(extCustomBorderColor, customBorderColorWithoutFormat, false),
 
       /* Depth clip matches D3D semantics where depth clamp does not */
-      ENABLE_EXT_FEATURE(extDepthClipEnable, depthClipEnable, false),
+      ENABLE_EXT_FEATURE(extDepthClipEnable, depthClipEnable, true),
 
       /* Controls depth bias behaviour with emulated depth formats */
       ENABLE_EXT_FEATURE(extDepthBiasControl, depthBiasControl, false),

--- a/src/dxvk/dxvk_device_info.h
+++ b/src/dxvk/dxvk_device_info.h
@@ -91,7 +91,6 @@ namespace dxvk {
     VkBool32                                                  khrSwapchain                    = VK_FALSE;
     VkBool32                                                  khrSwapchainMutableFormat       = VK_FALSE;
     VkBool32                                                  khrWin32KeyedMutex              = VK_FALSE;
-    VkPhysicalDeviceDescriptorPoolOverallocationFeaturesNV    nvDescriptorPoolOverallocation  = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_POOL_OVERALLOCATION_FEATURES_NV };
     VkBool32                                                  nvLowLatency2                   = VK_FALSE;
     VkPhysicalDeviceRawAccessChainsFeaturesNV                 nvRawAccessChains               = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAW_ACCESS_CHAINS_FEATURES_NV };
     VkBool32                                                  nvxBinaryImport                 = VK_FALSE;
@@ -149,7 +148,6 @@ namespace dxvk {
     VkExtensionProperties khrSwapchain                      = vk::makeExtension(VK_KHR_SWAPCHAIN_EXTENSION_NAME);
     VkExtensionProperties khrSwapchainMutableFormat         = vk::makeExtension(VK_KHR_SWAPCHAIN_MUTABLE_FORMAT_EXTENSION_NAME);
     VkExtensionProperties khrWin32KeyedMutex                = vk::makeExtension(VK_KHR_WIN32_KEYED_MUTEX_EXTENSION_NAME);
-    VkExtensionProperties nvDescriptorPoolOverallocation    = vk::makeExtension(VK_NV_DESCRIPTOR_POOL_OVERALLOCATION_EXTENSION_NAME);
     VkExtensionProperties nvLowLatency2                     = vk::makeExtension(VK_NV_LOW_LATENCY_2_EXTENSION_NAME);
     VkExtensionProperties nvRawAccessChains                 = vk::makeExtension(VK_NV_RAW_ACCESS_CHAINS_EXTENSION_NAME);
     VkExtensionProperties nvxBinaryImport                   = vk::makeExtension(VK_NVX_BINARY_IMPORT_EXTENSION_NAME);

--- a/src/dxvk/dxvk_graphics.cpp
+++ b/src/dxvk/dxvk_graphics.cpp
@@ -566,14 +566,10 @@ namespace dxvk {
       rsInfo.rasterizerDiscardEnable = VK_TRUE;
     }
 
-    // Set up depth clip state. If the extension is not supported,
-    // use depth clamp instead, even though this is not accurate.
-    if (device->features().extDepthClipEnable.depthClipEnable) {
-      rsDepthClipInfo.pNext = std::exchange(rsInfo.pNext, &rsDepthClipInfo);
-      rsDepthClipInfo.depthClipEnable = state.rs.depthClipEnable();
-    } else {
-      rsInfo.depthClampEnable = !state.rs.depthClipEnable();
-    }
+    // Set up depth clip state. Require depth clip support,
+    // this is *not* equivalent to disabling depth clamp.
+    rsDepthClipInfo.pNext = std::exchange(rsInfo.pNext, &rsDepthClipInfo);
+    rsDepthClipInfo.depthClipEnable = state.rs.depthClipEnable();
 
     // Set up conservative rasterization if requested by the application.
     if (state.rs.conservativeMode() != VK_CONSERVATIVE_RASTERIZATION_MODE_DISABLED_EXT) {

--- a/src/dxvk/dxvk_graphics.cpp
+++ b/src/dxvk/dxvk_graphics.cpp
@@ -1345,13 +1345,16 @@ namespace dxvk {
     if (m_device->canUseDescriptorBuffer())
       flags.flags |= VK_PIPELINE_CREATE_2_DESCRIPTOR_BUFFER_BIT_EXT;
 
-    VkPipelineLibraryCreateInfoKHR libInfo = { VK_STRUCTURE_TYPE_PIPELINE_LIBRARY_CREATE_INFO_KHR, &flags };
+    VkPipelineLibraryCreateInfoKHR libInfo = { VK_STRUCTURE_TYPE_PIPELINE_LIBRARY_CREATE_INFO_KHR };
     libInfo.libraryCount    = libraries.size();
     libInfo.pLibraries      = libraries.data();
 
     VkGraphicsPipelineCreateInfo info = { VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO, &libInfo };
     info.layout             = m_layout.getLayout(DxvkPipelineLayoutType::Independent)->getPipelineLayout();
     info.basePipelineIndex  = -1;
+
+    if (flags.flags)
+      flags.pNext = std::exchange(info.pNext, &flags);
 
     VkPipeline pipeline = VK_NULL_HANDLE;
     VkResult vr = vk->vkCreateGraphicsPipelines(vk->device(), VK_NULL_HANDLE, 1, &info, nullptr, &pipeline);
@@ -1402,7 +1405,7 @@ namespace dxvk {
     if (m_shaders.fs != nullptr)
       stageInfo.addStage(VK_SHADER_STAGE_FRAGMENT_BIT, getShaderCode(*m_shaders.fs, key.shState.fsInfo), &key.scState.scInfo);
 
-    VkPipelineCreateFlags2CreateInfo flags = { VK_STRUCTURE_TYPE_PIPELINE_CREATE_FLAGS_2_CREATE_INFO, &key.foState.rtInfo };
+    VkPipelineCreateFlags2CreateInfo flags = { VK_STRUCTURE_TYPE_PIPELINE_CREATE_FLAGS_2_CREATE_INFO };
 
     if (key.foState.feedbackLoop & VK_IMAGE_ASPECT_COLOR_BIT)
       flags.flags |= VK_PIPELINE_CREATE_2_COLOR_ATTACHMENT_FEEDBACK_LOOP_BIT_EXT;
@@ -1413,7 +1416,7 @@ namespace dxvk {
     if (m_device->canUseDescriptorBuffer())
       flags.flags |= VK_PIPELINE_CREATE_2_DESCRIPTOR_BUFFER_BIT_EXT;
 
-    VkGraphicsPipelineCreateInfo info = { VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO, &flags };
+    VkGraphicsPipelineCreateInfo info = { VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO, &key.foState.rtInfo };
     info.stageCount               = stageInfo.getStageCount();
     info.pStages                  = stageInfo.getStageInfos();
     info.pVertexInputState        = &key.viState.viInfo;
@@ -1430,6 +1433,9 @@ namespace dxvk {
     
     if (!key.prState.tsInfo.patchControlPoints)
       info.pTessellationState = nullptr;
+
+    if (flags.flags)
+      flags.pNext = std::exchange(info.pNext, &flags);
     
     VkPipeline pipeline = VK_NULL_HANDLE;
     VkResult vr = vk->vkCreateGraphicsPipelines(vk->device(), VK_NULL_HANDLE, 1, &info, nullptr, &pipeline);

--- a/src/dxvk/dxvk_shader.cpp
+++ b/src/dxvk/dxvk_shader.cpp
@@ -391,14 +391,10 @@ namespace dxvk {
     rsInfo.polygonMode        = VK_POLYGON_MODE_FILL;
     rsInfo.lineWidth          = 1.0f;
 
-    if (m_device->features().extDepthClipEnable.depthClipEnable) {
-      // Only use the fixed depth clip state if we can't make it dynamic
-      if (!m_device->features().extExtendedDynamicState3.extendedDynamicState3DepthClipEnable) {
-        rsDepthClipInfo.pNext = std::exchange(rsInfo.pNext, &rsDepthClipInfo);
-        rsDepthClipInfo.depthClipEnable = VK_TRUE;
-      }
-    } else {
-      rsInfo.depthClampEnable = VK_FALSE;
+    // Only use the fixed depth clip state if we can't make it dynamic
+    if (!m_device->features().extExtendedDynamicState3.extendedDynamicState3DepthClipEnable) {
+      rsDepthClipInfo.pNext = std::exchange(rsInfo.pNext, &rsDepthClipInfo);
+      rsDepthClipInfo.depthClipEnable = VK_TRUE;
     }
 
     // Only the view mask is used as input, and since we do not use MultiView, it is always 0

--- a/src/dxvk/dxvk_shader.cpp
+++ b/src/dxvk/dxvk_shader.cpp
@@ -537,10 +537,13 @@ namespace dxvk {
     if (m_device->canUseDescriptorBuffer())
       flagsInfo.flags |= VK_PIPELINE_CREATE_2_DESCRIPTOR_BUFFER_BIT_EXT;
 
-    VkComputePipelineCreateInfo info = { VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO, &flagsInfo };
+    VkComputePipelineCreateInfo info = { VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO };
     info.stage        = *stageInfo.getStageInfos();
     info.layout       = m_layout->getLayout(DxvkPipelineLayoutType::Merged)->getPipelineLayout();
     info.basePipelineIndex = -1;
+
+    if (flagsInfo.flags)
+      flagsInfo.pNext = std::exchange(info.pNext, &flagsInfo);
 
     VkPipeline pipeline = VK_NULL_HANDLE;
     VkResult vr = vk->vkCreateComputePipelines(vk->device(), VK_NULL_HANDLE, 1, &info, nullptr, &pipeline);

--- a/src/dxvk/hud/dxvk_hud_item.cpp
+++ b/src/dxvk/hud/dxvk_hud_item.cpp
@@ -748,17 +748,23 @@ namespace dxvk::hud {
       m_copyThreadLoad = uint32_t(double(100.0 * (busyTicks - m_copyThreadBusyTicks)) / ticks);
       m_copyThreadBusyTicks = busyTicks;
 
+      m_descriptorSetCountDisplay = m_descriptorSetCountMax;
+      m_descriptorSetCountMax = 0u;
+
       m_descriptorHeapUsed = m_descriptorHeapMax;
       m_descriptorHeapMax = 0u;
 
       m_lastUpdate = time;
     }
 
+    auto descriptorSetCount  = counters.getCtr(DxvkStatCounter::DescriptorSetCount);
     m_descriptorPoolCount = counters.getCtr(DxvkStatCounter::DescriptorPoolCount);
-    m_descriptorSetCount  = counters.getCtr(DxvkStatCounter::DescriptorSetCount);
 
     m_descriptorHeapCount = counters.getCtr(DxvkStatCounter::DescriptorHeapCount);
     m_descriptorHeapAlloc = counters.getCtr(DxvkStatCounter::DescriptorHeapSize);
+
+    m_descriptorSetCountMax = std::max(m_descriptorSetCountMax, descriptorSetCount - m_descriptorSetCount);
+    m_descriptorSetCount = descriptorSetCount;
 
     auto descriptorHeapUsed = counters.getCtr(DxvkStatCounter::DescriptorHeapUsed);
     m_descriptorHeapMax = std::max(descriptorHeapUsed - m_descriptorHeapPrev, m_descriptorHeapMax);
@@ -779,7 +785,7 @@ namespace dxvk::hud {
 
       position.y += 20;
       renderer.drawText(16, position, 0xff8040ff, "Descriptor sets:");
-      renderer.drawText(16, { position.x + 216, position.y }, 0xffffffffu, str::format(m_descriptorSetCount));
+      renderer.drawText(16, { position.x + 216, position.y }, 0xffffffffu, str::format(m_descriptorSetCountDisplay));
     }
 
     if (m_descriptorHeapAlloc) {

--- a/src/dxvk/hud/dxvk_hud_item.h
+++ b/src/dxvk/hud/dxvk_hud_item.h
@@ -484,7 +484,9 @@ namespace dxvk::hud {
     Rc<DxvkDevice> m_device;
 
     uint64_t m_descriptorPoolCount = 0;
-    uint64_t m_descriptorSetCount  = 0;
+    uint64_t m_descriptorSetCount = 0;
+    uint64_t m_descriptorSetCountDisplay = 0;
+    uint64_t m_descriptorSetCountMax = 0;
 
     uint64_t m_descriptorHeapCount = 0;
     uint64_t m_descriptorHeapAlloc = 0;


### PR DESCRIPTION
TL;DR `maintenance6` and `depthClipEnable` features are now a hard requirement; everything that can even remotely run D3D content should already support the latter anyway, and dxbc-spirv no longer implements any of the ancient and untested workarounds to deal with the feature not being present.

This also greatly simplifies the legacy descriptor set allocation and turns `VkDescriptorPool` objects into linear allocators that are swapped and reset every couple of frames; reasoning being here that the old code was incredibly hard to reason about *and* problematic with tooling, validation layers frequently got confused because we'd reuse descriptor sets without resetting the pool first, etc.

This **will** come at the cost of some CPU performance, but all relevant Linux drivers have `VK_EXT_descriptor_buffer` enabled anyway which isn't affected.

Needs some testing with descriptor_buffer explicitly disabled.