### PR TITLE
Add option to force draw time upload to work around game bug

### DIFF
--- a/src/d3d9/d3d9_common_buffer.cpp
+++ b/src/d3d9/d3d9_common_buffer.cpp
@@ -18,6 +18,8 @@ namespace dxvk {
 
     if (m_desc.Pool != D3DPOOL_DEFAULT)
       m_dirtyRange = D3D9Range(0, m_desc.Size);
+
+    m_uploadAtDraw = m_parent->GetOptions()->forceDrawTimeBufferUpload;
   }
 
   D3D9CommonBuffer::~D3D9CommonBuffer() {
@@ -81,11 +83,6 @@ namespace dxvk {
   D3D9_COMMON_BUFFER_MAP_MODE D3D9CommonBuffer::DetermineMapMode(const D3D9Options* options) const {
     if (m_desc.Pool != D3DPOOL_DEFAULT)
       return D3D9_COMMON_BUFFER_MAP_MODE_BUFFER;
-
-    // CSGO keeps vertex buffers locked across multiple frames and writes to it. It uses them for drawing without unlocking first.
-    // Tests show that D3D9 DEFAULT + USAGE_DYNAMIC behaves like a directly mapped buffer even when unlocked.
-    // DEFAULT + WRITEONLY does not behave like a directly mapped buffer EXCEPT if its locked at the moment.
-    // TODO: Work around that by adding option that maps WRITEONLY directly or disables the staging buffer for buffer uploads.
 
     if (!(m_desc.Usage & D3DUSAGE_DYNAMIC))
       return D3D9_COMMON_BUFFER_MAP_MODE_BUFFER;

--- a/src/d3d9/d3d9_common_buffer.h
+++ b/src/d3d9/d3d9_common_buffer.h
@@ -176,7 +176,7 @@ namespace dxvk {
     /**
      * \brief Whether or not the staging buffer needs to be copied to the actual buffer
      */
-    inline bool NeedsUpload() const { return m_desc.Pool != D3DPOOL_DEFAULT && !m_dirtyRange.IsDegenerate(); }
+    inline bool NeedsUpload() const { return (m_desc.Pool != D3DPOOL_DEFAULT || m_uploadAtDraw) && m_mapMode != D3D9_COMMON_BUFFER_MAP_MODE_DIRECT && !m_dirtyRange.IsDegenerate(); }
 
     void PreLoad();
 
@@ -232,6 +232,7 @@ namespace dxvk {
     DWORD                       m_mapFlags = 0;
     bool                        m_needsReadback = false;
     D3D9_COMMON_BUFFER_MAP_MODE m_mapMode;
+    bool                        m_uploadAtDraw = false;
 
     Rc<DxvkBuffer>              m_buffer;
     Rc<DxvkBuffer>              m_stagingBuffer;

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -5702,7 +5702,7 @@ namespace dxvk {
 
     // Only D3DPOOL_DEFAULT buffers get uploaded in UnlockBuffer.
     // D3DPOOL_SYSTEMMEM and D3DPOOL_MANAGED get uploaded at draw time.
-    if (pResource->Desc()->Pool != D3DPOOL_DEFAULT)
+    if (pResource->Desc()->Pool != D3DPOOL_DEFAULT || m_d3d9Options.forceDrawTimeBufferUpload)
       return D3D_OK;
 
     FlushBuffer(pResource);

--- a/src/d3d9/d3d9_options.cpp
+++ b/src/d3d9/d3d9_options.cpp
@@ -65,6 +65,7 @@ namespace dxvk {
     this->cachedWriteOnlyBuffers        = config.getOption<bool>        ("d3d9.cachedWriteOnlyBuffers",          false);
     this->deviceLocalConstantBuffers    = config.getOption<bool>        ("d3d9.deviceLocalConstantBuffers",    false);
     this->allowDirectBufferMapping      = config.getOption<bool>        ("d3d9.allowDirectBufferMapping",      true);
+    this->forceDrawTimeBufferUpload     = config.getOption<bool>        ("d3d9.forceDrawTimeBufferUpload",     false);
     this->seamlessCubes                 = config.getOption<bool>        ("d3d9.seamlessCubes",                 false);
     this->textureMemory                 = config.getOption<int32_t>     ("d3d9.textureMemory",                 100) << 20;
     this->deviceLossOnFocusLoss         = config.getOption<bool>        ("d3d9.deviceLossOnFocusLoss",         false);

--- a/src/d3d9/d3d9_options.h
+++ b/src/d3d9/d3d9_options.h
@@ -122,6 +122,12 @@ namespace dxvk {
     /// Disable direct buffer mapping
     bool allowDirectBufferMapping;
 
+    /// Force flushing D3DPOOL_DEFAULT buffers at draw time rather than on unlock
+    /// Used to work around game bugs in source engine games like CSGO and Insurgency.
+    /// Those games write to buffers after unlocking them. Uploading on unlock leads to black
+    /// objects because they never get their proper UVs.
+    bool forceDrawTimeBufferUpload;
+
     /// Don't use non seamless cube maps
     bool seamlessCubes;
 

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -595,9 +595,11 @@ namespace dxvk {
     }} },
     /* Counter Strike: Global Offensive
        Needs NVAPI to avoid a forced AO + Smoke
-       exploit so we must force AMD vendor ID.    */
+       exploit so we must force AMD vendor ID.
+       Also writes to buffer after unlocking it. */
     { R"(\\csgo\.exe$)", {{
       { "d3d9.hideNvidiaGpu",               "True" },
+      { "d3d9.forceDrawTimeBufferUpload",   "True" },
     }} },
     /* Vampire - The Masquerade Bloodlines        */
     { R"(\\vampire\.exe$)", {{
@@ -1155,6 +1157,11 @@ namespace dxvk {
      * Fixes occasional vertex explosions         */
     { R"(\\W40k(_gog)?\.exe$)", {{
       { "dxvk.zeroMappedMemory",            "True" },
+    }} },
+    /* Insurgency
+       Writes to buffer after unlocking it. */
+    { R"(\\insurgency\.exe$)", {{
+      { "d3d9.forceDrawTimeBufferUpload",   "True" },
     }} },
 
     /**********************************************/


### PR DESCRIPTION
Fixes https://github.com/ValveSoftware/Proton/issues/9694

The game seems to write to the buffer **after** unlocking it. We could also make that work by forcing direct buffer mapping but I prefer this way.