### PR TITLE
Rework the way device properties are accessed

### DIFF
--- a/src/d3d11/d3d11_device.cpp
+++ b/src/d3d11/d3d11_device.cpp
@@ -51,8 +51,8 @@ namespace dxvk {
     m_d3d11Formats      (m_dxvkDevice),
     m_d3d11Options      (m_dxvkDevice->instance()->config()),
     m_shaderOptions     (GetShaderOptions(m_dxvkDevice, m_d3d11Options)),
-    m_maxFeatureLevel   (GetMaxFeatureLevel(m_dxvkDevice->instance(), m_dxvkDevice->adapter())),
-    m_deviceFeatures    (m_dxvkDevice->instance(), m_dxvkDevice->adapter(), m_d3d11Options, m_featureLevel) {
+    m_maxFeatureLevel   (D3D11DeviceFeatures::GetMaxFeatureLevel(*m_dxvkDevice)),
+    m_deviceFeatures    (*m_dxvkDevice, m_d3d11Options, m_featureLevel) {
     m_initializer = new D3D11Initializer(this);
     m_context     = new D3D11ImmediateContext(this, m_dxvkDevice);
     m_d3d10Device = new D3D10Device(this, m_context.ptr());
@@ -1346,10 +1346,7 @@ namespace dxvk {
 
     if (m_featureLevel < featureLevel) {
       m_featureLevel = featureLevel;
-      m_deviceFeatures = D3D11DeviceFeatures(
-        m_dxvkDevice->instance(),
-        m_dxvkDevice->adapter(),
-        m_d3d11Options, m_featureLevel);
+      m_deviceFeatures = D3D11DeviceFeatures(*m_dxvkDevice, m_d3d11Options, m_featureLevel);
     }
 
     if (pChosenFeatureLevel)
@@ -2008,9 +2005,7 @@ namespace dxvk {
   }
   
   
-  D3D_FEATURE_LEVEL D3D11Device::GetMaxFeatureLevel(
-    const Rc<DxvkInstance>& Instance,
-    const Rc<DxvkAdapter>&  Adapter) {
+  D3D_FEATURE_LEVEL D3D11Device::GetMaxFeatureLevel(const DxvkDevice& Device) {
     // The feature level override always takes precedence
     static const std::array<std::pair<std::string, D3D_FEATURE_LEVEL>, 9> s_featureLevels = {{
       { "12_1", D3D_FEATURE_LEVEL_12_1 },
@@ -2024,7 +2019,7 @@ namespace dxvk {
       { "9_1",  D3D_FEATURE_LEVEL_9_1  },
     }};
     
-    std::string maxLevel = Instance->config().getOption<std::string>("d3d11.maxFeatureLevel");
+    std::string maxLevel = Device.instance()->config().getOption<std::string>("d3d11.maxFeatureLevel");
 
     auto entry = std::find_if(s_featureLevels.begin(), s_featureLevels.end(),
       [&] (const std::pair<std::string, D3D_FEATURE_LEVEL>& pair) {
@@ -2035,7 +2030,7 @@ namespace dxvk {
       return entry->second;
 
     // Otherwise, check the actually available device features
-    return D3D11DeviceFeatures::GetMaxFeatureLevel(Instance, Adapter);
+    return D3D11DeviceFeatures::GetMaxFeatureLevel(Device);
   }
   
   

--- a/src/d3d11/d3d11_device.h
+++ b/src/d3d11/d3d11_device.h
@@ -473,9 +473,7 @@ namespace dxvk {
       const Rc<DxvkImage>&            Image,
             VkImageUsageFlags         Usage);
 
-    static D3D_FEATURE_LEVEL GetMaxFeatureLevel(
-      const Rc<DxvkInstance>& Instance,
-      const Rc<DxvkAdapter>&  Adapter);
+    static D3D_FEATURE_LEVEL GetMaxFeatureLevel(const DxvkDevice& Device);
     
     DxvkBarrierControlFlags GetOptionsBarrierControlFlags() {
       DxvkBarrierControlFlags barrierControl = 0u;

--- a/src/d3d11/d3d11_features.cpp
+++ b/src/d3d11/d3d11_features.cpp
@@ -10,12 +10,11 @@ namespace dxvk {
 
 
   D3D11DeviceFeatures::D3D11DeviceFeatures(
-    const Rc<DxvkInstance>&     Instance,
-    const Rc<DxvkAdapter>&      Adapter,
+    const DxvkDevice&           Device,
     const D3D11Options&         Options,
-          D3D_FEATURE_LEVEL     FeatureLevel)
-  : m_features    (Adapter->features()),
-    m_properties  (Adapter->deviceProperties()) {
+          D3D_FEATURE_LEVEL     FeatureLevel) {
+    const auto& features = Device.features();
+
     // Assume no TBDR. DXVK does not optimize for TBDR architectures
     // anyway, and D3D11 does not really provide meaningful support.
     m_architectureInfo.TileBasedDeferredRenderer          = FALSE;
@@ -36,10 +35,10 @@ namespace dxvk {
     m_d3d10Options.ComputeShaders_Plus_RawAndStructuredBuffers_Via_Shader_4_x = TRUE;
 
     // D3D11.1 options. All of these are required for Feature Level 11_1.
-    auto sharedResourceTier = DetermineSharedResourceTier(Adapter, FeatureLevel);
+    auto sharedResourceTier = DetermineSharedResourceTier(Device, FeatureLevel);
 
-    bool hasDoublePrecisionSupport = m_features.core.features.shaderFloat64
-                                  && m_features.core.features.shaderInt64;
+    bool hasDoublePrecisionSupport = features.core.features.shaderFloat64
+                                  && features.core.features.shaderInt64;
 
     m_d3d11Options.DiscardAPIsSeenByDriver                = TRUE;
     m_d3d11Options.FlagsForUpdateAndCopySeenByDriver      = TRUE;
@@ -52,7 +51,7 @@ namespace dxvk {
     m_d3d11Options.ExtendedResourceSharing                = sharedResourceTier > D3D11_SHARED_RESOURCE_TIER_0;
 
     if (FeatureLevel >= D3D_FEATURE_LEVEL_10_0) {
-      m_d3d11Options.OutputMergerLogicOp                  = m_features.core.features.logicOp;
+      m_d3d11Options.OutputMergerLogicOp                  = features.core.features.logicOp;
       m_d3d11Options.MultisampleRTVWithForcedSampleCountOne = TRUE; // Not really
     }
 
@@ -63,7 +62,7 @@ namespace dxvk {
     }
 
     // D3D11.2 options.
-    auto tiledResourcesTier = DetermineTiledResourcesTier(FeatureLevel);
+    auto tiledResourcesTier = DetermineTiledResourcesTier(Device, FeatureLevel);
     m_d3d11Options1.TiledResourcesTier                    = tiledResourcesTier;
     m_d3d11Options1.MinMaxFiltering                       = tiledResourcesTier >= D3D11_TILED_RESOURCES_TIER_2;
     m_d3d11Options1.ClearViewAlsoSupportsDepthOnlyFormats = TRUE;
@@ -72,8 +71,8 @@ namespace dxvk {
       m_d3d11Options1.MapOnDefaultBuffers                 = TRUE;
 
     // D3D11.3 options
-    m_d3d11Options2.TypedUAVLoadAdditionalFormats         = DetermineUavExtendedTypedLoadSupport(Adapter, FeatureLevel);
-    m_d3d11Options2.ConservativeRasterizationTier         = DetermineConservativeRasterizationTier(FeatureLevel);
+    m_d3d11Options2.TypedUAVLoadAdditionalFormats         = DetermineUavExtendedTypedLoadSupport(Device, FeatureLevel);
+    m_d3d11Options2.ConservativeRasterizationTier         = DetermineConservativeRasterizationTier(Device, FeatureLevel);
     m_d3d11Options2.TiledResourcesTier                    = tiledResourcesTier;
     m_d3d11Options2.StandardSwizzle                       = FALSE;
     m_d3d11Options2.UnifiedMemoryArchitecture             = FALSE;
@@ -82,15 +81,15 @@ namespace dxvk {
       m_d3d11Options2.MapOnDefaultTextures                = TRUE;
 
     if (FeatureLevel >= D3D_FEATURE_LEVEL_11_1) {
-      m_d3d11Options2.ROVsSupported                       = m_features.extFragmentShaderInterlock.fragmentShaderPixelInterlock;
-      m_d3d11Options2.PSSpecifiedStencilRefSupported      = m_features.extShaderStencilExport;
+      m_d3d11Options2.ROVsSupported                       = features.extFragmentShaderInterlock.fragmentShaderPixelInterlock;
+      m_d3d11Options2.PSSpecifiedStencilRefSupported      = features.extShaderStencilExport;
     }
 
     // More D3D11.3 options
     if (FeatureLevel >= D3D_FEATURE_LEVEL_11_0) {
       m_d3d11Options3.VPAndRTArrayIndexFromAnyShaderFeedingRasterizer =
-        m_features.vk12.shaderOutputViewportIndex &&
-        m_features.vk12.shaderOutputLayer;
+        features.vk12.shaderOutputViewportIndex &&
+        features.vk12.shaderOutputLayer;
     }
 
     // D3D11.4 options
@@ -108,7 +107,7 @@ namespace dxvk {
     m_gpuVirtualAddress.MaxGPUVirtualAddressBitsPerProcess = 40;
 
     // Marker support only depends on the debug utils extension
-    m_marker.Profile = !Instance->debugFlags().isClear();
+    m_marker.Profile = !Device.debugFlags().isClear();
 
     // DXVK will keep all shaders in memory once created, and all Vulkan
     // drivers that we know of that can run DXVK have an on-disk cache.
@@ -116,7 +115,7 @@ namespace dxvk {
                                | D3D11_SHADER_CACHE_SUPPORT_AUTOMATIC_DISK_CACHE;
 
     // 16-bit precision is supported on capable devices
-    auto minPrecision = Adapter->features().core.features.shaderInt16 && Adapter->features().vk12.shaderFloat16
+    auto minPrecision = features.core.features.shaderInt16 && features.vk12.shaderFloat16
       ? D3D11_SHADER_MIN_PRECISION_16_BIT
       : D3D11_SHADER_MIN_PRECISION_SUPPORT(0u);
 
@@ -184,28 +183,55 @@ namespace dxvk {
   }
 
 
-  D3D_FEATURE_LEVEL D3D11DeviceFeatures::GetMaxFeatureLevel(
-    const Rc<DxvkInstance>&     Instance,
-    const Rc<DxvkAdapter>&      Adapter) {
-    D3D11Options options(Instance->config());
-    D3D11DeviceFeatures features(Instance, Adapter, options, D3D_FEATURE_LEVEL_12_1);
-    return features.GetMaxFeatureLevel();
+  D3D_FEATURE_LEVEL D3D11DeviceFeatures::GetMaxFeatureLevel(const DxvkDevice& Device) {
+    D3D11Options config(Device.instance()->config());
+    D3D11DeviceFeatures options(Device, config, D3D_FEATURE_LEVEL_12_1);
+
+    const auto& features = Device.features();
+
+    // Check Feature Level 11_0 features
+    if (!features.core.features.drawIndirectFirstInstance
+     || !features.core.features.fragmentStoresAndAtomics
+     || !features.core.features.multiDrawIndirect
+     || !features.core.features.tessellationShader)
+      return D3D_FEATURE_LEVEL_10_1;
+
+    // Check Feature Level 11_1 features
+    if (!options.m_d3d11Options.OutputMergerLogicOp
+     || !features.core.features.vertexPipelineStoresAndAtomics)
+      return D3D_FEATURE_LEVEL_11_0;
+
+    // Check Feature Level 12_0 features
+    if (options.m_d3d11Options2.TiledResourcesTier < D3D11_TILED_RESOURCES_TIER_2
+     || !options.m_d3d11Options2.TypedUAVLoadAdditionalFormats)
+      return D3D_FEATURE_LEVEL_11_1;
+
+    // Check Feature Level 12_1 features
+    if (!options.m_d3d11Options2.ConservativeRasterizationTier
+     || !options.m_d3d11Options2.ROVsSupported)
+      return D3D_FEATURE_LEVEL_12_0;
+
+    return D3D_FEATURE_LEVEL_12_1;
   }
 
 
   D3D11_CONSERVATIVE_RASTERIZATION_TIER D3D11DeviceFeatures::DetermineConservativeRasterizationTier(
+    const DxvkDevice&           Device,
           D3D_FEATURE_LEVEL     FeatureLevel) {
+    const auto& features = Device.features();
+    const auto& properties = Device.properties();
+
     if (FeatureLevel < D3D_FEATURE_LEVEL_11_1
-     || !m_features.extConservativeRasterization)
+     || !features.extConservativeRasterization)
       return D3D11_CONSERVATIVE_RASTERIZATION_NOT_SUPPORTED;
 
     // We don't really have a way to query uncertainty regions,
     // so just check degenerate triangle behaviour
-    if (!m_properties.extConservativeRasterization.degenerateTrianglesRasterized)
+    if (!properties.extConservativeRasterization.degenerateTrianglesRasterized)
       return D3D11_CONSERVATIVE_RASTERIZATION_TIER_1;
 
     // Inner coverage is required for Tier 3 support
-    if (!m_properties.extConservativeRasterization.fullyCoveredFragmentShaderInputVariable)
+    if (!properties.extConservativeRasterization.fullyCoveredFragmentShaderInputVariable)
       return D3D11_CONSERVATIVE_RASTERIZATION_TIER_2;
 
     return D3D11_CONSERVATIVE_RASTERIZATION_TIER_3;
@@ -213,13 +239,13 @@ namespace dxvk {
 
 
   D3D11_SHARED_RESOURCE_TIER D3D11DeviceFeatures::DetermineSharedResourceTier(
-    const Rc<DxvkAdapter>&      Adapter,
+    const DxvkDevice&           Device,
           D3D_FEATURE_LEVEL     FeatureLevel) {
     static std::atomic<bool> s_errorShown = { false };
 
     // Lie about supporting Tier 1 since that's the
     // minimum required tier for Feature Level 11_1
-    if (!Adapter->features().khrExternalMemoryWin32) {
+    if (!Device.features().khrExternalMemoryWin32) {
       if (!s_errorShown.exchange(true))
         Logger::warn("D3D11DeviceFeatures: External memory features not supported");
 
@@ -265,8 +291,8 @@ namespace dxvk {
     bool allNtHandlesSupported = true;
 
     for (auto f : requiredFormats) {
-      allKmtHandlesSupported &= CheckFormatSharingSupport(Adapter, f, VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_KMT_BIT);
-      allNtHandlesSupported &= CheckFormatSharingSupport(Adapter, f, VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT);
+      allKmtHandlesSupported &= CheckFormatSharingSupport(Device, f, VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_KMT_BIT);
+      allNtHandlesSupported &= CheckFormatSharingSupport(Device, f, VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT);
     }
 
     // Again, lie about at least tier 1 support
@@ -283,7 +309,7 @@ namespace dxvk {
 
     // Tier 3 additionally requires R11G11B10 to be
     // shareable with D3D12
-    if (!CheckFormatSharingSupport(Adapter, VK_FORMAT_B10G11R11_UFLOAT_PACK32, VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT))
+    if (!CheckFormatSharingSupport(Device, VK_FORMAT_B10G11R11_UFLOAT_PACK32, VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT))
       return D3D11_SHARED_RESOURCE_TIER_2;
 
     return D3D11_SHARED_RESOURCE_TIER_3;
@@ -291,26 +317,30 @@ namespace dxvk {
 
 
   D3D11_TILED_RESOURCES_TIER D3D11DeviceFeatures::DetermineTiledResourcesTier(
+    const DxvkDevice&           Device,
           D3D_FEATURE_LEVEL     FeatureLevel) {
+    const auto& features = Device.features();
+    const auto& properties = Device.properties();
+
     if (FeatureLevel < D3D_FEATURE_LEVEL_11_0
-     || !m_features.core.features.sparseBinding
-     || !m_features.core.features.sparseResidencyBuffer
-     || !m_features.core.features.sparseResidencyImage2D
-     || !m_features.core.features.sparseResidencyAliased
-     || !m_properties.core.properties.sparseProperties.residencyStandard2DBlockShape)
+     || !features.core.features.sparseBinding
+     || !features.core.features.sparseResidencyBuffer
+     || !features.core.features.sparseResidencyImage2D
+     || !features.core.features.sparseResidencyAliased
+     || !properties.core.properties.sparseProperties.residencyStandard2DBlockShape)
       return D3D11_TILED_RESOURCES_NOT_SUPPORTED;
 
     if (FeatureLevel < D3D_FEATURE_LEVEL_11_1
-     || !m_features.core.features.shaderResourceResidency
-     || !m_features.core.features.shaderResourceMinLod
-     || !m_features.vk12.samplerFilterMinmax
-     || !m_properties.vk12.filterMinmaxSingleComponentFormats
-     || !m_properties.core.properties.sparseProperties.residencyNonResidentStrict
-     || m_properties.core.properties.sparseProperties.residencyAlignedMipSize)
+     || !features.core.features.shaderResourceResidency
+     || !features.core.features.shaderResourceMinLod
+     || !features.vk12.samplerFilterMinmax
+     || !properties.vk12.filterMinmaxSingleComponentFormats
+     || !properties.core.properties.sparseProperties.residencyNonResidentStrict
+     || properties.core.properties.sparseProperties.residencyAlignedMipSize)
       return D3D11_TILED_RESOURCES_TIER_1;
 
-    if (!m_features.core.features.sparseResidencyImage3D
-     || !m_properties.core.properties.sparseProperties.residencyStandard3DBlockShape)
+    if (!features.core.features.sparseResidencyImage3D
+     || !properties.core.properties.sparseProperties.residencyStandard3DBlockShape)
       return D3D11_TILED_RESOURCES_TIER_2;
 
     return D3D11_TILED_RESOURCES_TIER_3;
@@ -318,7 +348,7 @@ namespace dxvk {
 
 
   BOOL D3D11DeviceFeatures::DetermineUavExtendedTypedLoadSupport(
-    const Rc<DxvkAdapter>&      Adapter,
+    const DxvkDevice&           Device,
           D3D_FEATURE_LEVEL     FeatureLevel) {
     static const std::array<VkFormat, 18> s_formats = {{
       VK_FORMAT_R32_SFLOAT,
@@ -344,8 +374,10 @@ namespace dxvk {
     if (FeatureLevel < D3D_FEATURE_LEVEL_11_0)
       return FALSE;
 
+    auto adapter = Device.adapter();
+
     for (auto f : s_formats) {
-      DxvkFormatFeatures features = Adapter->getFormatFeatures(f);
+      DxvkFormatFeatures features = adapter->getFormatFeatures(f);
       VkFormatFeatureFlags2 imgFeatures = features.optimal | features.linear;
 
       if (!(imgFeatures & VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT))
@@ -357,9 +389,11 @@ namespace dxvk {
 
 
   BOOL D3D11DeviceFeatures::CheckFormatSharingSupport(
-    const Rc<DxvkAdapter>&      Adapter,
+    const DxvkDevice&           Device,
           VkFormat              Format,
           VkExternalMemoryHandleTypeFlagBits HandleType) {
+    Rc<DxvkAdapter> adapter = Device.adapter();
+
     DxvkFormatQuery query = { };
     query.format = Format;
     query.type = VK_IMAGE_TYPE_2D;
@@ -371,35 +405,8 @@ namespace dxvk {
       = VK_EXTERNAL_MEMORY_FEATURE_EXPORTABLE_BIT
       | VK_EXTERNAL_MEMORY_FEATURE_IMPORTABLE_BIT;
 
-    auto limits = Adapter->getFormatLimits(query);
+    auto limits = adapter->getFormatLimits(query);
     return limits && (limits->externalFeatures & featureMask);
-  }
-
-
-  D3D_FEATURE_LEVEL D3D11DeviceFeatures::GetMaxFeatureLevel() const {
-    // Check Feature Level 11_0 features
-    if (!m_features.core.features.drawIndirectFirstInstance
-     || !m_features.core.features.fragmentStoresAndAtomics
-     || !m_features.core.features.multiDrawIndirect
-     || !m_features.core.features.tessellationShader)
-      return D3D_FEATURE_LEVEL_10_1;
-
-    // Check Feature Level 11_1 features
-    if (!m_d3d11Options.OutputMergerLogicOp
-     || !m_features.core.features.vertexPipelineStoresAndAtomics)
-      return D3D_FEATURE_LEVEL_11_0;
-
-    // Check Feature Level 12_0 features
-    if (m_d3d11Options2.TiledResourcesTier < D3D11_TILED_RESOURCES_TIER_2
-     || !m_d3d11Options2.TypedUAVLoadAdditionalFormats)
-      return D3D_FEATURE_LEVEL_11_1;
-
-    // Check Feature Level 12_1 features
-    if (!m_d3d11Options2.ConservativeRasterizationTier
-     || !m_d3d11Options2.ROVsSupported)
-      return D3D_FEATURE_LEVEL_12_0;
-
-    return D3D_FEATURE_LEVEL_12_1;
   }
 
 }

--- a/src/d3d11/d3d11_features.h
+++ b/src/d3d11/d3d11_features.h
@@ -20,8 +20,7 @@ namespace dxvk {
     D3D11DeviceFeatures();
 
     D3D11DeviceFeatures(
-      const Rc<DxvkInstance>&     Instance,
-      const Rc<DxvkAdapter>&      Adapter,
+      const DxvkDevice&           Device,
       const D3D11Options&         Options,
             D3D_FEATURE_LEVEL     FeatureLevel);
 
@@ -59,18 +58,12 @@ namespace dxvk {
     /**
      * \brief Tests maximum supported feature level
      *
-     * \param [in] Instance DXVK instance
-     * \param [in] Adapter DXVK adapter
+     * \param [in] Device DXVK device
      * \returns Highest supported feature level
      */
-    static D3D_FEATURE_LEVEL GetMaxFeatureLevel(
-      const Rc<DxvkInstance>&     Instance,
-      const Rc<DxvkAdapter>&      Adapter);
+    static D3D_FEATURE_LEVEL GetMaxFeatureLevel(const DxvkDevice& Device);
 
   private:
-
-    DxvkDeviceFeatures  m_features;
-    DxvkDeviceInfo      m_properties;
 
     D3D11_FEATURE_DATA_ARCHITECTURE_INFO              m_architectureInfo            = { };
     D3D11_FEATURE_DATA_D3D9_OPTIONS                   m_d3d9Options                 = { };
@@ -101,25 +94,25 @@ namespace dxvk {
     }
 
     D3D11_CONSERVATIVE_RASTERIZATION_TIER DetermineConservativeRasterizationTier(
+      const DxvkDevice&           Device,
             D3D_FEATURE_LEVEL     FeatureLevel);
 
     D3D11_SHARED_RESOURCE_TIER DetermineSharedResourceTier(
-      const Rc<DxvkAdapter>&      Adapter,
+      const DxvkDevice&           Device,
             D3D_FEATURE_LEVEL     FeatureLevel);
 
     D3D11_TILED_RESOURCES_TIER DetermineTiledResourcesTier(
+      const DxvkDevice&           Device,
             D3D_FEATURE_LEVEL     FeatureLevel);
 
     BOOL DetermineUavExtendedTypedLoadSupport(
-      const Rc<DxvkAdapter>&      Adapter,
+      const DxvkDevice&           Device,
             D3D_FEATURE_LEVEL     FeatureLevel);
 
     BOOL CheckFormatSharingSupport(
-      const Rc<DxvkAdapter>&      Adapter,
+      const DxvkDevice&           Device,
             VkFormat              Format,
             VkExternalMemoryHandleTypeFlagBits HandleType);
-
-    D3D_FEATURE_LEVEL GetMaxFeatureLevel() const;
 
   };
 

--- a/src/d3d11/d3d11_main.cpp
+++ b/src/d3d11/d3d11_main.cpp
@@ -63,33 +63,34 @@ extern "C" {
       pFeatureLevels = defaultFeatureLevels.data();
       FeatureLevels  = defaultFeatureLevels.size();
     }
-    
-    // Find the highest feature level supported by the device.
-    // This works because the feature level array is ordered.
-    D3D_FEATURE_LEVEL maxFeatureLevel = D3D11Device::GetMaxFeatureLevel(dxvkInstance, dxvkAdapter);
-    D3D_FEATURE_LEVEL minFeatureLevel = D3D_FEATURE_LEVEL();
-    D3D_FEATURE_LEVEL devFeatureLevel = D3D_FEATURE_LEVEL();
-
-    Logger::info(str::format("D3D11InternalCreateDevice: Maximum supported feature level: ", maxFeatureLevel));
-
-    for (uint32_t flId = 0 ; flId < FeatureLevels; flId++) {
-      minFeatureLevel = pFeatureLevels[flId];
-
-      if (minFeatureLevel <= maxFeatureLevel) {
-        devFeatureLevel = minFeatureLevel;
-        break;
-      }
-    }
-
-    if (!devFeatureLevel) {
-      Logger::err(str::format("D3D11InternalCreateDevice: Minimum required feature level ", minFeatureLevel, " not supported"));
-      return E_INVALIDARG;
-    }
 
     try {
-      Logger::info(str::format("D3D11InternalCreateDevice: Using feature level ", devFeatureLevel));
-
+      // Create Vulkan device so we have up-to-date features / properties
       Rc<DxvkDevice> dxvkDevice = dxvkAdapter->createDevice();
+
+      // Find the highest feature level supported by the device.
+      // This works because the feature level array is ordered.
+      D3D_FEATURE_LEVEL maxFeatureLevel = D3D11Device::GetMaxFeatureLevel(*dxvkDevice);
+      D3D_FEATURE_LEVEL minFeatureLevel = D3D_FEATURE_LEVEL();
+      D3D_FEATURE_LEVEL devFeatureLevel = D3D_FEATURE_LEVEL();
+
+      Logger::info(str::format("D3D11InternalCreateDevice: Maximum supported feature level: ", maxFeatureLevel));
+
+      for (uint32_t flId = 0 ; flId < FeatureLevels; flId++) {
+        minFeatureLevel = pFeatureLevels[flId];
+
+        if (minFeatureLevel <= maxFeatureLevel) {
+          devFeatureLevel = minFeatureLevel;
+          break;
+        }
+      }
+
+      if (!devFeatureLevel) {
+        Logger::err(str::format("D3D11InternalCreateDevice: Minimum required feature level ", minFeatureLevel, " not supported"));
+        return E_INVALIDARG;
+      }
+
+      Logger::info(str::format("D3D11InternalCreateDevice: Using feature level ", devFeatureLevel));
 
       Com<D3D11DXGIDevice> device = new D3D11DXGIDevice(
         pAdapter, nullptr, nullptr,
@@ -100,7 +101,7 @@ extern "C" {
         __uuidof(ID3D11Device),
         reinterpret_cast<void**>(ppDevice));
     } catch (const DxvkError& e) {
-      Logger::err("D3D11InternalCreateDevice: Failed to create D3D11 device");
+      Logger::err(str::format("D3D11InternalCreateDevice: Failed to create D3D11 device: ", e.message()));
       return E_FAIL;
     }
   }

--- a/src/d3d11/d3d11_query.cpp
+++ b/src/d3d11/d3d11_query.cpp
@@ -342,10 +342,7 @@ namespace dxvk {
   
   
   UINT64 D3D11Query::GetTimestampQueryFrequency() const {
-    Rc<DxvkDevice>  device  = m_parent->GetDXVKDevice();
-    Rc<DxvkAdapter> adapter = device->adapter();
-
-    const auto& limits = adapter->deviceProperties().core.properties.limits;
+    const auto& limits = m_parent->GetDXVKDevice()->properties().core.properties.limits;
     return uint64_t(1'000'000'000.0f / limits.timestampPeriod);
   }
 

--- a/src/d3d9/d3d9_adapter.cpp
+++ b/src/d3d9/d3d9_adapter.cpp
@@ -36,11 +36,13 @@ namespace dxvk {
   D3D9Adapter::D3D9Adapter(
           D3D9InterfaceEx* pParent,
     const D3D9ON12_ARGS*   p9On12Args,
+          Rc<DxvkInstance> Instance,
           Rc<DxvkAdapter>  Adapter,
           UINT             Ordinal,
           UINT             DisplayIndex)
   : m_parent          (pParent),
     m_adapter         (Adapter),
+    m_caps            (*Instance, Adapter->handle(), nullptr),
     m_ordinal         (Ordinal),
     m_displayIndex    (DisplayIndex),
     m_modeCacheFormat (D3D9Format::Unknown) {
@@ -180,8 +182,7 @@ namespace dxvk {
     // Nvidia specific depth bounds test hack
     // (supported ever since the GeForce 6 series)
     if (unlikely(CheckFormat == D3D9Format::NVDB && surface))
-      return (!isD3D8Compatible &&
-              m_adapter->features().core.features.depthBounds && isNvidia)
+      return (!isD3D8Compatible && m_caps.getFeatures().core.features.depthBounds && isNvidia)
         ? D3D_OK
         : D3DERR_NOTAVAILABLE;
 
@@ -272,16 +273,19 @@ namespace dxvk {
       return D3DERR_NOTAVAILABLE;
 
     // Therefore...
+    const auto& properties = m_caps.getProperties();
+    const auto& features = m_caps.getFeatures();
+
     VkSampleCountFlags sampleFlags = VkSampleCountFlags(sampleCount);
 
     VkSampleCountFlags availableFlags;
     if (dst.FormatColor == VK_FORMAT_UNDEFINED)
-      availableFlags = m_adapter->deviceProperties().core.properties.limits.framebufferDepthSampleCounts
-                     & m_adapter->deviceProperties().core.properties.limits.framebufferColorSampleCounts;
+      availableFlags = properties.core.properties.limits.framebufferDepthSampleCounts
+                     & properties.core.properties.limits.framebufferColorSampleCounts;
     else if (IsDepthStencilFormat(SurfaceFormat))
-      availableFlags = m_adapter->deviceProperties().core.properties.limits.framebufferDepthSampleCounts;
+      availableFlags = properties.core.properties.limits.framebufferDepthSampleCounts;
     else
-      availableFlags = m_adapter->deviceProperties().core.properties.limits.framebufferColorSampleCounts;
+      availableFlags = properties.core.properties.limits.framebufferColorSampleCounts;
 
     if (!(availableFlags & sampleFlags) && dst.FormatColor != VK_FORMAT_UNDEFINED) {
       // Adreno 7XX GPUs cannot report general support for 8x MSAA because they do not support it for 128 bit formats.
@@ -305,7 +309,7 @@ namespace dxvk {
       if (dst.ConversionFormatInfo.FormatType != D3D9ConversionFormat_None)
         query.usage |= VK_IMAGE_USAGE_STORAGE_BIT;
 
-      if (m_adapter->features().extAttachmentFeedbackLoopLayout.attachmentFeedbackLoopLayout)
+      if (features.extAttachmentFeedbackLoopLayout.attachmentFeedbackLoopLayout)
         query.usage |= VK_IMAGE_USAGE_ATTACHMENT_FEEDBACK_LOOP_BIT_EXT;
 
       auto limits = m_adapter->getFormatLimits(query);
@@ -397,7 +401,7 @@ namespace dxvk {
     auto& options = m_parent->GetOptions();
 
     const uint32_t maxShaderModel = m_parent->IsD3D8Compatible() ? std::min(1u, options.shaderModel) : options.shaderModel;
-    const auto& limits = m_adapter->deviceProperties().core.properties.limits;
+    const auto& limits = m_caps.getProperties().core.properties.limits;
 
     // TODO: Actually care about what the adapter supports here.
     // ^ For Intel and older cards most likely here.
@@ -854,7 +858,7 @@ namespace dxvk {
     if (pLUID == nullptr)
       return D3DERR_INVALIDCALL;
 
-    auto& vk11 = m_adapter->deviceProperties().vk11;
+    auto& vk11 = m_caps.getProperties().vk11;
 
     if (vk11.deviceLUIDValid)
       *pLUID = bit::cast<LUID>(vk11.deviceLUID);
@@ -1032,7 +1036,7 @@ namespace dxvk {
   void D3D9Adapter::CacheIdentifierInfo() {
     auto& options = m_parent->GetOptions();
 
-    const auto& props = m_adapter->deviceProperties();
+    const auto& props = m_caps.getProperties();
 
     m_deviceGuid   = bit::cast<GUID>(props.vk11.deviceUUID);
     m_vendorId     = props.core.properties.vendorID;

--- a/src/d3d9/d3d9_adapter.h
+++ b/src/d3d9/d3d9_adapter.h
@@ -20,6 +20,7 @@ namespace dxvk {
     D3D9Adapter(
             D3D9InterfaceEx* pParent,
       const D3D9ON12_ARGS*   p9On12Args,
+            Rc<DxvkInstance> Instance,
             Rc<DxvkAdapter>  Adapter,
             UINT             Ordinal,
             UINT             DisplayIndex);
@@ -104,6 +105,15 @@ namespace dxvk {
 
     bool IsD3D8Compatible() const;
 
+    force_inline void incRef() {
+      m_refCount.fetch_add(1u, std::memory_order_acquire);
+    }
+
+    force_inline void decRef() {
+      if (m_refCount.fetch_sub(1u, std::memory_order_acquire) == 1u)
+        delete this;
+    }
+
   private:
 
     // used as a global filter when mode count compatibility is enabled
@@ -139,9 +149,13 @@ namespace dxvk {
 
     void CacheIdentifierInfo();
 
+    std::atomic<uint32_t>         m_refCount = { 0u };
+
     D3D9InterfaceEx*              m_parent;
 
     Rc<DxvkAdapter>               m_adapter;
+    DxvkDeviceCapabilities        m_caps;
+
     UINT                          m_ordinal;
     UINT                          m_displayIndex;
 

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -1835,7 +1835,7 @@ namespace dxvk {
 
     // Update depth bias if necessary
     if (ds != nullptr && m_depthBiasRepresentation.depthBiasRepresentation != VK_DEPTH_BIAS_REPRESENTATION_FLOAT_EXT) {
-      const int32_t vendorId = m_dxvkDevice->adapter()->deviceProperties().core.properties.vendorID;
+      const int32_t vendorId = m_dxvkDevice->properties().core.properties.vendorID;
       const bool exact = m_depthBiasRepresentation.depthBiasExact;
       const bool forceUnorm = m_depthBiasRepresentation.depthBiasRepresentation == VK_DEPTH_BIAS_REPRESENTATION_LEAST_REPRESENTABLE_VALUE_FORCE_UNORM_EXT;
       const float rValue = GetDepthBufferRValue(ds->GetCommonTexture()->GetFormatMapping().FormatColor, vendorId, exact, forceUnorm);
@@ -8789,7 +8789,7 @@ namespace dxvk {
     rs[D3DRS_CLIPPLANEENABLE] = 0;
     m_dirty.set(D3D9DeviceDirtyFlag::ClipPlanes);
 
-    const auto& limits = m_dxvkDevice->adapter()->deviceProperties().core.properties.limits;
+    const auto& limits = m_dxvkDevice->properties().core.properties.limits;
 
     rs[D3DRS_POINTSPRITEENABLE]          = FALSE;
     rs[D3DRS_POINTSCALEENABLE]           = FALSE;

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -5997,12 +5997,11 @@ namespace dxvk {
 
 
   int64_t D3D9DeviceEx::DetermineInitialTextureMemory() {
-    auto memoryProp = m_adapter->GetDXVKAdapter()->memoryProperties();
+    auto adapterInfo = m_dxvkDevice->adapter()->info();
 
-    VkDeviceSize availableTextureMemory = 0;
-
-    for (uint32_t i = 0; i < memoryProp.memoryHeapCount; i++)
-      availableTextureMemory += memoryProp.memoryHeaps[i].size;
+    // Apparently we need to return video and system memory combined:
+    // https://github.com/doitsujin/dxvk/pull/1436
+    VkDeviceSize availableTextureMemory = adapterInfo.deviceMemory + adapterInfo.systemMemory;
 
     constexpr VkDeviceSize Megabytes = 1024 * 1024;
     // Windows will typically "reserve" some amount of video memory,

--- a/src/d3d9/d3d9_interface.cpp
+++ b/src/d3d9/d3d9_interface.cpp
@@ -51,7 +51,7 @@ namespace dxvk {
 
         if (adapter != nullptr) {
           const auto* d3d9On12Args = Find9On12Args(adapter, pOverrideList, OverrideCount);
-          m_adapters.emplace_back(this, d3d9On12Args, adapter, adapterOrdinal++, i - 1);
+          m_adapters.emplace_back(new D3D9Adapter(this, d3d9On12Args, m_instance, adapter, adapterOrdinal++, i - 1));
         }
       }
     }
@@ -63,7 +63,7 @@ namespace dxvk {
 
       for (uint32_t i = 0; i < adapterCount; i++) {
         const auto* d3d9On12Args = Find9On12Args(m_instance->enumAdapters(i), pOverrideList, OverrideCount);
-        m_adapters.emplace_back(this, d3d9On12Args, m_instance->enumAdapters(i), i, 0);
+        m_adapters.emplace_back(new D3D9Adapter(this, d3d9On12Args, m_instance, m_instance->enumAdapters(i), i, 0));
       }
     }
 

--- a/src/d3d9/d3d9_interface.cpp
+++ b/src/d3d9/d3d9_interface.cpp
@@ -535,15 +535,15 @@ namespace dxvk {
 #ifdef _WIN32
     for (uint32_t i = 0u; i < OverrideCount; i++) {
       if (pOverrides[i].pD3D12Device) {
-        const auto& vk11 = Adapter->deviceProperties().vk11;
+        auto info = Adapter->info();
 
-        if (vk11.deviceLUIDValid) {
+        if (info.luidIsValid) {
           Com<ID3D12Device> device = nullptr;
 
           if (SUCCEEDED(pOverrides[i].pD3D12Device->QueryInterface(__uuidof(ID3D12Device), reinterpret_cast<void**>(&device)))) {
             LUID luid = device->GetAdapterLuid();
 
-            if (!std::memcmp(&luid, vk11.deviceLUID, sizeof(vk11.deviceLUID)))
+            if (!std::memcmp(&luid, info.deviceLuid, sizeof(info.deviceLuid)))
               arg = &pOverrides[i];
           }
         }

--- a/src/d3d9/d3d9_interface.h
+++ b/src/d3d9/d3d9_interface.h
@@ -135,7 +135,7 @@ namespace dxvk {
 
     D3D9Adapter* GetAdapter(UINT Ordinal) {
       return Ordinal < m_adapters.size()
-        ? &m_adapters[Ordinal]
+        ? m_adapters[Ordinal].ptr()
         : nullptr;
     }
 
@@ -163,7 +163,7 @@ namespace dxvk {
 
     inline void RefreshAdapterFormatTables() {
       for (auto& adapter : m_adapters)
-        adapter.RefreshFormatsTable();
+        adapter->RefreshFormatsTable();
     }
 
     Rc<DxvkInstance>              m_instance;
@@ -176,7 +176,7 @@ namespace dxvk {
 
     D3D9Options                   m_d3d9Options;
 
-    std::vector<D3D9Adapter>      m_adapters;
+    std::vector<Rc<D3D9Adapter>>  m_adapters;
 
     D3D9VkInteropInterface        m_d3d9Interop;
 

--- a/src/d3d9/d3d9_query.cpp
+++ b/src/d3d9/d3d9_query.cpp
@@ -253,10 +253,7 @@ namespace dxvk {
 
 
   UINT64 D3D9Query::GetTimestampQueryFrequency() const {
-    Rc<DxvkDevice>  device  = m_parent->GetDXVKDevice();
-    Rc<DxvkAdapter> adapter = device->adapter();
-
-    const auto& limits = adapter->deviceProperties().core.properties.limits;
+    const auto& limits = m_parent->GetDXVKDevice()->properties().core.properties.limits;
     return uint64_t(1'000'000'000.0f / limits.timestampPeriod);
   }
 

--- a/src/dxgi/dxgi_adapter.cpp
+++ b/src/dxgi/dxgi_adapter.cpp
@@ -159,34 +159,41 @@ namespace dxvk {
     if (ppOutput == nullptr)
       return E_INVALIDARG;
 
-    const auto& deviceId = m_adapter->deviceProperties().vk11;
+    auto adapterInfo = m_adapter->info();
 
-    std::array<const LUID*, 2> adapterLUIDs = { };
-    uint32_t numLUIDs = 0;
+    small_vector<LUID, 2> adapterLUIDs = { };
+    small_vector<const LUID*, 2> luidPointers;
 
     if (m_adapter->isLinkedToDGPU())
       return DXGI_ERROR_NOT_FOUND;
 
-    if (deviceId.deviceLUIDValid)
-      adapterLUIDs[numLUIDs++] = reinterpret_cast<const LUID*>(deviceId.deviceLUID);
+    if (adapterInfo.luidIsValid) {
+      auto& luid = adapterLUIDs.emplace_back();
+      std::memcpy(&luid, adapterInfo.deviceLuid, sizeof(luid));
+    }
 
     auto linkedAdapter = m_adapter->linkedIGPUAdapter();
 
     // If either LUID is not valid, enumerate all monitors.
-    if (numLUIDs && linkedAdapter != nullptr) {
-      const auto& deviceId = linkedAdapter->deviceProperties().vk11;
+    if (!adapterLUIDs.empty() && linkedAdapter != nullptr) {
+      auto linkedInfo = linkedAdapter->info();
 
-      if (deviceId.deviceLUIDValid)
-        adapterLUIDs[numLUIDs++] = reinterpret_cast<const LUID*>(deviceId.deviceLUID);
-      else
-        numLUIDs = 0;
+      if (linkedInfo.luidIsValid) {
+        auto& luid = adapterLUIDs.emplace_back();
+        std::memcpy(&luid, linkedInfo.deviceLuid, sizeof(luid));
+      } else {
+        adapterLUIDs.clear();
+      }
     }
 
     // Enumerate all monitors if the robustness fallback is active.
     if (m_factory->UseMonitorFallback())
-      numLUIDs = 0;
+      adapterLUIDs.clear();
 
-    HMONITOR monitor = wsi::enumMonitors(adapterLUIDs.data(), numLUIDs, Output);
+    for (const auto& luid : adapterLUIDs)
+      luidPointers.push_back(&luid);
+
+    HMONITOR monitor = wsi::enumMonitors(luidPointers.data(), luidPointers.size(), Output);
 
     if (monitor == nullptr)
       return DXGI_ERROR_NOT_FOUND;

--- a/src/dxgi/dxgi_adapter.cpp
+++ b/src/dxgi/dxgi_adapter.cpp
@@ -382,18 +382,17 @@ namespace dxvk {
 
     const DxgiOptions* options = m_factory->GetOptions();
 
-    auto deviceProp = m_adapter->deviceProperties();
-    auto memoryProp = m_adapter->memoryProperties();
+    auto adapterInfo = m_adapter->info();
 
     // Custom Vendor / Device ID
     if (options->customVendorId >= 0)
-      deviceProp.core.properties.vendorID = options->customVendorId;
+      adapterInfo.vendorId = options->customVendorId;
 
     if (options->customDeviceId >= 0)
-      deviceProp.core.properties.deviceID = options->customDeviceId;
+      adapterInfo.deviceId = options->customDeviceId;
 
     std::string description = options->customDeviceDesc.empty()
-      ? std::string(deviceProp.core.properties.deviceName)
+      ? std::string(adapterInfo.deviceName)
       : options->customDeviceDesc;
 
     if (options->customVendorId < 0) {
@@ -410,22 +409,22 @@ namespace dxvk {
         fallbackDevice = 0x2487;
       }
 
-      bool hideNvidiaGpu = deviceProp.vk12.driverID == VK_DRIVER_ID_NVIDIA_PROPRIETARY
+      bool hideNvidiaGpu = adapterInfo.driverId == VK_DRIVER_ID_NVIDIA_PROPRIETARY
         ? options->hideNvidiaGpu : options->hideNvkGpu;
 
-      bool hideGpu = (deviceProp.core.properties.vendorID == uint16_t(DxvkGpuVendor::Nvidia) && hideNvidiaGpu)
-                  || (deviceProp.core.properties.vendorID == uint16_t(DxvkGpuVendor::Amd) && options->hideAmdGpu)
-                  || (deviceProp.core.properties.vendorID == uint16_t(DxvkGpuVendor::Intel) && options->hideIntelGpu);
+      bool hideGpu = (adapterInfo.vendorId == uint16_t(DxvkGpuVendor::Nvidia) && hideNvidiaGpu)
+                  || (adapterInfo.vendorId == uint16_t(DxvkGpuVendor::Amd) && options->hideAmdGpu)
+                  || (adapterInfo.vendorId == uint16_t(DxvkGpuVendor::Intel) && options->hideIntelGpu);
 
       if (hideGpu) {
-        deviceProp.core.properties.vendorID = fallbackVendor;
+        adapterInfo.vendorId = fallbackVendor;
 
         if (options->customDeviceId < 0)
-          deviceProp.core.properties.deviceID = fallbackDevice;
+          adapterInfo.deviceId = fallbackDevice;
 
         Logger::info(str::format("DXGI: Hiding actual GPU, reporting:\n",
-                                 "  vendor ID: 0x", std::hex, deviceProp.core.properties.vendorID, "\n",
-                                 "  device ID: 0x", std::hex, deviceProp.core.properties.deviceID, "\n"));
+                                 "  vendor ID: 0x", std::hex, adapterInfo.vendorId, "\n",
+                                 "  device ID: 0x", std::hex, adapterInfo.deviceId, "\n"));
       }
     }
 
@@ -435,22 +434,8 @@ namespace dxvk {
       description.c_str(), description.size());
 
     // Get amount of video memory based on the Vulkan heaps
-    VkDeviceSize deviceMemory = 0;
-    VkDeviceSize sharedMemory = 0;
-
-    for (uint32_t i = 0; i < memoryProp.memoryHeapCount; i++) {
-      VkMemoryHeap heap = memoryProp.memoryHeaps[i];
-
-      if (heap.flags & VK_MEMORY_HEAP_DEVICE_LOCAL_BIT) {
-        // In general we'll have one large device-local heap, and an additional
-        // smaller heap on dGPUs in case ReBAR is not supported. Assume that
-        // the largest available heap is the total amount of available VRAM.
-        deviceMemory = std::max(heap.size, deviceMemory);
-      } else {
-        // This is typically plain sysmem, don't care too much about limits here
-        sharedMemory += heap.size;
-      }
-    }
+    VkDeviceSize deviceMemory = adapterInfo.deviceMemory;
+    VkDeviceSize sharedMemory = adapterInfo.systemMemory;
 
     // This can happen on integrated GPUs with one memory heap, over-report
     // here since some games may be allergic to reporting no shared memory.
@@ -461,7 +446,7 @@ namespace dxvk {
     // which can be an integrated GPU on some systems. Report available memory as shared
     // memory and a small amount as dedicated carve-out if a dedicated GPU is present,
     // otherwise report memory normally to not unnecessarily confuse games on Deck.
-    if ((m_adapter->isLinkedToDGPU() && deviceProp.core.properties.deviceType == VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU)) {
+    if ((m_adapter->isLinkedToDGPU() && adapterInfo.deviceType == VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU)) {
       sharedMemory = std::max(sharedMemory, deviceMemory);
       deviceMemory = 512ull << 20;
     }
@@ -493,8 +478,8 @@ namespace dxvk {
       sharedMemory = std::min(sharedMemory, maxMemory);
     }
 
-    desc.VendorId                       = deviceProp.core.properties.vendorID;
-    desc.DeviceId                       = deviceProp.core.properties.deviceID;
+    desc.VendorId                       = adapterInfo.vendorId;
+    desc.DeviceId                       = adapterInfo.deviceId;
     desc.SubSysId                       = 0;
     desc.Revision                       = 0;
     desc.DedicatedVideoMemory           = deviceMemory;
@@ -505,8 +490,8 @@ namespace dxvk {
     desc.GraphicsPreemptionGranularity  = DXGI_GRAPHICS_PREEMPTION_DMA_BUFFER_BOUNDARY;
     desc.ComputePreemptionGranularity   = DXGI_COMPUTE_PREEMPTION_DMA_BUFFER_BOUNDARY;
 
-    if (deviceProp.vk11.deviceLUIDValid)
-      std::memcpy(&desc.AdapterLuid, deviceProp.vk11.deviceLUID, VK_LUID_SIZE);
+    if (adapterInfo.luidIsValid)
+      std::memcpy(&desc.AdapterLuid, adapterInfo.deviceLuid, VK_LUID_SIZE);
     else
       desc.AdapterLuid = GetAdapterLUID(m_index);
 

--- a/src/dxgi/dxgi_factory.cpp
+++ b/src/dxgi/dxgi_factory.cpp
@@ -105,13 +105,15 @@ namespace dxvk {
 
       // Remove all monitors that are associated
       // with the current adapter from the list.
-      const auto& vk11 = adapter->deviceProperties().vk11;
+      auto info = adapter->info();
 
-      if (vk11.deviceLUIDValid) {
-        auto luid = reinterpret_cast<const LUID*>(&vk11.deviceLUID);
+      if (info.luidIsValid) {
+        LUID luid = {};
+        std::memcpy(&luid, &info.deviceLuid[0u], sizeof(luid));
 
         for (uint32_t j = 0; ; j++) {
-          HMONITOR hmon = wsi::enumMonitors(&luid, 1, j);
+          const LUID* pLuid = &luid;
+          HMONITOR hmon = wsi::enumMonitors(&pLuid, 1, j);
 
           if (!hmon)
             break;

--- a/src/dxso/dxso_options.cpp
+++ b/src/dxso/dxso_options.cpp
@@ -8,9 +8,7 @@ namespace dxvk {
 
   DxsoOptions::DxsoOptions(D3D9DeviceEx* pDevice, const D3D9Options& options) {
     const Rc<DxvkDevice> device = pDevice->GetDXVKDevice();
-    const Rc<DxvkAdapter> adapter = device->adapter();
-
-    const DxvkDeviceInfo& devInfo = adapter->deviceProperties();
+    const DxvkDeviceInfo& devInfo = device->properties();
 
     // Apply shader-related options
     d3d9FloatEmulation   = options.d3d9FloatEmulation;

--- a/src/dxvk/dxvk_adapter.cpp
+++ b/src/dxvk/dxvk_adapter.cpp
@@ -55,6 +55,40 @@ namespace dxvk {
   }
 
   
+  DxvkAdapterInfo DxvkAdapter::info() const {
+    const auto& properties = m_capabilities.getProperties();
+    const auto& memory = m_capabilities.getMemoryInfo().core.memoryProperties;
+
+    DxvkAdapterInfo result = {};
+    result.vendorId = properties.core.properties.vendorID;
+    result.deviceId = properties.core.properties.deviceID;
+    result.deviceType = properties.core.properties.deviceType;
+    std::memcpy(result.deviceName, properties.core.properties.deviceName, sizeof(result.deviceName));
+    std::memcpy(result.deviceUuid, properties.vk11.deviceUUID, sizeof(result.deviceUuid));
+
+    if ((result.luidIsValid = properties.vk11.deviceLUIDValid))
+      std::memcpy(result.deviceLuid, properties.vk11.deviceLUID, sizeof(result.deviceLuid));
+
+    result.driverId = properties.vk12.driverID;
+    std::memcpy(result.driverName, properties.vk12.driverName, sizeof(result.driverName));
+    std::memcpy(result.driverInfo, properties.vk12.driverInfo, sizeof(result.driverInfo));
+    result.driverVersion = properties.core.properties.driverVersion;
+
+    for (uint32_t i = 0u; i < memory.memoryHeapCount; i++) {
+      if (memory.memoryHeaps[i].flags & VK_MEMORY_HEAP_DEVICE_LOCAL_BIT) {
+        // In general we'll have one large device-local heap, and an additional
+        // smaller heap on dGPUs in case ReBAR is not supported. Assume that
+        // the largest available heap is the total amount of available VRAM.
+        result.deviceMemory = std::max(result.deviceMemory, memory.memoryHeaps[i].size);
+      } else {
+        result.systemMemory += memory.memoryHeaps[i].size;
+      }
+    }
+
+    return result;
+  }
+
+
   bool DxvkAdapter::isCompatible(std::string& error) {
     std::array<char, 1024u> message = { };
 
@@ -323,7 +357,7 @@ namespace dxvk {
 
 
   bool DxvkAdapter::isUnifiedMemoryArchitecture() const {
-    auto memory = this->memoryProperties();
+    auto memory = m_capabilities.getMemoryInfo().core.memoryProperties;
     bool result = true;
 
     for (uint32_t i = 0; i < memory.memoryHeapCount; i++)

--- a/src/dxvk/dxvk_adapter.cpp
+++ b/src/dxvk/dxvk_adapter.cpp
@@ -165,24 +165,26 @@ namespace dxvk {
   Rc<DxvkDevice> DxvkAdapter::createDevice() {
     auto vk = m_instance->vki();
 
+    DxvkDeviceCapabilities caps(*m_instance, m_handle, nullptr);
+
     Logger::info("Creating device:");
-    m_capabilities.logDeviceInfo();
+    caps.logDeviceInfo();
 
     // Get device features to enable
     size_t featureBlobSize = 0u;
-    m_capabilities.queryDeviceFeatures(&featureBlobSize, nullptr);
+    caps.queryDeviceFeatures(&featureBlobSize, nullptr);
 
     std::vector<char> featureBlob(featureBlobSize);
-    m_capabilities.queryDeviceFeatures(&featureBlobSize, featureBlob.data());
+    caps.queryDeviceFeatures(&featureBlobSize, featureBlob.data());
 
     auto features = reinterpret_cast<const VkPhysicalDeviceFeatures2*>(featureBlob.data());
 
     // Get extension list and add extra extensions
     uint32_t extensionCount = 0u;
-    m_capabilities.queryDeviceExtensions(&extensionCount, nullptr);
+    caps.queryDeviceExtensions(&extensionCount, nullptr);
 
     std::vector<VkExtensionProperties> extensions(extensionCount);
-    m_capabilities.queryDeviceExtensions(&extensionCount, extensions.data());
+    caps.queryDeviceExtensions(&extensionCount, extensions.data());
 
     for (const auto& extra : m_extraExtensions) {
       bool found = false;
@@ -204,13 +206,13 @@ namespace dxvk {
       extensionNames.push_back(ext.extensionName);
 
     // Query queue infos
-    DxvkDeviceQueueMapping queueMapping = m_capabilities.getQueueMapping();
+    DxvkDeviceQueueMapping queueMapping = caps.getQueueMapping();
 
     uint32_t queueCount = { };
-    m_capabilities.queryDeviceQueues(&queueCount, nullptr);
+    caps.queryDeviceQueues(&queueCount, nullptr);
 
     std::vector<VkDeviceQueueCreateInfo> queues(queueCount, { VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO });
-    m_capabilities.queryDeviceQueues(&queueCount, queues.data());
+    caps.queryDeviceQueues(&queueCount, queues.data());
 
     uint32_t priorityCount = 0u;
 
@@ -226,7 +228,7 @@ namespace dxvk {
       priorityIndex += q.queueCount;
     }
 
-    m_capabilities.queryDeviceQueues(&queueCount, queues.data());
+    caps.queryDeviceQueues(&queueCount, queues.data());
 
     // Create the actual Vulkan device
     VkDeviceCreateInfo deviceInfo = { VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO };
@@ -246,11 +248,11 @@ namespace dxvk {
     Rc<vk::DeviceFn> vkd = new vk::DeviceFn(vk, true, device);
 
     DxvkDeviceQueueSet deviceQueues = { };
-    deviceQueues.graphics = getDeviceQueue(vkd, m_capabilities, queueMapping.graphics);
-    deviceQueues.transfer = getDeviceQueue(vkd, m_capabilities, queueMapping.transfer);
-    deviceQueues.sparse   = getDeviceQueue(vkd, m_capabilities, queueMapping.sparse);
+    deviceQueues.graphics = getDeviceQueue(vkd, caps, queueMapping.graphics);
+    deviceQueues.transfer = getDeviceQueue(vkd, caps, queueMapping.transfer);
+    deviceQueues.sparse   = getDeviceQueue(vkd, caps, queueMapping.sparse);
 
-    return new DxvkDevice(m_instance, this, vkd, m_capabilities.getFeatures(), deviceQueues, DxvkQueueCallback());
+    return new DxvkDevice(m_instance, this, vkd, caps, deviceQueues, DxvkQueueCallback());
   }
 
 
@@ -284,7 +286,7 @@ namespace dxvk {
     deviceQueues.transfer = getDeviceQueue(vkd, importCaps, queueMapping.transfer);
     deviceQueues.sparse   = getDeviceQueue(vkd, importCaps, queueMapping.sparse);
 
-    return new DxvkDevice(m_instance, this, vkd, importCaps.getFeatures(), deviceQueues, args.queueCallback);
+    return new DxvkDevice(m_instance, this, vkd, importCaps, deviceQueues, args.queueCallback);
   }
 
 

--- a/src/dxvk/dxvk_adapter.h
+++ b/src/dxvk/dxvk_adapter.h
@@ -154,27 +154,6 @@ namespace dxvk {
     DxvkAdapterInfo info() const;
     
     /**
-     * \brief Physical device properties
-     * 
-     * Returns a read-only reference to the core
-     * properties of the Vulkan physical device.
-     * \returns Physical device core properties
-     */
-    const DxvkDeviceInfo& deviceProperties() const {
-      return m_capabilities.getProperties();
-    }
-    
-    /**
-     * \brief Supportred device features
-     * 
-     * Queries the supported device features.
-     * \returns Device features
-     */
-    const DxvkDeviceFeatures& features() const {
-      return m_capabilities.getFeatures();
-    }
-    
-    /**
      * \brief Memory properties
      *
      * Queries the memory types and memory heaps of

--- a/src/dxvk/dxvk_adapter.h
+++ b/src/dxvk/dxvk_adapter.h
@@ -73,6 +73,26 @@ namespace dxvk {
 
 
   /**
+   * \brief Limited adapter properties
+   */
+  struct DxvkAdapterInfo {
+    uint32_t vendorId = 0u;
+    uint32_t deviceId = 0u;
+    VkPhysicalDeviceType deviceType = VK_PHYSICAL_DEVICE_TYPE_OTHER;
+    char deviceName[VK_MAX_PHYSICAL_DEVICE_NAME_SIZE];
+    uint8_t deviceUuid[VK_UUID_SIZE];
+    uint8_t deviceLuid[VK_LUID_SIZE];
+    bool luidIsValid = false;
+    VkDriverId driverId = VK_DRIVER_ID_MAX_ENUM;
+    char driverName[VK_MAX_DRIVER_NAME_SIZE];
+    char driverInfo[VK_MAX_DRIVER_INFO_SIZE];
+    uint32_t driverVersion = 0u;
+    VkDeviceSize deviceMemory = 0u;
+    VkDeviceSize systemMemory = 0u;
+  };
+
+
+  /**
    * \brief Device import info
    */
   struct DxvkDeviceImportInfo {
@@ -123,6 +143,15 @@ namespace dxvk {
     D3DKMT_HANDLE kmtLocal() const {
       return m_kmtLocal;
     }
+
+    /**
+     * \brief Limited device properties
+     *
+     * Returns some device properties that we can consider immutable,
+     * and are useful for device selection or identification.
+     * \returns Device properties
+     */
+    DxvkAdapterInfo info() const;
     
     /**
      * \brief Physical device properties

--- a/src/dxvk/dxvk_device.cpp
+++ b/src/dxvk/dxvk_device.cpp
@@ -745,7 +745,7 @@ namespace dxvk {
     // (GFX10+) for now, where it is proven to work.
     hints.preferComputeMipGen = (m_adapter->matchesDriver(VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR)
                              || (m_adapter->matchesDriver(VK_DRIVER_ID_MESA_RADV)
-                              && m_adapter->deviceProperties().vk13.minSubgroupSize == 32u));
+                              && m_properties.vk13.minSubgroupSize == 32u));
 
     // On AMD we can expect it to be optimal to simply pass the heap offset
     // to descriptor memory through as-is to avoid some ALU. Some other

--- a/src/dxvk/dxvk_device.cpp
+++ b/src/dxvk/dxvk_device.cpp
@@ -11,7 +11,7 @@ namespace dxvk {
     const Rc<DxvkInstance>&         instance,
     const Rc<DxvkAdapter>&          adapter,
     const Rc<vk::DeviceFn>&         vkd,
-    const DxvkDeviceFeatures&       features,
+    const DxvkDeviceCapabilities&   caps,
     const DxvkDeviceQueueSet&       queues,
     const DxvkQueueCallback&        queueCallback)
   : m_options           (instance->options()),
@@ -20,8 +20,8 @@ namespace dxvk {
     m_vkd               (vkd),
     m_debugFlags        (instance->debugFlags()),
     m_queues            (queues),
-    m_features          (features),
-    m_properties        (adapter->deviceProperties()),
+    m_features          (caps.getFeatures()),
+    m_properties        (caps.getProperties()),
     m_perfHints         (getPerfHints()),
     m_objects           (this),
     m_submissionQueue   (this, queueCallback) {

--- a/src/dxvk/dxvk_device.h
+++ b/src/dxvk/dxvk_device.h
@@ -88,7 +88,7 @@ namespace dxvk {
       const Rc<DxvkInstance>&         instance,
       const Rc<DxvkAdapter>&          adapter,
       const Rc<vk::DeviceFn>&         vkd,
-      const DxvkDeviceFeatures&       features,
+      const DxvkDeviceCapabilities&   caps,
       const DxvkDeviceQueueSet&       queues,
       const DxvkQueueCallback&        queueCallback);
       

--- a/src/dxvk/dxvk_device_filter.cpp
+++ b/src/dxvk/dxvk_device_filter.cpp
@@ -41,12 +41,13 @@ namespace dxvk {
 
 
   bool DxvkDeviceFilter::testAdapter(DxvkAdapter& adapter) const {
-    const auto& properties = adapter.deviceProperties();
+    auto adapterInfo = adapter.info();
+    auto driverVersion = DxvkDeviceCapabilities::decodeDriverVersion(adapterInfo.driverId, adapterInfo.driverVersion);
 
     Logger::info(str::format("Found device: ",
-      properties.core.properties.deviceName, " (",
-      properties.vk12.driverName, " ",
-      properties.driverVersion.toString(), ")"));
+      adapterInfo.deviceName, " (",
+      adapterInfo.driverName, " ",
+      driverVersion.toString(), ")"));
 
     std::string compatError;
 
@@ -56,14 +57,14 @@ namespace dxvk {
     }
 
     if (m_flags.test(DxvkDeviceFilterFlag::MatchDeviceName)) {
-      if (std::string(properties.core.properties.deviceName).find(m_matchDeviceName) == std::string::npos) {
+      if (std::string(adapterInfo.deviceName).find(m_matchDeviceName) == std::string::npos) {
         Logger::info("  Skipping: Device filter");
         return false;
       }
     }
 
     if (m_flags.test(DxvkDeviceFilterFlag::MatchDeviceUUID)) {
-      std::string uuidStr = convertUUID(properties.vk11.deviceUUID);
+      std::string uuidStr = convertUUID(adapterInfo.deviceUuid);
 
       if (uuidStr.find(m_matchDeviceUUID) == std::string::npos) {
         Logger::info("  Skipping: UUID filter");
@@ -72,7 +73,7 @@ namespace dxvk {
     }
 
     if (m_flags.test(DxvkDeviceFilterFlag::SkipCpuDevices)) {
-      if (properties.core.properties.deviceType == VK_PHYSICAL_DEVICE_TYPE_CPU) {
+      if (adapterInfo.deviceType == VK_PHYSICAL_DEVICE_TYPE_CPU) {
         Logger::info("  Skipping: Software driver");
         return false;
       }

--- a/src/dxvk/dxvk_device_info.h
+++ b/src/dxvk/dxvk_device_info.h
@@ -343,6 +343,14 @@ namespace dxvk {
      */
     void logDeviceInfo();
 
+    /**
+     * \brief Decodes vendor-specific driver version into something readable
+     *
+     * \param [in] driverId Driver ID
+     * \param [in] version Raw Vulkan driver version
+     */
+    static Version decodeDriverVersion(VkDriverId driverId, uint32_t version);
+
   private:
 
     struct FeatureEntry {
@@ -424,8 +432,6 @@ namespace dxvk {
             DxvkDeviceInfo&             properties);
 
     std::vector<FeatureEntry> getFeatureList();
-
-    static Version decodeDriverVersion(VkDriverId driverId, uint32_t version);
 
     template<typename T>
     static void copyFeature(

--- a/src/dxvk/dxvk_instance.cpp
+++ b/src/dxvk/dxvk_instance.cpp
@@ -78,9 +78,9 @@ namespace dxvk {
 
   Rc<DxvkAdapter> DxvkInstance::findAdapterByLuid(const void* luid) const {
     for (const auto& adapter : m_adapters) {
-      const auto& vk11 = adapter->deviceProperties().vk11;
+      auto adapterInfo = adapter->info();
 
-      if (vk11.deviceLUIDValid && !std::memcmp(luid, vk11.deviceLUID, VK_LUID_SIZE))
+      if (adapterInfo.luidIsValid && !std::memcmp(luid, adapterInfo.deviceLuid, VK_LUID_SIZE))
         return adapter;
     }
 
@@ -90,10 +90,10 @@ namespace dxvk {
   
   Rc<DxvkAdapter> DxvkInstance::findAdapterByDeviceId(uint16_t vendorId, uint16_t deviceId) const {
     for (const auto& adapter : m_adapters) {
-      const auto& props = adapter->deviceProperties();
+      auto adapterInfo = adapter->info();
 
-      if (props.core.properties.vendorID == vendorId
-       && props.core.properties.deviceID == deviceId)
+      if (adapterInfo.vendorId == vendorId
+       && adapterInfo.deviceId == deviceId)
         return adapter;
     }
 
@@ -331,8 +331,8 @@ namespace dxvk {
         uint32_t bRank = deviceTypes.size();
 
         for (uint32_t i = 0; i < std::min(aRank, bRank); i++) {
-          if (a->deviceProperties().core.properties.deviceType == deviceTypes[i]) aRank = i;
-          if (b->deviceProperties().core.properties.deviceType == deviceTypes[i]) bRank = i;
+          if (a->info().deviceType == deviceTypes[i]) aRank = i;
+          if (b->info().deviceType == deviceTypes[i]) bRank = i;
         }
 
         return aRank < bRank;

--- a/src/dxvk/dxvk_openvr.cpp
+++ b/src/dxvk/dxvk_openvr.cpp
@@ -179,38 +179,36 @@ namespace dxvk {
     std::vector<char> extensionList;
     DWORD len;
 
-    if (m_vr_key)
-    {
-        LSTATUS status;
-        char name[256];
-        DWORD type;
+    if (m_vr_key) {
+      LSTATUS status;
+      char name[256];
+      DWORD type;
 
-        if (!this->waitVrKeyReady())
-            return DxvkExtensionList();
+      if (!this->waitVrKeyReady())
+        return DxvkExtensionList();
 
-        sprintf(name, "PCIID:%04x:%04x",
-          adapter->deviceProperties().core.properties.vendorID,
-          adapter->deviceProperties().core.properties.deviceID);
+      auto adapterInfo = adapter->info();
+      sprintf(name, "PCIID:%04x:%04x", adapterInfo.vendorId, adapterInfo.deviceId);
 
-        len = 0;
-        if ((status = RegQueryValueExA(m_vr_key, name, nullptr, &type, nullptr, &len)))
-        {
-            Logger::err(str::format("OpenVR: could not query value, status ", status));
-            return DxvkExtensionList();
-        }
-        extensionList.resize(len);
-        if ((status = RegQueryValueExA(m_vr_key, name, nullptr, &type, reinterpret_cast<BYTE*>(extensionList.data()), &len)))
-        {
-            Logger::err(str::format("OpenVR: could not query value, status ", status));
-            return DxvkExtensionList();
-        }
+      len = 0;
+
+      if ((status = RegQueryValueExA(m_vr_key, name, nullptr, &type, nullptr, &len))) {
+        Logger::err(str::format("OpenVR: could not query value, status ", status));
+        return DxvkExtensionList();
+      }
+
+      extensionList.resize(len);
+
+      if ((status = RegQueryValueExA(m_vr_key, name, nullptr, &type, reinterpret_cast<BYTE*>(extensionList.data()), &len))) {
+        Logger::err(str::format("OpenVR: could not query value, status ", status));
+        return DxvkExtensionList();
+      }
+    } else {
+      len = m_compositor->GetVulkanDeviceExtensionsRequired(adapter->handle(), nullptr, 0);
+      extensionList.resize(len);
+      len = m_compositor->GetVulkanDeviceExtensionsRequired(adapter->handle(), extensionList.data(), len);
     }
-    else
-    {
-        len = m_compositor->GetVulkanDeviceExtensionsRequired(adapter->handle(), nullptr, 0);
-        extensionList.resize(len);
-        len = m_compositor->GetVulkanDeviceExtensionsRequired(adapter->handle(), extensionList.data(), len);
-    }
+
     return parseExtensionList(std::string(extensionList.data(), len));
   }
   


### PR DESCRIPTION
For games that use both D3D11 and D3D12, Nvidia will change descriptor heap properties once a D3D12 device is created, so any properties we query at `vkCreateInstance` time may no longer be valid for the D3D11 device at `vkCreateDevice` time.

Not sure if the driver behaviour is is in spec, especially since there is an inevitable race condition if the app creates different D3D devices concurrently, but it's good enough to make Metro Exodus work in D3D11 mode with descriptor heaps.

This seems like a good excuse to clean a few things up and make sure we no longer query properties and features from the adapter in general.

Needs testing so that we don't accidentally regress anything related to shared resources and monitors.