### PR TITLE
[d3d9] Fast skip DrawIndexedPrimitive(UP) calls with 0 NumVertices

### DIFF
--- a/src/d3d9/d3d9_caps.h
+++ b/src/d3d9/d3d9_caps.h
@@ -27,7 +27,7 @@ namespace dxvk::caps {
 
   constexpr uint32_t MaxTransforms                = 10 + 256;
 
-  constexpr uint32_t TextureStageCount           = MaxSimultaneousTextures;
+  constexpr uint32_t TextureStageCount            = MaxSimultaneousTextures;
 
   constexpr uint32_t MaxEnabledLights             = 8;
 

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -3019,7 +3019,7 @@ namespace dxvk {
       return D3DERR_INVALIDCALL;
 
     if (unlikely(!PrimitiveCount))
-      return S_OK;
+      return D3D_OK;
 
     bool dynamicSysmemVBOs;
     uint32_t firstIndex     = 0;
@@ -3071,8 +3071,8 @@ namespace dxvk {
     if (unlikely(m_state.vertexDecl == nullptr))
       return D3DERR_INVALIDCALL;
 
-    if (unlikely(!PrimitiveCount))
-      return S_OK;
+    if (unlikely(!PrimitiveCount || !NumVertices))
+      return D3D_OK;
 
     bool dynamicSysmemVBOs;
     bool dynamicSysmemIBO;
@@ -3120,11 +3120,14 @@ namespace dxvk {
           UINT             VertexStreamZeroStride) {
     D3D9DeviceLock lock = LockDevice();
 
+    if (unlikely(!VertexStreamZeroStride))
+      return D3DERR_INVALIDCALL;
+
     if (unlikely(m_state.vertexDecl == nullptr))
       return D3DERR_INVALIDCALL;
 
     if (unlikely(!PrimitiveCount))
-      return S_OK;
+      return D3D_OK;
 
     PrepareDraw(PrimitiveType, false, false);
 
@@ -3173,11 +3176,14 @@ namespace dxvk {
           UINT             VertexStreamZeroStride) {
     D3D9DeviceLock lock = LockDevice();
 
+    if (unlikely(!VertexStreamZeroStride))
+      return D3DERR_INVALIDCALL;
+
     if (unlikely(m_state.vertexDecl == nullptr))
       return D3DERR_INVALIDCALL;
 
-    if (unlikely(!PrimitiveCount))
-      return S_OK;
+    if (unlikely(!PrimitiveCount || !NumVertices))
+      return D3D_OK;
 
     PrepareDraw(PrimitiveType, false, false);
 
@@ -3261,7 +3267,7 @@ namespace dxvk {
       return D3D_OK;
     }
 
-    if (!VertexCount)
+    if (unlikely(!VertexCount))
       return D3D_OK;
 
     D3D9CommonBuffer* dst  = static_cast<D3D9VertexBuffer*>(pDestBuffer)->GetCommonBuffer();
@@ -3452,8 +3458,8 @@ namespace dxvk {
 
     InitReturnPtr(ppDecl);
 
-    if (ppDecl == nullptr)
-      return D3D_OK;
+    if (unlikely(ppDecl == nullptr))
+      return D3DERR_INVALIDCALL;
 
     if (m_state.vertexDecl == nullptr)
       return D3D_OK;
@@ -3488,7 +3494,7 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE D3D9DeviceEx::GetFVF(DWORD* pFVF) {
     D3D9DeviceLock lock = LockDevice();
 
-    if (pFVF == nullptr)
+    if (unlikely(pFVF == nullptr))
       return D3DERR_INVALIDCALL;
 
     *pFVF = m_state.vertexDecl != nullptr


### PR DESCRIPTION
Should fix #4803. @CookiePLMonster If you happen to still have that broken patch version around, would appreciate if you can confirm things work and look fine with this PR.

Native d3d9, unfortunately, does not validate either NumVertices, nor PrimitiveCount in any way, however it does appear to take into account the NumVertices value to fast skip calls.

Based on observed behavior on Windows XP:
`DrawPrimitive(D3DPT_TRIANGLELIST, 0, 8388608);` -> hard locks the OS
`DrawIndexedPrimitive(D3DPT_TRIANGLELIST, 0, 0, 5000, 0, 8388608);` -> hard locks the OS and crashes the GPU
`DrawIndexedPrimitive(D3DPT_TRIANGLELIST, 0, 0, 8, 0, 8388608);` -> works just fine (with the same valid index/vertex buffers)
`DrawIndexedPrimitive(D3DPT_TRIANGLELIST, 0, 0, 0, 0, 8388608);` -> also works just fine and returns immediately