### PR TITLE
[dxvk] Pefer old present_id/wait extensions over present_id2/wait2

### DIFF
--- a/src/dxvk/dxvk_device_info.cpp
+++ b/src/dxvk/dxvk_device_info.cpp
@@ -574,9 +574,12 @@ namespace dxvk {
       m_featuresSupported.extLineRasterization.smoothLines = VK_FALSE;
     }
 
-    // Ensure we only enable one of present_id or present_id_2
-    if (m_featuresSupported.khrPresentId2.presentId2)
-      m_featuresSupported.khrPresentId.presentId = VK_FALSE;
+    // Ensure we only enable one of present_id or present_id_2. Prefer the
+    // older versions of the present_id/wait extensions since the newer ones
+    // cause issues with external layers and apparently some Wayland setups
+    // on Mesa for unknown reasons.
+    if (m_featuresSupported.khrPresentId.presentId)
+      m_featuresSupported.khrPresentId2.presentId2 = VK_FALSE;
 
     // Sanitize features with other feature dependencies
     if (!m_featuresSupported.core.features.shaderInt16)


### PR DESCRIPTION
Apparently the newer extensions just cause breakage everywhere *except* on my own machine (see #5507, https://gitlab.freedesktop.org/mesa/mesa/-/issues/14674).

This is going to be a problem for present_timing support since that *requires* present_id2, but for now it seems like the sane choice until someone figures out what the hell is going on.