### PR TITLE
[d3d9+dxso] Remove a bunch of shader options that are mostly unused

### DIFF
--- a/dxvk.conf
+++ b/dxvk.conf
@@ -315,14 +315,6 @@
 # d3d9.clampNegativeLodBias = False
 
 
-# Declares vertex positions as invariant in order to solve
-# potential Z-fighting issues at a small performance cost.
-#
-# Supported values: True, False
-
-# d3d9.invariantPosition = True
-
-
 # Forces per-sample rate shading when MSAA is enabled, rather than per-pixel
 # shading. May improve visual clarity at a significant performance cost, but
 # may also introduce visual issues in some games.
@@ -583,29 +575,6 @@
 # - True, False: Always enable / disable
 
 # d3d9.dpiAware = True
-
-
-# Strict Constant Copies
-# 
-# Decides whether we should always copy defined constants to
-# the UBO when relative addressing is used, or only when the
-# relative addressing starts a defined constant.
-#
-# Supported values:
-# - True, False: Always enable / disable
-
-# d3d9.strictConstantCopies = False
-
-
-# Strict Pow
-# 
-# Decides whether we have an opSelect for handling pow(0,0) = 0
-# otherwise it becomes undefined.
-#
-# Supported values:
-# - True, False: Always enable / disable
-
-# d3d9.strictPow = True
 
 
 # Lenient Clear

--- a/src/d3d9/d3d9_fixed_function.cpp
+++ b/src/d3d9/d3d9_fixed_function.cpp
@@ -20,7 +20,6 @@
 namespace dxvk {
 
   D3D9FixedFunctionOptions::D3D9FixedFunctionOptions(const D3D9Options* options) {
-    invariantPosition = options->invariantPosition;
     forceSampleRateShading = options->forceSampleRateShading;
   }
 
@@ -1853,8 +1852,7 @@ namespace dxvk {
 
     // Declare Outputs
     m_vs.out.POSITION = declareIO(false, DxsoSemantic{ DxsoUsage::Position, 0 }, spv::BuiltInPosition);
-    if (m_options.invariantPosition)
-      m_module.decorate(m_vs.out.POSITION, spv::DecorationInvariant);
+    m_module.decorate(m_vs.out.POSITION, spv::DecorationInvariant);
 
     m_vs.out.POINTSIZE = declareIO(false, DxsoSemantic{ DxsoUsage::PointSize, 0 }, spv::BuiltInPointSize);
 

--- a/src/d3d9/d3d9_fixed_function.h
+++ b/src/d3d9/d3d9_fixed_function.h
@@ -50,7 +50,6 @@ namespace dxvk {
   struct D3D9FixedFunctionOptions {
     D3D9FixedFunctionOptions(const D3D9Options* options);
 
-    bool    invariantPosition;
     bool    forceSampleRateShading;
   };
 

--- a/src/d3d9/d3d9_options.cpp
+++ b/src/d3d9/d3d9_options.cpp
@@ -46,8 +46,6 @@ namespace dxvk {
     this->presentInterval               = config.getOption<int32_t>     ("d3d9.presentInterval",               -1);
     this->shaderModel                   = config.getOption<int32_t>     ("d3d9.shaderModel",                   3u);
     this->dpiAware                      = config.getOption<bool>        ("d3d9.dpiAware",                      true);
-    this->strictConstantCopies          = config.getOption<bool>        ("d3d9.strictConstantCopies",          false);
-    this->strictPow                     = config.getOption<bool>        ("d3d9.strictPow",                     true);
     this->lenientClear                  = config.getOption<bool>        ("d3d9.lenientClear",                  false);
     this->deferSurfaceCreation          = config.getOption<bool>        ("d3d9.deferSurfaceCreation",          false);
     this->samplerAnisotropy             = config.getOption<int32_t>     ("d3d9.samplerAnisotropy",             -1);
@@ -56,7 +54,6 @@ namespace dxvk {
     this->supportX4R4G4B4               = config.getOption<bool>        ("d3d9.supportX4R4G4B4",               true);
     this->useD32forD24                  = config.getOption<bool>        ("d3d9.useD32forD24",                  false);
     this->disableA8RT                   = config.getOption<bool>        ("d3d9.disableA8RT",                   false);
-    this->invariantPosition             = config.getOption<bool>        ("d3d9.invariantPosition",             true);
     this->memoryTrackTest               = config.getOption<bool>        ("d3d9.memoryTrackTest",               false);
     this->forceSamplerTypeSpecConstants = config.getOption<bool>        ("d3d9.forceSamplerTypeSpecConstants", false);
     this->forceSampleRateShading        = config.getOption<bool>        ("d3d9.forceSampleRateShading",        false);

--- a/src/d3d9/d3d9_options.h
+++ b/src/d3d9/d3d9_options.h
@@ -52,14 +52,6 @@ namespace dxvk {
     /// Whether or not to set the process as DPI aware in Windows when the API interface is created.
     bool dpiAware;
 
-    /// True:  Copy our constant set into UBO if we are relative indexing ever.
-    /// False: Copy our constant set into UBO if we are relative indexing at the start of a defined constant
-    /// Why?:  In theory, FXC should never generate code where this would be an issue.
-    bool strictConstantCopies;
-
-    /// Whether or not we should care about pow(0, 0) = 1
-    bool strictPow;
-
     /// Whether or not to do a fast path clear if we're close enough to the whole render target.
     bool lenientClear;
 
@@ -94,10 +86,6 @@ namespace dxvk {
     /// Specifically to work around a game
     /// bug in The Sims 2 that happens on native too!
     bool disableA8RT;
-
-    /// Work around a NV driver quirk
-    /// Fixes flickering/z-fighting in some games.
-    bool invariantPosition;
 
     /// Whether or not to respect memory tracking for
     /// failing resource allocation.

--- a/src/dxso/dxso_compiler.cpp
+++ b/src/dxso/dxso_compiler.cpp
@@ -922,8 +922,7 @@ namespace dxvk {
           m_meta.maxConstIndexF = std::min(m_meta.maxConstIndexF, m_layout->floatCount);
         } else {
           m_meta.maxConstIndexF = m_layout->floatCount;
-          m_meta.needsConstantCopies |= m_moduleInfo.options.strictConstantCopies
-                                     || m_cFloat.at(reg.id.num) != 0;
+          m_meta.needsConstantCopies |= m_cFloat.at(reg.id.num) != 0;
         }
         break;
       
@@ -973,21 +972,6 @@ namespace dxvk {
         cBufferId, indices.size(), indices.data());
 
       result.id = m_module.opLoad(typeId, ptrId);
-
-      if (relative && !m_moduleInfo.options.robustness2Supported) {
-        uint32_t constCount = m_module.constu32(m_layout->floatCount);
-
-        // Expand condition to bvec4 since the result has four components
-        uint32_t cond = m_module.opULessThan(m_module.defBoolType(), relativeIdx, constCount);
-        std::array<uint32_t, 4> condIds = { cond, cond, cond, cond };
-
-        cond = m_module.opCompositeConstruct(
-          m_module.defVectorType(m_module.defBoolType(), 4),
-          condIds.size(), condIds.data());
-
-        result.id = m_module.opSelect(typeId, cond, result.id,
-          m_module.constvec4f32(0.0f, 0.0f, 0.0f, 0.0f));
-      }
     } else {
       // Bool constants have no relative indexing, so we can do the bitfield
       // magic for SWVP at compile time.
@@ -2065,7 +2049,7 @@ namespace dxvk {
 
         result.id = m_module.opPow(typeId, base, exponent);
 
-        if (m_moduleInfo.options.strictPow && m_moduleInfo.options.d3d9FloatEmulation != D3D9FloatEmulation::Disabled) {
+        if (m_moduleInfo.options.d3d9FloatEmulation != D3D9FloatEmulation::Disabled) {
           DxsoRegisterValue cmp;
           cmp.type  = { DxsoScalarType::Bool, result.type.ccount };
           cmp.id    = m_module.opFOrdEqual(getVectorTypeId(cmp.type),
@@ -3600,9 +3584,7 @@ void DxsoCompiler::emitControlFlowGenericLoop(
       spv::StorageClassOutput);
 
     m_module.decorateBuiltIn(clipDistArray, spv::BuiltInClipDistance);
-
-    if (m_moduleInfo.options.invariantPosition)
-      m_module.decorate(m_vs.oPos.id, spv::DecorationInvariant);
+    m_module.decorate(m_vs.oPos.id, spv::DecorationInvariant);
     
     const uint32_t positionPtr = m_vs.oPos.id;
 

--- a/src/dxso/dxso_options.cpp
+++ b/src/dxso/dxso_options.cpp
@@ -8,26 +8,17 @@ namespace dxvk {
 
   DxsoOptions::DxsoOptions(D3D9DeviceEx* pDevice, const D3D9Options& options) {
     const Rc<DxvkDevice> device = pDevice->GetDXVKDevice();
-
     const Rc<DxvkAdapter> adapter = device->adapter();
 
-    const DxvkDeviceFeatures& devFeatures = device->features();
     const DxvkDeviceInfo& devInfo = adapter->deviceProperties();
 
     // Apply shader-related options
-    strictConstantCopies = options.strictConstantCopies;
-
-    strictPow            = options.strictPow;
     d3d9FloatEmulation   = options.d3d9FloatEmulation;
-
-    invariantPosition    = options.invariantPosition;
 
     forceSamplerTypeSpecConstants = options.forceSamplerTypeSpecConstants;
     forceSampleRateShading = options.forceSampleRateShading;
 
     vertexFloatConstantBufferAsSSBO = pDevice->GetVertexConstantLayout().floatSize() > devInfo.core.properties.limits.maxUniformBufferRange;
-
-    robustness2Supported = devFeatures.extRobustness2.robustBufferAccess2;
 
     sincosEmulation     = device->getShaderCompileOptions().flags.test(DxvkShaderCompileFlag::LowerSinCos);
   }

--- a/src/dxso/dxso_options.h
+++ b/src/dxso/dxso_options.h
@@ -12,22 +12,10 @@ namespace dxvk {
     DxsoOptions();
     DxsoOptions(D3D9DeviceEx* pDevice, const D3D9Options& options);
 
-    /// True:  Copy our constant set into UBO if we are relative indexing ever.
-    /// False: Copy our constant set into UBO if we are relative indexing at the start of a defined constant
-    /// Why?:  In theory, FXC should never generate code where this would be an issue.
-    bool strictConstantCopies;
-
     /// Whether to emulate d3d9 float behaviour using clampps
     /// True:  Perform emulation to emulate behaviour (ie. anything * 0 = 0)
     /// False: Don't do anything.
     D3D9FloatEmulation d3d9FloatEmulation;
-
-    /// Whether or not we should care about pow(0, 0) = 1
-    bool strictPow;
-
-    /// Work around a NV driver quirk
-    /// Fixes flickering/z-fighting in some games.
-    bool invariantPosition;
 
     /// Always use a spec constant to determine sampler type (instead of just in PS 1.x)
     /// Works around a game bug in Halo CE where it gives cube textures to 2d/volume samplers
@@ -38,9 +26,6 @@ namespace dxvk {
 
     /// Should the SWVP float constant buffer be a SSBO (because of the size on NV)
     bool vertexFloatConstantBufferAsSSBO;
-
-    /// Whether or not we can rely on robustness2 to handle oob constant access
-    bool robustness2Supported;
 
     /// Whether or not we need to use custom sincos
     bool sincosEmulation = false;

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -508,7 +508,6 @@ namespace dxvk {
 
     /* A Hat in Time                              */
     { R"(\\HatinTimeGame\.exe$)", {{
-      { "d3d9.strictPow",                  "False" },
       { "d3d9.lenientClear",                "True" },
     }} },
     /* Anarchy Online                             */


### PR DESCRIPTION
Most of those are pretty much never changed out of the box and I don't think we need to maintain micro-optimization options for end users.

The new compiler won't have those either.