### PR TITLE
Throttle resource eviction

### DIFF
--- a/src/dxvk/dxvk_memory.cpp
+++ b/src/dxvk/dxvk_memory.cpp
@@ -634,7 +634,12 @@ namespace dxvk {
       if (totalSize && totalSize + iter->first.size > size)
         break;
 
-      totalSize += iter->first.size;
+      // Reduce number of resource evictions performed per request by
+      // overestimating the amount of memory moved. May reduce stutter
+      // in high-ish frame rate scenarios.
+      totalSize += iter->second.mode == DxvkAllocationMode::NoDeviceMemory
+        ? iter->first.size * 16u
+        : iter->first.size;
 
       result.push_back(std::move(iter->second));
       m_entries.erase(iter);


### PR DESCRIPTION
Limits the amount of memory moved from VRAM to system memory to ~1MiB per submission.

Things were a bit *too* stuttery under extreme memory pressure while simultaneously running high frame rates; this isn't ever going to go away entirely for the very simple reason that randomly accessing resources in system memory *will* temporarily tank GPU performance, but we don't need to make it worse than necessary.