### PR TITLE
[d3d9] Use roundEven in FF ubershader

### DIFF
--- a/src/d3d9/shaders/d3d9_fixed_function_frag.glsl
+++ b/src/d3d9/shaders/d3d9_fixed_function_frag.glsl
@@ -506,7 +506,7 @@ void alphaTest() {
         // Adjust alpha to the given range and round
         float alphaFactor = float((256u << alphaPrecision) - 1u);
 
-        alpha = round(alpha * alphaFactor);
+        alpha = roundEven(alpha * alphaFactor);
     } else {
         alphaRef = float(alphaRefInitial) / 255.0;
     }


### PR DESCRIPTION
Otherwise I'd just forget about that.

As you suggested on the dxbc-spv PR.