### PR TITLE
[util] Tweak the regex for VTM - Bloodlines

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -599,8 +599,8 @@ namespace dxvk {
     { R"(\\csgo\.exe$)", {{
       { "d3d9.hideNvidiaGpu",               "True" },
     }} },
-    /* Vampire - The Masquerade Bloodlines        */
-    { R"(\\vampire\.exe$)", {{
+    /* Vampire: The Masquerade - Bloodlines       */
+    { R"(\\Vampire.*Bloodlines\\vampire\.exe$)", {{
       { "d3d9.deferSurfaceCreation",        "True" },
       { "d3d9.memoryTrackTest",             "True" },
       { "d3d9.maxAvailableMemory",          "1024" },


### PR DESCRIPTION
`vampire.exe` seems to be too popular for its own good, as Vampire: The Masquerade - Redemption also uses the same executable name. I'm fairly sure some visual novels have appropriated it as well.

For Bloodlines, GOG installs it in `Vampire - The Masquerade - Bloodlines`, Steam apparently in `Vampire The Masquerade - Bloodlines`, no idea about retail, but I'll make a reasonable assumption that whatever it is, it's also captured by the new regex.