### PR TITLE
[util] Allow wildcard option prefixes in user configs

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -1474,6 +1474,14 @@ namespace dxvk {
 
       ctx.active = key.str() == env::getExeName();
     } else {
+      // Allow '*.OptionName=value' type options
+      // n + 4 here is a minimum valid option size, e.g. '*.a=b'
+      // and '*' not in isValidKeyChar to prevent some *b*u*l*l*s*h*i*t=true
+      if (line.size() >= (n + 4) && line[n] == '*' && line[n+1] == '.') {
+        key << "*.";
+        n += 2;
+      }
+
       while (n < line.size() && isValidKeyChar(line[n]))
         key << line[n++];
 
@@ -1498,7 +1506,13 @@ namespace dxvk {
       }
 
       if (ctx.active)
-        config.setOption(key.str(), value.str());
+        if (key.str().substr(0, 2) == "*.") {
+          // Use actual valid key prefixes in place of '*'
+          // exept "dxvk" because it's core options
+          for (auto pre : {"dxgi", "d3d11", "d3d9", "d3d8"})
+            config.setOption(pre + key.str().substr(1), value.str());
+        } else
+          config.setOption(key.str(), value.str());
     }
   }
 


### PR DESCRIPTION
This will accept `*.optionName=value` options in user config files and treat them as any of `dxgi.`, `d3d11.`, `d3d9.`, `d3d8.` prefixed options.

Usable for dxgi/d3d9 or d3d11/d3d9 option pairs e.g. `*.maxFrameRate` or `.hideAmdGpu`, etc. Also when game supports (or uses) several different apis (d3d11 and d3d9 are common combinations) and user must periodically switch between them due to game bugs. Or when user have no clue what api game uses, etc. etc.

Tested with DXVK_CONFIG=...
```
info:  Found config env: bad*.bad=false;*bad.badbad=1;*.good=true;bad*bad.baddd=2;bad.bad*bad=3
info:  Effective configuration:
info:    d3d9.good = true
info:    d3d11.good = true
info:    d3d8.good = true
info:    dxgi.good = true
```

Closes: #5604