### PR TITLE
FF: Consider texture op when determining whether to sample textures

### DIFF
--- a/src/d3d9/shaders/d3d9_fixed_function_common.glsl
+++ b/src/d3d9/shaders/d3d9_fixed_function_common.glsl
@@ -163,7 +163,7 @@ struct BitfieldPosition {
 };
 
 // Needs to match d3d9_spec_constants.h
-BitfieldPosition SpecConstLayout[SpecConstantCount] = {
+const BitfieldPosition SpecConstLayout[SpecConstantCount] = {
     { 0, 0, 32 },  // SamplerType
 
     { 1, 0,  21 }, // SamplerDepthMode

--- a/src/d3d9/shaders/d3d9_fixed_function_frag.glsl
+++ b/src/d3d9/shaders/d3d9_fixed_function_frag.glsl
@@ -589,7 +589,9 @@ TextureStageState runTextureStage(uint stage, TextureStageState state) {
         || (colorArgs.arg2 & D3DTA_SELECTMASK) == D3DTA_TEXTURE
         || (alphaArgs.arg0 & D3DTA_SELECTMASK) == D3DTA_TEXTURE
         || (alphaArgs.arg1 & D3DTA_SELECTMASK) == D3DTA_TEXTURE
-        || (alphaArgs.arg2 & D3DTA_SELECTMASK) == D3DTA_TEXTURE;
+        || (alphaArgs.arg2 & D3DTA_SELECTMASK) == D3DTA_TEXTURE
+        || (colorOp == D3DTOP_BLENDTEXTUREALPHA || colorOp == D3DTOP_BLENDTEXTUREALPHAPM)
+        || (alphaOp == D3DTOP_BLENDTEXTUREALPHA || alphaOp == D3DTOP_BLENDTEXTUREALPHAPM);
 
     if (usesTexture) {
         // We need to replace TEXCOORD inputs with gl_PointCoord


### PR DESCRIPTION
Sims 2 uses `D3DTOP_BLENDTEXTUREALPHA`, and none of the arguments are `D3DTA_TEXTURE`, so we didn't actually end up sampling the texture.

Game is broken though, they clearly intended `BLENDCURRENTALPHA` because the texture that they do end up sampling is just random nonsense, it works completely by accident.

Should fix #5666.