### PR TITLE
[d3d11] Implement subresource surface support.

### DIFF
--- a/src/d3d11/d3d11_texture.cpp
+++ b/src/d3d11/d3d11_texture.cpp
@@ -945,6 +945,18 @@ namespace dxvk {
       m_gdiSurface = new D3D11GDISurface(m_resource, 0);
   }
 
+  D3D11DXGISurface::D3D11DXGISurface(
+          ID3D11Resource*     pParentResource,
+          UINT                Subresource)
+  : m_isSubresourceSurface(true),
+    m_subresource         (Subresource),
+    m_resource            (pParentResource),
+    m_gdiSurface(nullptr) {
+    auto texture = GetCommonTexture(pParentResource);
+    if (texture && texture->Desc()->MiscFlags & D3D11_RESOURCE_MISC_GDI_COMPATIBLE)
+      m_gdiSurface = new D3D11GDISurface(m_resource, m_subresource);
+  }
+
   
   D3D11DXGISurface::~D3D11DXGISurface() {
     if (m_gdiSurface)
@@ -965,6 +977,24 @@ namespace dxvk {
   HRESULT STDMETHODCALLTYPE D3D11DXGISurface::QueryInterface(
           REFIID                  riid,
           void**                  ppvObject) {
+
+    InitReturnPtr(ppvObject);
+
+    // Only a subset of interfaces are available for subresource surfaces
+    if (m_isSubresourceSurface) {
+      if (riid == __uuidof(IUnknown)
+       || riid == __uuidof(IDXGIObject)
+       || riid == __uuidof(IDXGIDeviceSubObject)
+       || riid == __uuidof(IDXGISurface)
+       || riid == __uuidof(IDXGISurface1)
+       || riid == __uuidof(IDXGISurface2)) {
+        *ppvObject = ref(this);
+        return S_OK;
+      }
+
+      return E_NOINTERFACE;
+    }
+
     return m_resource->QueryInterface(riid, ppvObject);
   }
 
@@ -1010,12 +1040,33 @@ namespace dxvk {
   
   HRESULT STDMETHODCALLTYPE D3D11DXGISurface::GetDesc(
           DXGI_SURFACE_DESC*      pDesc) {
+    auto buffer  = GetCommonBuffer (m_resource);
     auto texture = GetCommonTexture(m_resource);
 
     if (!pDesc)
       return DXGI_ERROR_INVALID_CALL;
 
-    if (texture) {
+    if (m_isSubresourceSurface) {
+      if (texture) {
+        auto desc = texture->Desc();
+
+        pDesc->Width      = std::max(1u, desc->Width >> (m_subresource % desc->MipLevels));
+        pDesc->Height     = std::max(1u, desc->Height >> (m_subresource % desc->MipLevels));
+        pDesc->Format     = desc->Format;
+        pDesc->SampleDesc = desc->SampleDesc;
+        return S_OK;
+      } else if (buffer) {
+        auto desc = buffer->Desc();
+        pDesc->Width              = desc->ByteWidth;
+        pDesc->Height             = 1;
+        pDesc->Format             = DXGI_FORMAT_UNKNOWN;
+        pDesc->SampleDesc.Count   = 1;
+        pDesc->SampleDesc.Quality = 0;
+        return S_OK;
+      } else {
+        return DXGI_ERROR_INVALID_CALL;
+      }
+    } else if (texture) {
       auto desc = texture->Desc();
       pDesc->Width      = desc->Width;
       pDesc->Height     = desc->Height;
@@ -1056,7 +1107,7 @@ namespace dxvk {
       return DXGI_ERROR_INVALID_CALL;
     
     D3D11_MAPPED_SUBRESOURCE sr;
-    HRESULT hr = context->Map(m_resource, 0,
+    HRESULT hr = context->Map(m_resource, m_subresource,
       mapType, 0, pLockedRect ? &sr : nullptr);
 
     if (hr != S_OK)
@@ -1075,7 +1126,7 @@ namespace dxvk {
     m_resource->GetDevice(&device);
     device->GetImmediateContext(&context);
     
-    context->Unmap(m_resource, 0);
+    context->Unmap(m_resource, m_subresource);
     return S_OK;
   }
 
@@ -1103,9 +1154,16 @@ namespace dxvk {
           REFIID                  riid,
           void**                  ppParentResource,
           UINT*                   pSubresourceIndex) {
-    HRESULT hr = m_resource->QueryInterface(riid, ppParentResource);
-    if (pSubresourceIndex)
-      *pSubresourceIndex = 0;
+    HRESULT hr;
+
+    if (!ppParentResource)
+      return E_POINTER;
+
+    InitReturnPtr(ppParentResource);
+    hr = m_resource->QueryInterface(riid, ppParentResource);
+    if (SUCCEEDED(hr))
+      *pSubresourceIndex = m_subresource;
+
     return hr;
   }
   

--- a/src/d3d11/d3d11_texture.h
+++ b/src/d3d11/d3d11_texture.h
@@ -635,6 +635,10 @@ namespace dxvk {
 
     D3D11DXGISurface(
             ID3D11Resource*     pResource);
+
+    D3D11DXGISurface(
+            ID3D11Resource*     pParentResource,
+            UINT                Subresource);
     
     ~D3D11DXGISurface();
     
@@ -693,6 +697,8 @@ namespace dxvk {
 
   private:
     
+    bool                m_isSubresourceSurface = false;
+    UINT                m_subresource = 0;
     ID3D11Resource*     m_resource;
     D3D11GDISurface*    m_gdiSurface;
 


### PR DESCRIPTION
For React Native applications. Tests are in test_subresource_surface() at wine/dlls/dxgi/tests/dxgi.c. The corresponding Wine MR is https://gitlab.winehq.org/wine/wine/-/merge_requests/8059.

Support for D3D11Buffer is unimplemented due to the missing support of D3D11DXGISurface for D3D11Buffer.