### PR TITLE
[d3d9] Use roundEven for fixed function array access

### DIFF
--- a/src/d3d9/d3d9_fixed_function.cpp
+++ b/src/d3d9/d3d9_fixed_function.cpp
@@ -1077,7 +1077,7 @@ namespace dxvk {
 
           if (m_vsKey.Data.Contents.VertexBlendIndexed) {
             uint32_t index = m_module.opCompositeExtract(m_floatType, m_vs.in.BLENDINDICES, 1, &i);
-                     index = m_module.opConvertFtoU(m_uint32Type, m_module.opRound(m_floatType, index));
+                     index = m_module.opConvertFtoU(m_uint32Type, m_module.opRoundEven(m_floatType, index));
 
             arrayIndices = { m_module.constu32(0), index };
           }

--- a/src/d3d9/shaders/d3d9_fixed_function_vert.vert
+++ b/src/d3d9/shaders/d3d9_fixed_function_vert.vert
@@ -367,7 +367,7 @@ void main() {
             for (uint i = 0; i <= vertexBlendCount(); i++) {
                 uint arrayIndex;
                 if (vertexBlendIndexed()) {
-                    arrayIndex = uint(round(in_BlendIndices[i]));
+                    arrayIndex = uint(roundEven(in_BlendIndices[i]));
                 } else {
                     arrayIndex = i;
                 }


### PR DESCRIPTION
Yet another fixed function nitpick. @K0bin FYI.