### PR TITLE
[d3d9] Changed `VK_FORMAT_R8_SRGB` to `VK_FORMAT_UNDEFINED` for `D3DFMT_L8`

### DIFF
--- a/src/d3d9/d3d9_format.cpp
+++ b/src/d3d9/d3d9_format.cpp
@@ -101,7 +101,7 @@ namespace dxvk {
 
       case D3D9Format::L8: return {
         VK_FORMAT_R8_UNORM,
-        VK_FORMAT_R8_SRGB,
+        VK_FORMAT_UNDEFINED,
         VK_IMAGE_ASPECT_COLOR_BIT,
         { VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_R,
           VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_ONE }};


### PR DESCRIPTION
Changing `VK_FORMAT_R8_SRGB` to `VK_FORMAT_UNDEFINED` will allow to fix `IMAGE_FORMAT_I8` (`D3DFMT_L8`) for Garry's mod. `D3DFMT_L8` was as black.

Result of pull request — format works fine as greyscale.
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/75c59fbe-5d1c-4d74-ac36-7b3a263ed05e" />

https://github.com/ValveSoftware/Proton/issues/2848#issuecomment-4319967489
Btw `D3DFMT_A8L8` works fine by default on DXVK.

Thats look of `D3DFMT_L8` with `VK_FORMAT_R8_SRGB`. Black render target.
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/afdbd9f2-a209-4530-8ffa-fbc14706a70e" />

