### PR TITLE
Fix some shader-related bugs

### DIFF
--- a/src/dxvk/dxvk_graphics.cpp
+++ b/src/dxvk/dxvk_graphics.cpp
@@ -882,6 +882,7 @@ namespace dxvk {
 
       info.fsDualSrcBlend = state.useDualSourceBlending();
       info.fsFlatShading = state.rs.flatShading() && shader->metadata().flatShadingInputs;
+      info.sampleLocations = state.useSampleLocations();
 
       for (uint32_t i = 0; i < MaxNumRenderTargets; i++) {
         if ((fsOutputMask & (1u << i)) && state.writesRenderTarget(i))
@@ -1308,6 +1309,11 @@ namespace dxvk {
         if (!canUseDynamicAlphaToCoverage
          && (state.ms.enableAlphaToCoverage())
          && !m_shaders.fs->metadata().flags.test(DxvkShaderFlag::ExportsSampleMask))
+          return false;
+
+        // We need to not enable sample rate shading for the the
+        // shader in case sample locations are used to avoid UB.
+        if (state.useSampleLocations())
           return false;
       }
     }

--- a/src/dxvk/dxvk_meta_blit.cpp
+++ b/src/dxvk/dxvk_meta_blit.cpp
@@ -231,7 +231,10 @@ namespace dxvk {
     }
 
     // Compute average and export
-    result = builder.add(ir::Op::FMul(pixelType, result, builder.makeConstant(1.0f / float(sampleIterations))));
+    ir::SsaDef factor = helper.emitReplicateScalar(builder, pixelType,
+      builder.makeConstant(1.0f / float(sampleIterations)));
+
+    result = builder.add(ir::Op::FMul(pixelType, result, factor));
     result = helper.emitFormatVector(builder, key.dstFormat, result);
 
     if (aspect == VK_IMAGE_ASPECT_DEPTH_BIT)

--- a/src/dxvk/dxvk_shader.cpp
+++ b/src/dxvk/dxvk_shader.cpp
@@ -15,8 +15,10 @@ namespace dxvk {
 
 
   bool DxvkShaderLinkage::eq(const DxvkShaderLinkage& other) const {
-    bool eq = fsDualSrcBlend == other.fsDualSrcBlend
-           && fsFlatShading == other.fsFlatShading;
+    bool eq = fsDualSrcBlend  == other.fsDualSrcBlend
+           && fsFlatShading   == other.fsFlatShading
+           && sampleLocations == other.sampleLocations
+           && semanticIo      == other.semanticIo;
 
     if (eq) {
       eq = prevStageOutputs.getVarCount() == other.prevStageOutputs.getVarCount();
@@ -40,6 +42,8 @@ namespace dxvk {
     DxvkHashState hash;
     hash.add(uint32_t(fsDualSrcBlend));
     hash.add(uint32_t(fsFlatShading));
+    hash.add(uint32_t(sampleLocations));
+    hash.add(uint32_t(semanticIo));
 
     for (uint32_t i = 0; i < prevStageOutputs.getVarCount(); i++)
       hash.add(prevStageOutputs.getVar(i).hash());

--- a/src/dxvk/dxvk_shader.h
+++ b/src/dxvk/dxvk_shader.h
@@ -220,6 +220,7 @@ namespace dxvk {
   struct DxvkShaderLinkage {
     bool fsDualSrcBlend  = false;
     bool fsFlatShading   = false;
+    bool sampleLocations = false;
     bool semanticIo      = false;
 
     VkPrimitiveTopology inputTopology = VK_PRIMITIVE_TOPOLOGY_MAX_ENUM;

--- a/src/dxvk/dxvk_shader_builtin.cpp
+++ b/src/dxvk/dxvk_shader_builtin.cpp
@@ -465,6 +465,22 @@ namespace dxvk {
   }
 
 
+  ir::SsaDef DxvkBuiltInShader::emitReplicateScalar(
+          ir::Builder&          builder,
+          ir::BasicType         type,
+          ir::SsaDef            value) {
+    if (type.isScalar())
+      return value;
+
+    ir::Op compositeOp(ir::OpCode::eCompositeConstruct, type);
+
+    for (uint32_t i = 0u; i < type.getVectorSize(); i++)
+      compositeOp.addOperand(value);
+
+    return builder.add(std::move(compositeOp));
+  }
+
+
   ir::SsaDef DxvkBuiltInShader::emitFormatVector(
           ir::Builder&          builder,
           VkFormat              format,

--- a/src/dxvk/dxvk_shader_builtin.h
+++ b/src/dxvk/dxvk_shader_builtin.h
@@ -384,6 +384,19 @@ namespace dxvk {
             ir::SsaDef            b);
 
     /**
+     * \brief Replicates scalar into a vector
+     *
+     * \param [in,out] builder Shader builder
+     * \param [in] type Vector type
+     * \param [in] value Scalar value
+     * \returns Concatenated vector
+     */
+    ir::SsaDef emitReplicateScalar(
+            ir::Builder&          builder,
+            ir::BasicType         type,
+            ir::SsaDef            value);
+
+    /**
      * \brief Masks output vector for a given format
      *
      * Replaces all color components that are not part of the given

--- a/src/dxvk/dxvk_shader_ir.cpp
+++ b/src/dxvk/dxvk_shader_ir.cpp
@@ -1728,7 +1728,9 @@ namespace dxvk {
           ioPass.resolvePatchConstantLocations(convertIoMap(linkage->prevStageOutputs, linkage->prevStage));
       }
 
-      if (m_metadata.stage == VK_SHADER_STAGE_FRAGMENT_BIT && m_info.options.flags.test(DxvkShaderCompileFlag::EnableSampleRateShading))
+      if (m_metadata.stage == VK_SHADER_STAGE_FRAGMENT_BIT
+       && m_info.options.flags.test(DxvkShaderCompileFlag::EnableSampleRateShading)
+       && (!linkage || !linkage->sampleLocations))
         ioPass.enableSampleInterpolation();
     }
 

--- a/src/dxvk/dxvk_shader_ir.cpp
+++ b/src/dxvk/dxvk_shader_ir.cpp
@@ -184,7 +184,8 @@ namespace dxvk {
     : m_builder (builder),
       m_shader  (shader),
       m_info    (info) {
-
+      if (m_info.options.flags.test(DxvkShaderCompileFlag::EnableSampleRateShading))
+        m_metadata.flags.set(DxvkShaderFlag::HasSampleRateShading);
     }
 
     /**


### PR DESCRIPTION
Fixes an assert w.r.t. multisampled blits, and fixes a potential issue with sample rate shading in D3D9 games that disable MSAA once we have SM3 support wired up.