### PR TITLE
[dxvk] Fix build failure with Clang 22

### DIFF
--- a/src/dxvk/dxvk_pipemanager.cpp
+++ b/src/dxvk/dxvk_pipemanager.cpp
@@ -380,7 +380,7 @@ namespace dxvk {
 
     auto iter = m_shaderLibraries.emplace(
       std::piecewise_construct,
-      std::tuple(),
+      std::tuple(key),
       std::tuple(m_device, this, key));
     return &iter.first->second;
   }


### PR DESCRIPTION
## Summary
- Fix compilation error with Clang/LLVM 22 in `createNullFsPipelineLibrary()`
- Pass the default-constructed key explicitly via `std::tuple(key)` instead of using an empty `std::tuple()` with `std::piecewise_construct`, which Clang 22 rejects due to stricter parameter pack validation

Closes #5545