### PR TITLE
[d3d9] Advertise multisample NULL format checks

### DIFF
--- a/src/d3d8/d3d8_device.cpp
+++ b/src/d3d8/d3d8_device.cpp
@@ -47,7 +47,7 @@ namespace dxvk {
     , m_behaviorFlags(BehaviorFlags)
     , m_multithread(BehaviorFlags & D3DCREATE_MULTITHREADED) {
     // Get the bridge interface to D3D9.
-    if (FAILED(GetD3D9()->QueryInterface(__uuidof(IDxvkD3D8Bridge), reinterpret_cast<void**>(&m_bridge)))) {
+    if (unlikely(FAILED(GetD3D9()->QueryInterface(__uuidof(IDxvkD3D8Bridge), reinterpret_cast<void**>(&m_bridge))))) {
       throw DxvkError("D3D8Device: ERROR! Failed to get D3D9 Bridge. d3d9.dll might not be DXVK!");
     }
 

--- a/src/d3d8/d3d8_main.cpp
+++ b/src/d3d8/d3d8_main.cpp
@@ -8,7 +8,14 @@ namespace dxvk {
     if (!ppDirect3D8)
       return D3DERR_INVALIDCALL;
 
-    *ppDirect3D8 = ref(new D3D8Interface());
+    try {
+      *ppDirect3D8 = ref(new D3D8Interface());
+    } catch (const DxvkError& e) {
+      Logger::err(e.message());
+      *ppDirect3D8 = nullptr;
+      return D3DERR_NOTAVAILABLE;
+    }
+
     return D3D_OK;
   }
 

--- a/src/d3d9/d3d9_adapter.cpp
+++ b/src/d3d9/d3d9_adapter.cpp
@@ -254,8 +254,7 @@ namespace dxvk {
       return D3DERR_NOTAVAILABLE;
 
     if (MultiSampleType != D3DMULTISAMPLE_NONE
-     && (SurfaceFormat == D3D9Format::NULL_FORMAT
-      || SurfaceFormat == D3D9Format::D16_LOCKABLE
+     && (SurfaceFormat == D3D9Format::D16_LOCKABLE
       || SurfaceFormat == D3D9Format::D32F_LOCKABLE
       || SurfaceFormat == D3D9Format::D32_LOCKABLE
       || SurfaceFormat == D3D9Format::INTZ

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -405,8 +405,7 @@ namespace dxvk {
         inputWidth * HardwareCursorFormatSize);
       const size_t copyHeight = std::min<size_t>(
         HardwareCursorHeight,
-        inputHeight
-      );
+        inputHeight);
 
       // Windows works with a stride of 128, let's respect that.
       for (uint32_t h = 0; h < copyHeight; h++)


### PR DESCRIPTION
Note to self: don't validate vendor hack tests on ancient cards that don't actually support those vendor hacks. Looks like modern cards expose all supported sample counts with NULL format as well.