### PR TITLE
[dxvk] Fix OOB indexing by queue.family when queue type is absent

### DIFF
--- a/src/dxvk/dxvk_adapter.cpp
+++ b/src/dxvk/dxvk_adapter.cpp
@@ -11,10 +11,11 @@ namespace dxvk {
     DxvkDeviceQueue result = { };
     result.queueFamily = queue.family;
     result.queueIndex = queue.index;
-    result.properties = caps.getQueueProperties(queue.family);
 
-    if (queue.family != VK_QUEUE_FAMILY_IGNORED)
+    if (queue.family != VK_QUEUE_FAMILY_IGNORED) {
+      result.properties = caps.getQueueProperties(queue.family);
       vkd->vkGetDeviceQueue(vkd->device(), queue.family, queue.index, &result.queueHandle);
+    }
 
     return result;
   }


### PR DESCRIPTION
Happened on device that doesn't have sparse queue exposed.

Fixes: 9157dcc0 ("[dxvk] Expose queue ownership transfer properties in device")