### PR TITLE
add arm build

### DIFF
--- a/build-arm64.txt
+++ b/build-arm64.txt
@@ -1,0 +1,17 @@
+# vim:ft=meson
+[binaries]
+c = 'aarch64-w64-mingw32-gcc'
+cpp = 'aarch64-w64-mingw32-g++'
+ar = 'aarch64-w64-mingw32-ar'
+strip = 'aarch64-w64-mingw32-strip'
+windres = 'aarch64-w64-mingw32-windres'
+
+[properties]
+needs_exe_wrapper = true
+# sys_root = '/data/data/com.termux/files/usr/opt/llvm-mingw-w64/generic-w64-mingw32'
+
+[host_machine]
+system = 'windows'
+cpu_family = 'aarch64'
+cpu = 'aarch64'
+endian = 'little'

--- a/meson.build
+++ b/meson.build
@@ -26,6 +26,7 @@ compiler_args = [
   '-Wno-extern-c-compat',
   '-Wno-unused-const-variable',
   '-Wno-missing-braces',
+  '-Wfatal-errors',
 ]
 
 link_args = []
@@ -37,6 +38,7 @@ if get_option('build_id')
 endif
 
 dxvk_include_dirs = ['./include']
+# dxvk_include_dirs += get_option('includedir')
 if fs.is_dir('./include/vulkan/include')
   dxvk_include_dirs += ['./include/vulkan/include']
 elif not cpp.check_header('vulkan/vulkan.h')


### PR DESCRIPTION
it should find the include dir from compiler

echo | aarch64-w64-mingw32-clang++ -E -Wp,-v -xc++ -

but I left some code anyway if some one need  more dirs

I ended up linking the necessary folders

ln -s $P/include/spirv $P/opt/llvm-mingw-w64/generic-w64-mingw32/include/
ln -s $P/include/vulkan $P/opt/llvm-mingw-w64/generic-w64-mingw32/include/
ln -s $P/include/vk_video $P/opt/llvm-mingw-w64/generic-w64-mingw32/include/

I am building in termux with

meson setup out --wipe --cross-file build-arm64.txt --prefix=$P
