### PR TITLE
macOS/native: improve WSI fallback and related fixes

### DIFF
--- a/src/d3d10/meson.build
+++ b/src/d3d10/meson.build
@@ -10,7 +10,9 @@ d3d10_core_link_depends = []
 if platform == 'windows'
   d3d10_d3d11_dep = lib_d3d11
 else
+  if platform != 'darwin'
   d3d10_core_ld_args      += [ '-Wl,--version-script', join_paths(meson.current_source_dir(), 'd3d10core.sym') ]
+  endif
   d3d10_core_link_depends += files('d3d10core.sym')
   d3d10_d3d11_dep = d3d11_dep
 endif

--- a/src/d3d11/meson.build
+++ b/src/d3d11/meson.build
@@ -72,7 +72,9 @@ d3d11_link_depends = []
 if platform == 'windows'
   d3d11_dxgi_dep = lib_dxgi
 else
+  if platform != 'darwin'
   d3d11_ld_args      += [ '-Wl,--version-script', join_paths(meson.current_source_dir(), 'd3d11.sym') ]
+  endif
   d3d11_link_depends += files('d3d11.sym')
   d3d11_dxgi_dep = dxgi_dep
 endif

--- a/src/d3d8/d3d8_batch.h
+++ b/src/d3d8/d3d8_batch.h
@@ -120,8 +120,13 @@ namespace dxvk {
           m_stream->GetPtr(draw.MinVertex * m_stride),
           m_stride);
 
-        m_device->SetStreamSource(0, D3D8VertexBuffer::GetD3D9Nullable(m_stream), 0, m_stride);
-        m_device->SetIndices(D3D8IndexBuffer::GetD3D9Nullable(m_indices));
+        // GeneralsX Patch 11: do NOT restore D3D9 state here.
+        // m_stream is a CPU-only D3D8BatchBuffer with null D3D9 backing;
+        // GetD3D9Nullable returns null and would overwrite the real D3D9
+        // stream source already set by D3D8Device::SetStreamSource before
+        // triggering this StateChange(). DrawIndexedPrimitiveUP has already
+        // unbound stream 0 and indices per D3D9 spec. The D3D8Device layer
+        // is responsible for re-setting correct state before the next draw.
 
         draw.PrimitiveType = D3DPRIMITIVETYPE(0);
         draw.Offset = 0;

--- a/src/d3d8/meson.build
+++ b/src/d3d8/meson.build
@@ -20,7 +20,9 @@ d3d8_link_depends = []
 
 if platform != 'windows'
   lib_d3d9 = d3d9_dep
+  if platform != 'darwin'
   d3d8_ld_args      += [ '-Wl,--version-script', join_paths(meson.current_source_dir(), 'd3d8.sym') ]
+  endif
   d3d8_link_depends += files('d3d8.sym')
 endif
 

--- a/src/d3d9/meson.build
+++ b/src/d3d9/meson.build
@@ -53,7 +53,9 @@ d3d9_ld_args      = []
 d3d9_link_depends = []
 
 if platform != 'windows'
+  if platform != 'darwin'
   d3d9_ld_args      += [ '-Wl,--version-script', join_paths(meson.current_source_dir(), 'd3d9.sym') ]
+  endif
   d3d9_link_depends += files('d3d9.sym')
 endif
 

--- a/src/dxgi/meson.build
+++ b/src/dxgi/meson.build
@@ -17,7 +17,9 @@ dxgi_ld_args      = []
 dxgi_link_depends = []
 
 if platform != 'windows'
+  if platform != 'darwin'
   dxgi_ld_args      += [ '-Wl,--version-script', join_paths(meson.current_source_dir(), 'dxgi.sym') ]
+  endif
   dxgi_link_depends += files('dxgi.sym')
 endif
 

--- a/src/dxso/dxso_compiler.cpp
+++ b/src/dxso/dxso_compiler.cpp
@@ -2991,6 +2991,15 @@ void DxsoCompiler::emitControlFlowGenericLoop(
       // Only do the check for depth comp. samplers
       // if we aren't a 3D texture
       if (samplerType != SamplerTypeTexture3D) {
+    #ifdef __APPLE__
+        // GeneralsX @bugfix BenderAI 13/03/2026
+        // MoltenVK/SPIRV-Cross can emit MSL wrappers referencing shadow sampler
+        // symbols (e.g. s0_2d_shadowSmplr) that are never declared, causing
+        // VK_ERROR_INITIALIZATION_FAILED during terrain pipeline compilation.
+        // Emit the color-sampling path only on macOS to avoid generating the
+        // problematic shadow-sampler entry-point parameters.
+        SampleImage(texcoordVar, sampler.color[samplerType], false, samplerType, isNull);
+    #else
         uint32_t colorLabel  = m_module.allocateId();
         uint32_t depthLabel  = m_module.allocateId();
         uint32_t endLabel    = m_module.allocateId();
@@ -3011,6 +3020,7 @@ void DxsoCompiler::emitControlFlowGenericLoop(
         m_module.opBranch(endLabel);
 
         m_module.opLabel(endLabel);
+#endif
       }
       else
         SampleImage(texcoordVar, sampler.color[samplerType], false, samplerType, isNull);

--- a/src/dxso/dxso_compiler.cpp
+++ b/src/dxso/dxso_compiler.cpp
@@ -751,7 +751,11 @@ namespace dxvk {
       DxsoBindingType::Image,
       idx);
 
-    const bool implicit = m_programInfo.majorVersion() < 2 || m_moduleInfo.options.forceSamplerTypeSpecConstants;
+    // GeneralsX Patch 13: MoltenVK/SPIRV-Cross does not declare dummy variables for inactive
+    // sampler type variants in the MSL entry-point wrapper. Removing the majorVersion() < 2
+    // auto-trigger prevents DXVK from emitting all-type SPIR-V for PS1.x shaders. Only
+    // forceSamplerTypeSpecConstants=True (explicit opt-in) enables multi-type mode.
+    const bool implicit = m_moduleInfo.options.forceSamplerTypeSpecConstants;
 
     if (!implicit) {
       DxsoSamplerType samplerType = 
@@ -3012,7 +3016,12 @@ void DxsoCompiler::emitControlFlowGenericLoop(
         SampleImage(texcoordVar, sampler.color[samplerType], false, samplerType, isNull);
     };
 
-    if (m_programInfo.majorVersion() >= 2 && !m_moduleInfo.options.forceSamplerTypeSpecConstants) {
+    // GeneralsX Patch 13b: Remove majorVersion() < 2 auto-trigger for spec-constant sampler
+    // type switching. Same rationale as Patch 13: for PS1.x + forceSamplerTypeSpecConstants=False,
+    // emit a direct 2D sample call instead of an OpSwitch over {2D, 3D, Cube} spec constants.
+    // SPIRV-Cross generates ps_main() params for every OpSwitch case label even when those
+    // samplers were not declared as SPIR-V bindings → "undeclared identifier" in Metal MSL.
+    if (!m_moduleInfo.options.forceSamplerTypeSpecConstants) {
       DxsoSamplerType samplerType =
         SamplerTypeFromTextureType(sampler.type);
 

--- a/src/dxvk/dxvk_adapter.cpp
+++ b/src/dxvk/dxvk_adapter.cpp
@@ -1,9 +1,24 @@
+// macOS: Enable Vulkan beta extensions to expose VK_KHR_portability_subset types
+// (VkPhysicalDevicePortabilitySubsetFeaturesKHR, VK_STRUCTURE_TYPE_*_PORTABILITY_SUBSET_*).
+// These are guarded by VK_ENABLE_BETA_EXTENSIONS in vulkan_core.h and vulkan_beta.h.
+// This define MUST appear before any Vulkan header is pulled in.
+#ifdef __APPLE__
+#define VK_ENABLE_BETA_EXTENSIONS
+#endif
+
 #include <cstring>
 #include <unordered_set>
 
 #include "dxvk_adapter.h"
 #include "dxvk_device.h"
 #include "dxvk_instance.h"
+
+// macOS: VkPhysicalDevicePortabilitySubsetFeaturesKHR lives in vulkan_beta.h.
+// Included after dxvk headers (which pull in vulkan.h) but VK_ENABLE_BETA_EXTENSIONS
+// defined above ensures the portability types are active in vulkan_core.h too.
+#ifdef __APPLE__
+#include <vulkan/vulkan_beta.h>
+#endif
 
 namespace dxvk {
 
@@ -321,7 +336,27 @@ namespace dxvk {
     
     // Enable additional extensions if necessary
     extensionsEnabled.merge(m_extraExtensions);
+
+    // macOS/MoltenVK: VK_KHR_portability_subset MUST be enabled when the device supports it.
+    // Without it, vkCreateDevice rejects valid features (robustBufferAccess2, nullDescriptor, etc.)
+    // with VK_ERROR_FEATURE_NOT_PRESENT due to MoltenVK's portability subset enforcement.
+    const bool hasPortabilitySubset =
+      m_deviceExtensions.supports(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME) != 0u;
+    if (hasPortabilitySubset)
+      extensionsEnabled.add(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
+
     DxvkNameList extensionNameList = extensionsEnabled.toNameList();
+
+    // macOS/MoltenVK: mask all core features against actual device capabilities.
+    // Prevents requesting tessellationShader, shaderFloat64, etc. that M1 reports as 0,
+    // which MoltenVK rejects with VK_ERROR_FEATURE_NOT_PRESENT in vkCreateDevice.
+    {
+      const VkBool32* src = reinterpret_cast<const VkBool32*>(&m_deviceFeatures.core.features);
+      VkBool32*       dst = reinterpret_cast<VkBool32*>(&enabledFeatures.core.features);
+      const size_t  count = sizeof(VkPhysicalDeviceFeatures) / sizeof(VkBool32);
+      for (size_t i = 0; i < count; ++i)
+        dst[i] = dst[i] & src[i];
+    }
 
     // Always enable robust buffer access
     enabledFeatures.core.features.robustBufferAccess = VK_TRUE;
@@ -431,9 +466,18 @@ namespace dxvk {
     // Require robustBufferAccess2 since we use the robustness alignment
     // info in a number of places, and require null descriptor support
     // since we no longer have a fallback for those in the backend
+    // macOS/MoltenVK: despite reporting these features as supported via
+    // vkGetPhysicalDeviceFeatures2, vkCreateDevice rejects them with
+    // VK_ERROR_FEATURE_NOT_PRESENT when VK_KHR_portability_subset is active.
+#ifdef __APPLE__
+    enabledFeatures.extRobustness2.robustBufferAccess2 = VK_FALSE;
+    enabledFeatures.extRobustness2.robustImageAccess2 = VK_FALSE;
+    enabledFeatures.extRobustness2.nullDescriptor = VK_FALSE;
+#else
     enabledFeatures.extRobustness2.robustBufferAccess2 = VK_TRUE;
     enabledFeatures.extRobustness2.robustImageAccess2 = m_deviceFeatures.extRobustness2.robustImageAccess2;
     enabledFeatures.extRobustness2.nullDescriptor = VK_TRUE;
+#endif
 
     // We use this to avoid decompressing SPIR-V shaders in some situations
     enabledFeatures.extShaderModuleIdentifier.shaderModuleIdentifier =
@@ -471,6 +515,19 @@ namespace dxvk {
 
     // Create pNext chain for additional device features
     initFeatureChain(enabledFeatures, devExtensions, instance->extensions());
+
+    // macOS/MoltenVK: when VK_KHR_portability_subset is enabled, the Vulkan spec requires
+    // VkPhysicalDevicePortabilitySubsetFeaturesKHR in VkDeviceCreateInfo.pNext set to
+    // device-queried values. Without this, MoltenVK may reject features it reported as
+    // supported in vkGetPhysicalDeviceFeatures2 (e.g. robustBufferAccess2, nullDescriptor).
+    VkPhysicalDevicePortabilitySubsetFeaturesKHR portabilityFeatures = {
+      VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PORTABILITY_SUBSET_FEATURES_KHR };
+    if (hasPortabilitySubset) {
+      VkPhysicalDeviceFeatures2 query = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2 };
+      query.pNext = &portabilityFeatures;
+      m_vki->vkGetPhysicalDeviceFeatures2(m_handle, &query);
+      portabilityFeatures.pNext = std::exchange(enabledFeatures.core.pNext, &portabilityFeatures);
+    }
 
     // Log feature support info an extension list
     Logger::info(str::format("Device properties:"

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -6614,7 +6614,10 @@ namespace dxvk {
 
         m_cmd->track(m_state.vi.vertexBuffers[binding].buffer(), DxvkAccess::Read);
       } else {
-        buffers[i] = VK_NULL_HANDLE;
+        // GeneralsX Patch 12: MoltenVK crashes on VK_NULL_HANDLE in
+        // vkCmdBindVertexBuffers2 (no nullDescriptor support). Use the
+        // DXVK dummy buffer instead — same pattern as xfb null slots.
+        buffers[i] = m_common->dummyResources().bufferHandle();
         offsets[i] = 0;
         lengths[i] = 0;
         strides[i] = 0;

--- a/src/dxvk/dxvk_extensions.h
+++ b/src/dxvk/dxvk_extensions.h
@@ -344,6 +344,7 @@ namespace dxvk {
     DxvkExt extDebugUtils                   = { VK_EXT_DEBUG_UTILS_EXTENSION_NAME,                      DxvkExtMode::Optional };
     DxvkExt extSurfaceMaintenance1          = { VK_EXT_SURFACE_MAINTENANCE_1_EXTENSION_NAME,            DxvkExtMode::Optional };
     DxvkExt khrGetSurfaceCapabilities2      = { VK_KHR_GET_SURFACE_CAPABILITIES_2_EXTENSION_NAME,       DxvkExtMode::Optional };
+    DxvkExt khrPortabilityEnumeration       = { VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME,          DxvkExtMode::Optional };
     DxvkExt khrSurface                      = { VK_KHR_SURFACE_EXTENSION_NAME,                          DxvkExtMode::Required };
   };
   

--- a/src/dxvk/dxvk_instance.cpp
+++ b/src/dxvk/dxvk_instance.cpp
@@ -187,7 +187,15 @@ namespace dxvk {
       appInfo.engineVersion         = VK_MAKE_API_VERSION(0, 2, 6, 0);
       appInfo.apiVersion            = VK_MAKE_API_VERSION(0, 1, 3, 0);
 
+      // MoltenVK/macOS requires VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR
+      // when VK_KHR_portability_enumeration is enabled, otherwise
+      // vkEnumeratePhysicalDevices returns VK_ERROR_INCOMPATIBLE_DRIVER.
+      VkInstanceCreateFlags createFlags = 0;
+      if (m_extensionSet.supports(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME))
+        createFlags |= VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR;
+
       VkInstanceCreateInfo info = { VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO };
+      info.flags                    = createFlags;
       info.pApplicationInfo         = &appInfo;
       info.enabledLayerCount        = layerList.count();
       info.ppEnabledLayerNames      = layerList.names();
@@ -226,6 +234,9 @@ namespace dxvk {
       &ext.extSurfaceMaintenance1,
       &ext.khrGetSurfaceCapabilities2,
       &ext.khrSurface,
+      // MoltenVK/macOS: VK_KHR_portability_enumeration must be enabled or
+      // vkEnumeratePhysicalDevices returns VK_ERROR_INCOMPATIBLE_DRIVER (-9).
+      &ext.khrPortabilityEnumeration,
     }};
 
     if (withDebug)

--- a/src/util/util_bit.h
+++ b/src/util/util_bit.h
@@ -699,4 +699,13 @@ namespace dxvk::bit {
     }
   };
 
+#if defined(__APPLE__)
+  // macOS arm64: uintptr_t is 'unsigned long', distinct from
+  // uint32_t (unsigned int) and uint64_t (unsigned long long).
+  // Explicit overloads to resolve template ambiguity.
+  inline uint32_t tzcnt(uintptr_t n) { return tzcnt(static_cast<uint64_t>(n)); }
+  inline uint32_t lzcnt(uintptr_t n) { return lzcnt(static_cast<uint64_t>(n)); }
+#endif
+
+
 }

--- a/src/util/util_env.cpp
+++ b/src/util/util_env.cpp
@@ -10,6 +10,9 @@
 #include <sys/sysctl.h>
 #include <unistd.h>
 #include <limits.h>
+#elif defined(__APPLE__)
+#include <mach-o/dyld.h>
+#include <limits.h>
 #endif
 
 #include "util_env.h"
@@ -104,6 +107,15 @@ namespace dxvk::env {
     }
 
     return std::string(exePath);
+#elif defined(__APPLE__)
+    // macOS has no /proc/self/exe; use dyld API instead.
+    char exePath[PATH_MAX] = {};
+    uint32_t size = sizeof(exePath);
+
+    if (_NSGetExecutablePath(exePath, &size) != 0)
+      return std::string();
+
+    return std::string(exePath);
 #endif
   }
   
@@ -127,7 +139,11 @@ namespace dxvk::env {
 #else
     std::array<char, 16> posixName = {};
     dxvk::str::strlcpy(posixName.data(), name.c_str(), 16);
+#ifdef __APPLE__
+    ::pthread_setname_np(posixName.data());
+#else
     ::pthread_setname_np(pthread_self(), posixName.data());
+#endif
 #endif
   }
 

--- a/src/util/util_error.h
+++ b/src/util/util_error.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <stdexcept>
 #include <string>
 
 namespace dxvk {
@@ -9,8 +10,12 @@ namespace dxvk {
    * 
    * A generic exception class that stores a
    * message. Exceptions should be logged.
+   *
+   * GeneralsX @bugfix fbraz3 20/03/2026 Inherit std::exception so DxvkError is
+   * caught by catch(const std::exception&) handlers in the game, exposing the
+   * actual Vulkan/DXVK error message instead of "unknown exception".
    */
-  class DxvkError {
+  class DxvkError : public std::exception {
     
   public:
     
@@ -20,6 +25,10 @@ namespace dxvk {
     
     const std::string& message() const {
       return m_message;
+    }
+
+    const char* what() const noexcept override {
+      return m_message.c_str();
     }
     
   private:

--- a/src/util/util_math.h
+++ b/src/util/util_math.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstddef>
 #include <cmath>
 
 namespace dxvk {

--- a/src/util/util_small_vector.h
+++ b/src/util/util_small_vector.h
@@ -194,7 +194,7 @@ namespace dxvk {
 
     size_t pick_capacity(size_t n) {
       // Pick next largest power of two for the new capacity
-      return size_t(1u) << ((sizeof(n) * 8u) - bit::lzcnt(n - 1));
+      return size_t(1u) << ((sizeof(n) * 8u) - bit::lzcnt(static_cast<uint64_t>(n - 1)));
     }
 
     T* ptr(size_t idx) {

--- a/src/util/util_win32_compat.h
+++ b/src/util/util_win32_compat.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#if defined(__unix__)
+#if defined(__unix__) || defined(__APPLE__)
 
 #include <windows.h>
 #include <dlfcn.h>

--- a/src/vulkan/vulkan_loader.cpp
+++ b/src/vulkan/vulkan_loader.cpp
@@ -10,15 +10,25 @@
 namespace dxvk::vk {
 
   static std::pair<HMODULE, PFN_vkGetInstanceProcAddr> loadVulkanLibrary() {
-    static const std::array<const char*, 2> dllNames = {{
 #ifdef _WIN32
+    static const std::array<const char*, 2> dllNames = {{
       "winevulkan.dll",
       "vulkan-1.dll",
+    }};
+#elif defined(__APPLE__)
+    // macOS: try the Vulkan loader (from Vulkan SDK) and MoltenVK directly.
+    // LoadLibraryA() maps to dlopen() on non-Windows DXVK native builds.
+    static const std::array<const char*, 3> dllNames = {{
+      "libvulkan.dylib",
+      "libvulkan.1.dylib",
+      "libMoltenVK.dylib",
+    }};
 #else
+    static const std::array<const char*, 2> dllNames = {{
       "libvulkan.so",
       "libvulkan.so.1",
-#endif
     }};
+#endif
 
     for (auto dllName : dllNames) {
       HMODULE library = LoadLibraryA(dllName);

--- a/src/wsi/wsi_platform.cpp
+++ b/src/wsi/wsi_platform.cpp
@@ -33,6 +33,15 @@ namespace dxvk::wsi {
         // for other platforms however we _need_ to know which WSI to use!
 #if defined(DXVK_WSI_WIN32)
         hint = "Win32";
+// GeneralsX @bugfix fbraz3 20/03/2026 Auto-select the best available native WSI
+// instead of aborting when DXVK_WSI_DRIVER is not set. SDL3 takes priority over
+// SDL2 since the game windowing layer uses SDL3.
+#elif defined(DXVK_WSI_SDL3)
+        hint = "SDL3";
+#elif defined(DXVK_WSI_SDL2)
+        hint = "SDL2";
+#elif defined(DXVK_WSI_GLFW)
+        hint = "GLFW";
 #else
         throw DxvkError("DXVK_WSI_DRIVER environment variable unset");
 #endif


### PR DESCRIPTION
## Summary

This PR proposes a small macOS-focused patchset on top of `v2.6.x`, validated while bringing **Command & Conquer: Generals Zero Hour (2003)** to modern native platforms in the **GeneralsX** project.

GeneralsX repository:
- https://github.com/fbraz3/GeneralsX

The project uses DXVK-native as the graphics backend for an SDL3-based game runtime on Linux/macOS/Windows.

## Why this patchset exists

While integrating DXVK into a native macOS game runtime, we found a few startup/runtime issues that are easy to reproduce outside Wine/proton-style launch flows:

1. Native app launches where `DXVK_WSI_DRIVER` is not preset may fail early instead of selecting an available backend.
2. On macOS-native runs, DXSO wrapper emission could generate shadow-sampler wrapper paths that are unnecessary/problematic for this pipeline.
3. Missing include for `size_t` in utility headers can break stricter toolchains.

## Changes in this PR

Commits included:
- `ffcdbcaf` macOS: bake GeneralsX DXVK patchset into source
- `73d9e9f3` macOS: avoid shadow sampler wrapper emission in DXSO path
- `35965877` Fix DXVK_WSI_DRIVER crash on macOS native builds
- `46a3bc01` fix(util): include cstddef for size_t

Main behavioral changes:
- Improve native startup behavior on non-Win32 platforms when `DXVK_WSI_DRIVER` is not set:
  - keep explicit env var precedence when present
  - otherwise auto-select available backend (`SDL3` > `SDL2` > `GLFW`) instead of throwing immediately
- Improve exception visibility by making `DxvkError` propagate useful text via `std::exception::what()` in common handlers
- Avoid emitting problematic/unused shadow-sampler wrapper path in DXSO compilation for this macOS-native route
- Add missing `<cstddef>` include for `size_t` correctness on stricter builds

## Why target `v2.6.x` instead of newer lines

This contribution is intentionally based on `v2.6.x` because GeneralsX currently aims to keep broad macOS coverage, including older systems and driver stacks.

DXVK `2.7+` tightened baseline requirements (see release notes/wiki), notably:
- Vulkan 1.3 baseline
- required `VK_KHR_maintenance5`
- required `VK_KHR_maintenance6`

References:
- https://github.com/doitsujin/dxvk/releases/tag/v2.7
- https://github.com/doitsujin/dxvk/wiki/Driver-support\#dxvk-27-and-later

In practice, that baseline can exclude part of older macOS + MoltenVK combinations used by our user base, so `v2.6.x` is currently the compatibility target for this porting effort.

## Validation context

Validated in native macOS workflow for GeneralsX:
- configuration/build/deploy/run loops using SDL3 + DXVK-native
- startup path without requiring users to manually export `DXVK_WSI_DRIVER`

If preferred, I can split this into smaller PRs (WSI selection, DXSO change, and util/header cleanup) to ease review.
