### PR TITLE
Correct a few native API data types

### DIFF
--- a/src/util/thread.cpp
+++ b/src/util/thread.cpp
@@ -80,7 +80,7 @@ namespace dxvk {
 namespace dxvk::this_thread {
 
   bool isInModuleDetachment() {
-    using PFN_RtlDllShutdownInProgress = BOOLEAN (WINAPI *)();
+    using PFN_RtlDllShutdownInProgress = BOOLEAN (NTAPI *)();
 
     static auto RtlDllShutdownInProgress = reinterpret_cast<PFN_RtlDllShutdownInProgress>(
       ::GetProcAddress(::GetModuleHandleW(L"ntdll.dll"), "RtlDllShutdownInProgress"));

--- a/src/util/util_sleep.h
+++ b/src/util/util_sleep.h
@@ -51,9 +51,9 @@ namespace dxvk {
 #ifdef _WIN32
     // On Windows, we use NtDelayExecution which has units of 100ns.
     using TimerDuration = std::chrono::duration<int64_t, std::ratio<1, 10000000>>;
-    using NtQueryTimerResolutionProc = UINT (WINAPI *) (ULONG*, ULONG*, ULONG*);
-    using NtSetTimerResolutionProc = UINT (WINAPI *) (ULONG, BOOL, ULONG*);
-    using NtDelayExecutionProc = UINT (WINAPI *) (BOOL, LARGE_INTEGER*);
+    using NtQueryTimerResolutionProc = LONG (NTAPI *) (ULONG*, ULONG*, ULONG*);
+    using NtSetTimerResolutionProc = LONG (NTAPI *) (ULONG, BOOLEAN, ULONG*);
+    using NtDelayExecutionProc = LONG (NTAPI *) (BOOLEAN, LARGE_INTEGER*);
     NtDelayExecutionProc NtDelayExecution = nullptr;
 #else
     // On other platforms, we use the std library, which calls through to nanosleep -- which is ns.


### PR DESCRIPTION
Microsoft use different-sized data type for boolean in their Native API and Win32 API.

And there are 2 types of calling conversion name as NTAPI and WINAPI, which are currently both being __stdcall but might worth being strict as NTAPI could change as they are undocumented.