### PR TITLE
[d3d9] Allow cursor clears on hidden HW cursors

### DIFF
--- a/src/d3d9/d3d9_cursor.cpp
+++ b/src/d3d9/d3d9_cursor.cpp
@@ -52,15 +52,10 @@ namespace dxvk {
     if (unlikely(!IsHardwareCursor() && !IsActiveSoftwareCursor()))
       return m_visible;
 
-    if (IsHardwareCursor()) {
-      // Prevents the win32 cursor from being overwritten with nullptr
-      // in situations when a hardware cursor is set, but not shown.
-      if (!m_visible && !bShow)
-        return m_visible;
+    if (IsHardwareCursor())
       ::SetCursor(bShow ? m_hCursor : nullptr);
-    } else {
+    else
       m_sCursor.DrawCursor = bShow;
-    }
 
     return std::exchange(m_visible, bShow);
   }


### PR DESCRIPTION
Addresses the sort of jank described in #5449, however it needs blessing from @Blisto91, since it will cause a regression with #4307. That game has broken cursor handling anyway, to be fair, but this "guard" at least gave users a visible cursor to work with, although its bitmap was wrong. Closes #5449.