### PR TITLE
[util] Remove redundant cachedWriteOnlyBuffers config options

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -341,12 +341,12 @@ namespace dxvk {
     /* Shantae and the Pirate's Curse             *
      * Game speeds up above 60 fps                */
     { R"(\\ShantaeCurse\.exe$)", {{
-      { "dxgi.maxFrameRate",                "-60" },
+      { "dxgi.maxFrameRate",                 "-60" },
     }} },
     /* Mighty Switch Force! Collection            *
      * Games speed up above 60 fps                */
     { R"(\\MSFC\.exe$)", {{
-      { "dxgi.maxFrameRate",                  "60" },
+      { "dxgi.maxFrameRate",                 "-60" },
     }} },
     /* Sonic Frontiers - flickering shadows and   *
      * vegetation when GPU-bound                  */
@@ -388,7 +388,7 @@ namespace dxvk {
      * Game speed increases when above 60 fps in  *
      * the tavern area                            */
     { R"(\\BLADESTORM Nightmare\\Launch_(EA|JP)\.exe$)", {{
-      { "dxgi.maxFrameRate",                  "-60" },
+      { "dxgi.maxFrameRate",                 "-60" },
     }} },
     /* Vindictus d3d11 CPU bound perf, and work   *
      * around the game not properly initializing  *
@@ -626,12 +626,12 @@ namespace dxvk {
      * D3DUSAGE_DYNAMIC | D3DUSAGE_WRITEONLY buffer. *
      * Legend flickers with next gen content option. */
     { R"(\\(trl|tra|tru)\.exe$)", {{
-      { "d3d9.cachedWriteOnlyBuffers",        "True" },
-      { "d3d9.maxFrameRate",                  "-60" },
+      { "d3d9.cachedWriteOnlyBuffers",      "True" },
+      { "d3d9.maxFrameRate",                 "-60" },
     }} },
     /* Everquest                                  */
     { R"(\\eqgame\.exe$)", {{
-      { "d3d9.cachedWriteOnlyBuffers",        "True" },
+      { "d3d9.cachedWriteOnlyBuffers",      "True" },
     }} },
     /* Dark Messiah of Might & Magic              */
     { R"(\\mm\.exe$)", {{
@@ -765,11 +765,10 @@ namespace dxvk {
     { R"(\\SR2_pc\.exe$)", {{
       { "d3d9.textureMemory",                  "0" },
     }} },
-    /* Witcher 1: Very long loading times         *
+    /* The Witcher (2007)                         *
      * Inventory hair explosion at very high fps  */
     { R"(\\witcher\.exe$)", {{
-      { "d3d9.cachedWriteOnlyBuffers",        "True" },
-      { "d3d9.maxFrameRate",                  "-300" },
+      { "d3d9.maxFrameRate",                "-300" },
     }} },
     /* Guitar Hero World Tour                     *
      * Very prone to address space crashes        */
@@ -786,13 +785,13 @@ namespace dxvk {
     }} },
     /* Hammer World Editor                        */
     { R"(\\(hammer(plusplus)?|mallet|wc)\.exe$)", {{
-      { "d3d9.cachedWriteOnlyBuffers",        "True" },
+      { "d3d9.cachedWriteOnlyBuffers",      "True" },
     }} },
     /* Sonic & All-Stars Racing Transformed       *
      * Helps performance when Resizable BAR       *
      * is enabled                                 */
     { R"(\\ASN_App_PcDx9_Final\.exe$)", {{
-      { "d3d9.cachedWriteOnlyBuffers",        "True" },
+      { "d3d9.cachedWriteOnlyBuffers",      "True" },
     }} },
     /* Final Fantasy XIV - Direct3D 9 mode        *
      * Can crash with unmapping                   */
@@ -816,7 +815,7 @@ namespace dxvk {
      * and CPU bound performance                  */
     { R"(\\(PANZERS|PANZERS_Phase_2)\.exe$)", {{
       { "d3d9.deferSurfaceCreation",        "True" },
-      { "d3d9.cachedWriteOnlyBuffers",        "True" },
+      { "d3d9.cachedWriteOnlyBuffers",      "True" },
     }} },
     /* DC Universe Online                         *
      * Freezes after alt tabbing                  */
@@ -864,7 +863,7 @@ namespace dxvk {
     }} },
     /* Battlestations Midway                      */
     { R"(\\Battlestationsmidway\.exe$)", {{
-      { "d3d9.cachedWriteOnlyBuffers",        "True" },
+      { "d3d9.cachedWriteOnlyBuffers",      "True" },
     }} },
     /* Assassin's Creed 2                         *
      * Helps alt tab crash on Linux               */
@@ -902,7 +901,7 @@ namespace dxvk {
     }} },
     /* Delta Force: Xtreme 1 & 2 - Performance    */
     { R"(\\(DFX|dfx2)\.exe$)", {{
-      { "d3d9.cachedWriteOnlyBuffers",        "True" },
+      { "d3d9.cachedWriteOnlyBuffers",      "True" },
     }} },
     /* Prototype                                  *
      * Incorrect shadows on AMD & Intel.          *
@@ -927,13 +926,13 @@ namespace dxvk {
     /* Dungeons and Dragons: Dragonshard          *
      * Massive FPS decreases in some scenes       */
     { R"(\\Dragonshard\.exe$)", {{
-      { "d3d9.cachedWriteOnlyBuffers",        "True" },
+      { "d3d9.cachedWriteOnlyBuffers",      "True" },
     }} },
     /* Battle for Middle-earth 2 and expansion    *
      * Slowdowns in certain scenarios             */
     { R"(\\(The Battle for Middle-earth( \(tm\))? II( Demo)?)"
       R"(|The Lord of the Rings, The Rise of the Witch-king)\\game\.dat$)", {{
-      { "d3d9.cachedWriteOnlyBuffers",        "True" },
+      { "d3d9.cachedWriteOnlyBuffers",      "True" },
     }} },
     /* WRC4 - Audio breaks above 60fps            */
     { R"(\\WRC4\.exe$)", {{
@@ -953,11 +952,11 @@ namespace dxvk {
     /* APB: Reloaded                              *
      * Fixes frametime jumps when shooting        */
     { R"(\\APB\.exe$)", {{
-      { "d3d9.cachedWriteOnlyBuffers",        "True" },
+      { "d3d9.cachedWriteOnlyBuffers",      "True" },
     }} },
     /* Battle Mages - helps CPU bound perf        */
     { R"(\\Battle Mages\\mages\.exe$)", {{
-      { "d3d9.cachedWriteOnlyBuffers",        "True" },
+      { "d3d9.cachedWriteOnlyBuffers",      "True" },
     }} },
     /* Prince of Persia (2008) - Can get stuck    *
      * during loading at very high fps            */
@@ -978,7 +977,7 @@ namespace dxvk {
      * Set cached dynamic buffers to True to      *
      * improve perf on all hardware.              */
     { R"(\\(FarCry2|farcry2game)\.exe$)", {{
-      { "d3d9.cachedWriteOnlyBuffers",        "True" },
+      { "d3d9.cachedWriteOnlyBuffers",      "True" },
     }} },
     /* Dark Sector - Crashes in places            */
     { R"(\\DS\.exe$)", {{
@@ -1019,12 +1018,12 @@ namespace dxvk {
     /* Lego Indiana Jones: The Original Adventures *
      * Fix UI performance                          */
     { R"(\\LEGOIndy\.exe$)", {{
-      { "d3d9.cachedWriteOnlyBuffers",        "True" },
+      { "d3d9.cachedWriteOnlyBuffers",      "True" },
     }} },
     /* Lego Batman: The Videogame                 *
      * Fix UI performance                         */
     { R"((\\LEGOBatman|LegoBatman\\Game)\.exe$)", {{
-      { "d3d9.cachedWriteOnlyBuffers",        "True" },
+      { "d3d9.cachedWriteOnlyBuffers",      "True" },
     }} },
     /* Thumper - Fixes missing track              */
     { R"(\\THUMPER_dx9\.exe$)", {{
@@ -1134,7 +1133,6 @@ namespace dxvk {
     }} },
     /* Motor City Online                          */
     { R"(\\MCity_d\.exe$)", {{
-      { "d3d9.cachedWriteOnlyBuffers",      "True" },
       { "d3d8.batching",                    "True" },
     }} },
     /* Railroad Tycoon 3                          */
@@ -1151,7 +1149,6 @@ namespace dxvk {
     /* Need for Speed III: Hot Pursuit            *
      * (with the "Modern Patch")                  */
     { R"(\\nfs3\.exe$)", {{
-      { "d3d9.cachedWriteOnlyBuffers",      "True" },
       { "d3d8.batching",                    "True" },
     }} },
     /* Need for Speed: High Stakes / Road         *
@@ -1159,18 +1156,18 @@ namespace dxvk {
      * Won't actually render anything in game     *
      * without a memory limit in place            */
     { R"(\\nfs4\.exe$)", {{
-      { "d3d9.cachedWriteOnlyBuffers",      "True" },
       { "d3d9.memoryTrackTest",             "True" },
       { "d3d9.maxAvailableMemory",          "1024" },
       { "d3d8.batching",                    "True" },
     }} },
     /* Need for Speed: Hot Pursuit 2              */
     { R"(\\NFSHP2\.exe$)", {{
-      { "d3d9.cachedWriteOnlyBuffers",        "True" },
+      { "d3d9.cachedWriteOnlyBuffers",      "True" },
     }} },
-    /* Project I.G.I. 2: Covert Strike            */
+    /* Project I.G.I. 2: Covert Strike            *
+     * Very stuttery frametime with own framecap  */
     { R"(\\igi2\.exe$)", {{
-      { "d3d9.cachedWriteOnlyBuffers",        "True" },
+      { "d3d9.maxFrameRate",                 "-60" },
     }} },
     /* Treasure Planet: Battle at Procyon         *
      * Declares v5 as color but shader uses v6    */
@@ -1209,11 +1206,11 @@ namespace dxvk {
     }} },
     /* Delta Force: Black Hawk Down               */
     { R"(\\dfbhd\.exe$)", {{
-      { "d3d9.cachedWriteOnlyBuffers",        "True" },
+      { "d3d9.cachedWriteOnlyBuffers",      "True" },
     }} },
     /* X2: The Threat                             */
     { R"(\\X2\.exe$)", {{
-      { "d3d9.cachedWriteOnlyBuffers",        "True" },
+      { "d3d9.cachedWriteOnlyBuffers",      "True" },
     }} },
     /* The Lord of the Rings:                     *
      * The Fellowship of the Ring                 */
@@ -1228,19 +1225,15 @@ namespace dxvk {
     }} },
     /* Art of Murder FBI Confidential - CPU perf  */
     { R"(\\Art of Murder - FBI Confidential\\game\.exe$)", {{
-      { "d3d9.cachedWriteOnlyBuffers",        "True" },
+      { "d3d9.cachedWriteOnlyBuffers",      "True" },
     }} },
     /* Max Payne 1 - Stalls waiting for an index buffer */
     { R"(\\MaxPayne\.exe$)", {{
       { "d3d9.allowDirectBufferMapping",   "False" },
     }} },
-    /* Z: Steel Soldiers                          */
-    { R"(\\z2\.exe$)", {{
-      { "d3d9.cachedWriteOnlyBuffers",        "True" },
-    }} },
     /* FIFA Football 2003                         */
     { R"(\\fifa2003(demo)?\.exe$)", {{
-      { "d3d9.cachedWriteOnlyBuffers",        "True" },
+      { "d3d9.cachedWriteOnlyBuffers",      "True" },
     }} },
     /* Splinter Cell: Pandora Tomorrow (Retail)   *
      * Missing shadows without dref scaling and   *


### PR DESCRIPTION
Remove a few now redundant `d3d9.cachedWriteOnlyBuffers` builtin configs, and adjust alignment.