### PR TITLE
[d3d11] Add D3D11Device::RegisterDeviceRemovedEvent() stub.

### DIFF
--- a/src/d3d11/d3d11_device.cpp
+++ b/src/d3d11/d3d11_device.cpp
@@ -1966,9 +1966,10 @@ namespace dxvk {
     static bool s_errorShown = false;
 
     if (!std::exchange(s_errorShown, true))
-      Logger::err("D3D11Device::RegisterDeviceRemovedEvent: Not implemented");
+      Logger::warn("D3D11Device::RegisterDeviceRemovedEvent: Stub");
 
-    return E_NOTIMPL;
+    *pdwCookie = 0xdeadbeef;
+    return S_OK;
   }
 
 


### PR DESCRIPTION
Required for React Native applications.