### PR TITLE
[d3d11] Fix null pointer deref in DSSetShader

### DIFF
--- a/src/d3d11/d3d11_context.cpp
+++ b/src/d3d11/d3d11_context.cpp
@@ -1645,7 +1645,8 @@ namespace dxvk {
     D3D10DeviceLock lock = LockContext();
 
     auto shader = static_cast<D3D11DomainShader*>(pDomainShader);
-    SetClassInstances<D3D11ShaderType::eDomain>(shader->GetCommonShader(), ppClassInstances, NumClassInstances);
+    SetClassInstances<D3D11ShaderType::eDomain>(
+      shader ? shader->GetCommonShader() : nullptr, ppClassInstances, NumClassInstances);
 
     if (m_state.ds != shader) {
       m_state.ds = shader;


### PR DESCRIPTION
I’m not sure if DSSetShader was missed at https://github.com/doitsujin/dxvk/commit/42a827ba90aa4357d01bb37a9ddc6848610a2b94 intentionally, but it seems to really cause issues in OGSR (X-Ray Engine modification for S.T.A.L.K.E.R):
```
[2026-01-23 18:12:45.201][t:  436][f:1234] !! Unhandled exception stack trace:
!C:\windows\system32\d3d11.dll at [00006FFFF8C2BDAB] [dxvk::D3D11CommonContext<dxvk::D3D11ImmediateContext>::DSSetShader()] + [75] byte(s) in [\\?\unix\home\vasily\PKGBUILDs\dxvk-git\src\build\x64\..\..\dxvk\src\d3d11\d3d11_context.cpp:1650] + [17] byte(s)
!C:\S.T.A.L.K.E.R.NS.OGSR\bin\xrEngine.exe at [00000001401F0F79] [R_dsgraph_structure::r_dsgraph_render_graph_dynamic()] + [733] byte(s) in [D:\!!!Narodnaya Solyanka!!!\!OGSR!\GitHub\NS_OGSR_Engine\ogsr_engine\Layers\xrRender\r__dsgraph_render.cpp:158] + [35] byte(s)
!C:\S.T.A.L.K.E.R.NS.OGSR\bin\xrEngine.exe at [00000001401A1DDA] [CRender::Render()] + [1390] byte(s) in [D:\!!!Narodnaya Solyanka!!!\!OGSR!\GitHub\NS_OGSR_Engine\ogsr_engine\Layers\xrRender\r4_R_render.cpp:386]
!C:\S.T.A.L.K.E.R.NS.OGSR\bin\xrEngine.exe at [0000000140269F9B] [CLevel::OnRender()] + [139] byte(s) in [D:\!!!Narodnaya Solyanka!!!\!OGSR!\GitHub\NS_OGSR_Engine\ogsr_engine\xrGame\Level.cpp:513]
!C:\S.T.A.L.K.E.R.NS.OGSR\bin\xrEngine.exe at [000000014004C34E] [CRenderDevice::process_render()] + [230] byte(s) in [D:\!!!Narodnaya Solyanka!!!\!OGSR!\GitHub\NS_OGSR_Engine\ogsr_engine\xrEngine\device.cpp:249] + [77] byte(s)
!C:\S.T.A.L.K.E.R.NS.OGSR\bin\xrEngine.exe at [000000014004C64D] [CRenderDevice::on_idle()] + [469] byte(s) in [D:\!!!Narodnaya Solyanka!!!\!OGSR!\GitHub\NS_OGSR_Engine\ogsr_engine\xrEngine\device.cpp:338]
!C:\S.T.A.L.K.E.R.NS.OGSR\bin\xrEngine.exe at [000000014004CB97] [CRenderDevice::Run()] + [527] byte(s) in [D:\!!!Narodnaya Solyanka!!!\!OGSR!\GitHub\NS_OGSR_Engine\ogsr_engine\xrEngine\device.cpp:482] + [73] byte(s)
!C:\S.T.A.L.K.E.R.NS.OGSR\bin\xrEngine.exe at [0000000140013D01] [`anonymous namespace'::Run()] + [817] byte(s) in [D:\!!!Narodnaya Solyanka!!!\!OGSR!\GitHub\NS_OGSR_Engine\ogsr_engine\xrEngine\x_ray.cpp:282]
!C:\S.T.A.L.K.E.R.NS.OGSR\bin\xrEngine.exe at [0000000140014329] [WinMain_impl()] + [617] byte(s) in [D:\!!!Narodnaya Solyanka!!!\!OGSR!\GitHub\NS_OGSR_Engine\ogsr_engine\xrEngine\x_ray.cpp:501]
!C:\S.T.A.L.K.E.R.NS.OGSR\bin\xrEngine.exe at [0000000140014561] [WinMain()] + [9] byte(s) in [D:\!!!Narodnaya Solyanka!!!\!OGSR!\GitHub\NS_OGSR_Engine\ogsr_engine\xrEngine\x_ray.cpp:529]
!C:\S.T.A.L.K.E.R.NS.OGSR\bin\xrEngine.exe at [0000000140A5E45A] [__scrt_common_main_seh()] + [262] byte(s) in [D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:288] + [33] byte(s)
```