### PR TITLE
[d3d9] Activate focus window when creating fullscreen device

### DIFF
--- a/src/d3d9/d3d9_interface.cpp
+++ b/src/d3d9/d3d9_interface.cpp
@@ -4,6 +4,7 @@
 #include "d3d9_caps.h"
 #include "d3d9_device.h"
 #include "d3d9_bridge.h"
+#include "d3d9_window.h"
 
 #include "../util/util_singleton.h"
 
@@ -413,6 +414,9 @@ namespace dxvk {
         hFocusWindow,
         BehaviorFlags,
         dxvkDevice);
+
+      if (!pPresentationParameters->Windowed)
+        ActivateFocusWindow(hFocusWindow ? hFocusWindow : pPresentationParameters->hDeviceWindow);
 
       hr = device->InitialReset(pPresentationParameters, pFullscreenDisplayMode);
 

--- a/src/d3d9/d3d9_window.cpp
+++ b/src/d3d9/d3d9_window.cpp
@@ -152,6 +152,10 @@ namespace dxvk
         it->second.deactivateProcessed = !processed;
       }
   }
+
+  void ActivateFocusWindow(HWND window) {
+      SetWindowPos(window, nullptr, 0, 0, 0, 0, SWP_NOSIZE | SWP_NOMOVE);
+  }
 #else
   D3D9WindowMessageFilter::D3D9WindowMessageFilter(HWND window, bool filter) {
 
@@ -171,6 +175,10 @@ namespace dxvk
 
   void SetActivateProcessed(HWND window, bool processed) {
   }
+
+  void ActivateFocusWindow(HWND window) {
+  }
+
 #endif
 
 }

--- a/src/d3d9/d3d9_window.h
+++ b/src/d3d9/d3d9_window.h
@@ -33,5 +33,6 @@ namespace dxvk {
   void ResetWindowProc(HWND window);
   void HookWindowProc(HWND window, D3D9SwapChainEx* swapchain);
   void SetActivateProcessed(HWND window, bool processed);
+  void ActivateFocusWindow(HWND window);
 
 }


### PR DESCRIPTION
Fixes From Dust (33460) which will crash after showing ESRB warning (unless it is alttabbed out during ESRB warning and stay minimized for a while before alttabbing back).

The problem exhibits as crash in game code trying to access game's own object which is NULL. The game is going to create d3d9 device alognth with RT / DS objects right after creating a window. However, if after device creation GetActiveWindow is not the game's window (currently NULL with DXVK), it will skip that part but later will still try to use that. That apparently goes different when window is minized, later on unminimize it will create the backbuffers anyway.

I think the other games used to get away without this because normally the window will be activated regardless a bit later (depends on native WM), the game here just starts to care too early.