### PR TITLE
[d3d9] Refactor calculating of binding slots.

### DIFF
--- a/src/d3d9/d3d9_constant_buffer.cpp
+++ b/src/d3d9/d3d9_constant_buffer.cpp
@@ -9,12 +9,12 @@ namespace dxvk {
 
 
   D3D9ConstantBuffer::D3D9ConstantBuffer(
-          D3D9DeviceEx*         pDevice,
-          D3D9ShaderType        ShaderStage,
-          DxsoConstantBuffers   BufferType,
-          VkDeviceSize          Size)
+          D3D9DeviceEx*                              pDevice,
+          D3D9ShaderType                             ShaderStage,
+          D3D9ShaderResourceMapping::ConstantBuffers BufferType,
+          VkDeviceSize                               Size)
   : D3D9ConstantBuffer(pDevice, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT | VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, GetShaderStage(ShaderStage),
-      computeResourceSlotId(ShaderStage, DxsoBindingType::ConstantBuffer, BufferType),
+      D3D9ShaderResourceMapping::computeCbvBinding(ShaderStage, BufferType),
       Size) {
 
   }

--- a/src/d3d9/d3d9_constant_buffer.h
+++ b/src/d3d9/d3d9_constant_buffer.h
@@ -7,6 +7,7 @@
 #include "../util/util_math.h"
 
 #include "d3d9_include.h"
+#include "d3d9_shader.h"
 
 namespace dxvk {
 
@@ -24,7 +25,7 @@ namespace dxvk {
     D3D9ConstantBuffer(
             D3D9DeviceEx*         pDevice,
             D3D9ShaderType        ShaderStage,
-            DxsoConstantBuffers   BufferType,
+            D3D9ShaderResourceMapping::ConstantBuffers BufferType,
             VkDeviceSize          Size);
 
     D3D9ConstantBuffer(

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -3396,10 +3396,10 @@ namespace dxvk {
       uint32_t byteOffset = cBufferOffset;
 
       ctx->bindShader<VK_SHADER_STAGE_GEOMETRY_BIT>(std::move(shader));
-      ctx->bindResourceBufferView(VK_SHADER_STAGE_GEOMETRY_BIT, getSWVPBufferSlot(), std::move(bufferView));
+      ctx->bindResourceBufferView(VK_SHADER_STAGE_GEOMETRY_BIT, D3D9ShaderResourceMapping::getSWVPBufferSlot(), std::move(bufferView));
       ctx->pushData(VK_SHADER_STAGE_GEOMETRY_BIT, 0u, sizeof(byteOffset), &byteOffset);
       ctx->draw(1u, &draw);
-      ctx->bindResourceBufferView(VK_SHADER_STAGE_GEOMETRY_BIT, getSWVPBufferSlot(), nullptr);
+      ctx->bindResourceBufferView(VK_SHADER_STAGE_GEOMETRY_BIT, D3D9ShaderResourceMapping::getSWVPBufferSlot(), nullptr);
       ctx->bindShader<VK_SHADER_STAGE_GEOMETRY_BIT>(nullptr);
     });
 
@@ -6023,47 +6023,47 @@ namespace dxvk {
 
     m_consts[uint32_t(D3D9ShaderType::VertexShader)].buffer = D3D9ConstantBuffer(this,
       D3D9ShaderType::VertexShader,
-      DxsoConstantBuffers::VSConstantBuffer,
+      D3D9ShaderResourceMapping::ConstantBuffers::VSConstantBuffer,
       DefaultConstantBufferSize);
 
     m_consts[uint32_t(D3D9ShaderType::VertexShader)].swvp.intBuffer = D3D9ConstantBuffer(this,
       D3D9ShaderType::VertexShader,
-      DxsoConstantBuffers::VSIntConstantBuffer,
+      D3D9ShaderResourceMapping::ConstantBuffers::VSIntConstantBuffer,
       SmallConstantBufferSize);
 
     m_consts[uint32_t(D3D9ShaderType::VertexShader)].swvp.boolBuffer = D3D9ConstantBuffer(this,
       D3D9ShaderType::VertexShader,
-      DxsoConstantBuffers::VSBoolConstantBuffer,
+      D3D9ShaderResourceMapping::ConstantBuffers::VSBoolConstantBuffer,
       SmallConstantBufferSize);
 
     m_consts[uint32_t(D3D9ShaderType::PixelShader)].buffer = D3D9ConstantBuffer(this,
       D3D9ShaderType::PixelShader,
-      DxsoConstantBuffers::PSConstantBuffer,
+      D3D9ShaderResourceMapping::ConstantBuffers::PSConstantBuffer,
       DefaultConstantBufferSize);
 
     m_vsClipPlanes = D3D9ConstantBuffer(this,
       D3D9ShaderType::VertexShader,
-      DxsoConstantBuffers::VSClipPlanes,
+      D3D9ShaderResourceMapping::ConstantBuffers::VSClipPlanes,
       caps::MaxClipPlanes * sizeof(D3D9ClipPlane));
 
     m_vsFixedFunction = D3D9ConstantBuffer(this,
       D3D9ShaderType::VertexShader,
-      DxsoConstantBuffers::VSFixedFunction,
+      D3D9ShaderResourceMapping::ConstantBuffers::VSFixedFunction,
       sizeof(D3D9FixedFunctionVS));
 
     m_psFixedFunction = D3D9ConstantBuffer(this,
       D3D9ShaderType::PixelShader,
-      DxsoConstantBuffers::PSFixedFunction,
+      D3D9ShaderResourceMapping::ConstantBuffers::PSFixedFunction,
       sizeof(D3D9FixedFunctionPS));
 
     m_psShared = D3D9ConstantBuffer(this,
       D3D9ShaderType::PixelShader,
-      DxsoConstantBuffers::PSShared,
+      D3D9ShaderResourceMapping::ConstantBuffers::VSVertexBlendData,
       sizeof(D3D9SharedPS));
 
     m_vsVertexBlend = D3D9ConstantBuffer(this,
       D3D9ShaderType::VertexShader,
-      DxsoConstantBuffers::VSVertexBlendData,
+      D3D9ShaderResourceMapping::ConstantBuffers::VSVertexBlendData,
       CanSWVP()
         ? sizeof(D3D9FixedFunctionVertexBlendDataSW)
         : sizeof(D3D9FixedFunctionVertexBlendDataHW));
@@ -6073,7 +6073,7 @@ namespace dxvk {
       m_specBuffer = D3D9ConstantBuffer(this,
         VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT,
         VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT,
-        getSpecConstantBufferSlot(),
+        D3D9ShaderResourceMapping::getSpecConstantBufferSlot(),
         D3D9SpecializationInfo::UBOSize);
     }
   }
@@ -7435,9 +7435,8 @@ namespace dxvk {
   void D3D9DeviceEx::BindSampler(DWORD Sampler) {
     auto samplerInfo = RemapStateSamplerShader(Sampler);
 
-    const uint32_t slot = computeResourceSlotId(
-      samplerInfo.first, DxsoBindingType::Image,
-      samplerInfo.second);
+    const uint32_t slot = D3D9ShaderResourceMapping::computeTextureBinding(
+      samplerInfo.first, uint32_t(samplerInfo.second));
 
     m_samplerBindCount++;
 
@@ -7523,8 +7522,8 @@ namespace dxvk {
   void D3D9DeviceEx::BindTexture(DWORD StateSampler) {
     auto shaderSampler = RemapStateSamplerShader(StateSampler);
 
-    uint32_t slot = computeResourceSlotId(shaderSampler.first,
-      DxsoBindingType::Image, uint32_t(shaderSampler.second));
+    uint32_t slot = D3D9ShaderResourceMapping::computeTextureBinding(shaderSampler.first,
+      uint32_t(shaderSampler.second));
 
     const bool srgb =
       m_state.samplerStates[StateSampler][D3DSAMP_SRGBTEXTURE] & 0x1;
@@ -7551,8 +7550,8 @@ namespace dxvk {
       for (uint32_t i : bit::BitMask(cMask)) {
         auto shaderSampler = RemapStateSamplerShader(i);
 
-        uint32_t slot = computeResourceSlotId(shaderSampler.first,
-          DxsoBindingType::Image, uint32_t(shaderSampler.second));
+        uint32_t slot = D3D9ShaderResourceMapping::computeTextureBinding(shaderSampler.first,
+          uint32_t(shaderSampler.second));
 
         VkShaderStageFlags stage = VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT;
         ctx->bindResourceImageView(stage, slot, nullptr);
@@ -9032,12 +9031,10 @@ namespace dxvk {
     EmitCs([
       cSize = m_state.textures->size()
     ](DxvkContext* ctx) {
-      VkShaderStageFlags stage = VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT;
-
       for (uint32_t i = 0; i < cSize; i++) {
         auto samplerInfo = RemapStateSamplerShader(DWORD(i));
-        uint32_t slot = computeResourceSlotId(samplerInfo.first, DxsoBindingType::Image, uint32_t(samplerInfo.second));
-        ctx->bindResourceImageView(stage, slot, nullptr);
+        uint32_t slot = D3D9ShaderResourceMapping::computeTextureBinding(samplerInfo.first, uint32_t(samplerInfo.second));
+        ctx->bindResourceImageView(GetShaderStage(samplerInfo.first), slot, nullptr);
       }
     });
 

--- a/src/d3d9/d3d9_fixed_function.cpp
+++ b/src/d3d9/d3d9_fixed_function.cpp
@@ -480,12 +480,12 @@ namespace dxvk {
 
     spvModule.setDebugName         (specBlock, "spec_state");
     spvModule.decorateDescriptorSet(specBlock, 0);
-    spvModule.decorateBinding      (specBlock, getSpecConstantBufferSlot());
+    spvModule.decorateBinding (specBlock, D3D9ShaderResourceMapping::getSpecConstantBufferSlot());
 
     auto& binding = bindings.emplace_back();
     binding.set             = 0u;
-    binding.binding         = getSpecConstantBufferSlot();
-    binding.resourceIndex   = getSpecConstantBufferSlot();
+    binding.binding         = D3D9ShaderResourceMapping::getSpecConstantBufferSlot();
+    binding.resourceIndex   = D3D9ShaderResourceMapping::getSpecConstantBufferSlot();
     binding.descriptorType  = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
     binding.access          = VK_ACCESS_UNIFORM_READ_BIT;
     binding.flags.set(DxvkDescriptorFlag::UniformBuffer);
@@ -1700,9 +1700,8 @@ namespace dxvk {
 
     m_module.setDebugName(m_vs.constantBuffer, "consts");
 
-    const uint32_t bindingId = computeResourceSlotId(
-      D3D9ShaderType::VertexShader, DxsoBindingType::ConstantBuffer,
-      DxsoConstantBuffers::VSFixedFunction);
+    const uint32_t bindingId = D3D9ShaderResourceMapping::computeCbvBinding(D3D9ShaderType::VertexShader,
+      D3D9ShaderResourceMapping::ConstantBuffers::VSFixedFunction);
 
     m_module.decorateDescriptorSet(m_vs.constantBuffer, 0);
     m_module.decorateBinding(m_vs.constantBuffer, bindingId);
@@ -1739,9 +1738,8 @@ namespace dxvk {
 
     m_module.setDebugName(m_vs.vertexBlendData, "VertexBlendData");
 
-    const uint32_t bindingId = computeResourceSlotId(
-      D3D9ShaderType::VertexShader, DxsoBindingType::ConstantBuffer,
-      DxsoConstantBuffers::VSVertexBlendData);
+    const uint32_t bindingId = D3D9ShaderResourceMapping::computeCbvBinding(D3D9ShaderType::VertexShader,
+      D3D9ShaderResourceMapping::ConstantBuffers::VSVertexBlendData);
 
     m_module.decorateDescriptorSet(m_vs.vertexBlendData, 0);
     m_module.decorateBinding(m_vs.vertexBlendData, bindingId);
@@ -2445,9 +2443,8 @@ namespace dxvk {
 
     m_module.setDebugName(m_ps.constantBuffer, "consts");
 
-    const uint32_t bindingId = computeResourceSlotId(
-      D3D9ShaderType::PixelShader, DxsoBindingType::ConstantBuffer,
-      DxsoConstantBuffers::PSFixedFunction);
+    const uint32_t bindingId = D3D9ShaderResourceMapping::computeCbvBinding(D3D9ShaderType::PixelShader,
+      D3D9ShaderResourceMapping::ConstantBuffers::PSFixedFunction);
 
     m_module.decorateDescriptorSet(m_ps.constantBuffer, 0);
     m_module.decorateBinding(m_ps.constantBuffer, bindingId);
@@ -2473,8 +2470,7 @@ namespace dxvk {
 
     // Samplers
     for (uint32_t i = 0; i < caps::TextureStageCount; i++) {
-      const uint32_t imageBindingId = computeResourceSlotId(D3D9ShaderType::PixelShader,
-        DxsoBindingType::Image, i);
+      const uint32_t imageBindingId = D3D9ShaderResourceMapping::computeTextureBinding(D3D9ShaderType::PixelShader, i);
 
       auto& imageBinding = m_bindings.emplace_back();
       imageBinding.set             = 0u;
@@ -2545,9 +2541,8 @@ namespace dxvk {
   void D3D9FFShaderCompiler::emitPsSharedConstants() {
     m_ps.sharedState = GetSharedConstants(m_module);
 
-    const uint32_t bindingId = computeResourceSlotId(
-      m_shaderType, DxsoBindingType::ConstantBuffer,
-      PSShared);
+    const uint32_t bindingId = D3D9ShaderResourceMapping::computeCbvBinding(m_shaderType,
+      D3D9ShaderResourceMapping::ConstantBuffers::PSShared);
 
     m_module.decorateDescriptorSet(m_ps.sharedState, 0);
     m_module.decorateBinding(m_ps.sharedState, bindingId);
@@ -2585,10 +2580,8 @@ namespace dxvk {
     m_module.decorate             (clipPlaneStruct, spv::DecorationBlock);
     m_module.memberDecorateOffset (clipPlaneStruct, 0, 0);
 
-    uint32_t bindingId = computeResourceSlotId(
-      D3D9ShaderType::VertexShader,
-      DxsoBindingType::ConstantBuffer,
-      DxsoConstantBuffers::VSClipPlanes);
+    const uint32_t bindingId = D3D9ShaderResourceMapping::computeCbvBinding(D3D9ShaderType::VertexShader,
+      D3D9ShaderResourceMapping::ConstantBuffers::VSClipPlanes);
 
     m_module.setDebugName         (clipPlaneBlock, "clip_info");
     m_module.decorateDescriptorSet(clipPlaneBlock, 0);
@@ -2743,7 +2736,7 @@ namespace dxvk {
     if (isVS) {
       std::array<DxvkBindingInfo, 4> bindings;
 
-      constexpr uint32_t specConstantBufferBindingId = getSpecConstantBufferSlot();
+      constexpr uint32_t specConstantBufferBindingId = D3D9ShaderResourceMapping::getSpecConstantBufferSlot();
       auto& specConstantBufferBinding = bindings[0];
       specConstantBufferBinding.set = 0u;
       specConstantBufferBinding.binding        = specConstantBufferBindingId;
@@ -2752,9 +2745,8 @@ namespace dxvk {
       specConstantBufferBinding.access = VK_ACCESS_UNIFORM_READ_BIT;
       specConstantBufferBinding.flags.set(DxvkDescriptorFlag::UniformBuffer);
 
-      constexpr uint32_t fixedFunctionDataBindingId = computeResourceSlotId(
-        D3D9ShaderType::VertexShader, DxsoBindingType::ConstantBuffer,
-        DxsoConstantBuffers::VSFixedFunction);
+      constexpr uint32_t fixedFunctionDataBindingId = D3D9ShaderResourceMapping::computeCbvBinding(
+        D3D9ShaderType::VertexShader, D3D9ShaderResourceMapping::ConstantBuffers::VSFixedFunction);
       auto& fixedFunctionDataBinding = bindings[1];
       fixedFunctionDataBinding.set             = 0u;
       fixedFunctionDataBinding.binding         = fixedFunctionDataBindingId;
@@ -2763,9 +2755,8 @@ namespace dxvk {
       fixedFunctionDataBinding.access          = VK_ACCESS_UNIFORM_READ_BIT;
       fixedFunctionDataBinding.flags.set(DxvkDescriptorFlag::UniformBuffer);
 
-      constexpr uint32_t vertexBlendBindingId = computeResourceSlotId(
-        D3D9ShaderType::VertexShader, DxsoBindingType::ConstantBuffer,
-        DxsoConstantBuffers::VSVertexBlendData);
+      constexpr uint32_t vertexBlendBindingId = D3D9ShaderResourceMapping::computeCbvBinding(
+        D3D9ShaderType::VertexShader, D3D9ShaderResourceMapping::ConstantBuffers::VSVertexBlendData);
       auto& vertexBlendBinding = bindings[2];
       vertexBlendBinding.set             = 0u;
       vertexBlendBinding.binding         = vertexBlendBindingId;
@@ -2774,9 +2765,8 @@ namespace dxvk {
       vertexBlendBinding.access          = VK_ACCESS_SHADER_READ_BIT;
       vertexBlendBinding.flags.set(DxvkDescriptorFlag::UniformBuffer);
 
-      constexpr uint32_t clipPlanesBindingId = computeResourceSlotId(
-        D3D9ShaderType::VertexShader, DxsoBindingType::ConstantBuffer,
-        DxsoConstantBuffers::VSClipPlanes);
+      constexpr uint32_t clipPlanesBindingId = D3D9ShaderResourceMapping::computeCbvBinding(
+        D3D9ShaderType::VertexShader, D3D9ShaderResourceMapping::ConstantBuffers::VSClipPlanes);
       auto& clipPlanesBinding = bindings[3];
       clipPlanesBinding.set             = 0u;
       clipPlanesBinding.binding         = clipPlanesBindingId;
@@ -2798,7 +2788,7 @@ namespace dxvk {
     } else {
       std::vector<DxvkBindingInfo> bindings;
 
-      constexpr uint32_t specConstantBufferBindingId = getSpecConstantBufferSlot();
+      constexpr uint32_t specConstantBufferBindingId = D3D9ShaderResourceMapping::getSpecConstantBufferSlot();
       auto& specConstantBufferBinding = bindings.emplace_back();
       specConstantBufferBinding.set = 0u;
       specConstantBufferBinding.binding        = specConstantBufferBindingId;
@@ -2807,9 +2797,8 @@ namespace dxvk {
       specConstantBufferBinding.access = VK_ACCESS_UNIFORM_READ_BIT;
       specConstantBufferBinding.flags.set(DxvkDescriptorFlag::UniformBuffer);
 
-      constexpr uint32_t fixedFunctionDataBindingId = computeResourceSlotId(
-        D3D9ShaderType::PixelShader, DxsoBindingType::ConstantBuffer,
-        DxsoConstantBuffers::PSFixedFunction);
+      constexpr uint32_t fixedFunctionDataBindingId = D3D9ShaderResourceMapping::computeCbvBinding(
+        D3D9ShaderType::PixelShader, D3D9ShaderResourceMapping::ConstantBuffers::PSFixedFunction);
       auto& fixedFunctionDataBinding = bindings.emplace_back();
       fixedFunctionDataBinding.set             = 0u;
       fixedFunctionDataBinding.binding         = fixedFunctionDataBindingId;
@@ -2818,9 +2807,8 @@ namespace dxvk {
       fixedFunctionDataBinding.access          = VK_ACCESS_UNIFORM_READ_BIT;
       fixedFunctionDataBinding.flags.set(DxvkDescriptorFlag::UniformBuffer);
 
-      constexpr uint32_t sharedDataBindingId = computeResourceSlotId(
-        D3D9ShaderType::PixelShader, DxsoBindingType::ConstantBuffer,
-        DxsoConstantBuffers::PSShared);
+      constexpr uint32_t sharedDataBindingId = D3D9ShaderResourceMapping::computeCbvBinding(
+        D3D9ShaderType::PixelShader, D3D9ShaderResourceMapping::ConstantBuffers::PSShared);
       auto& sharedDataBinding = bindings.emplace_back();
       sharedDataBinding.set             = 0u;
       sharedDataBinding.binding         = sharedDataBindingId;
@@ -2829,10 +2817,7 @@ namespace dxvk {
       sharedDataBinding.access          = VK_ACCESS_SHADER_READ_BIT;
       sharedDataBinding.flags.set(DxvkDescriptorFlag::UniformBuffer);
 
-      constexpr uint32_t textureBindingId = computeResourceSlotId(
-        D3D9ShaderType::PixelShader,
-        DxsoBindingType::Image,
-        0);
+      constexpr uint32_t textureBindingId = D3D9ShaderResourceMapping::computeTextureBinding(D3D9ShaderType::PixelShader, 0u);
       auto& textureBinding = bindings.emplace_back();
       textureBinding.set             = 0u;
       textureBinding.binding         = textureBindingId;
@@ -2842,10 +2827,7 @@ namespace dxvk {
       textureBinding.descriptorCount = caps::TextureStageCount;
 
       for (uint32_t i = 0; i < caps::TextureStageCount; i++) {
-        uint32_t samplerBindingId = computeResourceSlotId(
-          D3D9ShaderType::PixelShader,
-          DxsoBindingType::Image,
-          i);
+        uint32_t samplerBindingId = D3D9ShaderResourceMapping::computeTextureBinding(D3D9ShaderType::PixelShader, i);
 
         auto& samplerBinding = bindings.emplace_back();
         samplerBinding.resourceIndex   = samplerBindingId;

--- a/src/d3d9/d3d9_shader.h
+++ b/src/d3d9/d3d9_shader.h
@@ -51,6 +51,56 @@ namespace dxvk {
 
 #endif
 
+  /**
+   * \brief Shader resource mapping
+   *
+   * Helper class to compute backend resource
+   * indices for D3D9 binding slots.
+   */
+  struct D3D9ShaderResourceMapping {
+    enum ConstantBuffers : uint32_t {
+      VSConstantBuffer = 0,
+      VSFloatConstantBuffer = 0,
+      VSIntConstantBuffer = 1,
+      VSBoolConstantBuffer = 2,
+      VSClipPlanes     = 3,
+      VSFixedFunction  = 4,
+      VSVertexBlendData = 5,
+      VSCount,
+
+      PSConstantBuffer = 0,
+      PSFixedFunction  = 1,
+      PSShared         = 2,
+      PSCount
+    };
+
+    static constexpr uint32_t computeCbvBinding(D3D9ShaderType shaderType, uint32_t index) {
+      const uint32_t stageOffset = (ConstantBuffers::VSCount + caps::MaxTexturesVS) * computeStageIndex(shaderType);
+      return index + stageOffset;
+    }
+
+    static constexpr uint32_t computeTextureBinding(D3D9ShaderType shaderType, uint32_t index) {
+      const uint32_t stageIndex = computeStageIndex(shaderType);
+      const uint32_t stageOffset = (ConstantBuffers::VSCount + caps::MaxTexturesVS) * stageIndex;
+      return index + stageOffset
+        + (stageIndex == 1u
+          ? ConstantBuffers::PSCount
+          : ConstantBuffers::VSCount);
+    }
+
+    static constexpr uint32_t computeStageIndex(D3D9ShaderType shaderType) {
+      return uint32_t(shaderType);
+    }
+
+    static constexpr uint32_t getSWVPBufferSlot() {
+      return ConstantBuffers::VSCount + caps::MaxTexturesVS + ConstantBuffers::PSCount + caps::MaxTexturesPS + 1; // From last pixel shader slot, above.
+    }
+
+    static constexpr uint32_t getSpecConstantBufferSlot() {
+      return getSWVPBufferSlot() + 1;
+    }
+
+  };
 
   /**
    * \brief Common shader object

--- a/src/d3d9/d3d9_swvp_emu.cpp
+++ b/src/d3d9/d3d9_swvp_emu.cpp
@@ -132,7 +132,7 @@ namespace dxvk {
       m_module.setDebugName(pushConst, "pc");
 
       // Setup the buffer
-      uint32_t bufferSlot = getSWVPBufferSlot();
+      uint32_t bufferSlot = D3D9ShaderResourceMapping::getSWVPBufferSlot();
 
       uint32_t arrayType    = m_module.defRuntimeArrayTypeUnique(uint_t);
       m_module.decorateArrayStride(arrayType, sizeof(uint32_t));

--- a/src/d3d9/shaders/d3d9_fixed_function_common.glsl
+++ b/src/d3d9/shaders/d3d9_fixed_function_common.glsl
@@ -37,7 +37,7 @@ spirv_instruction(set = "GLSL.std.450", id = 81) vec4 spvNClamp(vec4, vec4, vec4
 
 
 // Dynamic "spec constants"
-// Binding has to match with getSpecConstantBufferSlot in dxso_util.h
+// Binding has to match with getSpecConstantBufferSlot in d3d9_shader.h
 layout(set = 0, binding = 31, scalar) uniform SpecConsts {
     uint dynamicSpecConstDword[20];
 };

--- a/src/d3d9/shaders/d3d9_fixed_function_frag.glsl
+++ b/src/d3d9/shaders/d3d9_fixed_function_frag.glsl
@@ -112,22 +112,16 @@ const uint VK_COMPARE_OP_ALWAYS           = 7;
 const uint PerTextureStageSpecConsts = SpecFFTextureStage1ColorOp - SpecFFTextureStage0ColorOp;
 
 
-// Bindings have to match with computeResourceSlotId in dxso_util.h
-// computeResourceSlotId(
-//     D3D9ShaderType::PixelShader,
-//     DxsoBindingType::ConstantBuffer,
-//     DxsoConstantBuffers::PSFixedFunction
-// ) = 11
+// Bindings have to match with D3D9ShaderResourceMapping in d3d9_shader.h
+// D3D9ShaderResourceMapping::computeCbvBinding(D3D9ShaderType::PixelShader,
+//         D3D9ShaderResourceMapping::ConstantBuffers::PSFixedFunction) = 11
 layout(set = 0, binding = 11, scalar, row_major) uniform ShaderData {
     D3D9FixedFunctionPS data;
 };
 
-// Bindings have to match with computeResourceSlotId in dxso_util.h
-// computeResourceSlotId(
-//     D3D9ShaderType::PixelShader,
-//     DxsoBindingType::ConstantBuffer,
-//     DxsoConstantBuffers::PSShared
-// ) = 12
+// Bindings have to match with D3D9ShaderResourceMapping in d3d9_shader.h
+// D3D9ShaderResourceMapping::computeCbvBinding(D3D9ShaderType::PixelShader,
+//         D3D9ShaderResourceMapping::ConstantBuffers::PSShared) = 12
 layout(set = 0, binding = 12, scalar, row_major) uniform SharedData {
     D3D9SharedPS sharedData;
 };

--- a/src/d3d9/shaders/d3d9_fixed_function_vert.vert
+++ b/src/d3d9/shaders/d3d9_fixed_function_vert.vert
@@ -129,12 +129,9 @@ const uint TCIOffset = 16;
 const uint TCIMask = (7 << TCIOffset);
 
 
-// Bindings have to match with computeResourceSlotId in dxso_util.h
-// computeResourceSlotId(
-//     D3D9ShaderType::VertexShader,
-//     DxsoBindingType::ConstantBuffer,
-//     DxsoConstantBuffers::VSFixedFunction
-// ) = 4
+// Bindings have to match with D3D9ShaderResourceMapping in d3d9_shader.h
+// D3D9ShaderResourceMapping::computeCbvBinding(D3D9ShaderType::Vertex,
+//         D3D9ShaderResourceMapping::ConstantBuffers::VSFixedFunction) = 4
 layout(set = 0, binding = 4, scalar, row_major) uniform ShaderData {
     D3D9FixedFunctionVS data;
 };
@@ -143,23 +140,17 @@ layout(push_constant, scalar, row_major) uniform RenderStates {
     D3D9RenderStateInfo rs;
 };
 
-// Bindings have to match with computeResourceSlotId in dxso_util.h
-// computeResourceSlotId(
-//     D3D9ShaderType::VertexShader,
-//     DxsoBindingType::ConstantBuffer,
-//     DxsoConstantBuffers::VSVertexBlendData
-// ) = 5
+// Bindings have to match with D3D9ShaderResourceMapping in d3d9_shader.h
+// D3D9ShaderResourceMapping::computeCbvBinding(D3D9ShaderType::Vertex,
+//         D3D9ShaderResourceMapping::ConstantBuffers::VSVertexBlendData) = 5
 layout(set = 0, binding = 5, std140, row_major) readonly buffer VertexBlendData {
     mat4 WorldViewArray[];
 };
 
 
-// Bindings have to match with computeResourceSlotId in dxso_util.h
-// computeResourceSlotId(
-//     D3D9ShaderType::VertexShader,
-//     DxsoBindingType::ConstantBuffer,
-//     DxsoConstantBuffers::VSClipPlanes
-// ) = 3
+// Bindings have to match with D3D9ShaderResourceMapping in d3d9_shader.h
+// D3D9ShaderResourceMapping::computeCbvBinding(D3D9ShaderType::Vertex,
+//         D3D9ShaderResourceMapping::ConstantBuffers::VSClipPlanes) = 3
 layout(set = 0, binding = 3, std140) uniform ClipPlanes {
     vec4 clipPlanes[MaxClipPlaneCount];
 };


### PR DESCRIPTION
Next preparation PR for the new shader compiler: refactor how we calculate resource bindings to look similar to how it's done in the D3D11 frontend. That'll allow us to get rid of `dxso_util.h` in the future.