### PR TITLE
Optimize copies from render targets

### DIFF
--- a/src/dxvk/dxvk_cmdlist.cpp
+++ b/src/dxvk/dxvk_cmdlist.cpp
@@ -549,7 +549,8 @@ namespace dxvk {
           } break;
 
           case VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE:
-          case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE: {
+          case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE:
+          case VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT: {
             if (info.descriptor)
               descriptor.image = info.descriptor->legacy.image;
           } break;
@@ -675,7 +676,8 @@ namespace dxvk {
           case VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER:
           case VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:
           case VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE:
-          case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE: {
+          case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE:
+          case VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT: {
             auto descriptor = info.descriptor;
 
             if (!descriptor)
@@ -770,7 +772,8 @@ namespace dxvk {
           case VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER:
           case VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:
           case VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE:
-          case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE: {
+          case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE:
+          case VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT: {
             auto descriptor = info.descriptor;
 
             if (!descriptor)

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -5955,6 +5955,7 @@ namespace dxvk {
     std::array<VkClearAttachment, MaxNumRenderTargets> lateClears = { };
 
     bool hasMipmappedRt = false;
+    bool hasInputAttachmentRt = false;
 
     for (uint32_t i = 0; i < MaxNumRenderTargets; i++) {
       const auto& colorTarget = framebufferInfo.getColorTarget(i);
@@ -5962,7 +5963,7 @@ namespace dxvk {
       auto& colorInfo = m_state.om.renderingInfo.color[i];
       colorInfo = { VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO };
 
-      if (colorTarget.view != nullptr) {
+      if (colorTarget.view) {
         colorFormats[i] = colorTarget.view->info().format;
 
         colorInfo.imageView = colorTarget.view->handle();
@@ -5971,6 +5972,8 @@ namespace dxvk {
         colorInfo.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
 
         renderingInheritance.rasterizationSamples = colorTarget.view->image()->info().sampleCount;
+
+        hasInputAttachmentRt |= bool(colorTarget.view->image()->info().usage & VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT);
 
         if (ops.colorOps[i].loadOp == VK_ATTACHMENT_LOAD_OP_CLEAR) {
           colorInfo.clearValue.color = ops.colorOps[i].clearValue;
@@ -6082,6 +6085,12 @@ namespace dxvk {
       renderingInfo.pStencilAttachment = &stencilInfo;
       renderingInheritance.stencilAttachmentFormat = depthStencilFormat;
     }
+
+    // Make sure we get compression with input attachments whenever possible
+    if (hasInputAttachmentRt
+     && m_device->features().khrMaintenance10.maintenance10
+     && m_device->features().khrDynamicRenderingLocalRead.dynamicRenderingLocalRead)
+      renderingInfo.flags |= VK_RENDERING_LOCAL_READ_CONCURRENT_ACCESS_CONTROL_BIT_KHR;
 
     // Reset render area tracking, will be adjusted when drawing with viewports.
     m_state.om.renderAreaLo = VkOffset2D { int32_t(fbSize.width), int32_t(fbSize.height) };

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -2564,6 +2564,16 @@ namespace dxvk {
   }
 
 
+  void DxvkContext::adjustRenderArea(const VkRect2D& rect) {
+    m_state.om.renderAreaLo = VkOffset2D {
+      std::min(m_state.om.renderAreaLo.x, rect.offset.x),
+      std::min(m_state.om.renderAreaLo.y, rect.offset.y) };
+    m_state.om.renderAreaHi = VkOffset2D {
+      std::max(m_state.om.renderAreaHi.x, int32_t(rect.offset.x + rect.extent.width)),
+      std::max(m_state.om.renderAreaHi.y, int32_t(rect.offset.y + rect.extent.height)) };
+  }
+
+
   void DxvkContext::updateBuffer(
     const Rc<DxvkBuffer>&           buffer,
           VkDeviceSize              offset,
@@ -4080,12 +4090,14 @@ namespace dxvk {
         flushClearsInline();
 
       // Inline clears may affect render area
-      m_state.om.renderAreaLo = VkOffset2D {
-        std::min(m_state.om.renderAreaLo.x, offset.x),
-        std::min(m_state.om.renderAreaLo.y, offset.y) };
-      m_state.om.renderAreaHi = VkOffset2D {
-        std::max(m_state.om.renderAreaHi.x, int32_t(offset.x + extent.width)),
-        std::max(m_state.om.renderAreaHi.y, int32_t(offset.y + extent.height)) };
+      VkClearRect clearRect = { };
+      clearRect.rect.offset.x = offset.x;
+      clearRect.rect.offset.y = offset.y;
+      clearRect.rect.extent.width = extent.width;
+      clearRect.rect.extent.height = extent.height;
+      clearRect.layerCount = imageView->info().layerCount;
+
+      adjustRenderArea(clearRect.rect);
 
       // Check whether we can fold the clear into the curret render pass. This is the
       // case when the framebuffer size matches the clear size, even if the clear itself
@@ -4131,13 +4143,6 @@ namespace dxvk {
       clear.aspectMask = aspect;
       clear.colorAttachment = colorIndex;
       clear.clearValue = value;
-
-      VkClearRect clearRect = { };
-      clearRect.rect.offset.x = offset.x;
-      clearRect.rect.offset.y = offset.y;
-      clearRect.rect.extent.width = extent.width;
-      clearRect.rect.extent.height = extent.height;
-      clearRect.layerCount = imageView->info().layerCount;
 
       m_cmd->cmdClearAttachments(DxvkCmdBuffer::ExecBuffer, 1, &clear, 1, &clearRect);
     }
@@ -7440,12 +7445,7 @@ namespace dxvk {
           std::min(scissor.extent.height, uint32_t(hi.y - lo.y)) };
 
         // Extend render area based on the final scissor rect
-        m_state.om.renderAreaLo = {
-          std::min(m_state.om.renderAreaLo.x, dst.offset.x),
-          std::min(m_state.om.renderAreaLo.y, dst.offset.y) };
-        m_state.om.renderAreaHi = {
-          std::max(m_state.om.renderAreaHi.x, int32_t(dst.offset.x + dst.extent.width)),
-          std::max(m_state.om.renderAreaHi.y, int32_t(dst.offset.y + dst.extent.height)) };
+        adjustRenderArea(dst);
       }
 
       m_cmd->cmdSetViewport(m_state.vp.viewportCount, m_state.vp.viewports.data());

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -503,7 +503,8 @@ namespace dxvk {
           VkImageSubresourceLayers srcSubresource,
           VkOffset3D            srcOffset,
           VkExtent3D            extent) {
-    if (this->copyImageClear(dstImage, dstSubresource, dstOffset, extent, srcImage, srcSubresource))
+    if (this->copyImageClear(dstImage, dstSubresource, dstOffset, extent, srcImage, srcSubresource)
+     || this->copyImageInline(*dstImage, dstSubresource, dstOffset, *srcImage, srcSubresource, srcOffset, extent))
       return;
 
     bool useFb = !formatsAreImageCopyCompatible(dstImage->info().format, srcImage->info().format);
@@ -4561,8 +4562,6 @@ namespace dxvk {
           VkExtent3D            dstExtent,
     const Rc<DxvkImage>&        srcImage,
           VkImageSubresourceLayers srcSubresource) {
-    this->endCurrentPass(true);
-
     // If the source image has a pending deferred clear, we can
     // implement the copy by clearing the destination image to
     // the same clear value.
@@ -4606,9 +4605,263 @@ namespace dxvk {
     if (dstImage->mipLevelExtent(dstSubresource.mipLevel, dstSubresource.aspectMask) != dstExtent)
       return false;
 
-    auto view = dstImage->createView(viewInfo);
+    clearRenderTarget(dstImage->createView(viewInfo),
+      srcSubresource.aspectMask, clear->clearValue, 0u);
+    return true;
+  }
 
-    deferClear(view, srcSubresource.aspectMask, clear->clearValue);
+
+  bool DxvkContext::copyImageInline(
+          DxvkImage&            dstImage,
+          VkImageSubresourceLayers dstSubresource,
+          VkOffset3D            dstOffset,
+          DxvkImage&            srcImage,
+          VkImageSubresourceLayers srcSubresource,
+          VkOffset3D            srcOffset,
+          VkExtent3D            extent) {
+    if (!m_flags.test(DxvkContextFlag::GpRenderPassActive))
+      return false;
+
+    // Ignore non-2D image due to extra complexity
+    if (dstImage.info().type != VK_IMAGE_TYPE_2D
+     || srcImage.info().type != VK_IMAGE_TYPE_2D)
+      return false;
+
+    // We need to write a storage image, so ignore non-color images
+    if (dstSubresource.aspectMask != VK_IMAGE_ASPECT_COLOR_BIT
+     || srcSubresource.aspectMask != VK_IMAGE_ASPECT_COLOR_BIT)
+      return false;
+
+    // Check whether the source image is bound as a color attachment
+    auto srcSubresourceRange = vk::makeSubresourceRange(srcSubresource);
+    int32_t colorAttachmentIndex = findColorAttachmentIndex(srcImage, srcSubresourceRange);
+
+    if (colorAttachmentIndex < 0)
+      return false;
+
+    // Destination must not be bound as a render target. We could technically
+    // support this by drawing to that render target, but things would get
+    // complicated real fast and no game actually seems to do that.
+    if (isBoundAsRenderTarget(dstImage, vk::makeSubresourceRange(dstSubresource)))
+      return false;
+
+    // Ignore images with feedback loop usage since there are weird interactions.
+    if (srcImage.info().usage & VK_IMAGE_USAGE_ATTACHMENT_FEEDBACK_LOOP_BIT_EXT)
+      return false;
+
+    // Make sure we can actually hit all the fast paths
+    if (!m_device->features().khrDynamicRenderingLocalRead.dynamicRenderingLocalRead
+     || !m_device->features().khrMaintenance10.maintenance10
+     || !srcImage.hasUnifiedLayout() || !dstImage.hasUnifiedLayout())
+      return false;
+
+    // We fake unified layouts on some GPUs, so we still need to ensure
+    // that we don't use the input attachment path with invalid layouts.
+    // That could happen with the feedback loop layout in some cases.
+    Rc<DxvkImageView> srcView = m_state.om.framebufferInfo.getColorTarget(colorAttachmentIndex).view;
+
+    if (srcView->getLayout() != VK_IMAGE_LAYOUT_GENERAL)
+      return false;
+
+    // Verify that the source region fits within the framebuffer
+    DxvkFramebufferSize fbSize = m_state.om.framebufferInfo.size();
+
+    if (uint32_t(srcOffset.x + extent.width)  > fbSize.width
+     || uint32_t(srcOffset.y + extent.height) > fbSize.height
+     || srcSubresource.baseArrayLayer + srcSubresource.layerCount > srcView->info().layerIndex + fbSize.layers)
+      return false;
+
+    // Modern hardware tends to not suffer from adding STORAGE_IMAGE
+    // usage to images, so just do that if unified layouts are supported
+    VkFormat srcFormat = srcView->info().format;
+    VkFormat dstFormat = getLinearFormat(srcFormat);
+
+    DxvkImageUsageInfo srcUsage = { };
+    srcUsage.usage |= VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT;
+    srcUsage.stages |= VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
+    srcUsage.access |= VK_ACCESS_INPUT_ATTACHMENT_READ_BIT;
+
+    DxvkImageUsageInfo dstUsage = { };
+    dstUsage.usage |= VK_IMAGE_USAGE_STORAGE_BIT;
+    dstUsage.stages |= VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
+    dstUsage.access |= VK_ACCESS_SHADER_WRITE_BIT;
+    dstUsage.viewFormatCount = 1u;
+    dstUsage.viewFormats = &dstFormat;
+
+    if (dstImage.formatInfo()->flags.test(DxvkFormatFlag::BlockCompressed)) {
+      dstUsage.flags |= VK_IMAGE_CREATE_BLOCK_TEXEL_VIEW_COMPATIBLE_BIT
+                     |  VK_IMAGE_CREATE_EXTENDED_USAGE_BIT_KHR;
+
+      if (dstSubresource.layerCount > 1u && !m_device->properties().khrMaintenance6.blockTexelViewCompatibleMultipleLayers)
+        return false;
+    }
+
+    if (!(dstImage.info().usage & VK_IMAGE_USAGE_STORAGE_BIT)) {
+      auto formatFeatures = m_device->adapter()->getFormatFeatures(dstFormat);
+      auto features = dstImage.info().tiling == VK_IMAGE_TILING_LINEAR ? formatFeatures.linear : formatFeatures.optimal;
+
+      if (!(features & VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT))
+        return false;
+    }
+
+    if (!ensureImageCompatibility(&dstImage, dstUsage)
+     || !ensureImageCompatibility(&srcImage, srcUsage))
+      return false;
+
+    // Track access to the destination resource since it may be bound
+    // as a resource to graphics staders as well
+    if (!dstImage.trackGfxStores())
+      return false;
+
+    // Might have ended the render pass in the meantime. This is fine,
+    // just means that we'll end up hitting the fast path next time.
+    if (!m_flags.test(DxvkContextFlag::GpRenderPassActive))
+      return false;
+
+    // Create actual storage image view to bind for the copy
+    DxvkImageViewKey key = { };
+    key.viewType = dstSubresource.layerCount > 1u
+      ? VK_IMAGE_VIEW_TYPE_2D_ARRAY
+      : VK_IMAGE_VIEW_TYPE_2D;
+    key.usage = VK_IMAGE_USAGE_STORAGE_BIT;
+    key.layout = VK_IMAGE_LAYOUT_GENERAL;
+    key.format = dstFormat;
+    key.aspects = dstSubresource.aspectMask;
+    key.layerIndex = dstSubresource.baseArrayLayer;
+    key.layerCount = dstSubresource.layerCount;
+    key.mipIndex = dstSubresource.mipLevel;
+    key.mipCount = 1u;
+
+    Rc<DxvkImageView> dstView = dstImage.createView(key);
+
+    // Check whether there are any hazards for the destination image,
+    // and track the write access as necessary.
+    if (resourceHasAccess(dstImage, dstSubresource, dstOffset, extent, DxvkAccess::Write, DxvkAccessOp::None)
+     || resourceHasAccess(dstImage, dstSubresource, dstOffset, extent, DxvkAccess::Read, DxvkAccessOp::None))
+      return false;
+
+    accessImageRegion(DxvkCmdBuffer::ExecBuffer, dstImage, dstSubresource,
+      dstOffset, extent, dstView->info().layout, VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT,
+      VK_ACCESS_2_SHADER_WRITE_BIT, DxvkAccessOp::None);
+
+    m_cmd->track(&dstImage, DxvkAccess::Write);
+
+    // Flush pending clears for the source image that we want to copy from
+    if (findOverlappingDeferredClear(srcImage, srcSubresourceRange))
+      flushClearsInline();
+
+    if (unlikely(m_features.test(DxvkContextFeature::DebugUtils))) {
+      const char* dstName = dstImage.info().debugName;
+      const char* srcName = srcImage.info().debugName;
+
+      m_cmd->cmdBeginDebugUtilsLabel(DxvkCmdBuffer::ExecBuffer,
+        vk::makeLabel(0xf0dcdc, str::format("Copy image (",
+          dstName ? dstName : "unknown", ", ",
+          srcName ? srcName : "unknown", ")").c_str()));
+    }
+
+    // Get pipeline for the current render pass setup
+    DxvkMetaInputAttachmentImageCopy::Key pipelineKey = { };
+    pipelineKey.srcViewType = srcView->info().viewType;
+    pipelineKey.dstViewType = key.viewType;
+    pipelineKey.dstFormat = key.format;
+    pipelineKey.srcAttachment = colorAttachmentIndex;
+    pipelineKey.depthFormat = m_state.om.framebufferInfo.getDepthFormat();
+
+    for (uint32_t i = 0u; i < MaxNumRenderTargets; i++)
+      pipelineKey.colorFormats[i] = m_state.om.framebufferInfo.getColorFormat(i);
+
+    DxvkMetaInputAttachmentImageCopy pipeline = m_common->metaCopy().getPipeline(pipelineKey);
+
+    if (!pipeline.pipeline)
+      return false;
+
+    // Issue by-region barrier before the copy
+    VkImageMemoryBarrier2 barrier = { VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER_2 };
+    barrier.image = srcImage.handle();
+    barrier.srcStageMask = VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT;
+    barrier.srcAccessMask = VK_ACCESS_2_COLOR_ATTACHMENT_WRITE_BIT
+                          | VK_ACCESS_2_COLOR_ATTACHMENT_READ_BIT;
+    barrier.dstStageMask = VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT;
+    barrier.dstAccessMask = VK_ACCESS_2_INPUT_ATTACHMENT_READ_BIT;
+    barrier.oldLayout = srcView->getLayout();
+    barrier.newLayout = srcView->getLayout();
+    barrier.subresourceRange = srcSubresourceRange;
+
+    VkDependencyInfo depInfo = { VK_STRUCTURE_TYPE_DEPENDENCY_INFO };
+    depInfo.dependencyFlags = VK_DEPENDENCY_BY_REGION_BIT;
+    depInfo.imageMemoryBarrierCount = 1u;
+    depInfo.pImageMemoryBarriers = &barrier;
+
+    m_cmd->cmdPipelineBarrier(DxvkCmdBuffer::ExecBuffer, &depInfo);
+
+    // Invalidate pipeline state and perform the actual draw
+    unbindGraphicsPipeline();
+
+    VkViewport viewport = { };
+    viewport.x = float(srcOffset.x);
+    viewport.y = float(srcOffset.y);
+    viewport.width = float(extent.width);
+    viewport.height = float(extent.height);
+    viewport.maxDepth = 1.0f;
+
+    VkRect2D scissor = { };
+    scissor.offset.x = srcOffset.x;
+    scissor.offset.y = srcOffset.y;
+    scissor.extent.width = extent.width;
+    scissor.extent.height = extent.height;
+
+    m_cmd->cmdSetViewport(1, &viewport);
+    m_cmd->cmdSetScissor(1, &scissor);
+
+    adjustRenderArea(scissor);
+
+    std::array<DxvkDescriptorWrite, 2u> descriptors = { };
+    descriptors[0].descriptorType = VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT;
+    descriptors[0].descriptor = srcView->getDescriptor();
+
+    descriptors[1].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
+    descriptors[1].descriptor = dstView->getDescriptor();
+
+    DxvkMetaInputAttachmentImageCopy::Args copyArgs = { };
+    copyArgs.srcOffset = VkOffset2D { srcOffset.x, srcOffset.y };
+    copyArgs.dstOffset = VkOffset2D { dstOffset.x, dstOffset.y };
+
+    if (dstImage.formatInfo()->flags.test(DxvkFormatFlag::BlockCompressed)) {
+      copyArgs.dstOffset.x /= dstImage.formatInfo()->blockSize.width;
+      copyArgs.dstOffset.y /= dstImage.formatInfo()->blockSize.height;
+    }
+
+    m_cmd->cmdBindPipeline(DxvkCmdBuffer::ExecBuffer,
+      VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline.pipeline);
+
+    m_cmd->bindResources(DxvkCmdBuffer::ExecBuffer, pipeline.layout,
+      descriptors.size(), descriptors.data(), 0u, nullptr);
+
+    for (uint32_t i = 0u; i < dstSubresource.layerCount; i++) {
+      copyArgs.srcLayer = i + srcSubresource.baseArrayLayer - srcView->info().layerIndex;
+      copyArgs.dstLayer = i + dstSubresource.baseArrayLayer;
+
+      m_cmd->bindResources(DxvkCmdBuffer::ExecBuffer, pipeline.layout,
+        0u, nullptr, sizeof(copyArgs), &copyArgs);
+      m_cmd->cmdDraw(3u, srcSubresource.layerCount, 0u, 1u);
+    }
+
+    // Issue by-region barrier after the copy and before subsequent rendering
+    std::swap(barrier.srcStageMask, barrier.dstStageMask);
+    std::swap(barrier.srcAccessMask, barrier.dstAccessMask);
+
+    m_cmd->cmdPipelineBarrier(DxvkCmdBuffer::ExecBuffer, &depInfo);
+
+    if (unlikely(m_features.test(DxvkContextFeature::DebugUtils)))
+      m_cmd->cmdEndDebugUtilsLabel(DxvkCmdBuffer::ExecBuffer);
+
+    m_renderPassBarrierSrc.stages |= VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
+    m_renderPassBarrierSrc.access |= VK_ACCESS_SHADER_WRITE_BIT | VK_ACCESS_INPUT_ATTACHMENT_READ_BIT;
+
+    m_state.om.attachmentMask.trackColorRead(colorAttachmentIndex);
+
+    m_flags.set(DxvkContextFlag::GpRenderPassSideEffects);
     return true;
   }
 
@@ -6339,7 +6592,8 @@ namespace dxvk {
                 DxvkContextFlag::GpDirtyDepthBias,
                 DxvkContextFlag::GpDirtyDepthBounds,
                 DxvkContextFlag::GpDirtyDepthClip,
-                DxvkContextFlag::GpDirtyDepthTest);
+                DxvkContextFlag::GpDirtyDepthTest,
+                DxvkContextFlag::GpDirtySpecConstants);
 
     m_flags.clr(DxvkContextFlag::GpHasPushData);
 
@@ -7258,6 +7512,26 @@ namespace dxvk {
     }
 
     return false;
+  }
+
+
+  int32_t DxvkContext::findColorAttachmentIndex(
+    const DxvkImage&              image,
+    const VkImageSubresourceRange& subresources) {
+    for (uint32_t i = 0u; i < MaxNumRenderTargets; i++) {
+      const auto& attachment = m_state.om.framebufferInfo.getColorTarget(i).view;
+
+      if (!attachment || attachment->image() != &image)
+        continue;
+
+      auto viewSubresources = attachment->imageSubresources();
+
+      if ((viewSubresources.aspectMask & subresources.aspectMask) == subresources.aspectMask
+       && vk::checkSubresourceRangeSuperset(viewSubresources, subresources))
+        return int32_t(i);
+    }
+
+    return -1;
   }
 
 

--- a/src/dxvk/dxvk_context.h
+++ b/src/dxvk/dxvk_context.h
@@ -1506,6 +1506,15 @@ namespace dxvk {
       const Rc<DxvkImage>&        srcImage,
             VkImageSubresourceLayers srcSubresource);
 
+    bool copyImageInline(
+            DxvkImage&            dstImage,
+            VkImageSubresourceLayers dstSubresource,
+            VkOffset3D            dstOffset,
+            DxvkImage&            srcImage,
+            VkImageSubresourceLayers srcSubresource,
+            VkOffset3D            srcOffset,
+            VkExtent3D            extent);
+
     template<bool ToBuffer>
     void copySparsePages(
       const Rc<DxvkPagedResource>& sparse,
@@ -1740,6 +1749,10 @@ namespace dxvk {
       const VkImageSubresourceRange& subresources);
 
     bool isBoundAsRenderTarget(
+      const DxvkImage&              image,
+      const VkImageSubresourceRange& subresources);
+
+    int32_t findColorAttachmentIndex(
       const DxvkImage&              image,
       const VkImageSubresourceRange& subresources);
 

--- a/src/dxvk/dxvk_context.h
+++ b/src/dxvk/dxvk_context.h
@@ -1653,6 +1653,8 @@ namespace dxvk {
             VkRenderingAttachmentInfo&  attachment,
             DxvkAccess                  access) const;
 
+    void adjustRenderArea(const VkRect2D& rect);
+
     void beginRenderPass();
     void endRenderPass(bool suspend);
 

--- a/src/dxvk/dxvk_descriptor_info.cpp
+++ b/src/dxvk/dxvk_descriptor_info.cpp
@@ -346,7 +346,7 @@ namespace dxvk {
     // texel buffer descriptors.
     auto properties = device->properties().extDescriptorHeap;
 
-    std::array<std::pair<VkDescriptorType, VkDeviceSize>, 7> types = {{
+    std::array<std::pair<VkDescriptorType, VkDeviceSize>, 8> types = {{
       { VK_DESCRIPTOR_TYPE_SAMPLER,              properties.samplerDescriptorAlignment },
       { VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,       properties.bufferDescriptorAlignment  },
       { VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,       properties.bufferDescriptorAlignment  },
@@ -354,6 +354,7 @@ namespace dxvk {
       { VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER, properties.imageDescriptorAlignment   },
       { VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE,        properties.imageDescriptorAlignment   },
       { VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,        properties.imageDescriptorAlignment   },
+      { VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT,     properties.imageDescriptorAlignment   },
     }};
 
     for (const auto& s : types) {
@@ -368,7 +369,7 @@ namespace dxvk {
 
       m_setAlignment = std::max(m_setAlignment, alignment);
 
-      if (s.first != VK_DESCRIPTOR_TYPE_SAMPLER) {
+      if (s.first != VK_DESCRIPTOR_TYPE_SAMPLER && s.first != VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT) {
         VkResourceDescriptorInfoEXT nullInfo = { VK_STRUCTURE_TYPE_RESOURCE_DESCRIPTOR_INFO_EXT };
         nullInfo.type = s.first;
 
@@ -388,7 +389,7 @@ namespace dxvk {
     auto vk = device->vkd();
     auto properties = device->properties().extDescriptorBuffer;
 
-    std::array<std::pair<VkDescriptorType, size_t>, 7u> sizes = {{
+    std::array<std::pair<VkDescriptorType, size_t>, 8u> sizes = {{
       { VK_DESCRIPTOR_TYPE_SAMPLER,               properties.samplerDescriptorSize                  },
       { VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,        properties.robustUniformBufferDescriptorSize      },
       { VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,        properties.robustStorageBufferDescriptorSize      },
@@ -396,6 +397,7 @@ namespace dxvk {
       { VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER,  properties.robustStorageTexelBufferDescriptorSize },
       { VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE,         properties.sampledImageDescriptorSize             },
       { VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,         properties.storageImageDescriptorSize             },
+      { VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT,      properties.inputAttachmentDescriptorSize          },
     }};
 
     for (const auto& s : sizes) {
@@ -406,7 +408,7 @@ namespace dxvk {
       info.size       = s.second;
       info.alignment  = 1u;
 
-      if (s.first != VK_DESCRIPTOR_TYPE_SAMPLER) {
+      if (s.first != VK_DESCRIPTOR_TYPE_SAMPLER && s.first != VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT) {
         VkDescriptorGetInfoEXT nullInfo = { VK_STRUCTURE_TYPE_DESCRIPTOR_GET_INFO_EXT };
         nullInfo.type = s.first;
 
@@ -430,7 +432,8 @@ namespace dxvk {
       "\n  Uniform texel buffer : ", getDescriptorTypeInfo(VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER).size,
       "\n  Storage texel buffer : ", getDescriptorTypeInfo(VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER).size,
       "\n  Sampled image        : ", getDescriptorTypeInfo(VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE).size,
-      "\n  Storage image        : ", getDescriptorTypeInfo(VK_DESCRIPTOR_TYPE_STORAGE_IMAGE).size));
+      "\n  Storage image        : ", getDescriptorTypeInfo(VK_DESCRIPTOR_TYPE_STORAGE_IMAGE).size,
+      "\n  Input attachment     : ", getDescriptorTypeInfo(VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT).size));
   }
 
 }

--- a/src/dxvk/dxvk_descriptor_info.h
+++ b/src/dxvk/dxvk_descriptor_info.h
@@ -179,7 +179,7 @@ namespace dxvk {
    * Not meaningful if the legacy descriptor model is used.
    */
   class DxvkDescriptorProperties {
-    constexpr static uint32_t TypeCount = uint32_t(VK_DESCRIPTOR_TYPE_STORAGE_BUFFER) + 1u;
+    constexpr static uint32_t TypeCount = uint32_t(VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT) + 1u;
   public:
 
     DxvkDescriptorProperties(DxvkDevice* device);

--- a/src/dxvk/dxvk_descriptor_pool.cpp
+++ b/src/dxvk/dxvk_descriptor_pool.cpp
@@ -136,13 +136,14 @@ namespace dxvk {
     // assume that all other descriptor types share pool memory.
     constexpr static uint32_t MaxSets = 1024u;
 
-    static const std::array<VkDescriptorPoolSize, 6> pools = {{
+    static const std::array<VkDescriptorPoolSize, 7> pools = {{
       { VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE,          MaxSets / 2  },
       { VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,          MaxSets / 64 },
       { VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER,   MaxSets / 2  },
       { VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER,   MaxSets / 64 },
       { VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,         MaxSets * 2  },
       { VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,         MaxSets / 2  },
+      { VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT,       MaxSets / 64 },
     }};
 
     VkDescriptorPoolCreateInfo info = { VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO };

--- a/src/dxvk/dxvk_device_info.cpp
+++ b/src/dxvk/dxvk_device_info.cpp
@@ -13,7 +13,7 @@ namespace dxvk {
   #define CORE_VERSIONS                            \
     HANDLE_CORE(vk11);                             \
     HANDLE_CORE(vk12);                             \
-    HANDLE_CORE(vk13);                             \
+    HANDLE_CORE(vk13);
 
   #define EXTENSIONS_WITH_FEATURES                 \
     HANDLE_EXT(extAttachmentFeedbackLoopLayout);   \
@@ -43,6 +43,7 @@ namespace dxvk {
     HANDLE_EXT(extSwapchainMaintenance1);          \
     HANDLE_EXT(extTransformFeedback);              \
     HANDLE_EXT(extVertexAttributeDivisor);         \
+    HANDLE_EXT(khrDynamicRenderingLocalRead);      \
     HANDLE_EXT(khrExternalMemoryWin32);            \
     HANDLE_EXT(khrExternalSemaphoreWin32);         \
     HANDLE_EXT(khrLoadStoreOpNone);                \
@@ -968,6 +969,9 @@ namespace dxvk {
       /* Vertex attribute divisor, used by client APIs */
       ENABLE_EXT_FEATURE(extVertexAttributeDivisor, vertexAttributeInstanceRateDivisor, false),
       ENABLE_EXT_FEATURE(extVertexAttributeDivisor, vertexAttributeInstanceRateZeroDivisor, false),
+
+      /* Tiler stuff */
+      ENABLE_EXT_FEATURE(khrDynamicRenderingLocalRead, dynamicRenderingLocalRead, false),
 
       /* External memory features for wine */
       ENABLE_EXT(khrExternalMemoryWin32, false),

--- a/src/dxvk/dxvk_device_info.h
+++ b/src/dxvk/dxvk_device_info.h
@@ -85,6 +85,7 @@ namespace dxvk {
     VkPhysicalDeviceSwapchainMaintenance1FeaturesEXT          extSwapchainMaintenance1        = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SWAPCHAIN_MAINTENANCE_1_FEATURES_EXT };
     VkPhysicalDeviceTransformFeedbackFeaturesEXT              extTransformFeedback            = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TRANSFORM_FEEDBACK_FEATURES_EXT };
     VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT         extVertexAttributeDivisor       = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_ATTRIBUTE_DIVISOR_FEATURES };
+    VkPhysicalDeviceDynamicRenderingLocalReadFeatures         khrDynamicRenderingLocalRead    = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DYNAMIC_RENDERING_LOCAL_READ_FEATURES_KHR };
     VkBool32                                                  khrExternalMemoryWin32          = VK_FALSE;
     VkBool32                                                  khrExternalSemaphoreWin32       = VK_FALSE;
     VkBool32                                                  khrLoadStoreOpNone              = VK_FALSE;
@@ -154,6 +155,7 @@ namespace dxvk {
     VkExtensionProperties extSwapchainMaintenance1          = vk::makeExtension(VK_EXT_SWAPCHAIN_MAINTENANCE_1_EXTENSION_NAME);
     VkExtensionProperties extTransformFeedback              = vk::makeExtension(VK_EXT_TRANSFORM_FEEDBACK_EXTENSION_NAME);
     VkExtensionProperties extVertexAttributeDivisor         = vk::makeExtension(VK_EXT_VERTEX_ATTRIBUTE_DIVISOR_EXTENSION_NAME);
+    VkExtensionProperties khrDynamicRenderingLocalRead      = vk::makeExtension(VK_KHR_DYNAMIC_RENDERING_LOCAL_READ_EXTENSION_NAME);
     VkExtensionProperties khrExternalMemoryWin32            = vk::makeExtension(VK_KHR_EXTERNAL_MEMORY_WIN32_EXTENSION_NAME);
     VkExtensionProperties khrExternalSemaphoreWin32         = vk::makeExtension(VK_KHR_EXTERNAL_SEMAPHORE_WIN32_EXTENSION_NAME);
     VkExtensionProperties khrLoadStoreOpNone                = vk::makeExtension(VK_KHR_LOAD_STORE_OP_NONE_EXTENSION_NAME);

--- a/src/dxvk/dxvk_framebuffer.h
+++ b/src/dxvk/dxvk_framebuffer.h
@@ -58,15 +58,6 @@ namespace dxvk {
 
 
   /**
-   * \brief Render target layouts
-   */
-  struct DxvkRenderTargetLayouts {
-    VkImageLayout color[MaxNumRenderTargets];
-    VkImageLayout depth;
-  };
-
-
-  /**
    * \brief Rendering info
    */
   struct DxvkRenderingInfo {

--- a/src/dxvk/dxvk_framebuffer.h
+++ b/src/dxvk/dxvk_framebuffer.h
@@ -126,6 +126,18 @@ namespace dxvk {
     }
 
     /**
+     * \brief Queries depth-stencil format
+     *
+     * \param [in] id Target Index
+     * \returns The depth-stencil format
+     */
+    VkFormat getDepthFormat() const {
+      return getDepthTarget().view
+        ? getDepthTarget().view->info().format
+        : VK_FORMAT_UNDEFINED;
+    }
+
+    /**
      * \brief Color target
      *
      * \param [in] id Target Index
@@ -133,6 +145,18 @@ namespace dxvk {
      */
     const DxvkAttachment& getColorTarget(uint32_t id) const {
       return m_renderTargets.color[id];
+    }
+
+    /**
+     * \brief Queries color format
+     *
+     * \param [in] id Target Index
+     * \returns The color target format
+     */
+    VkFormat getColorFormat(uint32_t id) const {
+      return getColorTarget(id).view
+        ? getColorTarget(id).view->info().format
+        : VK_FORMAT_UNDEFINED;
     }
 
     /**

--- a/src/dxvk/dxvk_image.cpp
+++ b/src/dxvk/dxvk_image.cpp
@@ -716,7 +716,8 @@ namespace dxvk {
       VK_IMAGE_USAGE_SAMPLED_BIT |
       VK_IMAGE_USAGE_STORAGE_BIT |
       VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT |
-      VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT;
+      VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT |
+      VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT;
 
     // Legalize view usage. We allow creating transfer-only view
     // objects so that some internal APIs can be more consistent.
@@ -729,10 +730,12 @@ namespace dxvk {
 
     // If the image has feedback loops enabled, forward the required
     // usage flags to the view as well.
-    if ((m_image->info().usage & VK_IMAGE_USAGE_ATTACHMENT_FEEDBACK_LOOP_BIT_EXT)
-     && (key.usage & (VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT))) {
-      key.usage |= VK_IMAGE_USAGE_ATTACHMENT_FEEDBACK_LOOP_BIT_EXT
-                |  VK_IMAGE_USAGE_SAMPLED_BIT;
+    if (key.usage & (VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT)) {
+      if (m_image->info().usage & VK_IMAGE_USAGE_ATTACHMENT_FEEDBACK_LOOP_BIT_EXT)
+        key.usage |= VK_IMAGE_USAGE_ATTACHMENT_FEEDBACK_LOOP_BIT_EXT | VK_IMAGE_USAGE_SAMPLED_BIT;
+
+      if (m_image->info().usage & VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT)
+        key.usage |= VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT;
     }
 
     // Only use one layer for non-arrayed view types

--- a/src/dxvk/dxvk_meta_blit.cpp
+++ b/src/dxvk/dxvk_meta_blit.cpp
@@ -438,7 +438,7 @@ namespace dxvk {
     state.vs = vsSpirv;
     state.fs = psSpirv;
     state.sampleCount = key.dstSamples;
-    state.colorFormat = aspect == VK_IMAGE_ASPECT_COLOR_BIT ? key.dstFormat : VK_FORMAT_UNDEFINED;
+    state.colorFormats[0] = aspect == VK_IMAGE_ASPECT_COLOR_BIT ? key.dstFormat : VK_FORMAT_UNDEFINED;
     state.depthFormat = aspect == VK_IMAGE_ASPECT_DEPTH_BIT ? key.dstFormat : VK_FORMAT_UNDEFINED;
 
     result.pipeline = m_device->createBuiltInGraphicsPipeline(result.layout, state);

--- a/src/dxvk/dxvk_meta_copy.cpp
+++ b/src/dxvk/dxvk_meta_copy.cpp
@@ -22,6 +22,14 @@ namespace dxvk {
   };
 
 
+  struct DxvkMetaInputAttachmentImageCopyPushArgs {
+    ir::SsaDef srcOffset  = { };
+    ir::SsaDef dstOffset  = { };
+    ir::SsaDef srcLayer   = { };
+    ir::SsaDef dstLayer   = { };
+  };
+
+
   static DxvkMetaImageCopyPushArgs loadImageCopyPushArgs(ir::Builder& builder, DxvkBuiltInShader& helper) {
     ir::BasicType coordType(ir::ScalarType::eU32, 3u);
 
@@ -30,6 +38,18 @@ namespace dxvk {
     result.srcExtent  = helper.declarePushData(builder, coordType, offsetof(DxvkMetaImageCopy::Args, srcExtent), "src_extent");
     result.layerIndex = helper.declarePushData(builder, ir::ScalarType::eU32, offsetof(DxvkMetaImageCopy::Args, layerIndex), "layer_index");
     result.stencilBit = helper.declarePushData(builder, ir::ScalarType::eU32, offsetof(DxvkMetaImageCopy::Args, stencilBit), "stencil_bit");
+    return result;
+  }
+
+
+  static DxvkMetaInputAttachmentImageCopyPushArgs loadInputAttachmentImageCopyPushArgs(ir::Builder& builder, DxvkBuiltInShader& helper) {
+    ir::BasicType coordType(ir::ScalarType::eU32, 2u);
+
+    DxvkMetaInputAttachmentImageCopyPushArgs result = { };
+    result.srcOffset  = helper.declarePushData(builder, coordType, offsetof(DxvkMetaInputAttachmentImageCopy::Args, srcOffset), "src_offset");
+    result.dstOffset  = helper.declarePushData(builder, coordType, offsetof(DxvkMetaInputAttachmentImageCopy::Args, dstOffset), "dst_offset");
+    result.srcLayer   = helper.declarePushData(builder, ir::ScalarType::eU32, offsetof(DxvkMetaInputAttachmentImageCopy::Args, srcLayer), "src_layer");
+    result.dstLayer   = helper.declarePushData(builder, ir::ScalarType::eU32, offsetof(DxvkMetaInputAttachmentImageCopy::Args, dstLayer), "dst_layer");
     return result;
   }
 
@@ -190,6 +210,19 @@ namespace dxvk {
   }
 
 
+  DxvkMetaInputAttachmentImageCopy DxvkMetaCopyObjects::getPipeline(const DxvkMetaInputAttachmentImageCopy::Key& key) {
+    std::lock_guard<dxvk::mutex> lock(m_mutex);
+
+    auto entry = m_inputAttachmentImageCopyPipelines.find(key);
+    if (entry != m_inputAttachmentImageCopyPipelines.end())
+      return entry->second;
+
+    DxvkMetaInputAttachmentImageCopy pipeline = createInputAttachmentCopyPipeline(key);
+    m_inputAttachmentImageCopyPipelines.insert({ key, pipeline });
+    return pipeline;
+  }
+
+
   DxvkMetaBufferToImageCopy DxvkMetaCopyObjects::getPipeline(const DxvkMetaBufferToImageCopy::Key& key) {
     std::lock_guard<dxvk::mutex> lock(m_mutex);
 
@@ -278,6 +311,25 @@ namespace dxvk {
   }
 
 
+  std::vector<uint32_t> DxvkMetaCopyObjects::createVsCopyInputAttachment(
+    const DxvkPipelineLayout*           layout,
+    const DxvkMetaInputAttachmentImageCopy::Key& key) {
+    dxbc_spv::ir::Builder builder;
+    DxvkBuiltInShader helper(m_device, layout, getName(key, "vs"));
+
+    helper.buildFullscreenVertexShader(builder);
+
+    ir::ResourceKind srcKind = helper.determineResourceKind(key.srcViewType, VK_SAMPLE_COUNT_1_BIT);
+
+    if (ir::resourceIsLayered(srcKind)) {
+      DxvkMetaInputAttachmentImageCopyPushArgs pushArgs = loadInputAttachmentImageCopyPushArgs(builder, helper);
+      helper.exportBuiltIn(builder, ir::BuiltIn::eLayerIndex, pushArgs.srcLayer);
+    }
+
+    return helper.buildShader(builder);
+  }
+
+
   std::vector<uint32_t> DxvkMetaCopyObjects::createVsCopyBufferToImage(
     const DxvkPipelineLayout*           layout,
     const DxvkMetaBufferToImageCopy::Key& key) {
@@ -352,6 +404,59 @@ namespace dxvk {
 
     exportCopyToImagePs(builder, helper, key.dstAspects, value0, value1,
       key.bitwiseStencil ? pushArgs.stencilBit : ir::SsaDef());
+    return helper.buildShader(builder);
+  }
+
+
+  std::vector<uint32_t> DxvkMetaCopyObjects::createPsCopyInputAttachment(
+    const DxvkPipelineLayout*           layout,
+    const DxvkMetaInputAttachmentImageCopy::Key& key) {
+    dxbc_spv::ir::Builder builder;
+
+    DxvkBuiltInShader helper(m_device, layout, getName(key, "ps"));
+    helper.buildPixelShader(builder);
+
+    DxvkMetaInputAttachmentImageCopyPushArgs pushArgs = loadInputAttachmentImageCopyPushArgs(builder, helper);
+
+    ir::ResourceKind kind = helper.determineResourceKind(key.dstViewType, VK_SAMPLE_COUNT_1_BIT);
+    uint32_t coordDims = ir::resourceCoordComponentCount(kind);
+
+    ir::BasicType coordTypeF(ir::ScalarType::eF32, 4u);
+    ir::BasicType coordTypeU(ir::ScalarType::eU32, coordDims);
+
+    ir::SsaDef coord = helper.declareBuiltInInput(builder, coordTypeF, ir::BuiltIn::ePosition);
+    coord = helper.emitExtractVector(builder, coord, 0u, coordDims);
+    coord = builder.add(ir::Op::ConvertFtoI(coordTypeU, coord));
+    coord = builder.add(ir::Op::ISub(coordTypeU, coord, helper.emitExtractVector(builder, pushArgs.srcOffset, 0u, coordDims)));
+    coord = builder.add(ir::Op::IAdd(coordTypeU, coord, helper.emitExtractVector(builder, pushArgs.dstOffset, 0u, coordDims)));
+
+    ir::SsaDef layer = resourceIsLayered(kind) ? pushArgs.dstLayer : ir::SsaDef();
+    ir::BasicType valueType(helper.determineSampledType(key.dstFormat, VK_IMAGE_ASPECT_COLOR_BIT), 4u);
+
+    ir::SsaDef imgSrc = helper.declareInputTarget(builder, 0u, "img_src",
+      key.srcAttachment, key.colorFormats[key.srcAttachment], VK_SAMPLE_COUNT_1_BIT);
+    ir::SsaDef imgDst = helper.declareImageUav(builder, 1u, "img_dst",
+      key.dstViewType, key.dstFormat);
+
+    ir::SsaDef value = builder.add(ir::Op::InputTargetLoad(valueType, imgSrc, ir::SsaDef()));
+    value = helper.emitFormatVector(builder, key.dstFormat, value);
+
+    auto resultType = builder.getOp(value).getType();
+
+    // Emit linear to sRGB conversion as necessary
+    auto srcFormatInfo = lookupFormatInfo(key.colorFormats[key.srcAttachment]);
+    auto dstFormatInfo = lookupFormatInfo(key.dstFormat);
+
+    ir::SsaDef conversionFunction = { };
+
+    if (srcFormatInfo->flags.test(DxvkFormatFlag::ColorSpaceSrgb)
+     && !dstFormatInfo->flags.test(DxvkFormatFlag::ColorSpaceSrgb))
+      conversionFunction = helper.buildLinearToSrgbFn(builder, resultType);
+
+    if (conversionFunction)
+      value = builder.add(ir::Op::FunctionCall(resultType, conversionFunction).addOperand(value));
+
+    builder.add(ir::Op::ImageStore(imgDst, layer, coord, value));
     return helper.buildShader(builder);
   }
 
@@ -835,6 +940,43 @@ namespace dxvk {
   }
 
 
+  DxvkMetaInputAttachmentImageCopy DxvkMetaCopyObjects::createInputAttachmentCopyPipeline(const DxvkMetaInputAttachmentImageCopy::Key& key) {
+    static const std::array<DxvkDescriptorSetLayoutBinding, 2> bindings = {{
+      { VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT,  1, VK_SHADER_STAGE_FRAGMENT_BIT },
+      { VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,     1, VK_SHADER_STAGE_FRAGMENT_BIT },
+    }};
+
+    // Disable depth-stencil writes
+    VkPipelineDepthStencilStateCreateInfo dsState = { VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO };
+    dsState.depthTestEnable = VK_FALSE;
+    dsState.depthWriteEnable = VK_FALSE;
+    dsState.stencilTestEnable = VK_FALSE;
+
+    DxvkMetaInputAttachmentImageCopy pipeline;
+    pipeline.layout = m_device->createBuiltInPipelineLayout(0u,
+      VK_SHADER_STAGE_FRAGMENT_BIT | VK_SHADER_STAGE_VERTEX_BIT,
+      sizeof(DxvkMetaInputAttachmentImageCopy::Args), bindings.size(), bindings.data());
+
+    auto vsSpirv = createVsCopyInputAttachment(pipeline.layout, key);
+    auto psSpirv = createPsCopyInputAttachment(pipeline.layout, key);
+
+    // Disable all color writes
+    std::array<VkPipelineColorBlendAttachmentState, MaxNumRenderTargets> cbAttachments = { };
+
+    util::DxvkBuiltInGraphicsState state = { };
+    state.vs = vsSpirv;
+    state.fs = psSpirv;
+    state.dsState = &dsState;
+    state.cbAttachment = cbAttachments.data();
+    state.sampleCount = VK_SAMPLE_COUNT_1_BIT;
+    state.depthFormat = key.depthFormat;
+    state.colorFormats = key.colorFormats;
+
+    pipeline.pipeline = m_device->createBuiltInGraphicsPipeline(pipeline.layout, state);
+    return pipeline;
+  }
+
+
   DxvkMetaImageCopy DxvkMetaCopyObjects::createImageCopyPipeline(const DxvkMetaImageCopy::Key& key) {
     static const std::array<DxvkDescriptorSetLayoutBinding, 2> bindings = {{
       { VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, 1, VK_SHADER_STAGE_FRAGMENT_BIT },
@@ -922,6 +1064,17 @@ namespace dxvk {
     if (key.samples > VK_SAMPLE_COUNT_1_BIT)
       name << "_msx" << uint32_t(key.samples);
 
+    return str::tolower(name.str());
+  }
+
+
+  std::string DxvkMetaCopyObjects::getName(const DxvkMetaInputAttachmentImageCopy::Key& key, const char* type) {
+    std::stringstream name;
+    name << "meta_" << type << "_copy_input_attachment";
+    name << "_" << str::format(key.srcViewType).substr(std::strlen("VK_IMAGE_VIEW_TYPE_"));
+    name << "_to_" << str::format(key.dstViewType).substr(std::strlen("VK_IMAGE_VIEW_TYPE_"));
+    name << "_" << str::format(key.colorFormats[key.srcAttachment]).substr(std::strlen("VK_FORMAT_"));
+    name << "_rt" << key.srcAttachment;
     return str::tolower(name.str());
   }
 

--- a/src/dxvk/dxvk_meta_copy.cpp
+++ b/src/dxvk/dxvk_meta_copy.cpp
@@ -823,7 +823,7 @@ namespace dxvk {
       state.depthFormat = dstFormat;
       state.dsState = &dsState;
     } else {
-      state.colorFormat = dstFormat;
+      state.colorFormats[0] = dstFormat;
     }
 
     if ((dstAspects & VK_IMAGE_ASPECT_STENCIL_BIT) && bitwiseStencil) {

--- a/src/dxvk/dxvk_meta_copy.h
+++ b/src/dxvk/dxvk_meta_copy.h
@@ -63,6 +63,58 @@ namespace dxvk {
 
 
   /**
+   * \brief Input attachment to image copy pipeline
+   */
+  struct DxvkMetaInputAttachmentImageCopy {
+    /** Shader args for image to image copies */
+    struct Args {
+      VkOffset2D srcOffset  = { };
+      VkOffset2D dstOffset  = { };
+      uint32_t srcLayer = { };
+      uint32_t dstLayer = { };
+    };
+
+    /** Look-up key for input attachment copy pipelines */
+    struct Key {
+      VkImageViewType srcViewType = VK_IMAGE_VIEW_TYPE_MAX_ENUM;
+      VkImageViewType dstViewType = VK_IMAGE_VIEW_TYPE_MAX_ENUM;
+      VkFormat dstFormat = VK_FORMAT_UNDEFINED;
+      uint32_t srcAttachment = 0u;
+      std::array<VkFormat, MaxNumRenderTargets> colorFormats = { };
+      VkFormat depthFormat = VK_FORMAT_UNDEFINED;
+
+      bool eq(const Key& other) const {
+        bool result = srcViewType   == other.srcViewType
+                   && dstViewType   == other.dstViewType
+                   && dstFormat     == other.dstFormat
+                   && srcAttachment == other.srcAttachment;
+
+        for (uint32_t i = 0u; i < MaxNumRenderTargets; i++)
+          result = result && colorFormats[i] == other.colorFormats[i];
+
+        result = result && depthFormat == other.depthFormat;
+        return result;
+      }
+
+      size_t hash() const {
+        DxvkHashState hash;
+        hash.add(uint32_t(srcViewType));
+        hash.add(uint32_t(dstViewType));
+        hash.add(uint32_t(dstFormat));
+        hash.add(uint32_t(srcAttachment));
+        for (uint32_t i = 0u; i < MaxNumRenderTargets; i++)
+          hash.add(uint32_t(colorFormats[i]));
+        hash.add(uint32_t(depthFormat));
+        return hash;
+      }
+    };
+
+    const DxvkPipelineLayout* layout = nullptr;
+    VkPipeline pipeline = VK_NULL_HANDLE;
+  };
+
+
+  /**
    * \brief Buffer-to-image copy pipeline
    *
    * The primary use case for these pipelines is to support interleaved
@@ -216,6 +268,14 @@ namespace dxvk {
     DxvkMetaImageCopy getPipeline(const DxvkMetaImageCopy::Key& key);
 
     /**
+     * \brief Gets or creates pipeline for input attachment-based image copies
+     *
+     * \param [in] key Pipeline properties
+     * \returns Pipeline object
+     */
+    DxvkMetaInputAttachmentImageCopy getPipeline(const DxvkMetaInputAttachmentImageCopy::Key& key);
+
+    /**
      * \brief Gets or creates pipeline for buffer to image copies
      *
      * \param [in] key Pipeline properties
@@ -264,6 +324,7 @@ namespace dxvk {
     dxvk::mutex m_mutex;
 
     std::unordered_map<DxvkMetaImageCopy::Key, DxvkMetaImageCopy, DxvkHash, DxvkEq> m_imageCopyPipelines;
+    std::unordered_map<DxvkMetaInputAttachmentImageCopy::Key, DxvkMetaInputAttachmentImageCopy, DxvkHash, DxvkEq> m_inputAttachmentImageCopyPipelines;
     std::unordered_map<DxvkMetaBufferToImageCopy::Key, DxvkMetaBufferToImageCopy, DxvkHash, DxvkEq> m_bufferImageCopyPipelines;
     std::unordered_map<DxvkMetaImageToBufferCopy::Key, DxvkMetaImageToBufferCopy, DxvkHash, DxvkEq> m_imageBufferCopyPipelines;
 
@@ -273,6 +334,10 @@ namespace dxvk {
       const DxvkPipelineLayout*           layout,
       const DxvkMetaImageCopy::Key&       key);
 
+    std::vector<uint32_t> createVsCopyInputAttachment(
+      const DxvkPipelineLayout*           layout,
+      const DxvkMetaInputAttachmentImageCopy::Key& key);
+
     std::vector<uint32_t> createVsCopyBufferToImage(
       const DxvkPipelineLayout*           layout,
       const DxvkMetaBufferToImageCopy::Key& key);
@@ -280,6 +345,10 @@ namespace dxvk {
     std::vector<uint32_t> createPsCopyImage(
       const DxvkPipelineLayout*           layout,
       const DxvkMetaImageCopy::Key&       key);
+
+    std::vector<uint32_t> createPsCopyInputAttachment(
+      const DxvkPipelineLayout*           layout,
+      const DxvkMetaInputAttachmentImageCopy::Key& key);
 
     std::vector<uint32_t> createPsCopyBufferToImage(
       const DxvkPipelineLayout*           layout,
@@ -305,6 +374,9 @@ namespace dxvk {
     DxvkMetaImageCopy createImageCopyPipeline(
       const DxvkMetaImageCopy::Key&       key);
 
+    DxvkMetaInputAttachmentImageCopy createInputAttachmentCopyPipeline(
+      const DxvkMetaInputAttachmentImageCopy::Key& key);
+
     DxvkMetaBufferToImageCopy createBufferToImageCopyPipeline(
       const DxvkMetaBufferToImageCopy::Key& key);
 
@@ -315,6 +387,8 @@ namespace dxvk {
       const DxvkMetaPackedBufferImageCopy::Key& key);
 
     static std::string getName(const DxvkMetaImageCopy::Key& key, const char* type);
+
+    static std::string getName(const DxvkMetaInputAttachmentImageCopy::Key& key, const char* type);
 
     static std::string getName(const DxvkMetaBufferToImageCopy::Key& key, const char* type);
 

--- a/src/dxvk/dxvk_meta_resolve.cpp
+++ b/src/dxvk/dxvk_meta_resolve.cpp
@@ -393,7 +393,7 @@ namespace dxvk {
     state.fs = psSpirv;
 
     if (formatInfo->aspectMask & VK_IMAGE_ASPECT_COLOR_BIT)
-      state.colorFormat = key.format;
+      state.colorFormats[0] = key.format;
 
     if (formatInfo->aspectMask & (VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT)) {
       state.depthFormat = key.format;
@@ -405,6 +405,8 @@ namespace dxvk {
       // a time by adjusting the write mask. Add the corresponding dynamic state.
       state.dynamicStateCount = dynState.size();
       state.dynamicStates = dynState.data();
+    } else {
+      state.colorFormats[0] = key.format;
     }
 
     pipeline.pipeline = m_device->createBuiltInGraphicsPipeline(pipeline.layout, state);

--- a/src/dxvk/dxvk_shader_builtin.cpp
+++ b/src/dxvk/dxvk_shader_builtin.cpp
@@ -126,7 +126,7 @@ namespace dxvk {
     auto resource = builder.add(ir::Op::DclSrv(type, entry, 0u, binding, 1u, kind));
     builder.add(ir::Op::DebugName(resource, name));
 
-    return builder.add(ir::Op::DescriptorLoad(ir::ScalarType::eSrv, resource, ir::SsaDef()));
+    return builder.add(ir::Op::DescriptorLoad(ir::ScalarType::eSrv, resource, builder.makeConstant(0u)));
   }
 
 
@@ -143,7 +143,7 @@ namespace dxvk {
     auto resource = builder.add(ir::Op::DclSrv(type, entry, 0u, binding, 1u, ir::ResourceKind::eBufferTyped));
     builder.add(ir::Op::DebugName(resource, name));
 
-    return builder.add(ir::Op::DescriptorLoad(ir::ScalarType::eSrv, resource, ir::SsaDef()));
+    return builder.add(ir::Op::DescriptorLoad(ir::ScalarType::eSrv, resource, builder.makeConstant(0u)));
   }
 
 
@@ -160,7 +160,7 @@ namespace dxvk {
     auto resource = builder.add(ir::Op::DclSrv(type, entry, 0u, binding, 1u, ir::ResourceKind::eBufferStructured));
     builder.add(ir::Op::DebugName(resource, name));
 
-    return builder.add(ir::Op::DescriptorLoad(ir::ScalarType::eSrv, resource, ir::SsaDef()));
+    return builder.add(ir::Op::DescriptorLoad(ir::ScalarType::eSrv, resource, builder.makeConstant(0u)));
   }
 
 
@@ -180,7 +180,7 @@ namespace dxvk {
       0u, binding, 1u, kind, ir::UavFlag::eWriteOnly));
     builder.add(ir::Op::DebugName(resource, name));
 
-    return builder.add(ir::Op::DescriptorLoad(ir::ScalarType::eUav, resource, ir::SsaDef()));
+    return builder.add(ir::Op::DescriptorLoad(ir::ScalarType::eUav, resource, builder.makeConstant(0u)));
   }
 
 
@@ -198,7 +198,7 @@ namespace dxvk {
       0u, binding, 1u, ir::ResourceKind::eBufferTyped, ir::UavFlag::eWriteOnly));
     builder.add(ir::Op::DebugName(resource, name));
 
-    return builder.add(ir::Op::DescriptorLoad(ir::ScalarType::eUav, resource, ir::SsaDef()));
+    return builder.add(ir::Op::DescriptorLoad(ir::ScalarType::eUav, resource, builder.makeConstant(0u)));
   }
 
 
@@ -216,7 +216,7 @@ namespace dxvk {
       0u, binding, 1u, ir::ResourceKind::eBufferStructured, ir::UavFlag::eWriteOnly));
     builder.add(ir::Op::DebugName(resource, name));
 
-    return builder.add(ir::Op::DescriptorLoad(ir::ScalarType::eUav, resource, ir::SsaDef()));
+    return builder.add(ir::Op::DescriptorLoad(ir::ScalarType::eUav, resource, builder.makeConstant(0u)));
   }
 
 
@@ -245,6 +245,30 @@ namespace dxvk {
 
     // Emit descriptor load using the loaded index
     return builder.add(ir::Op::DescriptorLoad(ir::ScalarType::eSampler, samplerHeap, index));
+  }
+
+
+  ir::SsaDef DxvkBuiltInShader::declareInputTarget(
+          ir::Builder&          builder,
+          uint32_t              binding,
+    const char*                 name,
+          uint32_t              attachment,
+          VkFormat              format,
+          VkSampleCountFlagBits samples) {
+    auto entry = findEntryPoint(builder);
+    dxbc_spv_assert(entry);
+
+    auto type = determineSampledType(format, VK_IMAGE_ASPECT_COLOR_BIT);
+
+    auto kind = samples > VK_SAMPLE_COUNT_1_BIT
+      ? ir::ResourceKind::eImage2DMS
+      : ir::ResourceKind::eImage2D;
+
+    auto resource = builder.add(ir::Op::DclInputTarget(type,
+      entry, 0u, binding, 1u, kind, attachment));
+    builder.add(ir::Op::DebugName(resource, name));
+
+    return builder.add(ir::Op::DescriptorLoad(ir::ScalarType::eInputTarget, resource, builder.makeConstant(0u)));
   }
 
 

--- a/src/dxvk/dxvk_shader_builtin.h
+++ b/src/dxvk/dxvk_shader_builtin.h
@@ -254,6 +254,25 @@ namespace dxvk {
       const char*                 name);
 
     /**
+     * \brief Helper to declare an input target
+     *
+     * \param [in,out] builder Shader builder
+     * \param [in] binding Binding index
+     * \param [in] name Debug name
+     * \param [in] attachment Render target index
+     * \param [in] format Render target format
+     * \param [in] samples Sample count
+     * \returns SSA def of the descriptor load
+     */
+    ir::SsaDef declareInputTarget(
+            ir::Builder&          builder,
+            uint32_t              binding,
+      const char*                 name,
+            uint32_t              attachment,
+            VkFormat              format,
+            VkSampleCountFlagBits samples);
+
+    /**
      * \brief Declares and loads push data parameter
      *
      * For graphics shaders, push data is unconditionally made

--- a/src/dxvk/dxvk_swapchain_blitter.cpp
+++ b/src/dxvk/dxvk_swapchain_blitter.cpp
@@ -763,7 +763,7 @@ namespace dxvk {
         : util::DxvkBuiltInShaderStage(dxvk_present_frag_ms, &specInfo);
     }
 
-    state.colorFormat = key.dstFormat;
+    state.colorFormats[0] = key.dstFormat;
     return m_device->createBuiltInGraphicsPipeline(m_blitLayout, state);
   }
 
@@ -818,7 +818,7 @@ namespace dxvk {
     util::DxvkBuiltInGraphicsState state = { };
     state.vs = util::DxvkBuiltInShaderStage(dxvk_cursor_vert, nullptr);
     state.fs = util::DxvkBuiltInShaderStage(dxvk_cursor_frag, &specInfo);
-    state.colorFormat = key.dstFormat;
+    state.colorFormats[0] = key.dstFormat;
     state.iaState = &iaState;
     state.cbAttachment = &cbAttachment;
 

--- a/src/dxvk/dxvk_util.h
+++ b/src/dxvk/dxvk_util.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "dxvk_include.h"
+#include "dxvk_limits.h"
 
 namespace dxvk::util {
 
@@ -85,7 +86,7 @@ namespace dxvk::util {
     /** Fragment shader. */
     DxvkBuiltInShaderStage fs;
     /** Color attachment format. */
-    VkFormat colorFormat = VK_FORMAT_UNDEFINED;
+    std::array<VkFormat, MaxNumRenderTargets> colorFormats = { };
     /** Depth-stencil attachment format */
     VkFormat depthFormat = VK_FORMAT_UNDEFINED;
     /** Sample count */

--- a/src/dxvk/hud/dxvk_hud_item.cpp
+++ b/src/dxvk/hud/dxvk_hud_item.cpp
@@ -523,7 +523,7 @@ namespace dxvk::hud {
     state.vs = util::DxvkBuiltInShaderStage(hud_graph_vert, nullptr);
     state.fs = util::DxvkBuiltInShaderStage(hud_graph_frag, &specInfo);
     state.iaState = &iaState;
-    state.colorFormat = key.format;
+    state.colorFormats[0] = key.format;
     state.cbAttachment = &cbAttachment;
 
     return m_device->createBuiltInGraphicsPipeline(m_gfxPipelineLayout, state);
@@ -1148,7 +1148,7 @@ namespace dxvk::hud {
 
     util::DxvkBuiltInGraphicsState state = { };
     state.iaState = &iaState;
-    state.colorFormat = key.format;
+    state.colorFormats[0] = key.format;
     state.cbAttachment = &cbAttachment;
 
     state.vs = util::DxvkBuiltInShaderStage(hud_chunk_vert_background, nullptr);

--- a/src/dxvk/hud/dxvk_hud_renderer.cpp
+++ b/src/dxvk/hud/dxvk_hud_renderer.cpp
@@ -489,7 +489,7 @@ namespace dxvk::hud {
     util::DxvkBuiltInGraphicsState state;
     state.vs = util::DxvkBuiltInShaderStage(hud_text_vert, nullptr);
     state.fs = util::DxvkBuiltInShaderStage(hud_text_frag, &specInfo);
-    state.colorFormat = key.format;
+    state.colorFormats[0] = key.format;
     state.cbAttachment = &cbAttachment;
 
     return m_device->createBuiltInGraphicsPipeline(m_textPipelineLayout, state);


### PR DESCRIPTION
Optimizes copies from a currently bound render target to another image using input attachments and binding the destination as a storage image. Mostly interesting for tilers since we can avoid a bunch of memory round-trips. There's a bunch of edge cases where this won't work (e.g. if the dst image is used for reading in the same render pass), but many games hit this for at least one copy per frame.

Needs a whole bunch of regression testing. Performance isn't really expected to change much on desktop, if it does then that's likely a regression worth looking into.