### PR TITLE
[dxvk] Re-add workaround for failed device creation with NVX extensions

### DIFF
--- a/src/dxvk/dxvk_adapter.cpp
+++ b/src/dxvk/dxvk_adapter.cpp
@@ -197,9 +197,22 @@ namespace dxvk {
 
 
   Rc<DxvkDevice> DxvkAdapter::createDevice() {
+    Rc<DxvkDevice> device = createDevice(false);
+
+    if (!device)
+      device = createDevice(true);
+
+    if (!device)
+      throw DxvkError("Failed to initialize DXVK device.");
+
+    return device;
+  }
+
+
+  Rc<DxvkDevice> DxvkAdapter::createDevice(bool safeMode) {
     auto vk = m_instance->vki();
 
-    DxvkDeviceCapabilities caps(*m_instance, m_handle, nullptr);
+    DxvkDeviceCapabilities caps(*m_instance, m_handle, nullptr, safeMode);
 
     Logger::info("Creating device:");
     caps.logDeviceInfo();
@@ -276,8 +289,11 @@ namespace dxvk {
     VkDevice device = VK_NULL_HANDLE;
     VkResult vr = vk->vkCreateDevice(m_handle, &deviceInfo, nullptr, &device);
 
-    if (vr)
-      throw DxvkError(str::format("Failed to create Vulkan device: ", vr));
+    if (vr) {
+      Logger::err(str::format("Failed to create Vulkan device: ", vr,
+        safeMode ? "" : ", retrying 'safe mode'."));
+      return nullptr;
+    }
 
     Rc<vk::DeviceFn> vkd = new vk::DeviceFn(vk, true, device);
 

--- a/src/dxvk/dxvk_adapter.h
+++ b/src/dxvk/dxvk_adapter.h
@@ -330,6 +330,8 @@ namespace dxvk {
 
     std::array<DxvkAdapterMemoryStats, VK_MAX_MEMORY_HEAPS> m_memoryStats = { };
 
+    Rc<DxvkDevice> createDevice(bool safeMode);
+
   };
   
 }

--- a/src/dxvk/dxvk_device_info.cpp
+++ b/src/dxvk/dxvk_device_info.cpp
@@ -95,7 +95,8 @@ namespace dxvk {
   DxvkDeviceCapabilities::DxvkDeviceCapabilities(
     const DxvkInstance&               instance,
           VkPhysicalDevice            adapter,
-    const VkDeviceCreateInfo*         deviceInfo) {
+    const VkDeviceCreateInfo*         deviceInfo,
+          bool                        safeMode) {
     // Can't query anything on a Vulkan 1.0 device
     auto vk = instance.vki();
     vk->vkGetPhysicalDeviceProperties(adapter, &m_properties.core.properties);
@@ -109,7 +110,7 @@ namespace dxvk {
     initQueueProperties(instance, adapter, deviceInfo);
     initMemoryProperties(instance, adapter);
 
-    disableUnusedFeatures(instance);
+    disableUnusedFeatures(instance, safeMode);
 
     enableFeaturesAndExtensions();
     enableQueues();
@@ -480,7 +481,8 @@ namespace dxvk {
 
 
   void DxvkDeviceCapabilities::disableUnusedFeatures(
-    const DxvkInstance&               instance) {
+    const DxvkInstance&               instance,
+          bool                        safeMode) {
     if (m_featuresSupported.extDescriptorHeap.descriptorHeap) {
       // Only enable descriptor heaps on drivers that are known to work
       // and don't have known performance regressions currently.
@@ -529,14 +531,16 @@ namespace dxvk {
     if (!instance.options().enableUnifiedImageLayout)
       m_featuresSupported.khrUnifiedImageLayouts.unifiedImageLayouts = VK_FALSE;
 
-    if (env::is32BitHostPlatform()) {
-      // CUDA interop is unnecessary on 32-bit, no games use it
+    if (env::is32BitHostPlatform() || safeMode) {
+      // CUDA interop is unnecessary on 32-bit, no games use it. These extensions
+      // can also cause device creation errors for unknown reasons.
       m_featuresSupported.nvxBinaryImport = VK_FALSE;
       m_featuresSupported.nvxImageViewHandle = VK_FALSE;
-
-      // Reflex is broken on 32-bit
-      m_featuresSupported.nvLowLatency2 = VK_FALSE;
     }
+
+    // Reflex is broken on 32-bit
+    if (env::is32BitHostPlatform())
+      m_featuresSupported.nvLowLatency2 = VK_FALSE;
 
     // EXT_multi_draw is broken on proprietary qcom on some devices
     if (m_properties.vk12.driverID == VK_DRIVER_ID_QUALCOMM_PROPRIETARY)

--- a/src/dxvk/dxvk_device_info.h
+++ b/src/dxvk/dxvk_device_info.h
@@ -228,7 +228,8 @@ namespace dxvk {
     DxvkDeviceCapabilities(
       const DxvkInstance&               instance,
             VkPhysicalDevice            adapter,
-      const VkDeviceCreateInfo*         deviceInfo);
+      const VkDeviceCreateInfo*         deviceInfo,
+            bool                        safeMode = false);
 
     DxvkDeviceCapabilities(const DxvkDeviceCapabilities&) = delete;
 
@@ -412,7 +413,8 @@ namespace dxvk {
             VkPhysicalDevice            adapter);
 
     void disableUnusedFeatures(
-      const DxvkInstance&               instance);
+      const DxvkInstance&               instance,
+            bool                        safeMode);
 
     void enableFeaturesAndExtensions();
 


### PR DESCRIPTION
Apparently Planetside 2 needs this. Obviously this means no DLSS for affected users.