### PR TITLE
[d3d9] Do not enable FP16 by default

### DIFF
--- a/src/d3d9/d3d9_options.cpp
+++ b/src/d3d9/d3d9_options.cpp
@@ -100,7 +100,7 @@ namespace dxvk {
       this->d3d9FloatEmulation = hasMulz ? D3D9FloatEmulation::Strict : D3D9FloatEmulation::Enabled;
     }
 
-    Tristate useFP16 = config.getOption<Tristate>("d3d9.useFP16", Tristate::Auto);
+    Tristate useFP16 = config.getOption<Tristate>("d3d9.useFP16", Tristate::False);
     if (useFP16 == Tristate::Auto) {
       this->useFP16 = !hasMulz;
     } else {


### PR DESCRIPTION
Games are dumb and require partial precision to actually be FP32 in too many places. We can opt in via app profiles for known-good games.