### PR TITLE
[dxvk] Fix DxvkShaderPipelineLibraryKey::eq

### DIFF
--- a/src/dxvk/dxvk_shader.cpp
+++ b/src/dxvk/dxvk_shader.cpp
@@ -157,6 +157,9 @@ namespace dxvk {
 
   bool DxvkShaderPipelineLibraryKey::eq(
     const DxvkShaderPipelineLibraryKey& other) const {
+    if (m_shaders.size() != other.m_shaders.size())
+      return false;
+
     bool eq = true;
 
     for (uint32_t i = 0; i < m_shaders.size() && eq; i++)


### PR DESCRIPTION
It always returned true when comparing with empty key, resulting in library from `createNullFsPipelineLibrary()->compilePipeline()` being returned for non-empty key on some platforms.

---

That resulted in very weird crashes in Turnip when dxvk was compiled as native library for Android:

```
libvulkan_freedreno.so (void tu_emit_program_state<(chip)7>(tu_cs*, tu_program_state*, tu_shader**)+1256) (BuildId: 1be5c0c86fd99c9128335cbc5d858b65c391fa6c)
libvulkan_freedreno.so (VkResult tu_pipeline_builder_build<(chip)7>(tu_pipeline_builder*, tu_pipeline**)+888) (BuildId: 1be5c0c86fd99c9128335cbc5d858b65c391fa6c)
libvulkan_freedreno.so (VkResult tu_graphics_pipeline_create<(chip)7>(VkDevice_T*, VkPipelineCache_T*, VkGraphicsPipelineCreateInfo const*, unsigned long, VkAllocationCallbacks const*, VkPipeline_T**)+172) (BuildId: 1be5c0c86fd99c9128335cbc5d858b65c391fa6c)
libvulkan_freedreno.so (VkResult tu_CreateGraphicsPipelines<(chip)7>(VkDevice_T*, VkPipelineCache_T*, unsigned int, VkGraphicsPipelineCreateInfo const*, VkAllocationCallbacks const*, VkPipeline_T**)+196) (BuildId: 1be5c0c86fd99c9128335cbc5d858b65c391fa6c)
libdxvk_d3d11.so (dxvk::DxvkGraphicsPipeline::createBasePipeline(dxvk::DxvkGraphicsPipelineBaseInstanceKey const&) const+384) (BuildId: a5f39f9992e958dc644c3ededbf69eca5f6106a8)
```