### PR TITLE
config: Disable descriptor buffer for NFS Most Wanted (2005)

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -662,7 +662,6 @@ namespace dxvk {
      * Descriptor buffer extension causes         *
      * crashes on Intel Arc drivers.              */
     { R"(\\speed\.exe$)", {{
-      { "d3d9.hideIntelGpu",                "False" },
       { "dxvk.enableDescriptorBuffer",      "False" },
       { "d3d9.cachedWriteOnlyBuffers",      "True" },
     }} },


### PR DESCRIPTION
Fixes #5460

The VK_EXT_descriptor_buffer extension (enabled by default in 2.7.1) causes VK_ERROR_DEVICE_LOST crashes on Intel Arc drivers for Need for Speed: Most Wanted (2005).

This PR adds a configuration profile for speed.exe with the following stable settings:

- `dxvk.enableDescriptorBuffer = False` - Primary Fix. Disables the extension responsible for the device loss/crash.
- `d3d9.cachedWriteOnlyBuffers = True` - Mitigates severe stuttering caused by the game reading from write-only buffers (a common issue in this engine).
- `d3d9.hideIntelGpu = False` - Ensures the game and DXVK identify the GPU correctly as Intel, preventing fallbacks to unstable vendor-specific paths (like the AMD profile).