### PR TITLE
Simplify shader creation

### DIFF
--- a/src/d3d11/d3d11_shader.cpp
+++ b/src/d3d11/d3d11_shader.cpp
@@ -231,20 +231,16 @@ namespace dxvk {
     const D3D11ShaderIcbInfo&     Icb,
     const D3D11BindingMask&       BindingMask,
           D3D11CommonShader*      pShader) {
-    // Use the shader's unique key for the lookup
-    { std::unique_lock<dxvk::mutex> lock(m_mutex);
-      
-      auto entry = m_modules.find(ShaderKey);
-      if (entry != m_modules.end()) {
-        *pShader = entry->second;
-        return S_OK;
-      }
+    std::unique_lock<dxvk::mutex> lock(m_mutex);
+
+    auto entry = m_modules.find(ShaderKey);
+    if (entry != m_modules.end()) {
+      *pShader = entry->second;
+      return S_OK;
     }
-    
-    // This shader has not been compiled yet, so we have to create a
-    // new module. This takes a while, so we won't lock the structure.
+
     D3D11CommonShader module;
-    
+
     try {
       module = D3D11CommonShader(pDevice, pLinkage, ShaderKey,
         ModuleInfo, pShaderBytecode, BytecodeLength, Icb, BindingMask);
@@ -252,20 +248,8 @@ namespace dxvk {
       Logger::err(e.message());
       return E_INVALIDARG;
     }
-    
-    // Insert the new module into the lookup table. If another thread
-    // has compiled the same shader in the meantime, we should return
-    // that object instead and discard the newly created module.
-    { std::unique_lock<dxvk::mutex> lock(m_mutex);
-      
-      auto status = m_modules.insert({ ShaderKey, module });
 
-      if (!status.second) {
-        *pShader = status.first->second;
-        return S_OK;
-      }
-    }
-    
+    m_modules.insert({ ShaderKey, module });
     *pShader = std::move(module);
     return S_OK;
   }

--- a/src/d3d9/d3d9_shader.cpp
+++ b/src/d3d9/d3d9_shader.cpp
@@ -230,30 +230,17 @@ namespace dxvk {
     const D3D9ShaderCreateInfo&   ModuleInfo,
     const void*                   pShaderBytecode,
           D3D9CommonShader*       pShader) {
-
-    // Use the shader's unique key for the lookup
-    { std::unique_lock<dxvk::mutex> lock(m_mutex);
-
-      auto entry = m_modules.find(ShaderKey);
-      if (entry != m_modules.end()) {
-        *pShader = entry->second;
-        return D3D_OK;
-      }
-    }
-
-    // This shader has not been compiled yet, so we have to create a
-    // new module. This takes a while, so we won't lock the structure.
-    *pShader = D3D9CommonShader(pDevice, ShaderKey, std::move(ShaderAnalysis), ModuleInfo, pShaderBytecode);
-
-    // Insert the new module into the lookup table. If another thread
-    // has compiled the same shader in the meantime, we should return
-    // that object instead and discard the newly created module.
     std::unique_lock<dxvk::mutex> lock(m_mutex);
 
-    auto status = m_modules.insert({ ShaderKey, *pShader });
-    if (!status.second)
-      *pShader = status.first->second;
+    auto entry = m_modules.find(ShaderKey);
+    if (entry != m_modules.end()) {
+      *pShader = entry->second;
+      return D3D_OK;
+    }
 
+    *pShader = D3D9CommonShader(pDevice, ShaderKey, std::move(ShaderAnalysis), ModuleInfo, pShaderBytecode);
+
+    m_modules.insert({ ShaderKey, *pShader });
     return D3D_OK;
   }
 


### PR DESCRIPTION
The only reason the double-lock was ever a good idea is because we did the SPIR-V translation on the app thread with the old compilers, but with dxbc-spirv that is no longer the case. Accessing the shader cache serializes anyway and there's nothing else happening here most of the time.