### PR TITLE
[util] enable zeroMappedMemory for Ridge Racer Unbounded

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -1126,6 +1126,11 @@ namespace dxvk {
     { R"(\\(BioDungeon|BioLab2|MineDungeon2)\.exe$)", {{
       { "d3d9.countLosableResources",      "False" },
     }} },
+    /* Ridge Racer Unbounded - Vertex explosions  */
+    { R"(\\RRU(_demo)?\.exe$)", {{
+      { "dxvk.zeroMappedMemory",            "True" },
+    }} },
+
 
     /**********************************************/
     /* D3D8 GAMES                                 */


### PR DESCRIPTION
Works around vertex explosions since commit 14990db.

Closes #5318