### PR TITLE
[d3d9] Advertise D3DDEVCAPS_TEXTURESYSTEMMEMORY device cap

### DIFF
--- a/src/d3d9/d3d9_adapter.cpp
+++ b/src/d3d9/d3d9_adapter.cpp
@@ -441,7 +441,7 @@ namespace dxvk {
                                     | D3DDEVCAPS_EXECUTEVIDEOMEMORY
                                     | D3DDEVCAPS_TLVERTEXSYSTEMMEMORY
                                     | D3DDEVCAPS_TLVERTEXVIDEOMEMORY
-                                 /* | D3DDEVCAPS_TEXTURESYSTEMMEMORY */
+                                    | D3DDEVCAPS_TEXTURESYSTEMMEMORY
                                     | D3DDEVCAPS_TEXTUREVIDEOMEMORY
                                     | D3DDEVCAPS_DRAWPRIMTLVERTEX
                                     | D3DDEVCAPS_CANRENDERAFTERFLIP


### PR DESCRIPTION
Related to b4e9757, we should also let applications know they can bind textures created in system memory. @K0bin said the backend has no problem supporting this, so I see no reason to not advertise it, especially since the native runtime does (and always has).

Edit: Nevermind, after some brainstorming it appears this is indeed unsupported.