### PR TITLE
[build] Build meta shaders with debug information in debug builds

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -194,6 +194,9 @@ glsl_args = [
   '@INPUT@',
   '-o', '@OUTPUT@',
 ]
+if get_option('debug')
+  glsl_args += ['-gVS']
+endif
 glsl_generator = generator(
   glsl_compiler,
   output    : [ '@BASENAME@.h' ],


### PR DESCRIPTION
Pretty straightforward.

This allows shader debugging in Renderdoc on the GLSL source code which is incredibly useful for debugging fixed function issues with the ubershader. I should've done this ages ago.