### PR TITLE
[d3d9] Implement `R8G8B8` as `VK_FORMAT_B8G8R8_*`

### DIFF
--- a/src/d3d9/d3d9_format.cpp
+++ b/src/d3d9/d3d9_format.cpp
@@ -9,7 +9,10 @@ namespace dxvk {
     switch (Format) {
       case D3D9Format::Unknown: return {};
 
-      case D3D9Format::R8G8B8: return {}; // Unsupported
+      case D3D9Format::R8G8B8: return {
+        VK_FORMAT_B8G8R8_UNORM,
+        VK_FORMAT_B8G8R8_SRGB,
+        VK_IMAGE_ASPECT_COLOR_BIT };
 
       case D3D9Format::A8R8G8B8: return {
         VK_FORMAT_B8G8R8A8_UNORM,


### PR DESCRIPTION
`R8G8B8` from D3D9 is invalid texture format for all video cards. But it used in Source Engine games as `.vtf` textures and render targets, but mostly created as FallBack to `R8G8B8A8`. Btw it will be nice to get Vulkan analogue as `VK_FORMAT_B8G8R8_*`.

- RenderDoc shows my texture with 3-layer `VK_FORMAT_B8G8R8_*` as 4-layer `B8G8R8A8`.
- I make test of writting alpha channel to my render target in Garry's mod game.

I write alpha channel by `128` value:
- I can see new color, if I write this to `B8G8R8A8`.
- But I can't see any colors, except white, in alpha channel of `R8G8B8` (even if I write down the color black).

This means that the alpha channel does not exist. This indicates the validity of `VK_FORMAT_B8G8R8_*`. 

### `128` value writting to alpha:

<details>
  <summary>B8G8R8 result:</summary>

<img width="1920" height="1037" alt="image" src="https://github.com/user-attachments/assets/50833772-a7da-4cd7-b408-2a9de5a04c26" />

</details>

<details>
  <summary>B8G8R8A8 result:</summary>
  
<img width="1920" height="1040" alt="image" src="https://github.com/user-attachments/assets/089f7852-1950-422c-b164-60ab6064aea6" />

</details>

### `0` value writting to alpha:


<details>
  <summary>B8G8R8 result:</summary>

<img width="1920" height="1037" alt="image" src="https://github.com/user-attachments/assets/d8571598-6809-4c9a-b0d5-2a35ac48627c" />

</details>


<details>
  <summary>B8G8R8A8 result:</summary>

<img width="1920" height="1043" alt="image" src="https://github.com/user-attachments/assets/b647d57d-d40e-40d8-b52c-5252fca90409" />

</details>

GTX1650, Windows.







