### PR TITLE
Switch from MinGW-m64 to UCRT64

### DIFF
--- a/build-win64.txt
+++ b/build-win64.txt
@@ -1,9 +1,9 @@
 [binaries]
-c = 'x86_64-w64-mingw32-gcc'
-cpp = 'x86_64-w64-mingw32-g++'
-ar = 'x86_64-w64-mingw32-ar'
-strip = 'x86_64-w64-mingw32-strip'
-windres = 'x86_64-w64-mingw32-windres'
+c = 'x86_64-w64-mingw32ucrt-gcc'
+cpp = 'x86_64-w64-mingw32ucrt-g++'
+ar = 'x86_64-w64-mingw32ucrt-ar'
+strip = 'x86_64-w64-mingw32ucrt-strip'
+windres = 'x86_64-w64-mingw32ucrt-windres'
 
 [properties]
 needs_exe_wrapper = true


### PR DESCRIPTION
UCRT64 is a new drop-in replacement for MinGW essentially.

Tested with The Sims 4, works great!