### PR TITLE
d3d9: Export 0,0,0,0 as default for color1 when using SM3 pixel shaders

### DIFF
--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -7734,6 +7734,8 @@ namespace dxvk {
 
       UpdatePixelShaderSamplerSpec(textureTypes, fetch4);
 
+      UpdatePixelShaderModelSpec(programInfo.majorVersion() >= 3);
+
       UpdatePixelBoolSpec(
         m_state.psConsts->bConsts[0] &
         m_consts[uint32_t(D3D9ShaderType::PixelShader)].meta.boolConstantMask);
@@ -7746,6 +7748,7 @@ namespace dxvk {
       }
 
       UpdatePixelBoolSpec(0);
+      UpdatePixelShaderModelSpec(false);
       UpdatePixelShaderSamplerSpec(m_textureSlotTracking.textureType, 0u);
 
       UpdateFixedFunctionPS();
@@ -9074,6 +9077,7 @@ namespace dxvk {
     UpdatePixelShaderSamplerSpec(0u, 0u);
     UpdateVertexBoolSpec(0u);
     UpdatePixelBoolSpec(0u);
+    UpdatePixelShaderModelSpec(false);
     UpdateCommonSamplerSpec(0u, 0u, 0u, 0u);
 
     UpdateAnyColorWrites<0>();
@@ -9334,6 +9338,12 @@ namespace dxvk {
 
   void D3D9DeviceEx::UpdatePixelBoolSpec(uint32_t value) {
     if (m_specInfo.set<SpecPixelShaderBools>(value))
+      m_dirty.set(D3D9DeviceDirtyFlag::SpecializationEntries);
+  }
+
+
+  void D3D9DeviceEx::UpdatePixelShaderModelSpec(bool isSM3) {
+    if (m_specInfo.set<SpecIsPSShaderModel3>(isSM3))
       m_dirty.set(D3D9DeviceDirtyFlag::SpecializationEntries);
   }
 

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -1481,6 +1481,7 @@ namespace dxvk {
     void UpdateAlphaTestSpec(VkCompareOp alphaOp, uint32_t precision);
     void UpdateVertexBoolSpec(uint32_t value);
     void UpdatePixelBoolSpec(uint32_t value);
+    void UpdatePixelShaderModelSpec(bool isSM3);
     void UpdatePixelShaderSamplerSpec(uint32_t types, uint32_t fetch4);
     void UpdateCommonSamplerSpec(uint32_t boundMask, uint32_t depthMask, uint32_t drefMask, uint32_t projections);
     void UpdatePointModeSpec(uint32_t mode);

--- a/src/d3d9/d3d9_spec_constants.h
+++ b/src/d3d9/d3d9_spec_constants.h
@@ -119,6 +119,7 @@ namespace dxvk {
     SpecFFTextureStage5AlphaArg0, // Range: 0 -> 6 + 2 flags  | Bits: 5
     SpecFFTextureStage6AlphaArg0, // Range: 0 -> 6 + 2 flags  | Bits: 5
     SpecFFTextureStage7AlphaArg0, // Range: 0 -> 6 + 2 flags  | Bits: 5
+    SpecIsPSShaderModel3,         // Bool                     | Bits: 1
 
     SpecConstantCount,
   };
@@ -249,6 +250,7 @@ namespace dxvk {
       { 16,  5, 5 },  // FFTextureStage5AlphaArg0
       { 16, 10, 5 },  // FFTextureStage6AlphaArg0
       { 16, 15, 5 },  // FFTextureStage7AlphaArg0
+      { 16, 20, 1 },  // SpecIsPSShaderModel3
     }};
 
     template <D3D9SpecConstantId Id, typename T>

--- a/src/dxso/dxso_compiler.cpp
+++ b/src/dxso/dxso_compiler.cpp
@@ -3474,14 +3474,23 @@ void DxsoCompiler::emitControlFlowGenericLoop(
       if (semantic == DxsoSemantic{ DxsoUsage::Color, 0}) {
         value = m_module.constvec4f32(1.0f, 1.0f, 1.0f, 1.0f);
       } else if (semantic.usage == DxsoUsage::Color) {
-        value = m_module.constvec4f32(0.0f, 0.0f, 0.0f, 1.0f);
+        if (semantic.usageIndex == 1) {
+          // If it's used with a SM3 PS, we need to export 0,0,0,0 as the default for color1.
+          uint32_t isSM3 = m_spec.get(m_module, m_specUbo, SpecIsPSShaderModel3);
+          isSM3 = m_module.opINotEqual(m_module.defBoolType(), isSM3, m_module.constu32(0));
+
+          value = m_module.opSelect(getVectorTypeId({ DxsoScalarType::Float32, 4 }),
+            isSM3,
+            m_module.constvec4f32(0.0f, 0.0f, 0.0f, 0.0f),
+            m_module.constvec4f32(0.0f, 0.0f, 0.0f, 1.0f));
+        } else {
+          value = m_module.constvec4f32(0.0f, 0.0f, 0.0f, 1.0f);
+        }
       } else if (semantic == DxsoSemantic{ DxsoUsage::Fog, 0}) {
         value = m_module.constf32(0.0);
       } else {
         value = m_module.constvec4f32(0.0f, 0.0f, 0.0f, 0.0f);
       }
-      // TODO: If it's used with a SM3 PS, we need to export 0,0,0,0 as the default for color1.
-      //       Implement that using a spec constant.
 
       uint32_t outputPtr = emitNewVariableDefault(info, value);
 
@@ -3500,6 +3509,9 @@ void DxsoCompiler::emitControlFlowGenericLoop(
       // If they do, the backend handles it. Color 0 is the exception because that needs a different value.
       if (!outputtedColor[0]) {
         OutputDefault(DxsoSemantic{ DxsoUsage::Color, 0 });
+      }
+      if (!outputtedColor[1]) {
+        OutputDefault(DxsoSemantic{ DxsoUsage::Color, 1 });
       }
     } else {
       // Emit the outputs that fixed function expects but the shader didn't emit itself.


### PR DESCRIPTION
Implements the requirement to use `0,0,0,0` as the default value for the secondary color target (`color1`) when a Shader Model 3 pixel shader is active. For older shader models and fixed-function, the default remains `0,0,0,1`.

Since the required default value depends on the pixel shader version rather than the vertex shader itself, I've implemented this using a new specialization constant `SpecIsPSShaderModel3`.

Changes:
- Added `SpecIsPSShaderModel3` specialization constant to `d3d9_spec_constants.h`.
- Updated `D3D9DeviceEx` to track the PS version and update the spec constant during state changes.
- Modified `DxsoCompiler` to use `opSelect` for the `color1` default value based on the specialization constant.
- Updated SM3 VS output setup to always export a default for `color1` if missing from the signature, matching existing behavior for `color0`.

This improves compatibility for games that rely on these specific default values when using SM3.

---
*PR created automatically by Jules for task [6883176983437566686](https://jules.google.com/task/6883176983437566686) started by @SoongVilda*