### PR TITLE
[d3d9] Reset texture projected bitmask

### DIFF
--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -8874,6 +8874,10 @@ namespace dxvk {
       stage[DXVK_TSS_RESULTARG]             = D3DTA_CURRENT;
       stage[DXVK_TSS_CONSTANT]              = 0x00000000;
     }
+
+    // Projected is set based on DXVK_TSS_TEXTURETRANSFORMFLAGS
+    m_textureSlotTracking.projected = 0;
+
     m_dirty.set(D3D9DeviceDirtyFlag::SharedPixelShaderData);
     m_dirty.set(D3D9DeviceDirtyFlag::FFPixelShader);
 


### PR DESCRIPTION
Fixes #5469

The game sets `D3DTSS_TEXTURETRANSFORMFLAGS` stage 1 exactly once in the first frame but never draws anything with that value and calls `Reset()` pretty soon afterwards. `D3DTSS_TEXTURETRANSFORMFLAGS` decides whether a texture should be projected (tex coords divided by the last component).
We never reset the `projected` Bitfield (even before the change that moved the bitfields into a struct cc67b2c027c96ba618fd0770650ab8e2d8b3453e), so the game ended up stuck with sampler 1 being configured to projected. It never touches `D3DTSS_TEXTURETRANSFORMFLAGS` for stage 1 after the reset.

This used to be fine because before my change that the fixed function pipeline use the same `projected` Bitfield as the programmable pipeline (dd427a2dbfde6bfc15d759b10777157fab02ad99), it just accessed the `D3DTSS_TEXTURETRANSFORMFLAGS` state directly when building the FF shader lookup key.

`key.Data.Contents.Projected       |= ((m_state.textureStages[i][DXVK_TSS_TEXTURETRANSFORMFLAGS] & D3DTTFF_PROJECTED) == D3DTTFF_PROJECTED) << i;`