### PR TITLE
Add missing DXVK config entry for Fallout New Vegas PCR version executable

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -944,7 +944,7 @@ namespace dxvk {
      * in mod New Vegas Reloaded. Nvidia path in  *
      * same mod use NvAPI_D3D9_StretchRectEx for  *
      * depth buffer resolves                      */
-    { R"(\\FalloutNV(Launcher)?\.exe$)", {{
+    { R"(\\FalloutNV(Launcher)?|Launcher)\.exe$)", {{
       { "d3d9.floatEmulation",            "Strict" },
       { "d3d9.hideNvidiaGpu",               "True" },
     }} },

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -944,7 +944,7 @@ namespace dxvk {
      * in mod New Vegas Reloaded. Nvidia path in  *
      * same mod use NvAPI_D3D9_StretchRectEx for  *
      * depth buffer resolves                      */
-    { R"(\\FalloutNV(Launcher)?|Launcher)\.exe$)", {{
+    { R"(\\Fallout New Vegas.*\\(FalloutNV)?(Launcher)?\.exe$)", {{
       { "d3d9.floatEmulation",            "Strict" },
       { "d3d9.hideNvidiaGpu",               "True" },
     }} },


### PR DESCRIPTION

Closes #5637 
The Fallout New Vegas PCR version includes Launcher.exe; it does not detect this file and does not hide the Nvidia GPU according to the configuration 