### PR TITLE
[dxvk] Enable descriptor heap by default on AMD and Lavapipe

### DIFF
--- a/src/dxvk/dxvk_device_info.cpp
+++ b/src/dxvk/dxvk_device_info.cpp
@@ -480,13 +480,12 @@ namespace dxvk {
   void DxvkDeviceCapabilities::disableUnusedFeatures(
     const DxvkInstance&               instance) {
     if (m_featuresSupported.extDescriptorHeap.descriptorHeap) {
-      // Only enable descriptor heaps on drivers that are either known to work,
-      // or are maintained well enough that any issues are likely to get fixed
+      // Only enable descriptor heaps on drivers that are known to work
+      // and don't have known performance regressions currently.
+      // TODO revisit w.r.t. Nvidia, Intel, Turnip.
       bool enableDescriptorHeap = m_properties.vk12.driverID == VK_DRIVER_ID_MESA_RADV
-                               || m_properties.vk12.driverID == VK_DRIVER_ID_MESA_NVK
                                || m_properties.vk12.driverID == VK_DRIVER_ID_MESA_LLVMPIPE
-                               || m_properties.vk12.driverID == VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA
-                               || m_properties.vk12.driverID == VK_DRIVER_ID_NVIDIA_PROPRIETARY;
+                               || m_properties.vk12.driverID == VK_DRIVER_ID_AMD_PROPRIETARY;
 
       applyTristate(enableDescriptorHeap, instance.options().enableDescriptorHeap);
 

--- a/src/dxvk/dxvk_options.cpp
+++ b/src/dxvk/dxvk_options.cpp
@@ -7,7 +7,7 @@ namespace dxvk {
     enableMemoryDefrag    = config.getOption<Tristate>("dxvk.enableMemoryDefrag",     Tristate::Auto);
     numCompilerThreads    = config.getOption<int32_t> ("dxvk.numCompilerThreads",     0);
     enableGraphicsPipelineLibrary = config.getOption<Tristate>("dxvk.enableGraphicsPipelineLibrary", Tristate::Auto);
-    enableDescriptorHeap  = config.getOption<Tristate>("dxvk.enableDescriptorHeap",   Tristate::False);
+    enableDescriptorHeap  = config.getOption<Tristate>("dxvk.enableDescriptorHeap",   Tristate::Auto);
     enableDescriptorBuffer = config.getOption<Tristate>("dxvk.enableDescriptorBuffer", Tristate::Auto);
     enableUnifiedImageLayout = config.getOption<bool> ("dxvk.enableUnifiedImageLayouts", true);
     enableImplicitResolves = config.getOption<bool>   ("dxvk.enableImplicitResolves", true);


### PR DESCRIPTION
The RADV MR is getting somewhere, so might as well change the default. NV still loses perf currently.