### PR TITLE
[d3d11] Avoid accessing keyed mutex pointer if not available

### DIFF
--- a/src/d3d11/d3d11_texture.cpp
+++ b/src/d3d11/d3d11_texture.cpp
@@ -742,8 +742,10 @@ namespace dxvk {
       auto keyedMutex = m_image->getKeyedMutex();
       desc.dxgi.mutex_handle = keyedMutex ? keyedMutex->kmtGlobal() : 0;
 
-      auto syncObject = keyedMutex->getSyncObject();
-      desc.dxgi.sync_handle = syncObject ? syncObject->kmtGlobal() : 0;
+      if (keyedMutex) {
+        auto syncObject = keyedMutex->getSyncObject();
+        desc.dxgi.sync_handle = syncObject ? syncObject->kmtGlobal() : 0;
+      }
     }
 
     switch (m_dimension) {


### PR DESCRIPTION
Should fix a regression caused by https://github.com/doitsujin/dxvk/pull/5257