### PR TITLE
meson: Fix glfw dependency request to use correct pkgconfig name

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -150,7 +150,7 @@ else
 
   lib_sdl3 = dependency('sdl3', required: get_option('native_sdl3'))
   lib_sdl2 = dependency('sdl2', required: get_option('native_sdl2'))
-  lib_glfw = dependency('glfw', required: get_option('native_glfw'))
+  lib_glfw = dependency('glfw3', required: get_option('native_glfw'))
   if lib_sdl3.found()
     compiler_args += ['-DDXVK_WSI_SDL3']
   endif


### PR DESCRIPTION
GLFW's actual pkgconfig module is "glfw3", so use the right name so it can be found.