### PR TITLE
[d3d9] Introduce proper Unwrap/Return API for interop purposes

### DIFF
--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -240,7 +240,8 @@ namespace dxvk {
       return S_OK;
     }
 
-    if (riid == __uuidof(ID3D9VkInteropDevice)) {
+    if (riid == __uuidof(ID3D9VkInteropDevice)
+     || riid == __uuidof(ID3D9VkInteropDevice1)) {
       *ppvObject = ref(&m_d3d9Interop);
       return S_OK;
     }

--- a/src/d3d9/d3d9_interface.h
+++ b/src/d3d9/d3d9_interface.h
@@ -172,10 +172,9 @@ namespace dxvk {
 
     std::vector<D3D9Adapter>      m_adapters;
 
-    D3D9VkInteropInterface        m_d3d9Interop;
-
     bool m_unlockAdditionalFormats = false;
 
+    D3D9VkInteropInterface        m_d3d9Interop;
     D3D9VkExtInterface            m_d3d9ExtInterface;
 
     static const D3D9ON12_ARGS* Find9On12Args(

--- a/src/d3d9/d3d9_interop.h
+++ b/src/d3d9/d3d9_interop.h
@@ -79,7 +79,7 @@ namespace dxvk {
 
   };
 
-  class D3D9VkInteropDevice final : public ID3D9VkInteropDevice {
+  class D3D9VkInteropDevice final : public ID3D9VkInteropDevice1 {
 
   public:
 
@@ -127,8 +127,17 @@ namespace dxvk {
             DWORD                MapFlags);
 
     HRESULT STDMETHODCALLTYPE CreateImage(
-            const D3D9VkExtImageDesc* desc,
+      const D3D9VkExtImageDesc*       desc,
             IDirect3DResource9**      ppResult);
+
+    HRESULT STDMETHODCALLTYPE UnwrapTexture(
+            IUnknown*                 pResource,
+            VkImage*                  pImage,
+            VkImageSubresourceRange*  pSubresources,
+            VkImageCreateInfo*        pInfo);
+
+    HRESULT STDMETHODCALLTYPE ReturnTexture(
+            ID3D9VkInteropTexture*    pResource);
 
   private:
 


### PR DESCRIPTION
TL;DR this deprecates the entirety of `ID3D9VkInteropTexture`, as well as `D3D9VkInteropDevice::TransitionTextureLayout`. These APIs no longer work conceptually due to changes in memory management and (more recently) synchronization and image layout-related stuff, and ideally I'd want to completely remove these since they simply cannot do the right thing in all cases anymore.

@AlpyneDreams @misyltoad gonna need some feedback here since you're actually using these.

Think once this is sorted out, I'll revisit #4506.