### PR TITLE
[meta] FIFA regex adjustment

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -129,7 +129,7 @@ namespace dxvk {
     }} },
     /* Fifa '19+: Binds typed buffer SRV to shader *
      * that expects raw/structured buffer SRV      */
-    { R"(\\FIFA(19|[2-9][0-9])(_demo)?\.exe$)", {{
+    { R"(\\FIFA(19|20|21|22)(_demo)?\.exe$)", {{
       { "dxvk.useRawSsbo",                  "True" },
     }} },
     /* Resident Evil 2/3: Ignore WaW hazards      */


### PR DESCRIPTION
Mostly a nitpick, but the current regex matches FIFA '97, '98, '99 :sweat_smile: ... not a problem for DXVK per se, but somebody think of the forks! :frog:

Doesn't hurt to be more explicit, since it appears that FIFA 23 is D3D12 exclusive, and starting with 2024 EA lost the FIFA license, so they're not called FIFA anymore for sure.