### PR TITLE
[wsi] Don't treat SDL_SetWindowPosition failure as fatal

### DIFF
--- a/src/wsi/sdl3/wsi_window_sdl3.cpp
+++ b/src/wsi/sdl3/wsi_window_sdl3.cpp
@@ -94,8 +94,7 @@ namespace dxvk::wsi {
     }
 
     if (!SDL_SetWindowPosition(window, bounds.x, bounds.y)) {
-      Logger::err(str::format("SDL3 WSI: enterFullscreenMode: SDL_SetWindowPosition: ", SDL_GetError()));
-      return false;
+      Logger::warn(str::format("SDL3 WSI: enterFullscreenMode: SDL_SetWindowPosition: ", SDL_GetError()));
     }
 
     SDL_DisplayMode closestMode = { };


### PR DESCRIPTION
On Wayland, `SDL_SetWindowPosition` fails because the protocol does not allow positioning non-popup windows, causing `enterFullscreenMode` to abort before reaching `SDL_SetWindowFullscreen`.

SDL stores the pending display ID before the backend rejects the move, so the call still serves as a display hint. Downgrade from error+abort to warning.

Fixes #5363