### PR TITLE
[util] Spoof GPU for Sims 3

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -1130,6 +1130,13 @@ namespace dxvk {
     { R"(\\RRU(_demo)?\.exe$)", {{
       { "dxvk.zeroMappedMemory",            "True" },
     }} },
+    /* Sims 3                                    *
+     * Worse shadow quality on unknown AMD cards */
+    { R"(\\TS3(W)?\.exe$)", {{
+      { "d3d9.customVendorId",              "10de" },
+      { "d3d9.customDeviceId",              "1080" },
+      { "d3d9.customDeviceDesc", "Geforce GTX 580" },
+    }} },
 
 
     /**********************************************/


### PR DESCRIPTION
Worse shadow quality on unknown AMD cards.

Closes #5458 