### PR TITLE
[d3d9] FF Ubershader: Apply SELECTMASK when checking for texture usage

### DIFF
--- a/src/d3d9/shaders/d3d9_fixed_function_frag.frag
+++ b/src/d3d9/shaders/d3d9_fixed_function_frag.frag
@@ -597,12 +597,12 @@ TextureStageState runTextureStage(uint stage, TextureStageState state) {
     };
 
     vec4 textureVal = vec4(0.0);
-    bool usesTexture = colorArgs.arg0 == D3DTA_TEXTURE
-        || colorArgs.arg1 == D3DTA_TEXTURE
-        || colorArgs.arg2 == D3DTA_TEXTURE
-        || alphaArgs.arg0 == D3DTA_TEXTURE
-        || alphaArgs.arg1 == D3DTA_TEXTURE
-        || alphaArgs.arg2 == D3DTA_TEXTURE;
+    bool usesTexture = (colorArgs.arg0 & D3DTA_SELECTMASK) == D3DTA_TEXTURE
+        || (colorArgs.arg1 & D3DTA_SELECTMASK) == D3DTA_TEXTURE
+        || (colorArgs.arg2 & D3DTA_SELECTMASK) == D3DTA_TEXTURE
+        || (alphaArgs.arg0 & D3DTA_SELECTMASK) == D3DTA_TEXTURE
+        || (alphaArgs.arg1 & D3DTA_SELECTMASK) == D3DTA_TEXTURE
+        || (alphaArgs.arg2 & D3DTA_SELECTMASK) == D3DTA_TEXTURE;
 
     if (usesTexture) {
         // We need to replace TEXCOORD inputs with gl_PointCoord


### PR DESCRIPTION
Fixes the shadows in Halo CE when using the fixed function ubershader. (Part of #5291)

The arguments contain flags in the two MSBs.