### PR TITLE
Fix black squares in Medieval: Total War 2.

### DIFF
--- a/src/d3d9/d3d9_common_texture.cpp
+++ b/src/d3d9/d3d9_common_texture.cpp
@@ -43,8 +43,7 @@ namespace dxvk {
                        (m_mapping.FormatColor == VK_FORMAT_D32_SFLOAT_S8_UINT || m_mapping.FormatColor == VK_FORMAT_D32_SFLOAT);
     m_supportsFetch4 = DetermineFetch4Compatibility();
 
-    const bool createImage = m_desc.Pool != D3DPOOL_SYSTEMMEM && m_desc.Pool != D3DPOOL_SCRATCH && m_desc.Format != D3D9Format::NULL_FORMAT;
-    if (createImage) {
+    if (TextureUsesImage(&m_desc)) {
       m_image = CreatePrimaryImage(ResourceType, pSharedHandle);
 
       if (unlikely(m_image == nullptr && (m_desc.Usage & D3DUSAGE_AUTOGENMIPMAP))) {
@@ -182,7 +181,9 @@ namespace dxvk {
     if (FAILED(hr))
       return hr;
 
-    if (ResourceType == D3DRTYPE_SURFACE) {
+    // We never create an image for SCRATCH, SYSTEMMEM or NULL FMT D3D9 textures, so there's no point in checking
+    // whether the GPU supports the specified sampled count for those.
+    if (ResourceType == D3DRTYPE_SURFACE && TextureUsesImage(pDesc)) {
       D3DMULTISAMPLE_TYPE d3dSampleCount = D3DMULTISAMPLE_TYPE(sampleCount);
       // VK_SAMPLE_COUNT_1_BIT = 1 but the D3D9 equivalent we need is D3DMULTISAMPLE_NONE = 0
       if (d3dSampleCount == D3DMULTISAMPLE_NONMASKABLE)

--- a/src/d3d9/d3d9_common_texture.h
+++ b/src/d3d9/d3d9_common_texture.h
@@ -195,6 +195,17 @@ namespace dxvk {
             D3D9_COMMON_TEXTURE_DESC*  pDesc);
 
     /**
+     * \brief Returns whether a Vulkan image is used for this D3D9 texture
+     *
+     * \param pDesc The texture description
+     */
+    static bool TextureUsesImage(const D3D9_COMMON_TEXTURE_DESC* pDesc) {
+      return pDesc->Pool   != D3DPOOL_SYSTEMMEM
+          && pDesc->Pool   != D3DPOOL_SCRATCH
+          && pDesc->Format != D3D9Format::NULL_FORMAT;
+    }
+
+    /**
      * \brief Shadow
      * \returns Whether the texture is to be depth compared
      */


### PR DESCRIPTION
<img width="1213" height="855" alt="image" src="https://github.com/user-attachments/assets/4796a010-6f6f-47b7-b53e-907052a1618c" />

Regression from bb91ac525c24cb3c9aefc44348b553a75a4d6e21

The game creates `POOL_SCRATCH` textures with `FMT_R8G8B8`. We don't support that format for actual textures (textures that can actually get sampled).

`D3D9Adapter::CheckDeviceMultiSampleType` checks whether the format is supported first so with the recent change which actually checks whether the sample count is supported for the format, we'd fail that check and thus fail creating the texture.

https://github.com/doitsujin/dxvk/blob/master/src/d3d9/d3d9_adapter.cpp#L253-L254

There's no point checking hardware support for sample count for textures that can't be used for sampling or rendering anyway. We never even create a Vulkan image for those D3D9 textures.