### PR TITLE
Update functionality and requirements

### DIFF
--- a/VP_DXVK_requirements.json
+++ b/VP_DXVK_requirements.json
@@ -82,9 +82,13 @@
             },
             "features": {
                 "VkPhysicalDeviceFeatures": {
+                    "fragmentStoresAndAtomics": true,
+                    "samplerAnisotropy": true,
+                    "shaderInt16": true,
                     "shaderSampledImageArrayDynamicIndexing" : true
                 },
                 "VkPhysicalDeviceVulkan12Features": {
+                    "shaderInt8": true,
                     "descriptorIndexing" : true,
                     "descriptorBindingSampledImageUpdateAfterBind" : true,
                     "descriptorBindingUpdateUnusedWhilePending" : true,
@@ -103,7 +107,9 @@
             },
             "properties": {
                 "VkPhysicalDeviceProperties": {
-                    "maxPushConstantsSize" : 256
+                    "limits": {
+                            "maxPushConstantsSize" : 256
+                    }
                 }
             }
         },
@@ -126,10 +132,10 @@
             },
             "features": {
                 "VkPhysicalDeviceFeatures": {
+                    "largePoints": true,
                     "wideLines": true
                 },
                 "VkPhysicalDeviceVulkan11Features": {
-                    "shaderInt16": true,
                     "storagePushConstant16": true
                 },
                 "VkPhysicalDeviceMaintenance7FeaturesKHR": {
@@ -223,8 +229,7 @@
                 "VkPhysicalDeviceFeatures": {
                     "depthBounds": true,
                     "vertexPipelineStoresAndAtomics": true,
-                    "pipelineStatisticsQuery": true,
-                    "samplerAnisotropy": true
+                    "pipelineStatisticsQuery": true
                 },
                 "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
                     "memoryPriority": true
@@ -304,8 +309,7 @@
                 "VkPhysicalDeviceFeatures": {
                     "depthBounds": true,
                     "pipelineStatisticsQuery": true,
-                    "logicOp": true,
-                    "samplerAnisotropy": true
+                    "logicOp": true
                 },
                 "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
                     "memoryPriority": true
@@ -332,7 +336,6 @@
             "features": {
                 "VkPhysicalDeviceFeatures": {
                     "drawIndirectFirstInstance": true,
-                    "fragmentStoresAndAtomics": true,
                     "multiDrawIndirect": true,
                     "tessellationShader": true
                 }

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -4783,7 +4783,7 @@ namespace dxvk {
 
 
   bool D3D9DeviceEx::SupportsSWVP() {
-    return m_dxvkDevice->features().core.features.vertexPipelineStoresAndAtomics && m_dxvkDevice->features().vk12.shaderInt8;
+    return m_dxvkDevice->features().core.features.vertexPipelineStoresAndAtomics;
   }
 
 

--- a/src/dxvk/dxvk_cmdlist.cpp
+++ b/src/dxvk/dxvk_cmdlist.cpp
@@ -585,12 +585,14 @@ namespace dxvk {
       std::memcpy(dataCopy.data(), pushData,
         std::min(dataCopy.size(), pushDataSize));
 
-      this->cmdPushConstants(cmdBuffer,
-        layout->getPipelineLayout(),
-        pushDataBlock.getStageMask(),
-        pushDataBlock.getOffset(),
-        pushDataBlock.getSize(),
-        dataCopy.data());
+      VkPushConstantsInfo pushInfo = { VK_STRUCTURE_TYPE_PUSH_CONSTANTS_INFO };
+      pushInfo.layout = layout->getPipelineLayout();
+      pushInfo.stageFlags = pushDataBlock.getStageMask();
+      pushInfo.offset = pushDataBlock.getOffset();
+      pushInfo.size = pushDataBlock.getSize();
+      pushInfo.pValues = dataCopy.data();
+
+      this->cmdPushConstants(cmdBuffer, &pushInfo);
     }
   }
 
@@ -816,12 +818,14 @@ namespace dxvk {
       std::memcpy(dataCopy.data(), pushData,
         std::min(dataCopy.size(), pushDataSize));
 
-      this->cmdPushConstants(cmdBuffer,
-        layout->getPipelineLayout(),
-        pushDataBlock.getStageMask(),
-        pushDataBlock.getOffset(),
-        pushDataBlock.getSize(),
-        dataCopy.data());
+      VkPushConstantsInfo pushInfo = { VK_STRUCTURE_TYPE_PUSH_CONSTANTS_INFO };
+      pushInfo.layout = layout->getPipelineLayout();
+      pushInfo.stageFlags = pushDataBlock.getStageMask();
+      pushInfo.offset = pushDataBlock.getOffset();
+      pushInfo.size = pushDataBlock.getSize();
+      pushInfo.pValues = dataCopy.data();
+
+      this->cmdPushConstants(cmdBuffer, &pushInfo);
     }
   }
 

--- a/src/dxvk/dxvk_cmdlist.cpp
+++ b/src/dxvk/dxvk_cmdlist.cpp
@@ -571,10 +571,14 @@ namespace dxvk {
 
       sets.push_back(set);
 
-      this->cmdBindDescriptorSets(cmdBuffer,
-        layout->getBindPoint(),
-        layout->getPipelineLayout(),
-        0u, sets.size(), sets.data());
+      VkBindDescriptorSetsInfo bindInfo = { VK_STRUCTURE_TYPE_BIND_DESCRIPTOR_SETS_INFO };
+      bindInfo.stageFlags = layout->getShaderStageMask();
+      bindInfo.layout = layout->getPipelineLayout();
+      bindInfo.firstSet = 0u;
+      bindInfo.descriptorSetCount = sets.size();
+      bindInfo.pDescriptorSets = sets.data();
+
+      this->cmdBindDescriptorSets(cmdBuffer, &bindInfo);
     }
 
     // Update push constants

--- a/src/dxvk/dxvk_cmdlist.cpp
+++ b/src/dxvk/dxvk_cmdlist.cpp
@@ -806,12 +806,15 @@ namespace dxvk {
       bufferOffsets[setCount] = storage.offset;
       setCount++;
 
-      cmdSetDescriptorBufferOffsetsEXT(cmdBuffer,
-        layout->getBindPoint(),
-        layout->getPipelineLayout(),
-        0u, setCount,
-        bufferIndices.data(),
-        bufferOffsets.data());
+      VkSetDescriptorBufferOffsetsInfoEXT bindInfo = { VK_STRUCTURE_TYPE_SET_DESCRIPTOR_BUFFER_OFFSETS_INFO_EXT };
+      bindInfo.stageFlags = layout->getShaderStageMask();
+      bindInfo.layout = layout->getPipelineLayout();
+      bindInfo.firstSet = 0u;
+      bindInfo.setCount = setCount;
+      bindInfo.pBufferIndices = bufferIndices.data();
+      bindInfo.pOffsets = bufferOffsets.data();
+
+      cmdSetDescriptorBufferOffsetsEXT(cmdBuffer, &bindInfo);
     }
 
     // Update push constants

--- a/src/dxvk/dxvk_cmdlist.h
+++ b/src/dxvk/dxvk_cmdlist.h
@@ -608,14 +608,8 @@ namespace dxvk {
 
     void cmdSetDescriptorBufferOffsetsEXT(
             DxvkCmdBuffer             cmdBuffer,
-            VkPipelineBindPoint       pipeline,
-            VkPipelineLayout          layout,
-            uint32_t                  firstSet,
-            uint32_t                  setCount,
-      const uint32_t*                 pBufferIndices,
-      const VkDeviceSize*             pOffsets) {
-      m_vkd->vkCmdSetDescriptorBufferOffsetsEXT(getCmdBuffer(cmdBuffer),
-        pipeline, layout, firstSet, setCount, pBufferIndices, pOffsets);
+      const VkSetDescriptorBufferOffsetsInfoEXT* info) {
+      m_vkd->vkCmdSetDescriptorBufferOffsets2EXT(getCmdBuffer(cmdBuffer), info);
     }
 
 

--- a/src/dxvk/dxvk_cmdlist.h
+++ b/src/dxvk/dxvk_cmdlist.h
@@ -625,16 +625,6 @@ namespace dxvk {
     }
 
 
-
-    void cmdBindIndexBuffer(
-            VkBuffer                buffer,
-            VkDeviceSize            offset,
-            VkIndexType             indexType) {
-      m_vkd->vkCmdBindIndexBuffer(getCmdBuffer(),
-        buffer, offset, indexType);
-    }
-    
-    
     void cmdBindIndexBuffer2(
             VkBuffer                buffer,
             VkDeviceSize            offset,

--- a/src/dxvk/dxvk_cmdlist.h
+++ b/src/dxvk/dxvk_cmdlist.h
@@ -601,14 +601,8 @@ namespace dxvk {
     
     void cmdBindDescriptorSets(
             DxvkCmdBuffer             cmdBuffer,
-            VkPipelineBindPoint       pipeline,
-            VkPipelineLayout          pipelineLayout,
-            uint32_t                  firstSet,
-            uint32_t                  descriptorSetCount,
-      const VkDescriptorSet*          descriptorSets) {
-      m_vkd->vkCmdBindDescriptorSets(getCmdBuffer(cmdBuffer),
-        pipeline, pipelineLayout, firstSet, descriptorSetCount,
-        descriptorSets, 0, nullptr);
+      const VkBindDescriptorSetsInfo* info) {
+      m_vkd->vkCmdBindDescriptorSets2KHR(getCmdBuffer(cmdBuffer), info);
     }
 
 

--- a/src/dxvk/dxvk_cmdlist.h
+++ b/src/dxvk/dxvk_cmdlist.h
@@ -955,13 +955,8 @@ namespace dxvk {
 
     void cmdPushConstants(
             DxvkCmdBuffer           cmdBuffer,
-            VkPipelineLayout        layout,
-            VkShaderStageFlags      stageFlags,
-            uint32_t                offset,
-            uint32_t                size,
-      const void*                   pValues) {
-      m_vkd->vkCmdPushConstants(getCmdBuffer(cmdBuffer),
-        layout, stageFlags, offset, size, pValues);
+      const VkPushConstantsInfo*    info) {
+      m_vkd->vkCmdPushConstants2KHR(getCmdBuffer(cmdBuffer), info);
     }
 
 

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -6559,9 +6559,15 @@ namespace dxvk {
       const uint32_t     bufferIndex = 0u;
       const VkDeviceSize bufferOffset = 0u;
 
-      m_cmd->cmdSetDescriptorBufferOffsetsEXT(DxvkCmdBuffer::ExecBuffer,
-        BindPoint, layout->getPipelineLayout(), 0u, 1u,
-        &bufferIndex, &bufferOffset);
+      VkSetDescriptorBufferOffsetsInfoEXT bindInfo = { VK_STRUCTURE_TYPE_SET_DESCRIPTOR_BUFFER_OFFSETS_INFO_EXT };
+      bindInfo.stageFlags = layout->getShaderStageMask();
+      bindInfo.layout = layout->getPipelineLayout();
+      bindInfo.firstSet = 0u;
+      bindInfo.setCount = 1u;
+      bindInfo.pBufferIndices = &bufferIndex;
+      bindInfo.pOffsets = &bufferOffset;
+
+      m_cmd->cmdSetDescriptorBufferOffsetsEXT(DxvkCmdBuffer::ExecBuffer, &bindInfo);
     } else {
       VkDescriptorSet set = m_device->getSamplerDescriptorSet().set;
 
@@ -6982,11 +6988,15 @@ namespace dxvk {
         m_cmd->cmdPushData(DxvkCmdBuffer::ExecBuffer, &pushInfo);
       } else {
         // Global sampler set will always be bound to index 0 if used
-        uint32_t setIndex = first + uint32_t(pipelineLayout->usesSamplerHeap());
+        VkSetDescriptorBufferOffsetsInfoEXT bindInfo = { VK_STRUCTURE_TYPE_SET_DESCRIPTOR_BUFFER_OFFSETS_INFO_EXT };
+        bindInfo.stageFlags = pipelineLayout->getShaderStageMask();
+        bindInfo.layout = pipelineLayout->getPipelineLayout();
+        bindInfo.firstSet = first + uint32_t(pipelineLayout->usesSamplerHeap());
+        bindInfo.setCount = count;
+        bindInfo.pBufferIndices = &bufferIndices[first];
+        bindInfo.pOffsets = &heapOffsets[first];
 
-        m_cmd->cmdSetDescriptorBufferOffsetsEXT(DxvkCmdBuffer::ExecBuffer,
-          BindPoint, pipelineLayout->getPipelineLayout(), setIndex, count,
-          &bufferIndices[first], &heapOffsets[first]);
+        m_cmd->cmdSetDescriptorBufferOffsetsEXT(DxvkCmdBuffer::ExecBuffer, &bindInfo);
       }
 
       dirtySetMask &= countMask;

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -3018,8 +3018,10 @@ namespace dxvk {
       // there is no spec-legal way to bind it, not even by starting a new
       // command buffer. For now, work around the problem by calling a
       // legacy descriptor set function.
-      m_cmd->cmdBindDescriptorSets(DxvkCmdBuffer::ExecBuffer,
-        VK_PIPELINE_BIND_POINT_COMPUTE, VK_NULL_HANDLE, 0, 0, nullptr);
+      VkBindDescriptorSetsInfo bindInfo = { VK_STRUCTURE_TYPE_BIND_DESCRIPTOR_SETS_INFO };
+      bindInfo.stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
+
+      m_cmd->cmdBindDescriptorSets(DxvkCmdBuffer::ExecBuffer, &bindInfo);
       m_cmd->invalidateDescriptorHeapBinding();
     }
 
@@ -6563,8 +6565,13 @@ namespace dxvk {
     } else {
       VkDescriptorSet set = m_device->getSamplerDescriptorSet().set;
 
-      m_cmd->cmdBindDescriptorSets(DxvkCmdBuffer::ExecBuffer,
-        BindPoint, layout->getPipelineLayout(), 0u, 1u, &set);
+      VkBindDescriptorSetsInfo bindInfo = { VK_STRUCTURE_TYPE_BIND_DESCRIPTOR_SETS_INFO };
+      bindInfo.stageFlags = layout->getShaderStageMask();
+      bindInfo.layout = layout->getPipelineLayout();
+      bindInfo.descriptorSetCount = 1u;
+      bindInfo.pDescriptorSets = &set;
+
+      m_cmd->cmdBindDescriptorSets(DxvkCmdBuffer::ExecBuffer, &bindInfo);
     }
   }
 
@@ -6791,11 +6798,14 @@ namespace dxvk {
         uint32_t count = bit::bsf(countMask) - first;
 
         // Global sampler set will always be bound to index 0
-        uint32_t setIndex = first + uint32_t(pipelineLayout->usesSamplerHeap());
+        VkBindDescriptorSetsInfo bindInfo = { VK_STRUCTURE_TYPE_BIND_DESCRIPTOR_SETS_INFO };
+        bindInfo.stageFlags = pipelineLayout->getShaderStageMask();
+        bindInfo.layout = pipelineLayout->getPipelineLayout();
+        bindInfo.firstSet = first + uint32_t(pipelineLayout->usesSamplerHeap());
+        bindInfo.descriptorSetCount = count;
+        bindInfo.pDescriptorSets = &sets[first];
 
-        m_cmd->cmdBindDescriptorSets(DxvkCmdBuffer::ExecBuffer,
-          BindPoint, pipelineLayout->getPipelineLayout(),
-          setIndex, count, &sets[first]);
+        m_cmd->cmdBindDescriptorSets(DxvkCmdBuffer::ExecBuffer, &bindInfo);
 
         dirtySetMask &= countMask;
       } while (dirtySetMask);

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -7677,9 +7677,14 @@ namespace dxvk {
     if (m_features.test(DxvkContextFeature::DescriptorHeap)) {
       m_cmd->cmdPushData(DxvkCmdBuffer::ExecBuffer, &pushInfo);
     } else {
-      m_cmd->cmdPushConstants(DxvkCmdBuffer::ExecBuffer,
-        layout->getPipelineLayout(), pushData.getStageMask(),
-        pushInfo.offset, pushInfo.data.size, pushInfo.data.address);
+      VkPushConstantsInfo pushConstants = { VK_STRUCTURE_TYPE_PUSH_CONSTANTS_INFO };
+      pushConstants.layout = layout->getPipelineLayout();
+      pushConstants.stageFlags = pushData.getStageMask();
+      pushConstants.offset = pushInfo.offset;
+      pushConstants.size = pushInfo.data.size;
+      pushConstants.pValues = pushInfo.data.address;
+
+      m_cmd->cmdPushConstants(DxvkCmdBuffer::ExecBuffer, &pushConstants);
     }
   }
 

--- a/src/dxvk/dxvk_device_info.cpp
+++ b/src/dxvk/dxvk_device_info.cpp
@@ -792,7 +792,7 @@ namespace dxvk {
       ENABLE_FEATURE(core.features, drawIndirectFirstInstance, false),
       ENABLE_FEATURE(core.features, dualSrcBlend, true),
       ENABLE_FEATURE(core.features, fillModeNonSolid, true),
-      ENABLE_FEATURE(core.features, fragmentStoresAndAtomics, false),
+      ENABLE_FEATURE(core.features, fragmentStoresAndAtomics, true),
       ENABLE_FEATURE(core.features, fullDrawIndexUint32, true),
       ENABLE_FEATURE(core.features, geometryShader, true),
       ENABLE_FEATURE(core.features, imageCubeArray, true),

--- a/src/dxvk/dxvk_device_info.cpp
+++ b/src/dxvk/dxvk_device_info.cpp
@@ -800,6 +800,7 @@ namespace dxvk {
       ENABLE_FEATURE(core.features, geometryShader, true),
       ENABLE_FEATURE(core.features, imageCubeArray, true),
       ENABLE_FEATURE(core.features, independentBlend, true),
+      ENABLE_FEATURE(core.features, largePoints, false),
       ENABLE_FEATURE(core.features, logicOp, false),
       ENABLE_FEATURE(core.features, multiDrawIndirect, true),
       ENABLE_FEATURE(core.features, multiViewport, true),

--- a/src/dxvk/dxvk_device_info.cpp
+++ b/src/dxvk/dxvk_device_info.cpp
@@ -581,9 +581,6 @@ namespace dxvk {
       m_featuresSupported.khrPresentId2.presentId2 = VK_FALSE;
 
     // Sanitize features with other feature dependencies
-    if (!m_featuresSupported.core.features.shaderInt16)
-      m_featuresSupported.vk11.storagePushConstant16 = VK_FALSE;
-
     if (!m_featuresSupported.khrPresentId2.presentId2)
       m_featuresSupported.khrPresentWait2.presentWait2 = VK_FALSE;
 
@@ -813,7 +810,7 @@ namespace dxvk {
       ENABLE_FEATURE(core.features, shaderCullDistance, true),
       ENABLE_FEATURE(core.features, shaderFloat64, false),
       ENABLE_FEATURE(core.features, shaderImageGatherExtended, true),
-      ENABLE_FEATURE(core.features, shaderInt16, false),
+      ENABLE_FEATURE(core.features, shaderInt16, true),
       ENABLE_FEATURE(core.features, shaderInt64, true),
       ENABLE_FEATURE(core.features, shaderUniformBufferArrayDynamicIndexing, false),
       ENABLE_FEATURE(core.features, shaderSampledImageArrayDynamicIndexing, true),
@@ -859,7 +856,7 @@ namespace dxvk {
       ENABLE_FEATURE(vk12, samplerMirrorClampToEdge, true),
       ENABLE_FEATURE(vk12, scalarBlockLayout, true),
       ENABLE_FEATURE(vk12, shaderFloat16, false),
-      ENABLE_FEATURE(vk12, shaderInt8, false),
+      ENABLE_FEATURE(vk12, shaderInt8, true),
       ENABLE_FEATURE(vk12, shaderOutputViewportIndex, false),
       ENABLE_FEATURE(vk12, shaderOutputLayer, false),
       ENABLE_FEATURE(vk12, timelineSemaphore, true),

--- a/src/dxvk/dxvk_device_info.cpp
+++ b/src/dxvk/dxvk_device_info.cpp
@@ -807,7 +807,7 @@ namespace dxvk {
       ENABLE_FEATURE(core.features, pipelineStatisticsQuery, false),
       ENABLE_FEATURE(core.features, robustBufferAccess, true),
       ENABLE_FEATURE(core.features, sampleRateShading, true),
-      ENABLE_FEATURE(core.features, samplerAnisotropy, false),
+      ENABLE_FEATURE(core.features, samplerAnisotropy, true),
       ENABLE_FEATURE(core.features, shaderClipDistance, true),
       ENABLE_FEATURE(core.features, shaderCullDistance, true),
       ENABLE_FEATURE(core.features, shaderFloat64, false),

--- a/src/dxvk/dxvk_meta_mipgen.cpp
+++ b/src/dxvk/dxvk_meta_mipgen.cpp
@@ -215,8 +215,7 @@ namespace dxvk {
 
     // The shader has some feature requirements that aren't otherwise
     // needed to run DXVK, make sure everything is supported.
-    if (!m_device->features().vk12.shaderInt8
-     || !m_device->features().vk12.shaderFloat16
+    if (!m_device->features().vk12.shaderFloat16
      || !m_device->features().khrShaderSubgroupUniformControlFlow.shaderSubgroupUniformControlFlow)
       return false;
 

--- a/src/dxvk/dxvk_pipelayout.cpp
+++ b/src/dxvk/dxvk_pipelayout.cpp
@@ -251,6 +251,7 @@ namespace dxvk {
     m_bindPoint = (key.getStageMask() == VK_SHADER_STAGE_COMPUTE_BIT)
       ? VK_PIPELINE_BIND_POINT_COMPUTE
       : VK_PIPELINE_BIND_POINT_GRAPHICS;
+    m_stageMask = key.getStageMask();
 
     // Get set layouts from pipeline layout key and compute memory size
     for (uint32_t i = 0; i < key.getDescriptorSetCount(); i++) {

--- a/src/dxvk/dxvk_pipelayout.h
+++ b/src/dxvk/dxvk_pipelayout.h
@@ -1218,6 +1218,14 @@ namespace dxvk {
     }
 
     /**
+     * \brief Queries shader stage mask that use resources
+     * \returns Shader stage mask
+     */
+    VkShaderStageFlags getShaderStageMask() const {
+      return m_stageMask;
+    }
+
+    /**
      * \brief Queries Vulkan pipeline layout
      *
      * Will be \c VK_NULL_HANDLE when descriptor heaps are used.
@@ -1317,6 +1325,7 @@ namespace dxvk {
 
     DxvkPipelineLayoutFlags m_flags;
     VkPipelineBindPoint     m_bindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
+    VkShaderStageFlags      m_stageMask = 0u;
 
     std::array<const DxvkDescriptorSetLayout*, DxvkPipelineLayoutKey::MaxSets> m_setLayouts = { };
 

--- a/src/dxvk/dxvk_sampler.cpp
+++ b/src/dxvk/dxvk_sampler.cpp
@@ -52,9 +52,6 @@ namespace dxvk {
     if (key.u.p.legacyCube && m_pool->m_device->features().extNonSeamlessCubeMap.nonSeamlessCubeMap)
       samplerInfo.flags |= VK_SAMPLER_CREATE_NON_SEAMLESS_CUBE_MAP_BIT_EXT;
 
-    if (!m_pool->m_device->features().core.features.samplerAnisotropy)
-      samplerInfo.anisotropyEnable = VK_FALSE;
-
     if (key.u.p.hasBorder) {
       samplerInfo.borderColor = determineBorderColorType(borderColorInfo);
 


### PR DESCRIPTION
Fixes profile and pulls in some features from the old Vulkan 1.4 PR without actually using Vulkan 1.4.

Main reason why the latter would be a pain in the arse is 11on12, we can't easily support multiple core versions without creating a huge mess, and bumping vkd3d-proon at the same time wasn't desired.