### PR TITLE
[d3d9] Add a config option for cube texture depth format support

### DIFF
--- a/dxvk.conf
+++ b/dxvk.conf
@@ -12,7 +12,7 @@
 # as determine it based on the DXGIOutput's current ColorSpace instead of
 # using CheckColorSpaceSupport.
 # This defaults to the value of the DXVK_HDR environment variable.
-# 
+#
 # Supported values: True, False
 
 # dxgi.enableHDR = True
@@ -45,7 +45,7 @@
 # the standard -Win64-Shipping.exe naming scheme. May be needed to avoid
 # crashes in D3D11 games on HDR-enabled systems due to statically linked
 # AMDAGS.
-# 
+#
 # Supported values: True, False
 
 # dxgi.enableUe4Workarounds = False
@@ -55,7 +55,7 @@
 # rather than when creating the swap chain. Some games that start
 # rendering with a different graphics API may require this option,
 # or otherwise the window may stay black.
-# 
+#
 # Supported values: True, False
 
 # dxgi.deferSurfaceCreation = False
@@ -65,7 +65,7 @@
 # Enforce a stricter maximum frame latency. Overrides the application
 # setting specified by calling IDXGIDevice::SetMaximumFrameLatency.
 # Setting this to 0 will have no effect.
-# 
+#
 # Supported values : 0 - 16
 
 # dxgi.maxFrameLatency = 0
@@ -109,7 +109,7 @@
 #         The implementation will either use VK_NV_low_latency2 if supported
 #         by the driver, or a custom algorithm.
 # - False: Disable Reflex support as well as built-in latency reduction.
-  
+
 # dxvk.latencySleep = Auto
 
 
@@ -252,7 +252,7 @@
 
 # Overrides the maximum allowed tessellation factor. This can be used to
 # improve performance in titles which overuse tessellation.
-# 
+#
 # Supported values: Any number between 8 and 64
 
 # d3d11.maxTessFactor = 0
@@ -288,7 +288,7 @@
 # bilinear filtering, or in other situations when an application
 # relies on fine grained control over samplers. Please do not report
 # bugs with this option enabled.
-# 
+#
 # Supported values: Any number between 0 and 16
 
 # d3d11.samplerAnisotropy = -1
@@ -422,7 +422,7 @@
 
 
 # Sets number of pipeline compiler threads.
-# 
+#
 # If the graphics pipeline library feature is enabled, the given
 # number of threads will be used for shader compilation. Some of
 # these threads will be reserved for high-priority work.
@@ -435,13 +435,13 @@
 
 
 # Toggles raw SSBO usage.
-# 
+#
 # Uses storage buffers to implement raw and structured buffer
 # views. Enabled by default on hardware which has a storage
 # buffer offset alignment requirement of 4 Bytes (e.g. AMD).
 # Enabling this may improve performance, but is not safe on
 # hardware with higher alignment requirements.
-# 
+#
 # Supported values:
 # - Auto: Don't change the default
 # - True, False: Always enable / disable
@@ -542,12 +542,12 @@
 
 
 # Sets enabled HUD elements
-# 
+#
 # Behaves like the DXVK_HUD environment variable if the
 # environment variable is not set, otherwise it will be
 # ignored. The syntax is identical.
 
-# dxvk.hud = 
+# dxvk.hud =
 
 
 # Reported shader model
@@ -555,7 +555,7 @@
 # The shader model to state that we support in the device
 # capabilities that the application queries. Note that
 # the value will be limited to 1 for D3D8 applications.
-# 
+#
 # Supported values:
 # - 0: Fixed-function only
 # - 1: Shader Model 1
@@ -566,7 +566,7 @@
 
 
 # DPI Awareness
-# 
+#
 # Decides whether we should call SetProcessDPIAware on device
 # creation. Helps avoid upscaling blur in modern Windows on
 # Hi-DPI screens/devices.
@@ -638,6 +638,21 @@
 
 # d3d9.deviceLocalConstantBuffers = False
 
+
+# Support cube texture depth formats
+#
+# Depth formats are unsupported for use with cube textures on any modern driver,
+# however older drivers both exposed support and allowed their use in D3D9.
+# While enabling support globally will cause issues in games like Gothic 3,
+# other games, such as SimCity Societies: Destinations, will crash on startup
+# if support is disabled.
+#
+# Supported values:
+# - True/False
+
+# d3d9.supportCubeDepthFormats = False
+
+
 # Support DF formats
 #
 # Support the vendor extension DF floating point depth formats on AMD and Intel.
@@ -649,6 +664,7 @@
 
 # d3d9.supportDFFormats = True
 
+
 # Use D32f for D24
 #
 # Useful for reproducing AMD issues on other hw.
@@ -657,6 +673,7 @@
 # - True/False
 
 # d3d9.useD32forD24 = False
+
 
 # Support X4R4G4B4
 #
@@ -668,6 +685,7 @@
 
 # d3d9.supportX4R4G4B4 = True
 
+
 # Disable A8 as a Render Target
 #
 # Disable support for A8 format render targets
@@ -677,6 +695,7 @@
 # - True/False
 
 # d3d9.disableA8RT = False
+
 
 # Force Sampler Type Spec Constants
 #
@@ -689,6 +708,7 @@
 
 # d3d9.forceSamplerTypeSpecConstants = False
 
+
 # Force Aspect Ratio
 #
 # Only exposes modes with a given aspect ratio.
@@ -698,6 +718,7 @@
 # - Any ratio, ie. "16:9", "4:3"
 
 # d3d9.forceAspectRatio = ""
+
 
 # Force Refresh Rate
 #
@@ -719,6 +740,7 @@
 # dxgi.forceRefreshRate = 0
 # d3d9.forceRefreshRate = 0
 
+
 # Mode Count Compatibility
 #
 # Attempts to aggressively limit the advertised mode count
@@ -736,6 +758,7 @@
 
 # d3d9.modeCountCompatibility = False
 
+
 # Enumerate by Displays
 #
 # Whether we should enumerate D3D9 adapters by display (windows behaviour)
@@ -746,6 +769,7 @@
 # - True/False
 
 # d3d9.enumerateByDisplays = True
+
 
 # Cached write-only Buffers
 #
@@ -759,6 +783,7 @@
 
 # d3d9.cachedWriteOnlyBuffers = False
 
+
 # Seamless Cubes
 #
 # Don't use non seamless cube maps even if they are supported.
@@ -768,6 +793,7 @@
 # - True/False
 
 # d3d9.seamlessCubes = False
+
 
 # Debug Utils
 #
@@ -779,6 +805,7 @@
 
 # dxvk.enableDebugUtils = False
 
+
 # Memory limit for locked D3D9 textures
 #
 # How much virtual memory will be used for textures (in MB).
@@ -787,6 +814,7 @@
 # DO NOT CHANGE THIS UNLESS YOU HAVE A VERY GOOD REASON.
 
 # d3d9.textureMemory = 100
+
 
 # Hide integrated graphics from applications
 #
@@ -798,6 +826,7 @@
 # - True/False
 
 # dxvk.hideIntegratedGraphics = False
+
 
 # Trigger DEVICELOST when losing focus
 #
@@ -811,6 +840,7 @@
 
 # d3d9.deviceLossOnFocusLoss = False
 
+
 # Reject Device::Reset if any losable resource is still alive
 #
 # D3D9 rejects Device::Reset if there's still any alive resources of specific types.
@@ -822,6 +852,7 @@
 
 # d3d9.countLosableResources = True
 
+
 # Add an extra frame buffer when necessary
 #
 # Some games create a swapchain with only 1 buffer and still expect GetFrontBufferData() to correctly return back the data of the last present.
@@ -829,6 +860,7 @@
 # This is unnecessary for all but a single modded game (Silent Hill 2 Enhanced Edition), that's why it's a config option.
 
 # d3d9.extraFrontbuffer = False
+
 
 # Dref scaling for DXS0/FVF
 #
@@ -839,6 +871,7 @@
 # Supported values: Any number representing bitDepth (typically 24).
 
 # d3d8.scaleDref = 0
+
 
 # Shadow perspective divide
 #
@@ -857,6 +890,7 @@
 
 # d3d8.shadowPerspectiveDivide = False
 
+
 # Force vertex shader declaration
 #
 # Some games rely on undefined behavior by using undeclared vertex shader inputs.
@@ -870,6 +904,7 @@
 
 # d3d8.forceVsDecl = ""
 
+
 # Draw call batching
 #
 # Specialized drawcall batcher, typically for games that draw a lot of similar
@@ -882,6 +917,7 @@
 # - True/False
 
 # d3d8.batching = False
+
 
 # P8 texture support workaround
 #
@@ -897,6 +933,7 @@
 # - True/False
 
 # d3d8.placeP8InScratch = False
+
 
 # Legacy discard buffer behavior
 #

--- a/src/d3d9/d3d9_adapter.cpp
+++ b/src/d3d9/d3d9_adapter.cpp
@@ -149,7 +149,9 @@ namespace dxvk {
     if (rt && volumeTexture)
       return D3DERR_NOTAVAILABLE;
 
-    if (unlikely(rt && CheckFormat == D3D9Format::A8 && m_parent->GetOptions().disableA8RT))
+    auto& options = m_parent->GetOptions();
+
+    if (unlikely(rt && CheckFormat == D3D9Format::A8 && options.disableA8RT))
       return D3DERR_NOTAVAILABLE;
 
     // NULL RT format hack (supported across all
@@ -221,7 +223,8 @@ namespace dxvk {
     if (mapping.FormatSrgb  == VK_FORMAT_UNDEFINED && srgb)
       return D3DERR_NOTAVAILABLE;
 
-    if (RType == D3DRTYPE_CUBETEXTURE && mapping.Aspect != VK_IMAGE_ASPECT_COLOR_BIT)
+    if (RType == D3DRTYPE_CUBETEXTURE && mapping.Aspect != VK_IMAGE_ASPECT_COLOR_BIT
+     && !options.supportCubeDepthFormats)
       return D3DERR_NOTAVAILABLE;
 
     // Let's actually ask Vulkan now that we got some quirks out the way!
@@ -229,6 +232,7 @@ namespace dxvk {
     if (unlikely(mapping.ConversionFormatInfo.FormatColor != VK_FORMAT_UNDEFINED)) {
       format = mapping.ConversionFormatInfo.FormatColor;
     }
+
     return CheckDeviceVkFormat(format, Usage, RType);
   }
 

--- a/src/d3d9/d3d9_common_texture.cpp
+++ b/src/d3d9/d3d9_common_texture.cpp
@@ -139,9 +139,12 @@ namespace dxvk {
         options->disableA8RT)
       return D3DERR_INVALIDCALL;
 
-    // Cube textures with depth formats are not supported on any native
+    // Cube textures with depth formats are not supported on any modern native
     // driver, and allowing them triggers a broken code path in Gothic 3.
-    if (ResourceType == D3DRTYPE_CUBETEXTURE && mapping.Aspect != VK_IMAGE_ASPECT_COLOR_BIT)
+    // Older drivers, however, both exposed support and allowed their use, and
+    // games such as SimCity Societies: Destinations will crash on startup otherwise.
+    if (ResourceType == D3DRTYPE_CUBETEXTURE && mapping.Aspect != VK_IMAGE_ASPECT_COLOR_BIT
+     && !options->supportCubeDepthFormats)
       return D3DERR_INVALIDCALL;
 
     // If the mapping is invalid then lets return invalid

--- a/src/d3d9/d3d9_options.cpp
+++ b/src/d3d9/d3d9_options.cpp
@@ -50,6 +50,7 @@ namespace dxvk {
     this->deferSurfaceCreation          = config.getOption<bool>        ("d3d9.deferSurfaceCreation",          false);
     this->samplerAnisotropy             = config.getOption<int32_t>     ("d3d9.samplerAnisotropy",             -1);
     this->maxAvailableMemory            = config.getOption<int32_t>     ("d3d9.maxAvailableMemory",            4096);
+    this->supportCubeDepthFormats       = config.getOption<bool>        ("d3d9.supportCubeDepthFormats",       false);
     this->supportDFFormats              = config.getOption<bool>        ("d3d9.supportDFFormats",              true);
     this->supportX4R4G4B4               = config.getOption<bool>        ("d3d9.supportX4R4G4B4",               true);
     this->useD32forD24                  = config.getOption<bool>        ("d3d9.useD32forD24",                  false);

--- a/src/d3d9/d3d9_options.h
+++ b/src/d3d9/d3d9_options.h
@@ -76,6 +76,9 @@ namespace dxvk {
     /// Whether shaders use FP16 for partial precision instructions
     bool useFP16;
 
+    /// Support depth formats for cube textures
+    bool supportCubeDepthFormats;
+
     /// Support the DF16 & DF24 texture format
     bool supportDFFormats;
 

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -1163,6 +1163,12 @@ namespace dxvk {
     { R"(\\insurgency\.exe$)", {{
       { "d3d9.forceDrawTimeBufferUpload",   "True" },
     }} },
+    /* SimCity Societies: Destinations            *
+     * Needs depth format cube texture support    *
+     * in order to start up properly              */
+    { R"(\\SCSDestinations\.exe$)", {{
+      { "d3d9.supportCubeDepthFormats",     "True" },
+    }} },
 
     /**********************************************/
     /* D3D8 GAMES                                 */


### PR DESCRIPTION
Fixes #5633.

There's no elegant way to handle this, since indeed these aren't supported on any modern drivers. Much like some cursed The Sims 2 only config options, I doubt this will ever be useful outside of this particular game.

Needs testing to actually confirm it works with the game, as I don't have it.