### PR TITLE
[d3d9] Unify specular state tracking and use

### DIFF
--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -188,6 +188,7 @@ namespace dxvk {
     m_dirty.set(D3D9DeviceDirtyFlag::FFPixelShader);
     m_dirty.set(D3D9DeviceDirtyFlag::FFViewport);
     m_dirty.set(D3D9DeviceDirtyFlag::FFPixelData);
+    m_dirty.set(D3D9DeviceDirtyFlag::FFGlobalSpecular);
     m_dirty.set(D3D9DeviceDirtyFlag::SharedPixelShaderData);
     m_dirty.set(D3D9DeviceDirtyFlag::DepthBounds);
     m_dirty.set(D3D9DeviceDirtyFlag::PointScale);
@@ -1668,6 +1669,7 @@ namespace dxvk {
       0);
   }
 
+
   HRESULT STDMETHODCALLTYPE D3D9DeviceEx::SetRenderTarget(
           DWORD              RenderTargetIndex,
           IDirect3DSurface9* pRenderTarget) {
@@ -2508,8 +2510,7 @@ namespace dxvk {
           break;
 
         case D3DRS_SPECULARENABLE:
-          m_dirty.set(D3D9DeviceDirtyFlag::FFPixelShader);
-          m_dirty.set(D3D9DeviceDirtyFlag::FFVertexShader);
+          m_dirty.set(D3D9DeviceDirtyFlag::FFGlobalSpecular);
           break;
 
         case D3DRS_FOGENABLE:
@@ -2861,6 +2862,7 @@ namespace dxvk {
     return D3D_OK;
   }
 
+
   HRESULT STDMETHODCALLTYPE D3D9DeviceEx::SetTextureStageState(
           DWORD                    Stage,
           D3DTEXTURESTAGESTATETYPE Type,
@@ -3103,6 +3105,7 @@ namespace dxvk {
 
     return D3D_OK;
   }
+
 
   HRESULT STDMETHODCALLTYPE D3D9DeviceEx::DrawIndexedPrimitive(
           D3DPRIMITIVETYPE PrimitiveType,
@@ -3971,7 +3974,6 @@ namespace dxvk {
       UpdateTextureTypeMismatchesForShader(newShader, newShaderMasks.samplerMask, 0);
 
       bool dirty = m_specInfo.set<D3D9SpecConstantId::SpecFFLastActiveTextureStage>(0u);
-      dirty |= m_specInfo.set<D3D9SpecConstantId::SpecFFGlobalSpecularEnabled>(0u);
       constexpr uint32_t perTextureStageSpecConsts = static_cast<uint32_t>(D3D9SpecConstantId::SpecFFTextureStage1ColorOp) - static_cast<uint32_t>(D3D9SpecConstantId::SpecFFTextureStage0ColorOp);
       for (uint32_t i = 0; i < caps::TextureStageCount; i++) {
         dirty |= m_specInfo.set(static_cast<D3D9SpecConstantId>(D3D9SpecConstantId::SpecFFTextureStage0ColorOp + perTextureStageSpecConsts * i), 0u);
@@ -5484,6 +5486,7 @@ namespace dxvk {
     ConsiderFlush(GpuFlushType::ImplicitWeakHint);
   }
 
+
   void D3D9DeviceEx::EmitGenerateMips(
     D3D9CommonTexture* pResource) {
     if (pResource->IsManaged())
@@ -5709,7 +5712,6 @@ namespace dxvk {
 
     return D3D_OK;
   }
-
 
 
   void D3D9DeviceEx::UploadPerDrawData(
@@ -6926,6 +6928,16 @@ namespace dxvk {
   }
 
 
+  void D3D9DeviceEx::UpdateGlobalSpecular() {
+    m_dirty.clr(D3D9DeviceDirtyFlag::FFGlobalSpecular);
+
+    bool specularEnabled = m_state.renderStates[D3DRS_SPECULARENABLE];
+
+    if (m_specInfo.set<D3D9SpecConstantId::SpecFFGlobalSpecularEnabled>(specularEnabled))
+      m_dirty.set(D3D9DeviceDirtyFlag::SpecializationEntries);
+  }
+
+
   void D3D9DeviceEx::BindFramebuffer() {
     m_dirty.clr(D3D9DeviceDirtyFlag::Framebuffer);
 
@@ -7690,6 +7702,9 @@ namespace dxvk {
 
     UpdatePointMode(PrimitiveType == D3DPT_POINTLIST);
 
+    if (unlikely(m_dirty.test(D3D9DeviceDirtyFlag::FFGlobalSpecular)))
+      UpdateGlobalSpecular();
+
     if (likely(UseProgrammableVS())) {
       UploadConstants<D3D9ShaderType::VertexShader>();
 
@@ -8035,6 +8050,7 @@ namespace dxvk {
     });
   }
 
+
   void D3D9DeviceEx::BindIndices() {
     D3D9CommonBuffer* buffer = GetCommonBuffer(m_state.indices);
 
@@ -8369,8 +8385,6 @@ namespace dxvk {
     key.Data.Contents.SpecularSource   = m_state.renderStates[D3DRS_SPECULARMATERIALSOURCE] & mask;
     key.Data.Contents.EmissiveSource   = m_state.renderStates[D3DRS_EMISSIVEMATERIALSOURCE] & mask;
 
-    key.Data.Contents.SpecularEnabled  = m_state.renderStates[D3DRS_SPECULARENABLE];
-
     uint32_t lightCount = 0;
 
     if (key.Data.Contents.UseLighting) {
@@ -8410,7 +8424,7 @@ namespace dxvk {
   }
 
 
-   void D3D9DeviceEx::UpdateFixedFunctionVS() {
+  void D3D9DeviceEx::UpdateFixedFunctionVS() {
     bool hasPositionT    = m_state.vertexDecl != nullptr && m_state.vertexDecl->TestFlag(D3D9VertexDeclFlag::HasPositionT);
     bool hasBlendWeight  = m_state.vertexDecl != nullptr && m_state.vertexDecl->TestFlag(D3D9VertexDeclFlag::HasBlendWeight);
     bool hasBlendIndices = m_state.vertexDecl != nullptr && m_state.vertexDecl->TestFlag(D3D9VertexDeclFlag::HasBlendIndices);
@@ -8584,8 +8598,6 @@ namespace dxvk {
       stage0.AlphaArg1 = D3DTA_DIFFUSE;
     }
 
-    stage0.GlobalSpecularEnable = m_state.renderStates[D3DRS_SPECULARENABLE];
-
     // The last stage *always* writes to current.
     if (activeTextureStageCount >= 1)
       key.Stages[activeTextureStageCount - 1].Contents.ResultIsTemp = false;
@@ -8620,7 +8632,6 @@ namespace dxvk {
 
       uint32_t lastActiveTextureStage = std::max(activeTextureStageCount, 1u) - 1u; // Subtract 1 to make it fit 3 bits
       bool dirty = m_specInfo.set<D3D9SpecConstantId::SpecFFLastActiveTextureStage>(lastActiveTextureStage);
-      dirty |= m_specInfo.set<D3D9SpecConstantId::SpecFFGlobalSpecularEnabled>(m_state.renderStates[D3DRS_SPECULARENABLE]);
       constexpr uint32_t perTextureStageSpecConsts = static_cast<uint32_t>(D3D9SpecConstantId::SpecFFTextureStage1ColorOp) - static_cast<uint32_t>(D3D9SpecConstantId::SpecFFTextureStage0ColorOp);
       for (uint32_t i = 0; i < caps::TextureStageCount; i++) {
         if (i <= activeTextureStageCount) {
@@ -9171,11 +9182,13 @@ namespace dxvk {
     return D3D_OK;
   }
 
+
   void D3D9DeviceEx::TrackBufferMappingBufferSequenceNumber(
         D3D9CommonBuffer* pResource) {
     uint64_t sequenceNumber = GetCurrentSequenceNumber();
     pResource->TrackMappingBufferSequenceNumber(sequenceNumber);
   }
+
 
   void D3D9DeviceEx::TrackTextureMappingBufferSequenceNumber(
       D3D9CommonTexture* pResource,
@@ -9183,6 +9196,7 @@ namespace dxvk {
     uint64_t sequenceNumber = GetCurrentSequenceNumber();
     pResource->TrackMappingBufferSequenceNumber(Subresource, sequenceNumber);
   }
+
 
   uint64_t D3D9DeviceEx::GetCurrentSequenceNumber() {
     // We do not flush empty chunks, so if we are tracking a resource
@@ -9205,6 +9219,7 @@ namespace dxvk {
     return ptr;
   }
 
+
   void D3D9DeviceEx::TouchMappedTexture(D3D9CommonTexture* pTexture) {
 #ifdef D3D9_ALLOW_UNMAPPING
     if (pTexture->GetMapMode() != D3D9_COMMON_TEXTURE_MAP_MODE_UNMAPPABLE)
@@ -9215,6 +9230,7 @@ namespace dxvk {
 #endif
   }
 
+
   void D3D9DeviceEx::RemoveMappedTexture(D3D9CommonTexture* pTexture) {
 #ifdef D3D9_ALLOW_UNMAPPING
     if (pTexture->GetMapMode() != D3D9_COMMON_TEXTURE_MAP_MODE_UNMAPPABLE)
@@ -9224,6 +9240,7 @@ namespace dxvk {
     m_mappedTextures.remove(pTexture);
 #endif
   }
+
 
   void D3D9DeviceEx::UnmapTextures() {
     // Will only be called inside the device lock
@@ -9268,6 +9285,7 @@ namespace dxvk {
       }
     }
   }
+
 
   void D3D9DeviceEx::NotifyWindowActivated(HWND window, bool activated) {
     D3D9DeviceLock lock = LockDevice();
@@ -9375,6 +9393,7 @@ namespace dxvk {
       return GpuFlushType::ImplicitWeakHint;
   }
 
+
   bool D3D9DeviceEx::ValidateSharedTexture(
     HANDLE                          handle,
     D3DRESOURCETYPE                 type,
@@ -9462,6 +9481,7 @@ namespace dxvk {
     return true;
   }
 
+
   bool D3D9DeviceEx::ValidateSharedBuffer(
       HANDLE                        handle,
       const dxvk::D3D9_BUFFER_DESC& bufferDesc) const {
@@ -9533,4 +9553,5 @@ namespace dxvk {
     /* ignore failures for legacy Proton implementation */
     return true;
   }
+
 }

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -80,6 +80,7 @@ namespace dxvk {
     FFPixelShader,
     FFViewport,
     FFPixelData,
+    FFGlobalSpecular,
     SharedPixelShaderData,
     DepthBounds,
     PointScale,
@@ -1037,6 +1038,8 @@ namespace dxvk {
     void UploadConstants();
 
     void UpdateClipPlanes();
+
+    void UpdateGlobalSpecular();
 
     /**
      * \brief Updates the push constant data at the given offset with data from the specified pointer.

--- a/src/d3d9/d3d9_spec_constants.h
+++ b/src/d3d9/d3d9_spec_constants.h
@@ -163,7 +163,7 @@ namespace dxvk {
       { 5, 24, 2 },  // PointMode
       { 5, 26, 5 },  // DrefScaling
 
-      { 6, 31, 1 },  // FFGlobalSpecularEnabled.
+      { 6, 31, 1 },  // FFGlobalSpecularEnabled
       // Packed with Texture stage 0 but placed here out of order so every texture stage
       // has the same number of entries in the Layout array.
 

--- a/src/d3d9/d3d9_state.h
+++ b/src/d3d9/d3d9_state.h
@@ -141,7 +141,6 @@ namespace dxvk {
         uint32_t TransformFlags : 24;
 
         uint32_t LightCount : 4;
-        uint32_t SpecularEnabled : 1;
 
         // End of uint32_t
 
@@ -213,10 +212,6 @@ namespace dxvk {
         uint32_t     AlphaArg2 : 6;
 
         uint32_t     ResultIsTemp : 1;
-
-        // Included in here, read from Stage 0 for packing reasons
-        // Affects all stages.
-        uint32_t     GlobalSpecularEnable : 1;
       } Contents;
 
       uint32_t Primitive[2];

--- a/src/d3d9/shaders/d3d9_fixed_function_common.glsl
+++ b/src/d3d9/shaders/d3d9_fixed_function_common.glsl
@@ -187,7 +187,7 @@ BitfieldPosition SpecConstLayout[SpecConstantCount] = {
     { 5, 24, 2 },  // PointMode
     { 5, 26, 5 },  // DrefScaling
 
-    { 6, 31, 1 },  // FFGlobalSpecularEnabled.
+    { 6, 31, 1 },  // FFGlobalSpecularEnabled
 
     { 6,  0, 5 },  // FFTextureStage0ColorOp
     { 6,  5, 5 },  // FFTextureStage0ColorArg1

--- a/src/d3d9/shaders/d3d9_fixed_function_vert.vert
+++ b/src/d3d9/shaders/d3d9_fixed_function_vert.vert
@@ -209,9 +209,6 @@ uint transformFlags() {
 uint lightCount() {
     return bitfieldExtract(data.KeyPrimitives[2], 24, 4);
 }
-bool specularEnabled() {
-    return bitfieldExtract(data.KeyPrimitives[2], 28, 1) != 0;
-}
 
 uint vertexTexcoordDeclMask() {
     return bitfieldExtract(data.KeyPrimitives[3], 0, 24);
@@ -679,7 +676,7 @@ void main() {
         finalColor1 = clamp(finalColor1, vec4(0.0), vec4(1.0));
 
         out_Color0 = finalColor0;
-        if (specularEnabled()) {
+        if (specBool(SpecFFGlobalSpecularEnabled)) {
             out_Color1 = finalColor1;
         } else {
             out_Color1 = vertexHasColor1() ? in_Color1 : vec4(0.0, 0.0, 0.0, 1.0);


### PR DESCRIPTION
I don't quite understand why this was cobbled together with the texture stage stuff, or duplicated in both shader key and spec constants, and at this point I'm too afraid to ask.

@K0bin Let me know if I missed anything, though it looks good in Halo, the bane of specular lighting.