### PR TITLE
Add Vulkan throughput-optimized config: max CPU/GPU saturation

### DIFF
--- a/config/dxvk-throughput.conf
+++ b/config/dxvk-throughput.conf
@@ -1,0 +1,50 @@
+# DXVK THROUGHPUT-OPTIMIZED CONFIG — Vulkan saturation build
+
+# === Threading & Compilation ===
+dxvk.numCompilerThreads = 0                  # use all CPU cores for shader compile
+dxvk.enableAsyncPipelineCompilation = True   # compile pipelines in parallel
+dxvk.enableAsyncSparseResidency = True       # async resource residency for streaming
+dxvk.enablePipelineCache = True              # persistent pipeline cache
+dxvk.enableSpirvCache = True                 # shader SPIR-V cache
+dxvk.deferSurfaceCreation = True             # delay surface setup to parallel threads
+
+# === Pipeline / Descriptor Behavior ===
+dxvk.enableGraphicsPipelineLibrary = Auto    # let driver decide optimal path
+dxvk.enableDescriptorBuffer = Auto
+dxvk.useRawSsboAccess = True                 # direct SSBO access, fewer indirections
+
+# === Barrier & Sync Control ===
+dxvk.memoryBarrierMode = Relaxed             # lighter synchronization
+dxvk.useEarlyDiscard = True                  # discard pixels early, boosts throughput
+dxvk.enableFastHostReads = True              # faster host->GPU reads where possible
+
+# === GPU Resource & Memory Management ===
+dxvk.enableMemoryDefrag = False              # skip defrag, higher raw perf
+dxvk.trackPipelineLifetime = False           # reduces CPU tracking overhead
+dxgi.maxDeviceMemory = 4096                  # advertise 4 GB VRAM to games
+dxgi.customVendorId = 10DE                   # NVIDIA vendor ID
+dxgi.customDeviceId = 139B                   # NVIDIA device ID (keep as-is if unsure)
+
+# === Presentation / Frame pacing ===
+# VSYNC and framerate limits handled by driver
+# dxgi.syncInterval = 0
+# d3d9.presentInterval = 0
+# dxgi.maxFrameRate = 0
+# d3d9.maxFrameLatency = 1
+# dxvk.latencySleep = True
+# dxvk.latencyTolerance = 250
+
+# === Precision & Feature Exposure ===
+d3d11.floatControls = Full                   # enable full IEEE float behavior
+d3d11.allowTearing = True                    # permit tearing for driver-level control
+d3d11.relaxedBarriers = True                 # lighter sync inside DXVK
+
+# === Optional Quality / Debug ===
+# d3d11.forceSampleRateShading = True        # better MSAA at heavy perf cost
+# d3d11.maxTessFactor = 64                   # very high tessellation
+# dxvk.use16BitStorage = True                # use 16-bit buffers if supported
+# dxvk.useSubgroupOperations = True          # subgroup ops if Vulkan driver supports
+
+# === HUD / Logging ===
+# dxvk.hud = devinfo,fps,gpuload,version
+# dxvk.logLevel = none

--- a/docs/vulkan-throughput.md
+++ b/docs/vulkan-throughput.md
@@ -1,0 +1,11 @@
+# DXVK Throughput-Optimized Build
+
+This fork includes a throughput-optimized DXVK configuration, aimed at saturating Vulkan pipelines.  
+Key changes:
+- Max CPU threads for shader compilation
+- Async pipeline & sparse residency
+- Relaxed barriers for higher throughput
+- Direct SSBO access
+- Optimized GPU memory handling for 4GB devices
+
+Use `dxvk-throughput.conf` to enable these settings.


### PR DESCRIPTION
Introduces a DXVK configuration aimed at saturating Vulkan pipelines for maximum CPU/GPU throughput. 
Enables async compilation, relaxed barriers, persistent caches, and direct SSBO access, trading some stability for raw performance. 
Intended for performance testing and benchmarking on NVIDIA 4GB devices.
