### PR TITLE
Fix parallel pipeline variant compiles

### DIFF
--- a/src/dxvk/dxvk_graphics.cpp
+++ b/src/dxvk/dxvk_graphics.cpp
@@ -1398,25 +1398,40 @@ namespace dxvk {
     DxvkGraphicsPipelineFastInstanceKey key(m_device,
       m_shaders, state, m_flags, m_specConstantMask);
 
-    std::lock_guard lock(m_fastMutex);
+    // Only need to hold the lock to look up or create the instance object.
+    std::unique_lock lock(m_fastMutex);
 
-    auto entry = m_fastPipelines.find(key);
-    if (entry != m_fastPipelines.end())
-      return entry->second;
+    auto entry = m_fastPipelines.emplace(std::piecewise_construct,
+      std::tuple(key),
+      std::tuple(VK_NOT_READY, VK_NULL_HANDLE));
 
-    // Keep pipeline locked to prevent multiple threads from compiling
-    // identical Vulkan pipelines. This should be rare, but has been
-    // buggy on some drivers in the past, so just don't allow it.
-    VkPipeline handle = createOptimizedPipeline(key);
+    lock.unlock();
 
-    if (handle)
-      m_fastPipelines.insert({ key, handle });
+    if (entry.second) {
+      // Pipeline doesn't exist yet. Compile it and write the status back last
+      // so that other threads can safely read the pipeline handle.
+      auto [status, handle] = createOptimizedPipeline(key);
 
-    return handle;
+      entry.first->second.pipeline = handle;
+      entry.first->second.status.store(status, std::memory_order_release);
+
+      return handle;
+    } else {
+      // Pipeline already exists. Busy-wait until status becomes something
+      // other than VK_NOT_READY in order to avoid compiling the same pipeline
+      // on multiple threads in parallel, which is problematic on some drivers.
+      // This should be quite rare anyway.
+      sync::spin(1000u, [&entry] {
+        auto status = entry.first->second.status.load(std::memory_order_acquire);
+        return status != VK_NOT_READY;
+      });
+
+      return entry.first->second.pipeline;
+    }
   }
 
 
-  VkPipeline DxvkGraphicsPipeline::createOptimizedPipeline(
+  std::pair<VkResult, VkPipeline> DxvkGraphicsPipeline::createOptimizedPipeline(
     const DxvkGraphicsPipelineFastInstanceKey& key) const {
     auto vk = m_device->vkd();
     auto layout = m_layout.getLayout(DxvkPipelineLayoutType::Merged);
@@ -1473,10 +1488,10 @@ namespace dxvk {
 
     if (vr != VK_SUCCESS) {
       Logger::err(str::format("DxvkGraphicsPipeline: Failed to compile pipeline: ", vr));
-      return VK_NULL_HANDLE;
+      return std::make_pair(vr, VK_NULL_HANDLE);
     }
 
-    return pipeline;
+    return std::make_pair(vr, pipeline);
   }
   
   
@@ -1494,7 +1509,7 @@ namespace dxvk {
 
   void DxvkGraphicsPipeline::destroyOptimizedPipelines() {
     for (const auto& instance : m_fastPipelines)
-      this->destroyVulkanPipeline(instance.second);
+      this->destroyVulkanPipeline(instance.second.pipeline);
 
     m_fastPipelines.clear();
   }

--- a/src/dxvk/dxvk_graphics.h
+++ b/src/dxvk/dxvk_graphics.h
@@ -472,6 +472,24 @@ namespace dxvk {
 
 
   /**
+   * \brief Fast instance object
+   *
+   * Stores the pipeline handle, as well as the compile status. Can
+   * be accessed from multiple threads concurrently. A status of
+   * VK_NOT_READY indicates that pipeline compilation is still in
+   * progress on another thread.
+   */
+  struct DxvkGraphicsPipelineFastInstanceObject {
+    DxvkGraphicsPipelineFastInstanceObject() = default;
+    DxvkGraphicsPipelineFastInstanceObject(VkResult s, VkPipeline p)
+    : pipeline(p), status(s) { }
+
+    VkPipeline pipeline = VK_NULL_HANDLE;
+    std::atomic<VkResult> status = { VK_NOT_READY };
+  };
+
+
+  /**
    * \brief Graphics pipeline
    * 
    * Stores the pipeline layout as well as methods to
@@ -625,7 +643,8 @@ namespace dxvk {
     dxvk::mutex                                   m_fastMutex;
     std::unordered_map<
       DxvkGraphicsPipelineFastInstanceKey,
-      VkPipeline, DxvkHash, DxvkEq>               m_fastPipelines;
+      DxvkGraphicsPipelineFastInstanceObject,
+      DxvkHash, DxvkEq> m_fastPipelines;
 
     DxvkGraphicsPipelineInstance* createInstance(
       const DxvkGraphicsPipelineStateInfo& state,
@@ -646,7 +665,7 @@ namespace dxvk {
     VkPipeline getOptimizedPipeline(
       const DxvkGraphicsPipelineStateInfo& state);
 
-    VkPipeline createOptimizedPipeline(
+    std::pair<VkResult, VkPipeline> createOptimizedPipeline(
       const DxvkGraphicsPipelineFastInstanceKey& key) const;
 
     void destroyBasePipelines();

--- a/src/dxvk/dxvk_pipemanager.cpp
+++ b/src/dxvk/dxvk_pipemanager.cpp
@@ -81,23 +81,28 @@ namespace dxvk {
 
   void DxvkPipelineWorkers::startWorkers() {
     if (!std::exchange(m_workersRunning, true)) {
-      // Use all available cores by default
-      uint32_t workerCount = dxvk::thread::hardware_concurrency();
+      // Determine number of available CPU cores, and clamp to a useful
+      // range. DXVK is not tested on extremely high core counts, and
+      // parallelism may be limited past a certain point.
+      uint32_t coreCount = dxvk::thread::hardware_concurrency();
+      coreCount = std::clamp(coreCount, 1u, 64u);
 
-      if (workerCount <  1) workerCount =  1;
-      if (workerCount > 64) workerCount = 64;
+      if (m_device->config().numCompilerThreads > 0)
+        coreCount = m_device->config().numCompilerThreads;
 
       // Reduce worker count on 32-bit to save adderss space
+      uint32_t workerCount = coreCount;
+
       if (env::is32BitHostPlatform())
         workerCount = std::min(workerCount, 16u);
 
-      if (m_device->config().numCompilerThreads > 0)
-        workerCount = m_device->config().numCompilerThreads;
-
       // Number of workers that can process pipeline pipelines with normal
       // priority. Any other workers can only build high-priority pipelines.
-      uint32_t npWorkerCount = std::max(((workerCount - 1) * 5) / 7, 1u);
-      uint32_t lpWorkerCount = std::max(((workerCount - 1) * 2) / 7, 1u);
+      // Base this on the available core count, not the worker count, since
+      // that is what determines the impact of having multiple threads do
+      // heavy CPU work.
+      uint32_t npWorkerCount = std::clamp(((coreCount - 1) * 5) / 7, 1u, workerCount);
+      uint32_t lpWorkerCount = std::clamp(((coreCount - 1) * 2) / 7, 1u, workerCount);
 
       m_workers.reserve(workerCount);
 


### PR DESCRIPTION
Bit of an oversight from the fixed-function rework.

Previously, we intentionally kept pipeline objects locked while compiling a single variant to avoid having multiple threads compile the exact same pipeline, which wasn't really an issue with regular shader pipelines because we'd typically have many different pipelines with only one or two variants each.

With the "new" D3D9 fixed-function shaders however, we have *one* pipeline that can easily have *hundreds* of variants, and since the shaders themselves are quite complex, compiling them can take quite a while too, so not having parallel background compiles work really isn't great. And we do absolutely need the background compiles for performance to be acceptable.

Needs a bit of spot testing to make sure nothing blows up, esp. on the 32-bit Nvidia front.