### PR TITLE
[d3d9] Use D_READONLY_S_OPTIMAL layout for DS sampling views

### DIFF
--- a/src/d3d9/d3d9_common_texture.cpp
+++ b/src/d3d9/d3d9_common_texture.cpp
@@ -719,12 +719,20 @@ namespace dxvk {
     // that have GENERAL (or FEEDBACK_LOOP) as their layout.
     // This will always be the case for images that can be sampled.
     // So just pick UNDEFINED here.
+
+    VkImageLayout layout = VK_IMAGE_LAYOUT_UNDEFINED;
+
+    // We default to DEPTH_READ_ONLY_STENCIL_ATTACHMENT_OPTIMAL for DS images that can be sampled.
+    // The backend defaults to DS_READ_ONLY, so we need to set the layout explicitly.
+    if (IsDepthStencil())
+      layout = VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_STENCIL_ATTACHMENT_OPTIMAL;
+
     m_sampleView.Color = CreateView(AllLayers, Lod,
-      VK_IMAGE_USAGE_SAMPLED_BIT, VK_IMAGE_LAYOUT_UNDEFINED, false);
+      VK_IMAGE_USAGE_SAMPLED_BIT, layout, false);
 
     if (IsSrgbCompatible()) {
       m_sampleView.Srgb = CreateView(AllLayers, Lod,
-        VK_IMAGE_USAGE_SAMPLED_BIT, VK_IMAGE_LAYOUT_UNDEFINED, true);
+        VK_IMAGE_USAGE_SAMPLED_BIT, layout, true);
     }
   }
 


### PR DESCRIPTION
Fixes:

> err:   UNASSIGNED-vkCmdExecuteCommands-commandBuffer-00001: 
err:   vkCmdExecuteCommands(): pCommandBuffers[0] was executed using VkImage 0x2cc70000002cc7 (subresource: aspectMask VK_IMAGE_ASPECT_DEPTH_BIT, array layer 0, mip level 0) which expects layout VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL--instead, image current layout is VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_STENCIL_ATTACHMENT_OPTIMAL.