### PR TITLE
[d3d9] Replace DxsoProgramType with new enum

### DIFF
--- a/src/d3d9/d3d9_constant_buffer.cpp
+++ b/src/d3d9/d3d9_constant_buffer.cpp
@@ -10,7 +10,7 @@ namespace dxvk {
 
   D3D9ConstantBuffer::D3D9ConstantBuffer(
           D3D9DeviceEx*         pDevice,
-          DxsoProgramType       ShaderStage,
+          D3D9ShaderType        ShaderStage,
           DxsoConstantBuffers   BufferType,
           VkDeviceSize          Size)
   : D3D9ConstantBuffer(pDevice, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT | VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, GetShaderStage(ShaderStage),

--- a/src/d3d9/d3d9_constant_buffer.h
+++ b/src/d3d9/d3d9_constant_buffer.h
@@ -23,7 +23,7 @@ namespace dxvk {
 
     D3D9ConstantBuffer(
             D3D9DeviceEx*         pDevice,
-            DxsoProgramType       ShaderStage,
+            D3D9ShaderType        ShaderStage,
             DxsoConstantBuffers   BufferType,
             VkDeviceSize          Size);
 

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -100,8 +100,8 @@ namespace dxvk {
     // Also check the required alignments.
     const bool supportsRobustness2 = m_dxvkDevice->features().extRobustness2.robustBufferAccess2;
     bool useRobustConstantAccess = supportsRobustness2;
-    D3D9ConstantSets& vsConstSet = m_consts[DxsoProgramType::VertexShader];
-    D3D9ConstantSets& psConstSet = m_consts[DxsoProgramType::PixelShader];
+    D3D9ConstantSets& vsConstSet = m_consts[uint32_t(D3D9ShaderType::VertexShader)];
+    D3D9ConstantSets& psConstSet = m_consts[uint32_t(D3D9ShaderType::PixelShader)];
     if (useRobustConstantAccess) {
       m_robustSSBOAlignment = m_dxvkDevice->properties().extRobustness2.robustStorageBufferAccessSizeAlignment;
       m_robustUBOAlignment  = m_dxvkDevice->properties().extRobustness2.robustUniformBufferAccessSizeAlignment;
@@ -193,8 +193,8 @@ namespace dxvk {
 
     m_specInfo.set<SpecDrefScaling, uint32_t>(m_d3d9Options.drefScaling);
 
-    BindFFUbershader<DxsoProgramType::VertexShader>();
-    BindFFUbershader<DxsoProgramType::PixelShader>();
+    BindFFUbershader<D3D9ShaderType::VertexShader>();
+    BindFFUbershader<D3D9ShaderType::PixelShader>();
 
     m_unlockAdditionalFormats = m_parent->HasFormatsUnlocked();
   }
@@ -3401,11 +3401,11 @@ namespace dxvk {
     // We unbound the pixel shader before,
     // let's make sure that gets rebound.
     if (m_state.pixelShader != nullptr) {
-      BindShader<DxsoProgramTypes::PixelShader>(
+      BindShader<D3D9ShaderType::PixelShader>(
         GetCommonShader(m_state.pixelShader));
     } else {
       m_dirty.set(D3D9DeviceDirtyFlag::FFPixelShader);
-      BindFFUbershader<DxsoProgramType::PixelShader>();
+      BindFFUbershader<D3D9ShaderType::PixelShader>();
     }
 
     if (dst->GetMapMode() == D3D9_COMMON_BUFFER_MAP_MODE_BUFFER) {
@@ -3481,10 +3481,10 @@ namespace dxvk {
 
     if (unlikely(usesProgrammableVS != wasUsingProgrammableVS)) {
       if (usesProgrammableVS) {
-        BindShader<DxsoProgramType::VertexShader>(GetCommonShader(m_state.vertexShader));
+        BindShader<D3D9ShaderType::VertexShader>(GetCommonShader(m_state.vertexShader));
       } else {
         m_dirty.set(D3D9DeviceDirtyFlag::FFVertexShader);
-        BindFFUbershader<DxsoProgramType::VertexShader>();
+        BindFFUbershader<D3D9ShaderType::VertexShader>();
       }
     }
 
@@ -3595,11 +3595,11 @@ namespace dxvk {
     bool oldCopies = oldShader && oldShader->GetMeta().needsConstantCopies;
     bool newCopies = newShader && newShader->GetMeta().needsConstantCopies;
 
-    m_consts[DxsoProgramTypes::VertexShader].dirty |= oldCopies || newCopies || !oldShader;
-    m_consts[DxsoProgramTypes::VertexShader].meta  = newShader ? newShader->GetMeta() : DxsoShaderMetaInfo();
+    m_consts[uint32_t(D3D9ShaderType::VertexShader)].dirty |= oldCopies || newCopies || !oldShader;
+    m_consts[uint32_t(D3D9ShaderType::VertexShader)].meta  = newShader ? newShader->GetMeta() : DxsoShaderMetaInfo();
 
     if (newShader && oldShader) {
-      m_consts[DxsoProgramTypes::VertexShader].dirty
+      m_consts[uint32_t(D3D9ShaderType::VertexShader)].dirty
         |= newShader->GetMeta().maxConstIndexF > oldShader->GetMeta().maxConstIndexF
         || newShader->GetMeta().maxConstIndexI > oldShader->GetMeta().maxConstIndexI
         || newShader->GetMeta().maxConstIndexB > oldShader->GetMeta().maxConstIndexB;
@@ -3612,12 +3612,12 @@ namespace dxvk {
     const bool usesProgrammableVS = UseProgrammableVS();
 
     if (usesProgrammableVS) {
-      BindShader<DxsoProgramTypes::VertexShader>(GetCommonShader(shader));
+      BindShader<D3D9ShaderType::VertexShader>(GetCommonShader(shader));
 
       UpdateTextureTypeMismatchesForShader(newShader, VSShaderMasks().samplerMask, FirstVSSamplerSlot);
     } else if (wasUsingProgrammableVS) {
       m_dirty.set(D3D9DeviceDirtyFlag::FFVertexShader);
-      BindFFUbershader<DxsoProgramType::VertexShader>();
+      BindFFUbershader<D3D9ShaderType::VertexShader>();
     }
 
     m_dirty.set(D3D9DeviceDirtyFlag::InputLayout);
@@ -3647,7 +3647,7 @@ namespace dxvk {
     D3D9DeviceLock lock = LockDevice();
 
     return SetShaderConstants<
-      DxsoProgramTypes::VertexShader,
+      D3D9ShaderType::VertexShader,
       D3D9ConstantType::Float>(
         StartRegister,
         pConstantData,
@@ -3662,7 +3662,7 @@ namespace dxvk {
     D3D9DeviceLock lock = LockDevice();
 
     return GetShaderConstants<
-      DxsoProgramTypes::VertexShader,
+      D3D9ShaderType::VertexShader,
       D3D9ConstantType::Float>(
         StartRegister,
         pConstantData,
@@ -3677,7 +3677,7 @@ namespace dxvk {
     D3D9DeviceLock lock = LockDevice();
 
     return SetShaderConstants<
-      DxsoProgramTypes::VertexShader,
+      D3D9ShaderType::VertexShader,
       D3D9ConstantType::Int>(
         StartRegister,
         pConstantData,
@@ -3692,7 +3692,7 @@ namespace dxvk {
     D3D9DeviceLock lock = LockDevice();
 
     return GetShaderConstants<
-      DxsoProgramTypes::VertexShader,
+      D3D9ShaderType::VertexShader,
       D3D9ConstantType::Int>(
         StartRegister,
         pConstantData,
@@ -3707,7 +3707,7 @@ namespace dxvk {
     D3D9DeviceLock lock = LockDevice();
 
     return SetShaderConstants<
-      DxsoProgramTypes::VertexShader,
+      D3D9ShaderType::VertexShader,
       D3D9ConstantType::Bool>(
         StartRegister,
         pConstantData,
@@ -3722,7 +3722,7 @@ namespace dxvk {
     D3D9DeviceLock lock = LockDevice();
 
     return GetShaderConstants<
-      DxsoProgramTypes::VertexShader,
+      D3D9ShaderType::VertexShader,
       D3D9ConstantType::Bool>(
         StartRegister,
         pConstantData,
@@ -3954,11 +3954,11 @@ namespace dxvk {
     bool oldCopies = oldShader && oldShader->GetMeta().needsConstantCopies;
     bool newCopies = newShader && newShader->GetMeta().needsConstantCopies;
 
-    m_consts[DxsoProgramTypes::PixelShader].dirty |= oldCopies || newCopies || !oldShader;
-    m_consts[DxsoProgramTypes::PixelShader].meta  = newShader ? newShader->GetMeta() : DxsoShaderMetaInfo();
+    m_consts[uint32_t(D3D9ShaderType::PixelShader)].dirty |= oldCopies || newCopies || !oldShader;
+    m_consts[uint32_t(D3D9ShaderType::PixelShader)].meta  = newShader ? newShader->GetMeta() : DxsoShaderMetaInfo();
 
     if (newShader && oldShader) {
-      m_consts[DxsoProgramTypes::PixelShader].dirty
+      m_consts[uint32_t(D3D9ShaderType::PixelShader)].dirty
         |= newShader->GetMeta().maxConstIndexF > oldShader->GetMeta().maxConstIndexF
         || newShader->GetMeta().maxConstIndexI > oldShader->GetMeta().maxConstIndexI
         || newShader->GetMeta().maxConstIndexB > oldShader->GetMeta().maxConstIndexB;
@@ -3969,7 +3969,7 @@ namespace dxvk {
     const D3D9ShaderMasks newShaderMasks = PSShaderMasks();
 
     if (shader != nullptr) {
-      BindShader<DxsoProgramTypes::PixelShader>(newShader);
+      BindShader<D3D9ShaderType::PixelShader>(newShader);
 
       UpdateTextureTypeMismatchesForShader(newShader, newShaderMasks.samplerMask, 0);
 
@@ -3994,7 +3994,7 @@ namespace dxvk {
     }
     else {
       m_dirty.set(D3D9DeviceDirtyFlag::FFPixelShader);
-      BindFFUbershader<DxsoProgramType::PixelShader>();
+      BindFFUbershader<D3D9ShaderType::PixelShader>();
 
       // TODO: What fixed function textures are in use?
       // Currently we are making all 8 of them as in use here.
@@ -4037,7 +4037,7 @@ namespace dxvk {
     D3D9DeviceLock lock = LockDevice();
 
     return SetShaderConstants <
-      DxsoProgramTypes::PixelShader,
+      D3D9ShaderType::PixelShader,
       D3D9ConstantType::Float>(
         StartRegister,
         pConstantData,
@@ -4052,7 +4052,7 @@ namespace dxvk {
     D3D9DeviceLock lock = LockDevice();
 
     return GetShaderConstants<
-      DxsoProgramTypes::PixelShader,
+      D3D9ShaderType::PixelShader,
       D3D9ConstantType::Float>(
         StartRegister,
         pConstantData,
@@ -4067,7 +4067,7 @@ namespace dxvk {
     D3D9DeviceLock lock = LockDevice();
 
     return SetShaderConstants<
-      DxsoProgramTypes::PixelShader,
+      D3D9ShaderType::PixelShader,
       D3D9ConstantType::Int>(
         StartRegister,
         pConstantData,
@@ -4082,7 +4082,7 @@ namespace dxvk {
     D3D9DeviceLock lock = LockDevice();
 
     return GetShaderConstants<
-      DxsoProgramTypes::PixelShader,
+      D3D9ShaderType::PixelShader,
       D3D9ConstantType::Int>(
         StartRegister,
         pConstantData,
@@ -4097,7 +4097,7 @@ namespace dxvk {
     D3D9DeviceLock lock = LockDevice();
 
     return SetShaderConstants<
-      DxsoProgramTypes::PixelShader,
+      D3D9ShaderType::PixelShader,
       D3D9ConstantType::Bool>(
         StartRegister,
         pConstantData,
@@ -4112,7 +4112,7 @@ namespace dxvk {
     D3D9DeviceLock lock = LockDevice();
 
     return GetShaderConstants<
-      DxsoProgramTypes::PixelShader,
+      D3D9ShaderType::PixelShader,
       D3D9ConstantType::Bool>(
         StartRegister,
         pConstantData,
@@ -4795,13 +4795,13 @@ namespace dxvk {
 
 
   void D3D9DeviceEx::DetermineConstantLayouts(bool canSWVP) {
-    D3D9ConstantSets& vsConstSet    = m_consts[DxsoProgramType::VertexShader];
+    D3D9ConstantSets& vsConstSet    = m_consts[uint32_t(D3D9ShaderType::VertexShader)];
     vsConstSet.layout.floatCount    = canSWVP ? caps::MaxFloatConstantsSoftware : caps::MaxFloatConstantsVS;
     vsConstSet.layout.intCount      = canSWVP ? caps::MaxOtherConstantsSoftware : caps::MaxOtherConstants;
     vsConstSet.layout.boolCount     = canSWVP ? caps::MaxOtherConstantsSoftware : caps::MaxOtherConstants;
     vsConstSet.layout.bitmaskCount  = align(vsConstSet.layout.boolCount, 32) / 32;
 
-    D3D9ConstantSets& psConstSet   = m_consts[DxsoProgramType::PixelShader];
+    D3D9ConstantSets& psConstSet   = m_consts[uint32_t(D3D9ShaderType::PixelShader)];
     psConstSet.layout.floatCount   = caps::MaxSM3FloatConstantsPS;
     psConstSet.layout.intCount     = caps::MaxOtherConstants;
     psConstSet.layout.boolCount    = caps::MaxOtherConstants;
@@ -6019,48 +6019,48 @@ namespace dxvk {
     constexpr VkDeviceSize DefaultConstantBufferSize  = 1024ull << 10;
     constexpr VkDeviceSize SmallConstantBufferSize    =   64ull << 10;
 
-    m_consts[DxsoProgramTypes::VertexShader].buffer = D3D9ConstantBuffer(this,
-      DxsoProgramType::VertexShader,
+    m_consts[uint32_t(D3D9ShaderType::VertexShader)].buffer = D3D9ConstantBuffer(this,
+      D3D9ShaderType::VertexShader,
       DxsoConstantBuffers::VSConstantBuffer,
       DefaultConstantBufferSize);
 
-    m_consts[DxsoProgramTypes::VertexShader].swvp.intBuffer = D3D9ConstantBuffer(this,
-      DxsoProgramType::VertexShader,
+    m_consts[uint32_t(D3D9ShaderType::VertexShader)].swvp.intBuffer = D3D9ConstantBuffer(this,
+      D3D9ShaderType::VertexShader,
       DxsoConstantBuffers::VSIntConstantBuffer,
       SmallConstantBufferSize);
 
-    m_consts[DxsoProgramTypes::VertexShader].swvp.boolBuffer = D3D9ConstantBuffer(this,
-      DxsoProgramType::VertexShader,
+    m_consts[uint32_t(D3D9ShaderType::VertexShader)].swvp.boolBuffer = D3D9ConstantBuffer(this,
+      D3D9ShaderType::VertexShader,
       DxsoConstantBuffers::VSBoolConstantBuffer,
       SmallConstantBufferSize);
 
-    m_consts[DxsoProgramTypes::PixelShader].buffer = D3D9ConstantBuffer(this,
-      DxsoProgramType::PixelShader,
+    m_consts[uint32_t(D3D9ShaderType::PixelShader)].buffer = D3D9ConstantBuffer(this,
+      D3D9ShaderType::PixelShader,
       DxsoConstantBuffers::PSConstantBuffer,
       DefaultConstantBufferSize);
 
     m_vsClipPlanes = D3D9ConstantBuffer(this,
-      DxsoProgramType::VertexShader,
+      D3D9ShaderType::VertexShader,
       DxsoConstantBuffers::VSClipPlanes,
       caps::MaxClipPlanes * sizeof(D3D9ClipPlane));
 
     m_vsFixedFunction = D3D9ConstantBuffer(this,
-      DxsoProgramType::VertexShader,
+      D3D9ShaderType::VertexShader,
       DxsoConstantBuffers::VSFixedFunction,
       sizeof(D3D9FixedFunctionVS));
 
     m_psFixedFunction = D3D9ConstantBuffer(this,
-      DxsoProgramType::PixelShader,
+      D3D9ShaderType::PixelShader,
       DxsoConstantBuffers::PSFixedFunction,
       sizeof(D3D9FixedFunctionPS));
 
     m_psShared = D3D9ConstantBuffer(this,
-      DxsoProgramType::PixelShader,
+      D3D9ShaderType::PixelShader,
       DxsoConstantBuffers::PSShared,
       sizeof(D3D9SharedPS));
 
     m_vsVertexBlend = D3D9ConstantBuffer(this,
-      DxsoProgramType::VertexShader,
+      D3D9ShaderType::VertexShader,
       DxsoConstantBuffers::VSVertexBlendData,
       CanSWVP()
         ? sizeof(D3D9FixedFunctionVertexBlendDataSW)
@@ -6085,7 +6085,7 @@ namespace dxvk {
      * to fit that. We rely on robustness to return 0 for OOB reads.
     */
 
-    D3D9ConstantSets& constSet = m_consts[DxsoProgramType::VertexShader];
+    D3D9ConstantSets& constSet = m_consts[uint32_t(D3D9ShaderType::VertexShader)];
 
     if (!constSet.dirty)
       return;
@@ -6147,13 +6147,13 @@ namespace dxvk {
   }
 
 
-  template <DxsoProgramType ShaderStage, typename HardwareLayoutType, typename SoftwareLayoutType, typename ShaderType>
+  template <D3D9ShaderType ShaderStage, typename HardwareLayoutType, typename SoftwareLayoutType, typename ShaderType>
   inline void D3D9DeviceEx::UploadConstantSet(const SoftwareLayoutType& Src, const D3D9ConstantLayout& Layout, const ShaderType& Shader) {
     /*
      * We just copy the float constants that have been set by the application and rely on robustness
      * to return 0 on OOB reads.
     */
-    D3D9ConstantSets& constSet = m_consts[ShaderStage];
+    D3D9ConstantSets& constSet = m_consts[uint32_t(ShaderStage)];
 
     if (!constSet.dirty)
       return;
@@ -6203,15 +6203,15 @@ namespace dxvk {
   }
 
 
-  template <DxsoProgramType ShaderStage>
+  template <D3D9ShaderType ShaderStage>
   void D3D9DeviceEx::UploadConstants() {
-    if constexpr (ShaderStage == DxsoProgramTypes::VertexShader) {
+    if constexpr (ShaderStage == D3D9ShaderType::VertexShader) {
       if (CanSWVP())
-        return UploadSoftwareConstantSet(m_state.vsConsts.get(), m_consts[ShaderStage].layout);
+        return UploadSoftwareConstantSet(m_state.vsConsts.get(), m_consts[uint32_t(ShaderStage)].layout);
       else
-        return UploadConstantSet<ShaderStage, D3D9ShaderConstantsVSHardware>(m_state.vsConsts.get(), m_consts[ShaderStage].layout, m_state.vertexShader);
+        return UploadConstantSet<ShaderStage, D3D9ShaderConstantsVSHardware>(m_state.vsConsts.get(), m_consts[uint32_t(ShaderStage)].layout, m_state.vertexShader);
     } else {
-      return UploadConstantSet<ShaderStage, D3D9ShaderConstantsPS>(m_state.psConsts.get(), m_consts[ShaderStage].layout, m_state.pixelShader);
+      return UploadConstantSet<ShaderStage, D3D9ShaderConstantsPS>(m_state.psConsts.get(), m_consts[uint32_t(ShaderStage)].layout, m_state.pixelShader);
     }
   }
 
@@ -7689,12 +7689,12 @@ namespace dxvk {
     UpdatePointMode(PrimitiveType == D3DPT_POINTLIST);
 
     if (likely(UseProgrammableVS())) {
-      UploadConstants<DxsoProgramTypes::VertexShader>();
+      UploadConstants<D3D9ShaderType::VertexShader>();
 
       if (likely(!CanSWVP())) {
         UpdateVertexBoolSpec(
           m_state.vsConsts->bConsts[0] &
-          m_consts[DxsoProgramType::VertexShader].meta.boolConstantMask);
+          m_consts[uint32_t(D3D9ShaderType::VertexShader)].meta.boolConstantMask);
       } else
         UpdateVertexBoolSpec(0);
     }
@@ -7708,7 +7708,7 @@ namespace dxvk {
 
     uint32_t projected = m_textureSlotTracking.projected;
     if (likely(UseProgrammablePS())) {
-      UploadConstants<DxsoProgramTypes::PixelShader>();
+      UploadConstants<D3D9ShaderType::PixelShader>();
 
       const uint32_t psTextureMask = usedTextureMask & ((1u << caps::MaxTexturesPS) - 1u);
       const uint32_t fetch4        = m_textureSlotTracking.fetch4    & psTextureMask;
@@ -7735,7 +7735,7 @@ namespace dxvk {
 
       UpdatePixelBoolSpec(
         m_state.psConsts->bConsts[0] &
-        m_consts[DxsoProgramType::PixelShader].meta.boolConstantMask);
+        m_consts[uint32_t(D3D9ShaderType::PixelShader)].meta.boolConstantMask);
     }
     else {
       // Fixed function shaders use the projected spec constant too.
@@ -7880,7 +7880,7 @@ namespace dxvk {
   }
 
 
-  template <DxsoProgramType ShaderStage>
+  template <D3D9ShaderType ShaderStage>
   void D3D9DeviceEx::BindShader(
   const D3D9CommonShader*                 pShaderModule) {
     auto shader = pShaderModule->GetShader();
@@ -7897,9 +7897,9 @@ namespace dxvk {
   }
 
 
-  template <DxsoProgramType ShaderStage>
+  template <D3D9ShaderType ShaderStage>
   void D3D9DeviceEx::BindFFUbershader() {
-    if (ShaderStage == DxsoProgramType::VertexShader) {
+    if (ShaderStage == D3D9ShaderType::VertexShader) {
       EmitCs([
        &cShaders = m_ffModules
       ](DxvkContext* ctx) {
@@ -8088,7 +8088,7 @@ namespace dxvk {
     m_state.vsConsts->bConsts[idx] &= ~mask;
     m_state.vsConsts->bConsts[idx] |= bits & mask;
 
-    m_consts[DxsoProgramTypes::VertexShader].dirty = true;
+    m_consts[uint32_t(D3D9ShaderType::VertexShader)].dirty = true;
   }
 
 
@@ -8096,7 +8096,7 @@ namespace dxvk {
     m_state.psConsts->bConsts[idx] &= ~mask;
     m_state.psConsts->bConsts[idx] |= bits & mask;
 
-    m_consts[DxsoProgramTypes::PixelShader].dirty = true;
+    m_consts[uint32_t(D3D9ShaderType::PixelShader)].dirty = true;
   }
 
 
@@ -8120,15 +8120,15 @@ namespace dxvk {
 
 
   template <
-    DxsoProgramType  ProgramType,
+    D3D9ShaderType   ShaderType,
     D3D9ConstantType ConstantType,
     typename         T>
     HRESULT D3D9DeviceEx::SetShaderConstants(
             UINT  StartRegister,
       const T*    pConstantData,
             UINT  Count) {
-    const     uint32_t regCountHardware = DetermineHardwareRegCount<ProgramType, ConstantType>();
-    constexpr uint32_t regCountSoftware = DetermineSoftwareRegCount<ProgramType, ConstantType>();
+    const     uint32_t regCountHardware = DetermineHardwareRegCount<ShaderType, ConstantType>();
+    constexpr uint32_t regCountSoftware = DetermineSoftwareRegCount<ShaderType, ConstantType>();
 
     // Error out in case of StartRegister + Count overflow
     if (unlikely(StartRegister > std::numeric_limits<uint32_t>::max() - Count))
@@ -8149,20 +8149,20 @@ namespace dxvk {
       return D3DERR_INVALIDCALL;
 
     if (unlikely(ShouldRecord()))
-      return m_recorder->SetShaderConstants<ProgramType, ConstantType, T>(
+      return m_recorder->SetShaderConstants<ShaderType, ConstantType, T>(
         StartRegister,
         pConstantData,
         Count);
 
-    D3D9ConstantSets& constSet = m_consts[ProgramType];
+    D3D9ConstantSets& constSet = m_consts[uint32_t(ShaderType)];
 
     if constexpr (ConstantType == D3D9ConstantType::Float) {
       constSet.maxChangedConstF = std::max(constSet.maxChangedConstF, StartRegister + Count);
-    } else if constexpr (ConstantType == D3D9ConstantType::Int && ProgramType == DxsoProgramType::VertexShader) {
+    } else if constexpr (ConstantType == D3D9ConstantType::Int && ShaderType == D3D9ShaderType::VertexShader) {
       // We only track changed int constants for vertex shaders (and it's only used when the device uses the SWVP UBO layout).
       // Pixel shaders (and vertex shaders on HWVP devices) always copy all int constants into the same UBO as the float constants
       constSet.maxChangedConstI = std::max(constSet.maxChangedConstI, StartRegister + Count);
-    } else  if constexpr (ConstantType == D3D9ConstantType::Bool && ProgramType == DxsoProgramType::VertexShader) {
+    } else  if constexpr (ConstantType == D3D9ConstantType::Bool && ShaderType == D3D9ShaderType::VertexShader) {
       // We only track changed bool constants for vertex shaders (and it's only used when the device uses the SWVP UBO layout).
       // Pixel shaders (and vertex shaders on HWVP devices) always put all bool constants into a single spec constant.
       constSet.maxChangedConstB = std::max(constSet.maxChangedConstB, StartRegister + Count);
@@ -8174,13 +8174,13 @@ namespace dxvk {
         : constSet.meta.maxConstIndexI;
 
       constSet.dirty |= StartRegister < maxCount;
-    } else if constexpr (ProgramType == DxsoProgramType::VertexShader) {
+    } else if constexpr (ShaderType == D3D9ShaderType::VertexShader) {
       if (unlikely(CanSWVP())) {
         constSet.dirty |= StartRegister < constSet.meta.maxConstIndexB;
       }
     }
 
-    UpdateStateConstants<ProgramType, ConstantType, T>(
+    UpdateStateConstants<ShaderType, ConstantType, T>(
       &m_state,
       StartRegister,
       pConstantData,

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -1030,10 +1030,10 @@ namespace dxvk {
 
     inline void* CopySoftwareConstants(D3D9ConstantBuffer& dstBuffer, const void* src, uint32_t size);
 
-    template <DxsoProgramType ShaderStage, typename HardwareLayoutType, typename SoftwareLayoutType, typename ShaderType>
+    template <D3D9ShaderType ShaderStage, typename HardwareLayoutType, typename SoftwareLayoutType, typename ShaderType>
     inline void UploadConstantSet(const SoftwareLayoutType& Src, const D3D9ConstantLayout& Layout, const ShaderType& Shader);
 
-    template <DxsoProgramType ShaderStage>
+    template <D3D9ShaderType ShaderStage>
     void UploadConstants();
 
     void UpdateClipPlanes();
@@ -1085,11 +1085,11 @@ namespace dxvk {
 
     void EnsureSamplerLimit();
 
-    template <DxsoProgramType ShaderStage>
+    template <D3D9ShaderType ShaderStage>
     void BindShader(
     const D3D9CommonShader*                 pShaderModule);
 
-    template <DxsoProgramType ShaderStage>
+    template <D3D9ShaderType ShaderStage>
     void BindFFUbershader();
 
     void BindInputLayout();
@@ -1139,8 +1139,8 @@ namespace dxvk {
             VkImageLayout            OldLayout,
             VkImageLayout            NewLayout);
 
-    const D3D9ConstantLayout& GetVertexConstantLayout() { return m_consts[DxsoProgramType::VertexShader].layout; }
-    const D3D9ConstantLayout& GetPixelConstantLayout()  { return m_consts[DxsoProgramType::PixelShader].layout; }
+    const D3D9ConstantLayout& GetVertexConstantLayout() { return m_consts[uint32_t(D3D9ShaderType::VertexShader)].layout; }
+    const D3D9ConstantLayout& GetPixelConstantLayout()  { return m_consts[uint32_t(D3D9ShaderType::PixelShader)].layout; }
 
     void ResetState(D3DPRESENT_PARAMETERS* pPresentationParameters);
     HRESULT ResetSwapChain(D3DPRESENT_PARAMETERS* pPresentationParameters, D3DDISPLAYMODEEX* pFullscreenDisplayMode);
@@ -1364,10 +1364,10 @@ namespace dxvk {
     }
 
     // So we don't do OOB.
-    template <DxsoProgramType  ProgramType,
+    template <D3D9ShaderType   ShaderType,
               D3D9ConstantType ConstantType>
     inline static constexpr uint32_t DetermineSoftwareRegCount() {
-      constexpr bool isVS = ProgramType == DxsoProgramType::VertexShader;
+      constexpr bool isVS = ShaderType == D3D9ShaderType::VertexShader;
 
       switch (ConstantType) {
         default:
@@ -1378,10 +1378,10 @@ namespace dxvk {
     }
 
     // So we don't copy more than we need.
-    template <DxsoProgramType  ProgramType,
+    template <D3D9ShaderType   ShaderType,
               D3D9ConstantType ConstantType>
     inline uint32_t DetermineHardwareRegCount() const {
-      const auto& layout = m_consts[ProgramType].layout;
+      const auto& layout = m_consts[uint32_t(ShaderType)].layout;
 
       switch (ConstantType) {
         default:
@@ -1396,7 +1396,7 @@ namespace dxvk {
     }
 
     template <
-      DxsoProgramType  ProgramType,
+      D3D9ShaderType   ShaderType,
       D3D9ConstantType ConstantType,
       typename         T>
       HRESULT SetShaderConstants(
@@ -1405,7 +1405,7 @@ namespace dxvk {
               UINT  Count);
 
     template <
-      DxsoProgramType  ProgramType,
+      D3D9ShaderType   ShaderType,
       D3D9ConstantType ConstantType,
       typename         T>
     HRESULT GetShaderConstants(
@@ -1413,8 +1413,8 @@ namespace dxvk {
             T*   pConstantData,
             UINT Count) {
       auto GetHelper = [&] (const auto& set) {
-        const     uint32_t regCountHardware = DetermineHardwareRegCount<ProgramType, ConstantType>();
-        constexpr uint32_t regCountSoftware = DetermineSoftwareRegCount<ProgramType, ConstantType>();
+        const     uint32_t regCountHardware = DetermineHardwareRegCount<ShaderType, ConstantType>();
+        constexpr uint32_t regCountSoftware = DetermineSoftwareRegCount<ShaderType, ConstantType>();
 
         if (StartRegister + Count > regCountSoftware)
           return D3DERR_INVALIDCALL;
@@ -1458,7 +1458,7 @@ namespace dxvk {
         return D3D_OK;
       };
 
-      return ProgramType == DxsoProgramTypes::VertexShader
+      return ShaderType == D3D9ShaderType::VertexShader
         ? GetHelper(m_state.vsConsts)
         : GetHelper(m_state.psConsts);
     }
@@ -1679,7 +1679,7 @@ namespace dxvk {
     uint32_t                        m_robustSSBOAlignment     = 1;
     uint32_t                        m_robustUBOAlignment      = 1;
 
-    D3D9ConstantSets                m_consts[DxsoProgramTypes::Count];
+    D3D9ConstantSets                m_consts[uint32_t(D3D9ShaderType::PixelShader) + 1];
 
     D3D9UserDefinedAnnotation*      m_annotation = nullptr;
 

--- a/src/d3d9/d3d9_fixed_function.cpp
+++ b/src/d3d9/d3d9_fixed_function.cpp
@@ -852,7 +852,7 @@ namespace dxvk {
     uint32_t emitMatrixTimesVector(uint32_t rowCount, uint32_t colCount, uint32_t matrix, uint32_t vector);
     uint32_t emitVectorTimesMatrix(uint32_t rowCount, uint32_t colCount, uint32_t vector, uint32_t matrix);
 
-    bool isVS() { return m_programType == DxsoProgramType::VertexShader; }
+    bool isVS() { return m_shaderType == D3D9ShaderType::VertexShader; }
     bool isPS() { return !isVS(); }
 
     std::string           m_filename;
@@ -865,7 +865,7 @@ namespace dxvk {
     uint32_t              m_outputMask      = 0u;
     uint32_t              m_flatShadingMask = 0u;
 
-    DxsoProgramType       m_programType;
+    D3D9ShaderType        m_shaderType;
     D3D9FFShaderKeyVS     m_vsKey;
     D3D9FFShaderKeyFS     m_fsKey;
 
@@ -907,7 +907,7 @@ namespace dxvk {
           D3D9FixedFunctionOptions Options)
   : m_filename    ( Name )
   , m_module      ( spvVersion(1, 3) )
-  , m_programType ( DxsoProgramTypes::VertexShader )
+  , m_shaderType  ( D3D9ShaderType::VertexShader )
   , m_vsKey       ( Key )
   , m_options     ( Options ) { }
 
@@ -919,7 +919,7 @@ namespace dxvk {
           D3D9FixedFunctionOptions Options)
   : m_filename    ( Name )
   , m_module      ( spvVersion(1, 3) )
-  , m_programType ( DxsoProgramTypes::PixelShader )
+  , m_shaderType  ( D3D9ShaderType::PixelShader )
   , m_fsKey       ( Key )
   , m_options     ( Options ) { }
 
@@ -1702,7 +1702,7 @@ namespace dxvk {
     m_module.setDebugName(m_vs.constantBuffer, "consts");
 
     const uint32_t bindingId = computeResourceSlotId(
-      DxsoProgramType::VertexShader, DxsoBindingType::ConstantBuffer,
+      D3D9ShaderType::VertexShader, DxsoBindingType::ConstantBuffer,
       DxsoConstantBuffers::VSFixedFunction);
 
     m_module.decorateDescriptorSet(m_vs.constantBuffer, 0);
@@ -1741,7 +1741,7 @@ namespace dxvk {
     m_module.setDebugName(m_vs.vertexBlendData, "VertexBlendData");
 
     const uint32_t bindingId = computeResourceSlotId(
-      DxsoProgramType::VertexShader, DxsoBindingType::ConstantBuffer,
+      D3D9ShaderType::VertexShader, DxsoBindingType::ConstantBuffer,
       DxsoConstantBuffers::VSVertexBlendData);
 
     m_module.decorateDescriptorSet(m_vs.vertexBlendData, 0);
@@ -2448,7 +2448,7 @@ namespace dxvk {
     m_module.setDebugName(m_ps.constantBuffer, "consts");
 
     const uint32_t bindingId = computeResourceSlotId(
-      DxsoProgramType::PixelShader, DxsoBindingType::ConstantBuffer,
+      D3D9ShaderType::PixelShader, DxsoBindingType::ConstantBuffer,
       DxsoConstantBuffers::PSFixedFunction);
 
     m_module.decorateDescriptorSet(m_ps.constantBuffer, 0);
@@ -2475,7 +2475,7 @@ namespace dxvk {
 
     // Samplers
     for (uint32_t i = 0; i < caps::TextureStageCount; i++) {
-      const uint32_t imageBindingId = computeResourceSlotId(DxsoProgramType::PixelShader,
+      const uint32_t imageBindingId = computeResourceSlotId(D3D9ShaderType::PixelShader,
         DxsoBindingType::Image, i);
 
       auto& imageBinding = m_bindings.emplace_back();
@@ -2548,7 +2548,7 @@ namespace dxvk {
     m_ps.sharedState = GetSharedConstants(m_module);
 
     const uint32_t bindingId = computeResourceSlotId(
-      m_programType, DxsoBindingType::ConstantBuffer,
+      m_shaderType, DxsoBindingType::ConstantBuffer,
       PSShared);
 
     m_module.decorateDescriptorSet(m_ps.sharedState, 0);
@@ -2588,7 +2588,7 @@ namespace dxvk {
     m_module.memberDecorateOffset (clipPlaneStruct, 0, 0);
 
     uint32_t bindingId = computeResourceSlotId(
-      DxsoProgramType::VertexShader,
+      D3D9ShaderType::VertexShader,
       DxsoBindingType::ConstantBuffer,
       DxsoConstantBuffers::VSClipPlanes);
 
@@ -2738,9 +2738,9 @@ namespace dxvk {
 
   D3D9FFShader::D3D9FFShader(
           D3D9DeviceEx*         pDevice,
-          DxsoProgramType       ProgramType) {
+          D3D9ShaderType        ShaderType) {
 
-    bool isVS = ProgramType == DxsoProgramType::VertexShader;
+    bool isVS = ShaderType == D3D9ShaderType::VertexShader;
 
     if (isVS) {
       std::array<DxvkBindingInfo, 4> bindings;
@@ -2755,7 +2755,7 @@ namespace dxvk {
       specConstantBufferBinding.flags.set(DxvkDescriptorFlag::UniformBuffer);
 
       constexpr uint32_t fixedFunctionDataBindingId = computeResourceSlotId(
-        DxsoProgramType::VertexShader, DxsoBindingType::ConstantBuffer,
+        D3D9ShaderType::VertexShader, DxsoBindingType::ConstantBuffer,
         DxsoConstantBuffers::VSFixedFunction);
       auto& fixedFunctionDataBinding = bindings[1];
       fixedFunctionDataBinding.set             = 0u;
@@ -2766,7 +2766,7 @@ namespace dxvk {
       fixedFunctionDataBinding.flags.set(DxvkDescriptorFlag::UniformBuffer);
 
       constexpr uint32_t vertexBlendBindingId = computeResourceSlotId(
-        DxsoProgramType::VertexShader, DxsoBindingType::ConstantBuffer,
+        D3D9ShaderType::VertexShader, DxsoBindingType::ConstantBuffer,
         DxsoConstantBuffers::VSVertexBlendData);
       auto& vertexBlendBinding = bindings[2];
       vertexBlendBinding.set             = 0u;
@@ -2777,7 +2777,7 @@ namespace dxvk {
       vertexBlendBinding.flags.set(DxvkDescriptorFlag::UniformBuffer);
 
       constexpr uint32_t clipPlanesBindingId = computeResourceSlotId(
-        DxsoProgramType::VertexShader, DxsoBindingType::ConstantBuffer,
+        D3D9ShaderType::VertexShader, DxsoBindingType::ConstantBuffer,
         DxsoConstantBuffers::VSClipPlanes);
       auto& clipPlanesBinding = bindings[3];
       clipPlanesBinding.set             = 0u;
@@ -2810,7 +2810,7 @@ namespace dxvk {
       specConstantBufferBinding.flags.set(DxvkDescriptorFlag::UniformBuffer);
 
       constexpr uint32_t fixedFunctionDataBindingId = computeResourceSlotId(
-        DxsoProgramType::PixelShader, DxsoBindingType::ConstantBuffer,
+        D3D9ShaderType::PixelShader, DxsoBindingType::ConstantBuffer,
         DxsoConstantBuffers::PSFixedFunction);
       auto& fixedFunctionDataBinding = bindings.emplace_back();
       fixedFunctionDataBinding.set             = 0u;
@@ -2821,7 +2821,7 @@ namespace dxvk {
       fixedFunctionDataBinding.flags.set(DxvkDescriptorFlag::UniformBuffer);
 
       constexpr uint32_t sharedDataBindingId = computeResourceSlotId(
-        DxsoProgramType::PixelShader, DxsoBindingType::ConstantBuffer,
+        D3D9ShaderType::PixelShader, DxsoBindingType::ConstantBuffer,
         DxsoConstantBuffers::PSShared);
       auto& sharedDataBinding = bindings.emplace_back();
       sharedDataBinding.set             = 0u;
@@ -2832,7 +2832,7 @@ namespace dxvk {
       sharedDataBinding.flags.set(DxvkDescriptorFlag::UniformBuffer);
 
       constexpr uint32_t textureBindingId = computeResourceSlotId(
-        DxsoProgramType::PixelShader,
+        D3D9ShaderType::PixelShader,
         DxsoBindingType::Image,
         0);
       auto& textureBinding = bindings.emplace_back();
@@ -2845,7 +2845,7 @@ namespace dxvk {
 
       for (uint32_t i = 0; i < caps::TextureStageCount; i++) {
         uint32_t samplerBindingId = computeResourceSlotId(
-          DxsoProgramType::PixelShader,
+          D3D9ShaderType::PixelShader,
           DxsoBindingType::Image,
           i);
 
@@ -2897,8 +2897,8 @@ namespace dxvk {
 
 
   D3D9FFShaderModuleSet::D3D9FFShaderModuleSet(D3D9DeviceEx* pDevice)
-    : m_vsUbershader(pDevice, DxsoProgramType::VertexShader)
-    , m_fsUbershader(pDevice, DxsoProgramType::PixelShader) {}
+    : m_vsUbershader(pDevice, D3D9ShaderType::VertexShader)
+    , m_fsUbershader(pDevice, D3D9ShaderType::PixelShader) {}
 
 
   D3D9FFShader D3D9FFShaderModuleSet::GetShaderModule(

--- a/src/d3d9/d3d9_fixed_function.h
+++ b/src/d3d9/d3d9_fixed_function.h
@@ -142,7 +142,7 @@ namespace dxvk {
 
     D3D9FFShader(
             D3D9DeviceEx*         pDevice,
-            DxsoProgramType       ProgramType);
+            D3D9ShaderType        ShaderType);
 
     template <typename T>
     void Dump(D3D9DeviceEx* pDevice, const T& Key, const std::string& Name);

--- a/src/d3d9/d3d9_include.h
+++ b/src/d3d9/d3d9_include.h
@@ -103,3 +103,8 @@ IDirect3DDevice9On12 : public IUnknown {
 __CRT_UUID_DECL(IDirect3DDevice9On12,      0xe7fda234,0xb589,0x4049,0x94,0x0d,0x88,0x78,0x97,0x75,0x31,0xc8);
 #endif
 
+enum class D3D9ShaderType : uint16_t {
+  VertexShader = 0,
+  PixelShader  = 1,
+};
+

--- a/src/d3d9/d3d9_shader_validator.cpp
+++ b/src/d3d9/d3d9_shader_validator.cpp
@@ -141,14 +141,14 @@ namespace dxvk {
 
     DxsoReader reader = { reinterpret_cast<const char*>(pdwInst) };
     uint32_t headerToken = reader.readu32();
-    uint32_t shaderType  = headerToken & 0xffff0000;
-    DxsoProgramType programType;
+    uint32_t shaderTypeDword  = headerToken & 0xffff0000;
+    D3D9ShaderType shaderType;
 
-    if (shaderType == 0xffff0000) { // Pixel Shader
-      programType = DxsoProgramTypes::PixelShader;
+    if (shaderTypeDword == 0xffff0000) { // Pixel Shader
+      shaderType = D3D9ShaderType::PixelShader;
       m_isPixelShader = true;
-    } else if (shaderType == 0xfffe0000) { // Vertex Shader
-      programType = DxsoProgramTypes::VertexShader;
+    } else if (shaderTypeDword == 0xfffe0000) { // Vertex Shader
+      shaderType = D3D9ShaderType::VertexShader;
       m_isPixelShader = false;
     } else {
       return ErrorCallback(pFile, Line, 0x6, pdwInst, cdw,
@@ -158,7 +158,7 @@ namespace dxvk {
 
     m_majorVersion = D3DSHADER_VERSION_MAJOR(headerToken);
     m_minorVersion = D3DSHADER_VERSION_MINOR(headerToken);
-    m_ctx   = std::make_unique<DxsoDecodeContext>(DxsoProgramInfo{ programType, m_minorVersion, m_majorVersion });
+    m_ctx   = std::make_unique<DxsoDecodeContext>(DxsoProgramInfo{ shaderType, m_minorVersion, m_majorVersion });
     m_state = D3D9ShaderValidatorState::ValidatingInstructions;
 
     const char* shaderTypeOutput = m_isPixelShader ? "PS" : "VS";

--- a/src/d3d9/d3d9_state.h
+++ b/src/d3d9/d3d9_state.h
@@ -419,7 +419,7 @@ namespace dxvk {
   using D3D9DeviceState = D3D9State<static_item>;
 
   template <
-    DxsoProgramType  ProgramType,
+    D3D9ShaderType   ShaderType,
     D3D9ConstantType ConstantType,
     typename         T,
     typename         StateType>
@@ -464,7 +464,7 @@ namespace dxvk {
       return D3D_OK;
     };
 
-    return ProgramType == DxsoProgramTypes::VertexShader
+    return ShaderType == D3D9ShaderType::VertexShader
       ? UpdateHelper(pState->vsConsts)
       : UpdateHelper(pState->psConsts);
   }

--- a/src/d3d9/d3d9_stateblock.cpp
+++ b/src/d3d9/d3d9_stateblock.cpp
@@ -283,7 +283,7 @@ namespace dxvk {
     const float* pConstantData,
           UINT   Vector4fCount) {
     return SetShaderConstants<
-      DxsoProgramTypes::VertexShader,
+      D3D9ShaderType::VertexShader,
       D3D9ConstantType::Float>(
         StartRegister,
         pConstantData,
@@ -296,7 +296,7 @@ namespace dxvk {
     const int* pConstantData,
           UINT Vector4iCount) {
     return SetShaderConstants<
-      DxsoProgramTypes::VertexShader,
+      D3D9ShaderType::VertexShader,
       D3D9ConstantType::Int>(
         StartRegister,
         pConstantData,
@@ -309,7 +309,7 @@ namespace dxvk {
     const BOOL* pConstantData,
           UINT  BoolCount) {
     return SetShaderConstants<
-      DxsoProgramTypes::VertexShader,
+      D3D9ShaderType::VertexShader,
       D3D9ConstantType::Bool>(
         StartRegister,
         pConstantData,
@@ -322,7 +322,7 @@ namespace dxvk {
     const float* pConstantData,
           UINT   Vector4fCount) {
     return SetShaderConstants<
-      DxsoProgramTypes::PixelShader,
+      D3D9ShaderType::PixelShader,
       D3D9ConstantType::Float>(
         StartRegister,
         pConstantData,
@@ -335,7 +335,7 @@ namespace dxvk {
     const int* pConstantData,
           UINT Vector4iCount) {
     return SetShaderConstants<
-      DxsoProgramTypes::PixelShader,
+      D3D9ShaderType::PixelShader,
       D3D9ConstantType::Int>(
         StartRegister,
         pConstantData,
@@ -348,7 +348,7 @@ namespace dxvk {
     const BOOL* pConstantData,
           UINT  BoolCount) {
     return SetShaderConstants<
-      DxsoProgramTypes::PixelShader,
+      D3D9ShaderType::PixelShader,
       D3D9ConstantType::Bool>(
         StartRegister,
         pConstantData,

--- a/src/d3d9/d3d9_stateblock.h
+++ b/src/d3d9/d3d9_stateblock.h
@@ -345,7 +345,7 @@ namespace dxvk {
     }
 
     template <
-      DxsoProgramType  ProgramType,
+      D3D9ShaderType   ShaderType,
       D3D9ConstantType ConstantType,
       typename         T>
     HRESULT SetShaderConstants(
@@ -353,7 +353,7 @@ namespace dxvk {
       const T*    pConstantData,
             UINT  Count) {
       auto SetHelper = [&](auto& setCaptures) {
-        if constexpr (ProgramType == DxsoProgramTypes::VertexShader)
+        if constexpr (ShaderType == D3D9ShaderType::VertexShader)
           m_captures.flags.set(D3D9CapturedStateFlag::VsConstants);
         else
           m_captures.flags.set(D3D9CapturedStateFlag::PsConstants);
@@ -369,7 +369,7 @@ namespace dxvk {
         }
 
         UpdateStateConstants<
-          ProgramType,
+          ShaderType,
           ConstantType,
           T>(
             &m_state,
@@ -381,7 +381,7 @@ namespace dxvk {
         return D3D_OK;
       };
 
-      return ProgramType == DxsoProgramTypes::VertexShader
+      return ShaderType == D3D9ShaderType::VertexShader
         ? SetHelper(m_captures.vsConsts)
         : SetHelper(m_captures.psConsts);
     }

--- a/src/d3d9/d3d9_util.h
+++ b/src/d3d9/d3d9_util.h
@@ -85,13 +85,13 @@ namespace dxvk {
    * The displacement map sampler will be treated as a 17th pixel shader sampler.
    *
    * @param Sampler Sampler index (according to our internal way of storing samplers)
-   * @return std::pair<DxsoProgramType, DWORD> Shader stage that it belongs to and the relative sampler index
+   * @return std::pair<D3D9ShaderType, DWORD> Shader stage that it belongs to and the relative sampler index
    */
-  inline std::pair<DxsoProgramType, DWORD> RemapStateSamplerShader(DWORD Sampler) {
+  inline std::pair<D3D9ShaderType, DWORD> RemapStateSamplerShader(DWORD Sampler) {
     if (Sampler >= FirstVSSamplerSlot)
-      return std::make_pair(DxsoProgramTypes::VertexShader, Sampler - FirstVSSamplerSlot);
+      return std::make_pair(D3D9ShaderType::VertexShader, Sampler - FirstVSSamplerSlot);
 
-    return std::make_pair(DxsoProgramTypes::PixelShader, Sampler);
+    return std::make_pair(D3D9ShaderType::PixelShader, Sampler);
   }
 
   /**
@@ -122,9 +122,9 @@ namespace dxvk {
    * @brief Remaps the sampler from an index (counted according to the API) to one relative to the shader stage and returns the shader type
    *
    * @param Sampler Sampler index (according to the API)
-   * @return std::pair<DxsoProgramType, DWORD> Shader stage that it belongs to and the relative sampler index
+   * @return std::pair<D3D9ShaderType, DWORD> Shader stage that it belongs to and the relative sampler index
    */
-  inline std::pair<DxsoProgramType, DWORD> RemapSamplerShader(DWORD Sampler) {
+  inline std::pair<D3D9ShaderType, DWORD> RemapSamplerShader(DWORD Sampler) {
     Sampler = RemapSamplerState(Sampler);
 
     return RemapStateSamplerShader(Sampler);
@@ -160,11 +160,11 @@ namespace dxvk {
     return srgb ? srgbFormat : format;
   }
 
-  constexpr VkShaderStageFlagBits GetShaderStage(DxsoProgramType ProgramType) {
-    switch (ProgramType) {
-      case DxsoProgramTypes::VertexShader:  return VK_SHADER_STAGE_VERTEX_BIT;
-      case DxsoProgramTypes::PixelShader:   return VK_SHADER_STAGE_FRAGMENT_BIT;
-      default:                              return VkShaderStageFlagBits(0);
+  constexpr VkShaderStageFlagBits GetShaderStage(D3D9ShaderType ShaderType) {
+    switch (ShaderType) {
+      case D3D9ShaderType::VertexShader: return VK_SHADER_STAGE_VERTEX_BIT;
+      case D3D9ShaderType::PixelShader:  return VK_SHADER_STAGE_FRAGMENT_BIT;
+      default:                           return VkShaderStageFlagBits(0);
     }
   }
 

--- a/src/d3d9/shaders/d3d9_fixed_function_frag.glsl
+++ b/src/d3d9/shaders/d3d9_fixed_function_frag.glsl
@@ -114,7 +114,7 @@ const uint PerTextureStageSpecConsts = SpecFFTextureStage1ColorOp - SpecFFTextur
 
 // Bindings have to match with computeResourceSlotId in dxso_util.h
 // computeResourceSlotId(
-//     DxsoProgramType::PixelShader,
+//     D3D9ShaderType::PixelShader,
 //     DxsoBindingType::ConstantBuffer,
 //     DxsoConstantBuffers::PSFixedFunction
 // ) = 11
@@ -124,7 +124,7 @@ layout(set = 0, binding = 11, scalar, row_major) uniform ShaderData {
 
 // Bindings have to match with computeResourceSlotId in dxso_util.h
 // computeResourceSlotId(
-//     DxsoProgramType::PixelShader,
+//     D3D9ShaderType::PixelShader,
 //     DxsoBindingType::ConstantBuffer,
 //     DxsoConstantBuffers::PSShared
 // ) = 12

--- a/src/d3d9/shaders/d3d9_fixed_function_vert.vert
+++ b/src/d3d9/shaders/d3d9_fixed_function_vert.vert
@@ -131,7 +131,7 @@ const uint TCIMask = (7 << TCIOffset);
 
 // Bindings have to match with computeResourceSlotId in dxso_util.h
 // computeResourceSlotId(
-//     DxsoProgramType::VertexShader,
+//     D3D9ShaderType::VertexShader,
 //     DxsoBindingType::ConstantBuffer,
 //     DxsoConstantBuffers::VSFixedFunction
 // ) = 4
@@ -145,7 +145,7 @@ layout(push_constant, scalar, row_major) uniform RenderStates {
 
 // Bindings have to match with computeResourceSlotId in dxso_util.h
 // computeResourceSlotId(
-//     DxsoProgramType::VertexShader,
+//     D3D9ShaderType::VertexShader,
 //     DxsoBindingType::ConstantBuffer,
 //     DxsoConstantBuffers::VSVertexBlendData
 // ) = 5
@@ -156,7 +156,7 @@ layout(set = 0, binding = 5, std140, row_major) readonly buffer VertexBlendData 
 
 // Bindings have to match with computeResourceSlotId in dxso_util.h
 // computeResourceSlotId(
-//     DxsoProgramType::VertexShader,
+//     D3D9ShaderType::VertexShader,
 //     DxsoBindingType::ConstantBuffer,
 //     DxsoConstantBuffers::VSClipPlanes
 // ) = 3

--- a/src/dxso/dxso_common.h
+++ b/src/dxso/dxso_common.h
@@ -2,6 +2,8 @@
 
 #include "dxso_include.h"
 
+#include "../d3d9/d3d9_include.h"
+
 #include <cstdint>
 
 namespace dxvk {
@@ -12,14 +14,8 @@ namespace dxvk {
  * Defines the shader stage that a DXSO
  * module has been compiled for.
  */
-  namespace DxsoProgramTypes {
-    enum DxsoProgramType : uint16_t {
-      VertexShader = 0,
-      PixelShader  = 1,
-      Count        = 2,
-    };
-  }
-  using DxsoProgramType = DxsoProgramTypes::DxsoProgramType;
+  using DxsoProgramType = D3D9ShaderType;
+  using DxsoProgramTypes = D3D9ShaderType;
 
   class DxsoProgramInfo {
 


### PR DESCRIPTION
Looks a lot scarier than it is.

This is the first PR in preparation for the new shader compiler.

The PR replaces the `DxsoProgramType` enum with a new `D3D9ShaderType` enum that lives in `d3d9_include.h` rather than one of the `dxso/` files.
That is because the long term plan once the new SM3 compiler is merged is to get rid of that entire `dxso/` folder similar to how we got rid of the `dxbc/` folder.