### PR TITLE
[dxvk] [ai] [poc] Selectively apply VRS coarse rate shading and remove sample rate shading for additive blending

### DIFF
--- a/src/dxvk/dxvk_device_info.cpp
+++ b/src/dxvk/dxvk_device_info.cpp
@@ -27,6 +27,7 @@ namespace dxvk {
     HANDLE_EXT(extExtendedDynamicState3);          \
     HANDLE_EXT(extFragmentShaderInterlock);        \
     HANDLE_EXT(extFullScreenExclusive);            \
+    HANDLE_EXT(khrFragmentShadingRate);            \
     HANDLE_EXT(extGraphicsPipelineLibrary);        \
     HANDLE_EXT(extHdrMetadata);                    \
     HANDLE_EXT(extLineRasterization);              \
@@ -78,6 +79,7 @@ namespace dxvk {
     HANDLE_EXT(extDescriptorBuffer);               \
     HANDLE_EXT(extDescriptorHeap);                 \
     HANDLE_EXT(extExtendedDynamicState3);          \
+    HANDLE_EXT(khrFragmentShadingRate);            \
     HANDLE_EXT(extGraphicsPipelineLibrary);        \
     HANDLE_EXT(extLineRasterization);              \
     HANDLE_EXT(extMultiDraw);                      \
@@ -926,6 +928,12 @@ namespace dxvk {
 
       /* Windows-only extension to work around driver-side FSE issues */
       ENABLE_EXT(extFullScreenExclusive, false),
+
+      /* Variable rate shading — used to apply coarse shading rate to
+       * heavy transparent passes (fire/smoke/glow) for big perf wins
+       * with minimal visual impact. Only pipelineFragmentShadingRate
+       * is required; primitive/attachment rates are not used. */
+      ENABLE_EXT_FEATURE(khrFragmentShadingRate, pipelineFragmentShadingRate, false),
 
       /* Graphics pipeline libraries for stutter-free gameplay */
       ENABLE_EXT_FEATURE(extGraphicsPipelineLibrary, graphicsPipelineLibrary, false),

--- a/src/dxvk/dxvk_device_info.h
+++ b/src/dxvk/dxvk_device_info.h
@@ -31,6 +31,7 @@ namespace dxvk {
     VkPhysicalDeviceDescriptorBufferPropertiesEXT             extDescriptorBuffer             = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_BUFFER_PROPERTIES_EXT };
     VkPhysicalDeviceDescriptorHeapPropertiesEXT               extDescriptorHeap               = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_HEAP_PROPERTIES_EXT };
     VkPhysicalDeviceExtendedDynamicState3PropertiesEXT        extExtendedDynamicState3        = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_3_PROPERTIES_EXT };
+    VkPhysicalDeviceFragmentShadingRatePropertiesKHR          khrFragmentShadingRate          = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADING_RATE_PROPERTIES_KHR };
     VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT      extGraphicsPipelineLibrary      = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_GRAPHICS_PIPELINE_LIBRARY_PROPERTIES_EXT };
     VkPhysicalDeviceLineRasterizationPropertiesEXT            extLineRasterization            = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_LINE_RASTERIZATION_PROPERTIES_EXT };
     VkPhysicalDeviceMultiDrawPropertiesEXT                    extMultiDraw                    = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTI_DRAW_PROPERTIES_EXT };
@@ -68,6 +69,7 @@ namespace dxvk {
     VkPhysicalDeviceDescriptorHeapFeaturesEXT                 extDescriptorHeap               = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_HEAP_FEATURES_EXT };
     VkPhysicalDeviceExtendedDynamicState3FeaturesEXT          extExtendedDynamicState3        = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_3_FEATURES_EXT };
     VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT        extFragmentShaderInterlock      = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADER_INTERLOCK_FEATURES_EXT };
+    VkPhysicalDeviceFragmentShadingRateFeaturesKHR            khrFragmentShadingRate          = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADING_RATE_FEATURES_KHR };
     VkBool32                                                  extFullScreenExclusive          = VK_FALSE;
     VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT        extGraphicsPipelineLibrary      = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_GRAPHICS_PIPELINE_LIBRARY_FEATURES_EXT };
     VkBool32                                                  extHdrMetadata                  = VK_FALSE;
@@ -139,6 +141,7 @@ namespace dxvk {
     VkExtensionProperties extDescriptorHeap                 = vk::makeExtension(VK_EXT_DESCRIPTOR_HEAP_EXTENSION_NAME);
     VkExtensionProperties extExtendedDynamicState3          = vk::makeExtension(VK_EXT_EXTENDED_DYNAMIC_STATE_3_EXTENSION_NAME);
     VkExtensionProperties extFragmentShaderInterlock        = vk::makeExtension(VK_EXT_FRAGMENT_SHADER_INTERLOCK_EXTENSION_NAME);
+    VkExtensionProperties khrFragmentShadingRate            = vk::makeExtension(VK_KHR_FRAGMENT_SHADING_RATE_EXTENSION_NAME);
     VkExtensionProperties extFullScreenExclusive            = vk::makeExtension(VK_EXT_FULL_SCREEN_EXCLUSIVE_EXTENSION_NAME);
     VkExtensionProperties extGraphicsPipelineLibrary        = vk::makeExtension(VK_EXT_GRAPHICS_PIPELINE_LIBRARY_EXTENSION_NAME);
     VkExtensionProperties extHdrMetadata                    = vk::makeExtension(VK_EXT_HDR_METADATA_EXTENSION_NAME);

--- a/src/dxvk/dxvk_graphics.cpp
+++ b/src/dxvk/dxvk_graphics.cpp
@@ -292,20 +292,13 @@ namespace dxvk {
 
     feedbackLoop = state.om.feedbackLoop();
 
-    // Two classifications:
-    //   - hasAnyBlend: any color attachment has blend enabled. Gates the
-    //     pipeline-level sampleShadingEnable below. REQUIRED for VRS to
-    //     take effect: per-sample shading would otherwise force the GPU
-    //     back to a 1x1 shading rate even when we set {2,2}. Also recovers
-    //     per-sample cost on alpha-blend (text/UI/glass) when
-    //     d3d9.forceSampleRateShading is on.
-    //   - isAdditivePass: blend is additive (dst=ONE) or multiplicative
-    //     (DST_COLOR+ZERO). Narrower than hasAnyBlend. Drives the VRS 2x2
-    //     coarse rate + SampleRateShading capability strip. Excludes
-    //     standard alpha-blend (SrcAlpha+InvSrcAlpha) used by text/UI so
-    //     those stay at native shading rate and remain sharp.
+    // isAdditivePass: blend is additive (dst=ONE) or multiplicative
+    // (DST_COLOR+ZERO). Drives the VRS 2x2 coarse rate, the
+    // SampleRateShading capability strip, and the sampleShadingEnable
+    // gate. Excludes standard alpha-blend (SrcAlpha+InvSrcAlpha) used by
+    // text/UI/glass and soft-edge foliage — those keep native per-pixel
+    // shading and stay sharp.
     bool isAdditivePass = false;
-    bool hasAnyBlend    = false;
 
     for (uint32_t i = 0; i < MaxNumRenderTargets; i++) {
       rtColorFormats[i] = state.rt.getColorFormat(i);
@@ -333,7 +326,6 @@ namespace dxvk {
             cbAttachments[i].colorWriteMask = writeMask;
 
             if (cbAttachments[i].blendEnable) {
-              hasAnyBlend = true;
               VkBlendFactor src = cbAttachments[i].srcColorBlendFactor;
               VkBlendFactor dst = cbAttachments[i].dstColorBlendFactor;
               // Additive: src=(ONE|SRC_ALPHA), dst=ONE
@@ -390,13 +382,18 @@ namespace dxvk {
         : VK_SAMPLE_COUNT_1_BIT;
     }
 
-    // Per-sample shading is only enabled for opaque pipelines. Any blend
-    // draw (additive fire/glow, standard alpha-blend text/UI) skips it.
-    // Required so the VRS 2x2 rate set below for additive draws actually
-    // applies — sampleShadingEnable = TRUE silently downgrades the rate
-    // back to 1x1 regardless of what we requested. Also recovers per-sample
-    // cost on alpha-blend pipelines when d3d9.forceSampleRateShading is on.
-    if (shaders.fs && shaders.fs->metadata().flags.test(DxvkShaderFlag::HasSampleRateShading) && !hasAnyBlend) {
+    // Per-sample shading is skipped only on the pipelines we coarsen with
+    // VRS (additive/multiplicative). It MUST be off there: with
+    // sampleShadingEnable = TRUE, the driver silently downgrades the
+    // requested shading rate back to 1x1 — VRS would do nothing.
+    //
+    // Standard alpha-blend (text/UI/glass, soft-edge foliage) keeps
+    // per-sample shading on. Disabling it across all blend modes is
+    // tempting (it recovers per-sample cost on alpha-blend when
+    // d3d9.forceSampleRateShading is on) but visibly degrades alpha-blend
+    // edge quality — foliage aliases in particular. The narrower gate
+    // trades that perf win for correct rendering.
+    if (shaders.fs && shaders.fs->metadata().flags.test(DxvkShaderFlag::HasSampleRateShading) && !isAdditivePass) {
       msInfo.sampleShadingEnable  = VK_TRUE;
       msInfo.minSampleShading     = 1.0f;
     }

--- a/src/dxvk/dxvk_graphics.cpp
+++ b/src/dxvk/dxvk_graphics.cpp
@@ -292,6 +292,21 @@ namespace dxvk {
 
     feedbackLoop = state.om.feedbackLoop();
 
+    // Two classifications:
+    //   - hasAnyBlend: any color attachment has blend enabled. Gates the
+    //     pipeline-level sampleShadingEnable below. REQUIRED for VRS to
+    //     take effect: per-sample shading would otherwise force the GPU
+    //     back to a 1x1 shading rate even when we set {2,2}. Also recovers
+    //     per-sample cost on alpha-blend (text/UI/glass) when
+    //     d3d9.forceSampleRateShading is on.
+    //   - isAdditivePass: blend is additive (dst=ONE) or multiplicative
+    //     (DST_COLOR+ZERO). Narrower than hasAnyBlend. Drives the VRS 2x2
+    //     coarse rate + SampleRateShading capability strip. Excludes
+    //     standard alpha-blend (SrcAlpha+InvSrcAlpha) used by text/UI so
+    //     those stay at native shading rate and remain sharp.
+    bool isAdditivePass = false;
+    bool hasAnyBlend    = false;
+
     for (uint32_t i = 0; i < MaxNumRenderTargets; i++) {
       rtColorFormats[i] = state.rt.getColorFormat(i);
 
@@ -316,6 +331,20 @@ namespace dxvk {
           if (writeMask) {
             cbAttachments[i] = state.omBlend[i].state();
             cbAttachments[i].colorWriteMask = writeMask;
+
+            if (cbAttachments[i].blendEnable) {
+              hasAnyBlend = true;
+              VkBlendFactor src = cbAttachments[i].srcColorBlendFactor;
+              VkBlendFactor dst = cbAttachments[i].dstColorBlendFactor;
+              // Additive: src=(ONE|SRC_ALPHA), dst=ONE
+              // Multiplicative: src=DST_COLOR, dst=ZERO
+              bool additive = dst == VK_BLEND_FACTOR_ONE
+                           && (src == VK_BLEND_FACTOR_ONE || src == VK_BLEND_FACTOR_SRC_ALPHA);
+              bool multiplicative = src == VK_BLEND_FACTOR_DST_COLOR
+                                 && dst == VK_BLEND_FACTOR_ZERO;
+              if (additive || multiplicative)
+                isAdditivePass = true;
+            }
 
             // If we're rendering to an emulated alpha-only render target, fix up blending
             if (cbAttachments[i].blendEnable && formatInfo->componentMask == VK_COLOR_COMPONENT_R_BIT && state.omSwizzle[i].rIndex() == 3) {
@@ -361,10 +390,24 @@ namespace dxvk {
         : VK_SAMPLE_COUNT_1_BIT;
     }
 
-    if (shaders.fs && shaders.fs->metadata().flags.test(DxvkShaderFlag::HasSampleRateShading)) {
+    // Per-sample shading is only enabled for opaque pipelines. Any blend
+    // draw (additive fire/glow, standard alpha-blend text/UI) skips it.
+    // Required so the VRS 2x2 rate set below for additive draws actually
+    // applies — sampleShadingEnable = TRUE silently downgrades the rate
+    // back to 1x1 regardless of what we requested. Also recovers per-sample
+    // cost on alpha-blend pipelines when d3d9.forceSampleRateShading is on.
+    if (shaders.fs && shaders.fs->metadata().flags.test(DxvkShaderFlag::HasSampleRateShading) && !hasAnyBlend) {
       msInfo.sampleShadingEnable  = VK_TRUE;
       msInfo.minSampleShading     = 1.0f;
     }
+
+    // Pipeline-level fragment shading rate. Only additive/multiplicative
+    // blend modes get a coarse rate — those are the classic "kill-FPS"
+    // transparent layers (fire/glow/smoke). Standard alpha blend used by
+    // text/UI stays at {1,1} so it remains sharp.
+    if (isAdditivePass
+     && device->features().khrFragmentShadingRate.pipelineFragmentShadingRate)
+      shadingRate = { 2u, 2u };
 
     // Alpha to coverage is not supported with sample mask exports.
     cbUseDynamicAlphaToCoverage = !shaders.fs || !shaders.fs->metadata().flags.test(DxvkShaderFlag::ExportsSampleMask);
@@ -394,7 +437,9 @@ namespace dxvk {
            && msSampleMask                    == other.msSampleMask
            && cbUseDynamicBlendConstants      == other.cbUseDynamicBlendConstants
            && cbUseDynamicAlphaToCoverage     == other.cbUseDynamicAlphaToCoverage
-           && feedbackLoop                    == other.feedbackLoop;
+           && feedbackLoop                    == other.feedbackLoop
+           && shadingRate.width               == other.shadingRate.width
+           && shadingRate.height              == other.shadingRate.height;
 
     for (uint32_t i = 0; i < rtInfo.colorAttachmentCount && eq; i++)
       eq = rtColorFormats[i] == other.rtColorFormats[i];
@@ -435,6 +480,8 @@ namespace dxvk {
     hash.add(uint32_t(cbUseDynamicBlendConstants));
     hash.add(uint32_t(cbUseDynamicAlphaToCoverage));
     hash.add(uint32_t(feedbackLoop));
+    hash.add(uint32_t(shadingRate.width));
+    hash.add(uint32_t(shadingRate.height));
 
     for (uint32_t i = 0; i < rtInfo.colorAttachmentCount; i++)
       hash.add(uint32_t(rtColorFormats[i]));
@@ -888,6 +935,29 @@ namespace dxvk {
         if ((fsOutputMask & (1u << i)) && state.writesRenderTarget(i))
           info.rtSwizzles[i] = state.omSwizzle[i].mapping();
       }
+
+      // Strip SampleRateShading on additive/multiplicative draws so the
+      // KHR_fragment_shading_rate coarse rate set in FragmentOutputState
+      // actually applies. Only meaningful when the PS originally declared
+      // the capability (e.g. via d3d9.forceSampleRateShading). Standard
+      // alpha-blend used by text/UI/glass is excluded so it keeps
+      // per-sample shading and stays sharp.
+      if (shaderMeta.flags.test(DxvkShaderFlag::HasSampleRateShading)) {
+        for (uint32_t i = 0; i < MaxNumRenderTargets; i++) {
+          if (!state.rt.getColorFormat(i) || !state.omBlend[i].blendEnable())
+            continue;
+          VkBlendFactor src = state.omBlend[i].srcColorBlendFactor();
+          VkBlendFactor dst = state.omBlend[i].dstColorBlendFactor();
+          bool additive = dst == VK_BLEND_FACTOR_ONE
+                       && (src == VK_BLEND_FACTOR_ONE || src == VK_BLEND_FACTOR_SRC_ALPHA);
+          bool multiplicative = src == VK_BLEND_FACTOR_DST_COLOR
+                             && dst == VK_BLEND_FACTOR_ZERO;
+          if (additive || multiplicative) {
+            info.fsStripSampleRateShading = true;
+            break;
+          }
+        }
+      }
     }
 
     // Deal with undefined shader inputs
@@ -1222,6 +1292,26 @@ namespace dxvk {
     if (!m_device->canUseGraphicsPipelineLibrary())
       return false;
 
+    // VRS state is pre-rasterization in the GPL split, but our decision
+    // to coarsen the rate depends on per-pipeline blend state which the
+    // pre-rasterization library doesn't see. Force the monolithic compile
+    // path whenever an additive/multiplicative draw would opt into VRS
+    // so the shading rate can be baked correctly.
+    if (m_device->features().khrFragmentShadingRate.pipelineFragmentShadingRate) {
+      for (uint32_t i = 0; i < MaxNumRenderTargets; i++) {
+        if (!state.rt.getColorFormat(i) || !state.omBlend[i].blendEnable())
+          continue;
+        VkBlendFactor src = state.omBlend[i].srcColorBlendFactor();
+        VkBlendFactor dst = state.omBlend[i].dstColorBlendFactor();
+        bool additive = dst == VK_BLEND_FACTOR_ONE
+                     && (src == VK_BLEND_FACTOR_ONE || src == VK_BLEND_FACTOR_SRC_ALPHA);
+        bool multiplicative = src == VK_BLEND_FACTOR_DST_COLOR
+                           && dst == VK_BLEND_FACTOR_ZERO;
+        if (additive || multiplicative)
+          return false;
+      }
+    }
+
     // We do not implement setting certain rarely used render
     // states dynamically since they are generally not used
     bool isLineRendering = DxvkGraphicsPipelinePreRasterizationState::isLineRendering(m_shaders, state);
@@ -1447,6 +1537,17 @@ namespace dxvk {
     if (m_device->canUseDescriptorBuffer())
       flags.flags |= VK_PIPELINE_CREATE_2_DESCRIPTOR_BUFFER_BIT_EXT;
 
+    // Chain VRS state when this pipeline opted into a coarse shading rate.
+    // Combiners are KEEP so per-primitive / per-attachment rates (which we
+    // don't use) won't override the pipeline-level value.
+    VkPipelineFragmentShadingRateStateCreateInfoKHR vrsInfo = { VK_STRUCTURE_TYPE_PIPELINE_FRAGMENT_SHADING_RATE_STATE_CREATE_INFO_KHR };
+    vrsInfo.fragmentSize    = key.foState.shadingRate;
+    vrsInfo.combinerOps[0]  = VK_FRAGMENT_SHADING_RATE_COMBINER_OP_KEEP_KHR;
+    vrsInfo.combinerOps[1]  = VK_FRAGMENT_SHADING_RATE_COMBINER_OP_KEEP_KHR;
+
+    const bool wantsVrs = key.foState.shadingRate.width  != 1u
+                       || key.foState.shadingRate.height != 1u;
+
     VkGraphicsPipelineCreateInfo info = { VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO, &key.foState.rtInfo };
     info.stageCount               = stageInfo.getStageCount();
     info.pStages                  = stageInfo.getStageInfos();
@@ -1467,7 +1568,10 @@ namespace dxvk {
 
     if (flags.flags)
       flags.pNext = std::exchange(info.pNext, &flags);
-    
+
+    if (wantsVrs)
+      vrsInfo.pNext = std::exchange(info.pNext, &vrsInfo);
+
     VkPipeline pipeline = VK_NULL_HANDLE;
     VkResult vr = vk->vkCreateGraphicsPipelines(vk->device(), VK_NULL_HANDLE, 1, &info, nullptr, &pipeline);
 

--- a/src/dxvk/dxvk_graphics.cpp
+++ b/src/dxvk/dxvk_graphics.cpp
@@ -266,6 +266,23 @@ namespace dxvk {
   }
 
 
+  // Returns the validated effective shading rate for transparent
+  // pipelines, or {1,1} if VRS is off / unsupported / unsupported-by-hw.
+  // The caller still needs to gate on whether the pipeline is actually
+  // additive/multiplicative.
+  static VkExtent2D getEffectiveShadingRate(const DxvkDevice* device) {
+    if (!device->features().khrFragmentShadingRate.pipelineFragmentShadingRate)
+      return { 1u, 1u };
+    VkExtent2D rate = device->config().transparentShadingRate;
+    if (rate.width <= 1u && rate.height <= 1u)
+      return { 1u, 1u };
+    VkExtent2D maxSize = device->properties().khrFragmentShadingRate.maxFragmentSize;
+    if (rate.width > maxSize.width || rate.height > maxSize.height)
+      return { 1u, 1u };
+    return rate;
+  }
+
+
   DxvkGraphicsPipelineFragmentOutputState::DxvkGraphicsPipelineFragmentOutputState() {
 
   }
@@ -382,29 +399,27 @@ namespace dxvk {
         : VK_SAMPLE_COUNT_1_BIT;
     }
 
-    // Per-sample shading is skipped only on the pipelines we coarsen with
-    // VRS (additive/multiplicative). It MUST be off there: with
-    // sampleShadingEnable = TRUE, the driver silently downgrades the
-    // requested shading rate back to 1x1 — VRS would do nothing.
+    // Resolve the effective VRS rate from config + hardware support.
+    // {1,1} means "disabled" (off / unsupported / clamped by hw).
+    VkExtent2D effectiveRate = getEffectiveShadingRate(device);
+    bool vrsActive = (effectiveRate.width > 1u || effectiveRate.height > 1u)
+                  && isAdditivePass;
+
+    // Per-sample shading is skipped only on pipelines we're actively
+    // coarsening (vrsActive). MUST be off there: sampleShadingEnable =
+    // TRUE forces the driver to downgrade the requested rate to 1x1.
     //
     // Standard alpha-blend (text/UI/glass, soft-edge foliage) keeps
-    // per-sample shading on. Disabling it across all blend modes is
-    // tempting (it recovers per-sample cost on alpha-blend when
-    // d3d9.forceSampleRateShading is on) but visibly degrades alpha-blend
-    // edge quality — foliage aliases in particular. The narrower gate
-    // trades that perf win for correct rendering.
-    if (shaders.fs && shaders.fs->metadata().flags.test(DxvkShaderFlag::HasSampleRateShading) && !isAdditivePass) {
+    // per-sample shading on — disabling it across all blend modes
+    // visibly aliases foliage edges.
+    if (shaders.fs && shaders.fs->metadata().flags.test(DxvkShaderFlag::HasSampleRateShading) && !vrsActive) {
       msInfo.sampleShadingEnable  = VK_TRUE;
       msInfo.minSampleShading     = 1.0f;
     }
 
-    // Pipeline-level fragment shading rate. Only additive/multiplicative
-    // blend modes get a coarse rate — those are the classic "kill-FPS"
-    // transparent layers (fire/glow/smoke). Standard alpha blend used by
-    // text/UI stays at {1,1} so it remains sharp.
-    if (isAdditivePass
-     && device->features().khrFragmentShadingRate.pipelineFragmentShadingRate)
-      shadingRate = { 2u, 2u };
+    // Pipeline-level fragment shading rate (dxvk.transparentShadingRate).
+    if (vrsActive)
+      shadingRate = effectiveRate;
 
     // Alpha to coverage is not supported with sample mask exports.
     cbUseDynamicAlphaToCoverage = !shaders.fs || !shaders.fs->metadata().flags.test(DxvkShaderFlag::ExportsSampleMask);
@@ -878,13 +893,14 @@ namespace dxvk {
 
 
   DxvkGraphicsPipelineShaderState::DxvkGraphicsPipelineShaderState(
+    const DxvkDevice*                     device,
     const DxvkGraphicsPipelineShaders&    shaders,
     const DxvkGraphicsPipelineStateInfo&  state)
-  : vsInfo  (getLinkage(shaders, shaders.vs, state)),
-    tcsInfo (getLinkage(shaders, shaders.tcs, state)),
-    tesInfo (getLinkage(shaders, shaders.tes, state)),
-    gsInfo  (getLinkage(shaders, shaders.gs, state)),
-    fsInfo  (getLinkage(shaders, shaders.fs, state)) {
+  : vsInfo  (getLinkage(device, shaders, shaders.vs, state)),
+    tcsInfo (getLinkage(device, shaders, shaders.tcs, state)),
+    tesInfo (getLinkage(device, shaders, shaders.tes, state)),
+    gsInfo  (getLinkage(device, shaders, shaders.gs, state)),
+    fsInfo  (getLinkage(device, shaders, shaders.fs, state)) {
 
   }
 
@@ -910,6 +926,7 @@ namespace dxvk {
 
 
   DxvkShaderLinkage DxvkGraphicsPipelineShaderState::getLinkage(
+    const DxvkDevice*                     device,
     const DxvkGraphicsPipelineShaders&    shaders,
     const Rc<DxvkShader>&                 shader,
     const DxvkGraphicsPipelineStateInfo&  state) {
@@ -939,7 +956,9 @@ namespace dxvk {
       // the capability (e.g. via d3d9.forceSampleRateShading). Standard
       // alpha-blend used by text/UI/glass is excluded so it keeps
       // per-sample shading and stays sharp.
-      if (shaderMeta.flags.test(DxvkShaderFlag::HasSampleRateShading)) {
+      VkExtent2D vrsRate = getEffectiveShadingRate(device);
+      bool vrsEnabled = vrsRate.width > 1u || vrsRate.height > 1u;
+      if (vrsEnabled && shaderMeta.flags.test(DxvkShaderFlag::HasSampleRateShading)) {
         for (uint32_t i = 0; i < MaxNumRenderTargets; i++) {
           if (!state.rt.getColorFormat(i) || !state.omBlend[i].blendEnable())
             continue;
@@ -1294,7 +1313,8 @@ namespace dxvk {
     // pre-rasterization library doesn't see. Force the monolithic compile
     // path whenever an additive/multiplicative draw would opt into VRS
     // so the shading rate can be baked correctly.
-    if (m_device->features().khrFragmentShadingRate.pipelineFragmentShadingRate) {
+    VkExtent2D vrsRate = getEffectiveShadingRate(m_device);
+    if (vrsRate.width > 1u || vrsRate.height > 1u) {
       for (uint32_t i = 0; i < MaxNumRenderTargets; i++) {
         if (!state.rt.getColorFormat(i) || !state.omBlend[i].blendEnable())
           continue;

--- a/src/dxvk/dxvk_graphics.h
+++ b/src/dxvk/dxvk_graphics.h
@@ -246,6 +246,7 @@ namespace dxvk {
     DxvkGraphicsPipelineShaderState();
 
     DxvkGraphicsPipelineShaderState(
+      const DxvkDevice*                     device,
       const DxvkGraphicsPipelineShaders&    shaders,
       const DxvkGraphicsPipelineStateInfo&  state);
 
@@ -262,6 +263,7 @@ namespace dxvk {
   private:
 
     DxvkShaderLinkage getLinkage(
+      const DxvkDevice*                     device,
       const DxvkGraphicsPipelineShaders&    shaders,
       const Rc<DxvkShader>&                 shader,
       const DxvkGraphicsPipelineStateInfo&  state);
@@ -438,7 +440,7 @@ namespace dxvk {
       const DxvkGraphicsPipelineStateInfo&    state,
             DxvkGraphicsPipelineFlags         flags,
             uint32_t                          specConstantMask)
-    : shState(shaders, state),
+    : shState(device, shaders, state),
       dyState(device, state, flags),
       viState(device, state, shaders),
       prState(device, state, shaders),

--- a/src/dxvk/dxvk_graphics.h
+++ b/src/dxvk/dxvk_graphics.h
@@ -121,6 +121,13 @@ namespace dxvk {
 
     VkImageAspectFlags                              feedbackLoop = 0u;
 
+    // VK_KHR_fragment_shading_rate pipeline-level rate. Defaults to {1,1}
+    // (per-pixel). Set to {2,2} for additive/multiplicative blend passes
+    // (fire/glow/smoke). The pipeline is forced off the graphics-pipeline-
+    // library fast path because VRS state is part of pre-rasterization
+    // state and our decision is per-pipeline.
+    VkExtent2D                                      shadingRate = { 1u, 1u };
+
     bool eq(const DxvkGraphicsPipelineFragmentOutputState& other) const;
 
     size_t hash() const;

--- a/src/dxvk/dxvk_options.cpp
+++ b/src/dxvk/dxvk_options.cpp
@@ -2,6 +2,22 @@
 
 namespace dxvk {
 
+  static VkExtent2D parseShadingRate(const std::string& s) {
+    // Accept "WxH" (W, H in {1,2,4}) or "off". Case-insensitive.
+    std::string lower; lower.reserve(s.size());
+    for (char c : s) lower.push_back(c >= 'A' && c <= 'Z' ? char(c + 32) : c);
+
+    if (lower.empty() || lower == "off" || lower == "1x1") return { 1u, 1u };
+    if (lower == "2x1") return { 2u, 1u };
+    if (lower == "1x2") return { 1u, 2u };
+    if (lower == "2x2") return { 2u, 2u };
+    if (lower == "4x2") return { 4u, 2u };
+    if (lower == "2x4") return { 2u, 4u };
+    if (lower == "4x4") return { 4u, 4u };
+    // Unknown — keep default rather than silently going to {1,1}.
+    return { 2u, 2u };
+  }
+
   DxvkOptions::DxvkOptions(const Config& config) {
     enableDebugUtils      = config.getOption<bool>    ("dxvk.enableDebugUtils",       false);
     enableMemoryDefrag    = config.getOption<Tristate>("dxvk.enableMemoryDefrag",     Tristate::Auto);
@@ -27,6 +43,9 @@ namespace dxvk {
 
     auto budget = config.getOption<int32_t>("dxvk.maxMemoryBudget", 0);
     maxMemoryBudget = VkDeviceSize(std::max(budget, 0)) << 20u;
+
+    transparentShadingRate = parseShadingRate(
+      config.getOption<std::string>("dxvk.transparentShadingRate", "2x2"));
   }
 
 }

--- a/src/dxvk/dxvk_options.h
+++ b/src/dxvk/dxvk_options.h
@@ -81,6 +81,16 @@ namespace dxvk {
 
     /// Device name
     std::string deviceFilter;
+
+    /// Fragment shading rate applied to additive/multiplicative blend
+    /// pipelines (fire/glow/smoke/particles). Defaults to {2,2} (4x FS
+    /// reduction). Values: Off / 1x1 (patch disabled), 2x1 / 1x2 (2x
+    /// reduction, less visible pixelation), 2x2 (4x reduction), 4x2 /
+    /// 2x4 / 4x4 (8x-16x reduction, hardware-dependent and visibly
+    /// blocky on small effects). Parsed from "dxvk.transparentShadingRate".
+    /// Validated against device khrFragmentShadingRate.maxFragmentSize;
+    /// invalid or unsupported values fall back to {1,1}.
+    VkExtent2D transparentShadingRate = { 2u, 2u };
   };
 
 }

--- a/src/dxvk/dxvk_shader.cpp
+++ b/src/dxvk/dxvk_shader.cpp
@@ -15,10 +15,11 @@ namespace dxvk {
 
 
   bool DxvkShaderLinkage::eq(const DxvkShaderLinkage& other) const {
-    bool eq = fsDualSrcBlend  == other.fsDualSrcBlend
-           && fsFlatShading   == other.fsFlatShading
-           && sampleLocations == other.sampleLocations
-           && semanticIo      == other.semanticIo;
+    bool eq = fsDualSrcBlend            == other.fsDualSrcBlend
+           && fsFlatShading             == other.fsFlatShading
+           && sampleLocations           == other.sampleLocations
+           && semanticIo                == other.semanticIo
+           && fsStripSampleRateShading  == other.fsStripSampleRateShading;
 
     if (eq) {
       eq = prevStageOutputs.getVarCount() == other.prevStageOutputs.getVarCount();
@@ -44,6 +45,7 @@ namespace dxvk {
     hash.add(uint32_t(fsFlatShading));
     hash.add(uint32_t(sampleLocations));
     hash.add(uint32_t(semanticIo));
+    hash.add(uint32_t(fsStripSampleRateShading));
 
     for (uint32_t i = 0; i < prevStageOutputs.getVarCount(); i++)
       hash.add(prevStageOutputs.getVar(i).hash());
@@ -76,7 +78,30 @@ namespace dxvk {
   }
 
 
-  
+  void DxvkShader::stripSampleRateShading(SpirvCodeBuffer& code) {
+    // Collect offsets of OpCapability SampleRateShading and every
+    // OpDecorate %x Sample. We erase them in reverse order so earlier
+    // offsets stay valid through the mutation.
+    std::vector<std::pair<size_t, size_t>> removals;
+
+    for (auto ins : code) {
+      if (ins.opCode() == spv::OpCapability
+       && ins.arg(1) == spv::CapabilitySampleRateShading) {
+        removals.emplace_back(ins.offset(), ins.length());
+      } else if (ins.opCode() == spv::OpDecorate
+              && ins.arg(2) == spv::DecorationSample) {
+        removals.emplace_back(ins.offset(), ins.length());
+      }
+    }
+
+    for (auto it = removals.rbegin(); it != removals.rend(); ++it) {
+      code.beginInsertion(it->first);
+      code.erase(it->second);
+    }
+
+    code.endInsertion();
+  }
+
 
   DxvkShaderStageInfo::DxvkShaderStageInfo(const DxvkDevice* device, const DxvkPipelineLayout* layout)
   : m_device(device) {

--- a/src/dxvk/dxvk_shader.h
+++ b/src/dxvk/dxvk_shader.h
@@ -223,6 +223,14 @@ namespace dxvk {
     bool sampleLocations = false;
     bool semanticIo      = false;
 
+    // Strip OpCapability SampleRateShading + OpDecorate Sample from the FS
+    // SPIR-V before compile. Used by the selective VRS path: per-sample
+    // shading would otherwise force the pipeline's shading rate back to
+    // 1x1 regardless of what we requested via KHR_fragment_shading_rate.
+    // Set in DxvkGraphicsPipelineShaderState::getLinkage() when the shader
+    // declares SampleRateShading and the pipeline opts into VRS coarsening.
+    bool fsStripSampleRateShading = false;
+
     VkPrimitiveTopology inputTopology = VK_PRIMITIVE_TOPOLOGY_MAX_ENUM;
 
     VkShaderStageFlagBits prevStage = VK_SHADER_STAGE_FLAG_BITS_MAX_ENUM;
@@ -371,6 +379,16 @@ namespace dxvk {
      * \returns Shader dump path, or empty string
      */
     static const std::string& getShaderDumpPath();
+
+    /**
+     * \brief Strips SampleRateShading capability + Sample decorations
+     *
+     * Mutates the given SPIR-V module in place. Idempotent: safe to call
+     * on code that doesn't declare the capability (no-op in that case).
+     * Used by the selective VRS path so the pipeline's coarse shading
+     * rate is not silently downgraded back to 1x1 by per-sample shading.
+     */
+    static void stripSampleRateShading(SpirvCodeBuffer& code);
 
   private:
 

--- a/src/dxvk/dxvk_shader_ir.cpp
+++ b/src/dxvk/dxvk_shader_ir.cpp
@@ -1792,7 +1792,14 @@ namespace dxvk {
     dxbc_spv::spirv::SpirvBuilder spirvBuilder(irBuilder, mapping, options);
     spirvBuilder.buildSpirvBinary();
 
-    return SpirvCodeBuffer(spirvBuilder.getSpirvBinary());
+    SpirvCodeBuffer spirvCode(spirvBuilder.getSpirvBinary());
+
+    // Strip SampleRateShading + Sample decorations when the pipeline
+    // opts into VRS coarse rate (see DxvkShaderLinkage comment).
+    if (linkage && m_metadata.stage == VK_SHADER_STAGE_FRAGMENT_BIT && linkage->fsStripSampleRateShading)
+      DxvkShader::stripSampleRateShading(spirvCode);
+
+    return spirvCode;
   }
 
 

--- a/src/dxvk/dxvk_shader_spirv.cpp
+++ b/src/dxvk/dxvk_shader_spirv.cpp
@@ -95,6 +95,11 @@ namespace dxvk {
       // Emit input decorations for flat shading as necessary
       if (m_metadata.stage == VK_SHADER_STAGE_FRAGMENT_BIT && linkage->fsFlatShading)
         emitFlatShadingDeclarations(spirvCode, m_info.flatShadingInputs);
+
+      // Strip SampleRateShading + Sample decorations when the pipeline
+      // opts into VRS coarse rate (see DxvkShaderLinkage comment).
+      if (m_metadata.stage == VK_SHADER_STAGE_FRAGMENT_BIT && linkage->fsStripSampleRateShading)
+        DxvkShader::stripSampleRateShading(spirvCode);
     }
 
     return spirvCode;


### PR DESCRIPTION
This is a proof of concept by calude opus 4.7. It was built to fix a specific performance issue I have and I'm not even sure this belongs in DXVK upstream. Sharing here as it might be useful to someone for reference, I am not intending this PR to be merged as-is and only wanted to fix an annoying performance drop I had in some games. The fix works well so may be useful for others.

### Initial problem

In D3D9 titles when `forceSampleRateShading` is enabled, glow/spell/particle effects often introduce a noticable FPS drop, especially when they take up a large portion of the screen.

`forceSampleRateShading` looks fantastic and modern GPUs can handle it easily on old D3D9 games... except in this scenario with lots of transparency and blending on the screen. Which don't benefit from SRS anyway.

It does the following:

1. Disables per-sample shading for blend enabled pipelines
2. Enables 2x2 VRS coarse rate shading for additive/multiplicative blending 

### Result

DXVK 2.7.1 - 75fps
With this patch (against git master) - 196fps (hitting in-game 200fps cap)

My questions are:

1. If this was tidied up would it even be welcome in DXVK? I know you [removed the option to force MSAA](https://github.com/doitsujin/dxvk/issues/5133) citing that DXVK is not focussed on adding new features and this feels similar
2. If it was to be accepted, should it be behind a config option? I assume so, but again, all the arguments against the `forceSwapChainMsaa` options apply here
