### PR TITLE
[d3d8] Readjust ZBIAS factor

### DIFF
--- a/src/d3d8/d3d8_caps.h
+++ b/src/d3d8/d3d8_caps.h
@@ -2,7 +2,11 @@
 
 namespace dxvk::d8caps {
 
-  inline constexpr uint32_t MAX_TEXTURE_STAGES = 8;
-  inline constexpr uint32_t MAX_STREAMS = 16;
+  constexpr uint32_t MAX_TEXTURE_STAGES = 8;
+  constexpr uint32_t MAX_STREAMS        = 16;
+
+  // ZBIAS can be an integer from 0 to 16 and needs to be remapped to float
+  constexpr float    ZBIAS_SCALE        = -1.0f / ((1u << 16) - 1); // Consider D16 precision
+  constexpr float    ZBIAS_SCALE_INV    = 1 / ZBIAS_SCALE;
 
 }

--- a/src/d3d8/d3d8_device.cpp
+++ b/src/d3d8/d3d8_device.cpp
@@ -1681,10 +1681,6 @@ namespace dxvk {
     return GetD3D9()->DeletePatch(Handle);
   }
 
-  // ZBIAS can be an integer from 0 to 16 and needs to be remapped to float
-  static constexpr float ZBIAS_SCALE     = -10.0f / (1 << 16); // Consider 10x D16 precision
-  static constexpr float ZBIAS_SCALE_INV = 1 / ZBIAS_SCALE;
-
   HRESULT STDMETHODCALLTYPE D3D8Device::SetRenderState(D3DRENDERSTATETYPE State, DWORD Value) {
     D3D8DeviceLock lock = LockDevice();
 
@@ -1718,7 +1714,7 @@ namespace dxvk {
 
       case D3DRS_ZBIAS:
         State9 = d3d9::D3DRS_DEPTHBIAS;
-        Value  = bit::cast<DWORD>(static_cast<float>(Value) * ZBIAS_SCALE);
+        Value  = bit::cast<DWORD>(static_cast<float>(Value) * d8caps::ZBIAS_SCALE);
         break;
 
       case D3DRS_SOFTWAREVERTEXPROCESSING:
@@ -1786,7 +1782,7 @@ namespace dxvk {
       case D3DRS_ZBIAS: {
         DWORD bias  = 0;
         HRESULT res = GetD3D9()->GetRenderState(d3d9::D3DRS_DEPTHBIAS, &bias);
-        *pValue     = static_cast<DWORD>(bit::cast<float>(bias) * ZBIAS_SCALE_INV);
+        *pValue     = static_cast<DWORD>(bit::cast<float>(bias) * d8caps::ZBIAS_SCALE_INV);
         return res;
       } break;
 

--- a/src/d3d8/d3d8_main.cpp
+++ b/src/d3d8/d3d8_main.cpp
@@ -62,7 +62,7 @@ extern "C" {
       const size_t errorMessageSize = errorMessage.size() + 1;
       // Wine tests call HeapFree() on the returned error string,
       // so the expectation is for it to be allocated on the heap.
-      *pErrorString = (char*) HeapAlloc(GetProcessHeap(), 0, errorMessageSize);
+      *pErrorString = static_cast<char*>(HeapAlloc(GetProcessHeap(), 0, errorMessageSize));
       if (*pErrorString)
         memcpy(*pErrorString, errorMessage.c_str(), errorMessageSize);
     }
@@ -110,7 +110,7 @@ extern "C" {
       const size_t errorMessageSize = errorMessage.size() + 1;
       // Wine tests call HeapFree() on the returned error string,
       // so the expectation is for it to be allocated on the heap.
-      *pErrorString = (char*) HeapAlloc(GetProcessHeap(), 0, errorMessageSize);
+      *pErrorString = static_cast<char*>(HeapAlloc(GetProcessHeap(), 0, errorMessageSize));
       if (*pErrorString)
         memcpy(*pErrorString, errorMessage.c_str(), errorMessageSize);
     }

--- a/src/d3d8/d3d8_shader.cpp
+++ b/src/d3d8/d3d8_shader.cpp
@@ -85,14 +85,14 @@ namespace dxvk {
    */
   constexpr DWORD encodeDestRegister(d3d9::D3DSHADER_PARAM_REGISTER_TYPE type, UINT reg) {
     DWORD token = 0;
-    token    |= reg & 0x7FF;                  // bits 0:10   num
-    token    |= ((type & 0x07) << 28);        // bits 28:30  type[0:2]
-    token    |= ((type & 0x18) >>  3) << 11;  // bits 11:12  type[3:4]
-    // UINT addrMode : 1;                     // bit  13     hasRelative
-    token    |= 0b1111 << 16;                 // bits 16:19  DxsoRegMask
-    // UINT resultModifier : 3;               // bits 20:23
-    // UINT resultShift : 3;                  // bits 24:27
-    token    |= 1 << 31;                      // bit  31     always 1
+    token |= reg & 0x7FF;                  // bits 0:10   num
+    token |= ((type & 0x07) << 28);        // bits 28:30  type[0:2]
+    token |= ((type & 0x18) >>  3) << 11;  // bits 11:12  type[3:4]
+    // UINT addrMode : 1;                  // bit  13     hasRelative
+    token |= 0b1111 << 16;                 // bits 16:19  DxsoRegMask
+    // UINT resultModifier : 3;            // bits 20:23
+    // UINT resultShift : 3;               // bits 24:27
+    token |= 1u << 31;                     // bit  31     always 1
     return token;
   }
 
@@ -105,7 +105,7 @@ namespace dxvk {
     DWORD token = 0;
     token |= VSD_ENCODE(usage, D3DSP_DCL_USAGE);       // bits 0:4   DxsoUsage (TODO: missing MSB)
     token |= VSD_ENCODE(index, D3DSP_DCL_USAGEINDEX);  // bits 16:19 usageIndex
-    token |= 1 << 31;                                  // bit 31     always 1
+    token |= 1u << 31;                                 // bit 31     always 1
     return token;
   }
 
@@ -123,7 +123,6 @@ namespace dxvk {
 
     HRESULT res = D3D_OK;
 
-    std::vector<DWORD>& tokens = pTranslatedVS.function;
     std::vector<DWORD> defs; // Constant definitions
 
     // shaderInputRegisters:
@@ -279,6 +278,8 @@ namespace dxvk {
     }
 
     if (pFunction != nullptr) {
+      std::vector<DWORD>& tokens = pTranslatedVS.function;
+
       // Copy first token (version)
       tokens.push_back(pFunction[0]);
 

--- a/src/d3d9/d3d9_interface.cpp
+++ b/src/d3d9/d3d9_interface.cpp
@@ -445,15 +445,15 @@ namespace dxvk {
   HRESULT D3D9InterfaceEx::ValidatePresentationParametersEx(
     const D3DPRESENT_PARAMETERS* pPresentationParameters,
     const D3DDISPLAYMODEEX*      pFullscreenDisplayMode) {
+    if (unlikely(pPresentationParameters == nullptr))
+      return D3DERR_INVALIDCALL;
+
     // pFullscreenDisplayMode must not be NULL in full screen mode.
     if (unlikely(!pPresentationParameters->Windowed && pFullscreenDisplayMode == nullptr))
       return D3DERR_INVALIDCALL;
 
     // pFullscreenDisplayMode must be NULL in windowed mode.
     if (unlikely(pPresentationParameters->Windowed && pFullscreenDisplayMode != nullptr))
-      return D3DERR_INVALIDCALL;
-
-    if (unlikely(pPresentationParameters == nullptr))
       return D3DERR_INVALIDCALL;
 
     // On extended devices, the backbuffer dimensions


### PR DESCRIPTION
It appears I was a bit too lenient in my previous adjustment, since some games will need the extra precision to render/overlay distant objects correctly, see the health vials inside of the barrels below:

<details>
<summary>Master</summary>

<img width="1024" height="768" alt="D16" src="https://github.com/user-attachments/assets/e4c934d6-797d-4a0a-bcae-9a2b06dfcc9e" />

</details>

<details>
<summary>This PR</summary>

<img width="1024" height="768" alt="D24" src="https://github.com/user-attachments/assets/3ca135e4-9e5b-4cfe-9d33-fdb01d4e0726" />

</details>

To make both D16 and D24 happy without getting into other issues with float epsilon values, this value appears to pass the test of time, as I've been using it for about a month now with no ill effect.

Compared to what we've been using traditionally, namely `0.000005`, the adjusted value in the PR lands at roughly `0.0000153` which appeases games that felt the original value was too small (for D16), and is still "good enough" for D24 (as in the case of the above screenshots).

Other than that I've included some minor nits and fixed some derps that I've noticed some time ago, but made no sense to bother with on their own.