### PR TITLE
[util] Disable counting losables for Core Awaken 2.5

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -1120,9 +1120,10 @@ namespace dxvk {
     { R"(\\Blitzkrieg 2( - Fall of the Reich| - Liberation)?\\bin\\game\.exe$)", {{
       { "d3d9.memoryTrackTest",             "True" },
     }} },
-    /* Core Awaken ~Jilelen and LittleSnow~       *
-     * Freezes on boot                            */
-    { R"(\\BioDungeon\.exe$)", {{
+    /* Core Awaken series (Jilelen and LittleSnow/The Yuka) & *
+     * Mine Dungeon 2 ~Rurumu's trip~                         *
+     * Freezes on boot                                        */
+    { R"(\\(BioDungeon|BioLab2|MineDungeon2)\.exe$)", {{
       { "d3d9.countLosableResources",      "False" },
     }} },
 


### PR DESCRIPTION
Core Awaken 2.5 (\~Jilelen and crimson dungeon\~) freeze on boot with couting losables enabled. This patch overrides the default configuration to disable it.
This patch has been tested on Wine 10.7(Alpine 3.22.2) with latest master dxvk