### PR TITLE
[d3d11] Re-introduce heuristic to drop Flush calls on tilers

### DIFF
--- a/src/d3d11/d3d11_context.cpp
+++ b/src/d3d11/d3d11_context.cpp
@@ -903,6 +903,9 @@ namespace dxvk {
       });
     }
 
+    if constexpr (!IsDeferred)
+      GetTypedContext()->NotifyResolve();
+
     if (dstTextureInfo->HasSequenceNumber())
       GetTypedContext()->TrackTextureSequenceNumber(dstTextureInfo, DstSubresource);
   }
@@ -5337,6 +5340,7 @@ namespace dxvk {
       return;
 
     bool needsUpdate = false;
+    bool isMultisampled = false;
 
     if (likely(NumRTVs != D3D11_KEEP_RENDER_TARGETS_AND_DEPTH_STENCIL)) {
       // Native D3D11 does not change the render targets if
@@ -5357,6 +5361,8 @@ namespace dxvk {
           if (NumUAVs == D3D11_KEEP_UNORDERED_ACCESS_VIEWS)
             ResolveOmUavHazards(rtv);
         }
+
+        isMultisampled = isMultisampled || (rtv && rtv->GetSampleCount() > 1u);
       }
 
       auto dsv = static_cast<D3D11DepthStencilView*>(pDepthStencilView);
@@ -5411,7 +5417,7 @@ namespace dxvk {
       BindFramebuffer();
 
       if constexpr (!IsDeferred)
-        GetTypedContext()->NotifyRenderPassBoundary();
+        GetTypedContext()->NotifyRenderPassBoundary(isMultisampled);
     }
   }
 

--- a/src/d3d11/d3d11_context_imm.cpp
+++ b/src/d3d11/d3d11_context_imm.cpp
@@ -164,27 +164,17 @@ namespace dxvk {
 
 
   void STDMETHODCALLTYPE D3D11ImmediateContext::Flush() {
-    D3D10DeviceLock lock = LockContext();
-
-    if (unlikely(m_device->debugFlags().test(DxvkDebugFlag::Capture)))
-      m_flushReason = "Explicit Flush";
-
-    ExecuteFlush(GpuFlushType::ExplicitFlush, nullptr, true);
+    RequestFlush(D3D11_CONTEXT_TYPE_ALL, nullptr);
   }
 
 
   void STDMETHODCALLTYPE D3D11ImmediateContext::Flush1(
           D3D11_CONTEXT_TYPE          ContextType,
           HANDLE                      hEvent) {
-    D3D10DeviceLock lock = LockContext();
-
-    if (unlikely(m_device->debugFlags().test(DxvkDebugFlag::Capture)))
-      m_flushReason = "Explicit Flush";
-
-    ExecuteFlush(GpuFlushType::ExplicitFlush, hEvent, true);
+    RequestFlush(ContextType, hEvent);
   }
-  
-  
+
+
   HRESULT STDMETHODCALLTYPE D3D11ImmediateContext::Signal(
           ID3D11Fence*                pFence,
           UINT64                      Value) {
@@ -1112,6 +1102,8 @@ namespace dxvk {
     if (!GetPendingCsChunks() && !hEvent)
       return;
 
+    m_hasPendingUnresolvedPass = false;
+
     // Unbind unused resources
     ApplyDirtyNullBindings();
 
@@ -1195,11 +1187,14 @@ namespace dxvk {
   }
 
 
-  void D3D11ImmediateContext::NotifyRenderPassBoundary() {
+  void D3D11ImmediateContext::NotifyRenderPassBoundary(bool IsMultisampled) {
     // Doing this makes it less likely to flush during render passes
     ConsiderFlush(GpuFlushType::ImplicitWeakHint);
 
     if (m_device->perfHints().preferRenderPassOps) {
+      // Make sure that explicit flushes get ignored until the next resolve
+      m_hasPendingUnresolvedPass = m_hasPendingUnresolvedPass || IsMultisampled;
+
       // On tilers, we want to avoid submitting during a render pass or a sequence
       // of render passes as much as possible, but if a submission request has been
       // rejected before, we should do it now in order to avoid read-back delays.
@@ -1208,6 +1203,29 @@ namespace dxvk {
       if (pending != GpuFlushType::None)
         ExecuteFlush(pending, nullptr, false);
     }
+  }
+
+
+  void D3D11ImmediateContext::NotifyResolve() {
+    m_hasPendingUnresolvedPass = false;
+  }
+
+
+  void D3D11ImmediateContext::RequestFlush(
+          D3D11_CONTEXT_TYPE          ContextType,
+          HANDLE                      hEvent) {
+    D3D10DeviceLock lock = LockContext();
+
+    // If we're in tiler mode and a render pass hasn't been resolved yet,
+    // ignore explicit flushes. This is a very dirty heuristic to work
+    // around some Unity Engine performance issues.
+    if (m_hasPendingUnresolvedPass && !m_parent->Is11on12Device())
+      return;
+
+    if (unlikely(m_device->debugFlags().test(DxvkDebugFlag::Capture)))
+      m_flushReason = "Explicit Flush";
+
+    ExecuteFlush(GpuFlushType::ExplicitFlush, hEvent, true);
   }
 
 

--- a/src/d3d11/d3d11_context_imm.h
+++ b/src/d3d11/d3d11_context_imm.h
@@ -140,6 +140,8 @@ namespace dxvk {
 
     std::string             m_flushReason;
 
+    bool                    m_hasPendingUnresolvedPass = false;
+
     HRESULT MapBuffer(
             D3D11Buffer*                pResource,
             D3D11_MAP                   MapType,
@@ -212,7 +214,14 @@ namespace dxvk {
     void ThrottleDiscard(
             VkDeviceSize                Size);
 
-    void NotifyRenderPassBoundary();
+    void NotifyRenderPassBoundary(
+            bool                        IsMultisampled);
+
+    void NotifyResolve();
+
+    void RequestFlush(
+            D3D11_CONTEXT_TYPE          ContextType,
+            HANDLE                      hEvent);
 
     DxvkStagingBufferStats GetStagingMemoryStatistics();
 


### PR DESCRIPTION
Should be slightly less annoying to maintain than the old implementation.

Doesn't handle deferred contexts *at all* and also doesn't stop any implicit flushing that may be going on since we'd risk deadlocks, but on the flip side this shouldn't require a config option.