### PR TITLE
[util] Add a frame cap for The Evil Within 2

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -348,6 +348,11 @@ namespace dxvk {
     { R"(\\MSFC\.exe$)", {{
       { "dxgi.maxFrameRate",                 "-60" },
     }} },
+    /* The Evil Within 2 *
+    * Game speeds up above 120 fps */
+    { R"(\\TEW2\.exe$)", {{
+      { "dxgi.maxFrameRate",                 "-120" },
+    }} },
     /* Sonic Frontiers - flickering shadows and   *
      * vegetation when GPU-bound                  */
     { R"(\\SonicFrontiers\.exe$)", {{


### PR DESCRIPTION
Game speeds up above 120 fps, causing physics and animations to break.