### PR TITLE
Enable maint11 and enable descriptor heap on Nvidia

### DIFF
--- a/VP_DXVK_requirements.json
+++ b/VP_DXVK_requirements.json
@@ -119,6 +119,7 @@
                 "VK_KHR_maintenance8": 1,
                 "VK_KHR_maintenance9": 1,
                 "VK_KHR_maintenance10": 1,
+                "VK_KHR_maintenance11": 1,
                 "VK_KHR_present_id2": 1,
                 "VK_KHR_present_wait2": 1,
                 "VK_KHR_shader_subgroup_uniform_control_flow": 1,
@@ -149,6 +150,9 @@
                 },
                 "VkPhysicalDeviceMaintenance10FeaturesKHR": {
                     "maintenance10": true
+                },
+                "VkPhysicalDeviceMaintenance11FeaturesKHR": {
+                    "maintenance11": true
                 },
                 "VkPhysicalDevicePresentId2FeaturesKHR": {
                     "presentId2": true

--- a/src/dxvk/dxvk_device_info.cpp
+++ b/src/dxvk/dxvk_device_info.cpp
@@ -484,10 +484,14 @@ namespace dxvk {
     if (m_featuresSupported.extDescriptorHeap.descriptorHeap) {
       // Only enable descriptor heaps on drivers that are known to work
       // and don't have known performance regressions currently.
-      // TODO revisit w.r.t. Nvidia, Intel, Turnip.
+      // TODO revisit w.r.t. Intel, Turnip.
       bool enableDescriptorHeap = m_properties.vk12.driverID == VK_DRIVER_ID_MESA_RADV
                                || m_properties.vk12.driverID == VK_DRIVER_ID_MESA_LLVMPIPE
                                || m_properties.vk12.driverID == VK_DRIVER_ID_AMD_PROPRIETARY;
+
+      // Heap regresses performance on the initial NV driver releases
+      if (m_properties.vk12.driverID == VK_DRIVER_ID_NVIDIA_PROPRIETARY)
+        enableDescriptorHeap = m_featuresSupported.khrMaintenance11.maintenance11;
 
       applyTristate(enableDescriptorHeap, instance.options().enableDescriptorHeap);
 

--- a/src/dxvk/dxvk_device_info.cpp
+++ b/src/dxvk/dxvk_device_info.cpp
@@ -53,6 +53,7 @@ namespace dxvk {
     HANDLE_EXT(khrMaintenance8);                   \
     HANDLE_EXT(khrMaintenance9);                   \
     HANDLE_EXT(khrMaintenance10);                  \
+    HANDLE_EXT(khrMaintenance11);                  \
     HANDLE_EXT(khrPipelineLibrary);                \
     HANDLE_EXT(khrPresentId);                      \
     HANDLE_EXT(khrPresentId2);                     \
@@ -988,6 +989,7 @@ namespace dxvk {
       ENABLE_EXT_FEATURE(khrMaintenance8, maintenance8, false),
       ENABLE_EXT_FEATURE(khrMaintenance9, maintenance9, false),
       ENABLE_EXT_FEATURE(khrMaintenance10, maintenance10, false),
+      ENABLE_EXT_FEATURE(khrMaintenance11, maintenance11, false),
 
       /* Dependency for graphics pipeline library */
       ENABLE_EXT(khrPipelineLibrary, false),

--- a/src/dxvk/dxvk_device_info.h
+++ b/src/dxvk/dxvk_device_info.h
@@ -95,6 +95,7 @@ namespace dxvk {
     VkPhysicalDeviceMaintenance8FeaturesKHR                   khrMaintenance8                 = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_8_FEATURES_KHR };
     VkPhysicalDeviceMaintenance9FeaturesKHR                   khrMaintenance9                 = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_9_FEATURES_KHR };
     VkPhysicalDeviceMaintenance10FeaturesKHR                  khrMaintenance10                = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_10_FEATURES_KHR };
+    VkPhysicalDeviceMaintenance11FeaturesKHR                  khrMaintenance11                = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_11_FEATURES_KHR };
     VkBool32                                                  khrPipelineLibrary              = VK_FALSE;
     VkPhysicalDevicePresentIdFeaturesKHR                      khrPresentId                    = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRESENT_ID_FEATURES_KHR };
     VkPhysicalDevicePresentId2FeaturesKHR                     khrPresentId2                   = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRESENT_ID_2_FEATURES_KHR };
@@ -165,6 +166,7 @@ namespace dxvk {
     VkExtensionProperties khrMaintenance8                   = vk::makeExtension(VK_KHR_MAINTENANCE_8_EXTENSION_NAME);
     VkExtensionProperties khrMaintenance9                   = vk::makeExtension(VK_KHR_MAINTENANCE_9_EXTENSION_NAME);
     VkExtensionProperties khrMaintenance10                  = vk::makeExtension(VK_KHR_MAINTENANCE_10_EXTENSION_NAME);
+    VkExtensionProperties khrMaintenance11                  = vk::makeExtension(VK_KHR_MAINTENANCE_11_EXTENSION_NAME);
     VkExtensionProperties khrPipelineLibrary                = vk::makeExtension(VK_KHR_PIPELINE_LIBRARY_EXTENSION_NAME);
     VkExtensionProperties khrPresentId                      = vk::makeExtension(VK_KHR_PRESENT_ID_EXTENSION_NAME);
     VkExtensionProperties khrPresentId2                     = vk::makeExtension(VK_KHR_PRESENT_ID_2_EXTENSION_NAME);


### PR DESCRIPTION
the KHR_maintenance11 features themselves aren't super interesting for us, but the Nvidia dev driver that supports the extension also seems to fix performance regressions with descriptor heaps, so enable it by default if the ext is supported.

Needs a winevulkan update as well to actually do anything.