### PR TITLE
[CI] Run steamrt container with --user 1001

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -36,7 +36,9 @@ jobs:
 
   artifacts-steamrt-sniper:
     runs-on: ubuntu-latest
-    container: registry.gitlab.steamos.cloud/steamrt/sniper/sdk:beta
+    container: 
+      image: registry.gitlab.steamos.cloud/steamrt/sniper/sdk:beta
+      options: --user 1001
 
     steps:
     - name: Checkout code


### PR DESCRIPTION
Avoids the "fatal: detected dubious ownership in repository" issue that happens because git doesn't like the user that owns the folder in the container. See https://github.com/actions/runner/issues/2033#issuecomment-1598547465

This fixes dxvk-native CI builds not containing the commit in the version string because the `git describe --dirty=+` command in meson.build fails.