### PR TITLE
[d3d11] Promote D16 depth textures to D32 when also used as shader resource

### DIFF
--- a/src/d3d11/d3d11_texture.cpp
+++ b/src/d3d11/d3d11_texture.cpp
@@ -25,6 +25,16 @@ namespace dxvk {
     DXGI_VK_FORMAT_INFO   formatPacked = m_device->LookupPackedFormat(m_desc.Format, formatMode);
     m_packedFormat = formatPacked.Format;
 
+    // Promote D16 to D32 when the texture is used as both depth and shader resource.
+    // D16 shadow maps sampled with SampleCmp produce visible banding artifacts on
+    // Vulkan that are not present on native D3D11 or OpenGL, likely because those
+    // APIs or their drivers use higher internal precision for D16 depth buffers.
+    if (formatInfo.Format == VK_FORMAT_D16_UNORM &&
+        (m_desc.BindFlags & D3D11_BIND_DEPTH_STENCIL) &&
+        (m_desc.BindFlags & D3D11_BIND_SHADER_RESOURCE)) {
+      formatInfo.Format = VK_FORMAT_D32_SFLOAT;
+    }
+
     DxvkImageCreateInfo imageInfo;
     imageInfo.type            = GetVkImageType();
     imageInfo.format          = formatInfo.Format;

--- a/src/d3d11/d3d11_view_dsv.cpp
+++ b/src/d3d11/d3d11_view_dsv.cpp
@@ -18,8 +18,16 @@ namespace dxvk {
     D3D11_COMMON_RESOURCE_DESC resourceDesc;
     GetCommonResourceDesc(pResource, &resourceDesc);
 
+    auto texture = GetCommonTexture(pResource);
+
     DxvkImageViewKey viewInfo;
     viewInfo.format = pDevice->LookupFormat(pDesc->Format, DXGI_VK_FORMAT_MODE_DEPTH).Format;
+
+    // Match promoted format (e.g. D16 -> D32 for shadow maps)
+    if (viewInfo.format == VK_FORMAT_D16_UNORM &&
+        texture->GetImage()->info().format == VK_FORMAT_D32_SFLOAT) {
+      viewInfo.format = VK_FORMAT_D32_SFLOAT;
+    }
     viewInfo.layout = GetViewLayout();
     viewInfo.aspects = lookupFormatInfo(viewInfo.format)->aspectMask;
     viewInfo.usage = VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT;

--- a/src/d3d11/d3d11_view_srv.cpp
+++ b/src/d3d11/d3d11_view_srv.cpp
@@ -74,7 +74,14 @@ namespace dxvk {
     } else {
       auto texture = GetCommonTexture(pResource);
       auto formatInfo = pDevice->LookupFormat(pDesc->Format, texture->GetFormatMode());
-      
+
+      // If the image format was promoted (e.g. D16 -> D32 for shadow maps),
+      // use the actual image format for the view instead of the D3D11 format.
+      if (formatInfo.Format == VK_FORMAT_D16_UNORM &&
+          texture->GetImage()->info().format == VK_FORMAT_D32_SFLOAT) {
+        formatInfo.Format = VK_FORMAT_D32_SFLOAT;
+      }
+
       DxvkImageViewKey viewInfo;
       viewInfo.format = formatInfo.Format;
       viewInfo.aspects = formatInfo.Aspect;


### PR DESCRIPTION
## Summary
- Promote D16_UNORM to D32_SFLOAT for textures bound as both depth stencil and shader resource
- Update DSV and SRV view creation to match the promoted image format

## Problem
Games that use D16 shadow maps with `SampleCmp` (PCF filtering) exhibit visible banding/moiré artifacts on Vulkan that are not present on native D3D11 or wined3d (OpenGL).

Vulkan's `VK_FORMAT_D16_UNORM` provides exactly 16 bits of depth precision. D3D11 and OpenGL drivers likely use higher internal precision for D16 depth buffers, as the OpenGL spec explicitly allows implementations to use higher bitdepth than requested for internal formats.

## Fix
When a texture is created with both `D3D11_BIND_DEPTH_STENCIL` and `D3D11_BIND_SHADER_RESOURCE` and the format resolves to `VK_FORMAT_D16_UNORM`, promote it to `VK_FORMAT_D32_SFLOAT`. This matches the effective precision behavior of native D3D11/OpenGL, eliminating the shadow banding artifacts.

## Testing
- Verified fix with Star Trek Resurgence apitrace (issue #3583) — shadow banding eliminated
- Regression tested with Age of Empires: Definitive Edition — no visual issues

Closes #3583