### PR TITLE
Enable dxbc-spirv for D3D9 by default

### DIFF
--- a/src/d3d9/d3d9_options.cpp
+++ b/src/d3d9/d3d9_options.cpp
@@ -76,7 +76,7 @@ namespace dxvk {
     this->extraFrontbuffer              = config.getOption<bool>        ("d3d9.extraFrontbuffer",              false);
     this->ffUbershaderVS                = config.getOption<bool>        ("d3d9.ffUbershaderVS",                true);
     this->ffUbershaderFS                = config.getOption<bool>        ("d3d9.ffUbershaderFS",                true);
-    this->useDxbcSpirv                  = config.getOption<bool>        ("d3d9.useDxbcSpirv",                  false);
+    this->useDxbcSpirv                  = config.getOption<bool>        ("d3d9.useDxbcSpirv",                  true);
 
     // D3D8 options
     this->drefScaling                   = config.getOption<int32_t>     ("d3d8.scaleDref",                     0);


### PR DESCRIPTION
Given that everything we know of compiles cleanly and produces valid spirv, this is kinda tempting now.