### PR TITLE
[d3d8] Properly handle W11V11U10 support

### DIFF
--- a/src/d3d9/d3d9_adapter.cpp
+++ b/src/d3d9/d3d9_adapter.cpp
@@ -865,6 +865,11 @@ namespace dxvk {
   }
 
 
+  void D3D9Adapter::RefreshFormatsTable() const {
+    m_d3d9Formats->RefreshFormatSupport(this);
+  }
+
+
   bool D3D9Adapter::IsExtended() const {
     return m_parent->IsExtended();
   }

--- a/src/d3d9/d3d9_adapter.h
+++ b/src/d3d9/d3d9_adapter.h
@@ -98,6 +98,8 @@ namespace dxvk {
       return m_9On12Args;
     }
 
+    void RefreshFormatsTable() const;
+
     bool IsExtended() const;
 
     bool IsD3D8Compatible() const;
@@ -153,7 +155,7 @@ namespace dxvk {
     std::vector<D3DDISPLAYMODEEX>            m_modes;
     D3D9Format                               m_modeCacheFormat;
 
-    std::unique_ptr<const D3D9VkFormatTable> m_d3d9Formats;
+    std::unique_ptr<D3D9VkFormatTable>       m_d3d9Formats;
 
   };
 

--- a/src/d3d9/d3d9_format.h
+++ b/src/d3d9/d3d9_format.h
@@ -222,6 +222,9 @@ namespace dxvk {
     const DxvkFormatInfo* GetUnsupportedFormatInfo(
       D3D9Format            Format) const;
 
+    void RefreshFormatSupport(
+      const D3D9Adapter*          pParent);
+
   private:
 
     bool CheckImageFormatSupport(
@@ -230,13 +233,13 @@ namespace dxvk {
             VkFormatFeatureFlags2 Features) const;
 
     bool m_isExtended;
-    bool m_isD3D8Compatible;
 
     bool m_d24s8Support;
     bool m_d16s8Support;
 
     bool m_dfSupport;
     bool m_x4r4g4b4Support;
+    bool m_w11v11u10Support;
     bool m_d16lockableSupport;
 
     bool m_d32flockableSupport;

--- a/src/d3d9/d3d9_interface.h
+++ b/src/d3d9/d3d9_interface.h
@@ -147,6 +147,7 @@ namespace dxvk {
 
     void EnableD3D8CompatibilityMode() {
       m_isD3D8Compatible = true;
+      RefreshAdapterFormatTables();
       Logger::info("The D3D9 interface is now operating in D3D8 compatibility mode.");
     }
 
@@ -155,10 +156,15 @@ namespace dxvk {
     bool HasFormatsUnlocked() const { return m_unlockAdditionalFormats; }
 
     void EnableAdditionalFormats() {
-            m_unlockAdditionalFormats = true;
+      m_unlockAdditionalFormats = true;
     }
 
   private:
+
+    inline void RefreshAdapterFormatTables() {
+      for (auto& adapter : m_adapters)
+        adapter.RefreshFormatsTable();
+    }
 
     Rc<DxvkInstance>              m_instance;
 


### PR DESCRIPTION
Ever since 10aacfd W11V11U10 has been advertised as unsupported, because the adapter D3D9VkFormatTable gets created before the D3D9 bridge can call to set the D3D8 compatibility mode, and remains set in stone.

To accommodate this, and other format support changes caused by comparability mode toggles (we have plenty of those in D7VK e.g.), I'm simply refreshing the relevant bits in D3D9VkFormatTable on all adapters whenever a compatibility mode gets set. It was possible to simply re-create the table as well, but that would have been a tad wasteful.

@K0bin Please review, but hopefully I haven't bunged this a second time.