### PR TITLE
[util] Splinter a Steam profile for Pandora Tomorrow

### DIFF
--- a/src/d3d8/d3d8_state_block.h
+++ b/src/d3d8/d3d8_state_block.h
@@ -44,7 +44,7 @@ namespace dxvk {
   struct D3D8CapturableState {
     std::array<D3D8VBOP, d8caps::MAX_STREAMS>                      streams;
     std::array<IDirect3DBaseTexture8*, d8caps::MAX_TEXTURE_STAGES> textures;
-    
+
     IDirect3DIndexBuffer8* indices = nullptr;
     UINT  baseVertexIndex    = 0;
     DWORD vertexShaderHandle = 0;

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -1252,11 +1252,17 @@ namespace dxvk {
     { R"(\\fifa2003(demo)?\.exe$)", {{
       { "d3d9.cachedDynamicBuffers",        "True" },
     }} },
-    /* Splinter Cell: Pandora Tomorrow            *
-     * Broken inputs and physics above 60 FPS     */
-    { R"(\\SplinterCell2\.exe$)", {{
+    /* Splinter Cell: Pandora Tomorrow (Retail)   *
+     * Missing shadows without dref scaling and   *
+     * broken inputs and physics above 60 FPS     */
+    { R"(\\offline\\system\\SplinterCell2\.exe$)", {{
       { "d3d9.maxFrameRate",                  "60" },
       { "d3d8.scaleDref",                     "24" },
+    }} },
+    /* Splinter Cell: Pandora Tomorrow (Steam)    *
+     * Broken inputs and physics above 60 FPS     */
+    { R"(\\Splinter Cell Pandora Tomorrow\\system\\SplinterCell2\.exe$)", {{
+      { "d3d9.maxFrameRate",                  "60" },
     }} },
     /* Chrome: Gold Edition                       *
      * Broken character model motion at high FPS  */


### PR DESCRIPTION
Long story short, the Steam release of Splinter Cell: Pandora Tomorrow has fixed shadows and is broken by our dref scaling fix-up, so we need to work around that and only keep it for retail copies. Luckily, the folder structure is slightly different between the two.