### PR TITLE
chore: add infinite warfare / iw7-mod support

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -182,6 +182,11 @@ namespace dxvk {
     { R"(\\hmw-mod\.exe$)", {{
       { "dxgi.customVendorId",              "10de" },
     }} },
+    /* Infinite Warfare                           *
+     * AMD AGS crash                              */
+    { R"(\\iw7(_ship|-mod)\.exe$)", {{
+      { "dxgi.customVendorId",              "10de" },
+    }} },
     /* Modern Warfare 2 Campaign Remastered       *
      * AMD AGS crash same as above                */
     { R"(\\MW2CR\.exe$)", {{


### PR DESCRIPTION
Similar to #5456 

This adds iw7_ship and iw7-mod to the config to help circumvent the AMD AGS crash that is notorious for happening on older COD titles