### PR TITLE
[util] Disable direct buffer mapping for Lego Racers 2

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -1323,6 +1323,11 @@ namespace dxvk {
     { R"(\\LEGO Racers 2\.exe$)", {{
       { "d3d9.allowDirectBufferMapping",   "False" },
     }} },
+    /* Smash Up Derby - Poor performance on Intel *
+     * due to queue syncs on certain race tracks  */
+    { R"(\\Smash up Derby\\cars\.exe$)", {{
+      { "d3d9.allowDirectBufferMapping",   "False" },
+    }} },
   };
 
 

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -1318,6 +1318,11 @@ namespace dxvk {
     { R"(\\TopSpin\.exe$)", {{
       { "d3d8.forceLegacyDiscard",          "True" },
     }} },
+    /* Lego Racers 2 - Hits an incredible amount  *
+     * of queue syncs with direct buffer mapping  */
+    { R"(\\LEGO Racers 2\.exe$)", {{
+      { "d3d9.allowDirectBufferMapping",   "False" },
+    }} },
   };
 
 


### PR DESCRIPTION
Should fix #5235 based on my testing.