### PR TITLE
Improve unsynchronized render pass heuristics

### DIFF
--- a/src/dxvk/dxvk_context.h
+++ b/src/dxvk/dxvk_context.h
@@ -26,6 +26,8 @@ namespace dxvk {
     constexpr static VkDeviceSize MaxDiscardSize     =  16u << 10u;
 
     constexpr static uint32_t DirectMultiDrawBatchSize = 256u;
+
+    constexpr static uint32_t MaxUnsynchronizedDraws = 64u;
   public:
     
     DxvkContext(const Rc<DxvkDevice>& device);
@@ -1336,7 +1338,8 @@ namespace dxvk {
 
     uint64_t                m_trackingId = 0u;
     uint32_t                m_renderPassIndex = 0u;
-    
+    uint32_t                m_unsynchronizedDrawCount = 0u;
+
     Rc<DxvkCommandList>     m_cmd;
     Rc<DxvkBuffer>          m_zeroBuffer;
 


### PR DESCRIPTION
Turns out that we massively regressed Ashes of the Benchmark because the game draws a couple thousand quads into some texture atlas every single frame, which obviously happens without a depth buffer so our heuristic for "cheap" render passes fires.

Counting draws actually works here because a) there are real barriers before those draws anyway and b) it's *so many* draws that they are spread across multiple command lists on desktop.

In an ideal universe, we could also make (some) passes with depth buffers unsynchronized, but given that those are typically very expensive we'd need to enable secondary command buffers for those, and then everything becomes a mess and I'd honestly rather not go there.