### PR TITLE
[d3d9] Don't hold adapter pointer in format table

### DIFF
--- a/src/d3d9/d3d9_format.cpp
+++ b/src/d3d9/d3d9_format.cpp
@@ -478,9 +478,10 @@ namespace dxvk {
             D3D9Adapter*     pParent,
       const Rc<DxvkAdapter>& adapter,
       const D3D9Options&     options)
-    : m_parent (pParent) {
+    : m_isExtended (pParent->IsExtended()),
+      m_isD3D8Compatible (pParent->IsD3D8Compatible()) {
 
-    const uint32_t vendorId = m_parent->GetVendorId();
+    const uint32_t vendorId = pParent->GetVendorId();
     const bool     isNvidia = vendorId == uint32_t(DxvkGpuVendor::Nvidia);
     const bool     isAmd    = vendorId == uint32_t(DxvkGpuVendor::Amd);
     const bool     isIntel  = vendorId == uint32_t(DxvkGpuVendor::Intel);
@@ -528,7 +529,7 @@ namespace dxvk {
       return D3D9_VK_FORMAT_MAPPING();
 
     // W11V11U10 is only supported by d3d8
-    if (Format == D3D9Format::W11V11U10 && !m_parent->IsD3D8Compatible())
+    if (Format == D3D9Format::W11V11U10 && !m_isD3D8Compatible)
       return D3D9_VK_FORMAT_MAPPING();
 
     if (Format == D3D9Format::D16_LOCKABLE && !m_d16lockableSupport)
@@ -617,14 +618,14 @@ namespace dxvk {
 
       // only considered on d3d9Ex interfaces
       case D3D9Format::D32_LOCKABLE:
-        if (m_parent->IsExtended())
+        if (m_isExtended)
           return &d32_lockable;
 
         [[fallthrough]];
 
       // only considered on d3d9Ex interfaces
       case D3D9Format::S8_LOCKABLE:
-        if (m_parent->IsExtended())
+        if (m_isExtended)
           return &s8_lockable;
 
         [[fallthrough]];

--- a/src/d3d9/d3d9_format.h
+++ b/src/d3d9/d3d9_format.h
@@ -229,7 +229,8 @@ namespace dxvk {
             VkFormat              Format,
             VkFormatFeatureFlags2 Features) const;
 
-    D3D9Adapter* m_parent = nullptr;
+    bool m_isExtended;
+    bool m_isD3D8Compatible;
 
     bool m_d24s8Support;
     bool m_d16s8Support;


### PR DESCRIPTION
Fixes a crash when launching Max Payne 1 on systems with more than 1 monitor.

The only reason this hasn't been a widespread problem is that we only check `IsExtended()` and `IsD3D8Compatible()` for a handful of formats. `W11V11U10`, `D32_LOCKABLE` and `S8_LOCKABLE`. On top of that you needed more than 1 monitor for it to become a problem.

The adapter owns the format table and right now the format table holds a reference to the adapter.
That's problematic when the adapter is inside a `std::vector`.

I could've also reserved enough space in the vector upfront like the non `m_d3d9Options.enumerateByDisplays` path does or turned it into a vector of `std::unique_ptr`s but I think storing those two bools is the simplest solution.