### PR TITLE
[util] Extend Fallout NV regex to include the GOG release

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -278,7 +278,7 @@ namespace dxvk {
     /* Crazy Machines 3 - crashes on long device  *
      * descriptions                               */
     { R"(\\cm3\.exe$)", {{
-      { "dxgi.customDeviceDesc",            "DXVK Device" },
+      { "dxgi.customDeviceDesc",     "DXVK Device" },
     }} },
     /* World of Final Fantasy: Broken and useless use     *
      * of 4x MSAA throughout the renderer. Water doesn't  *
@@ -286,7 +286,7 @@ namespace dxvk {
      * us plebs aren't worthy of the divine pixel liquid. */
     { R"(\\WOFF\.exe$)", {{
       { "d3d11.disableMsaa",                "True" },
-      { "dxgi.customDeviceDesc",            "DXVK Device" },
+      { "dxgi.customDeviceDesc",     "DXVK Device" },
     }} },
     /* Mary Skelter 2 - Broken MSAA               */
     { R"(\\MarySkelter2\.exe$)", {{
@@ -362,7 +362,7 @@ namespace dxvk {
     /* The Evil Within 2 *
     * Game speeds up above 120 fps */
     { R"(\\TEW2\.exe$)", {{
-      { "dxgi.maxFrameRate",                 "-120" },
+      { "dxgi.maxFrameRate",                "-120" },
     }} },
     /* Sonic Frontiers - flickering shadows and   *
      * vegetation when GPU-bound                  */
@@ -759,8 +759,8 @@ namespace dxvk {
      * Resolution change crash and cached         *
      * dynamic buffers for performance reasons    */
     { R"(\\eoa\.exe$)", {{
-      { "d3d9.cachedWriteOnlyBuffers",        "True" },
-      { "d3d9.countLosableResources",         "False" },
+      { "d3d9.cachedWriteOnlyBuffers",      "True" },
+      { "d3d9.countLosableResources",      "False" },
     }} },
     /* Supreme Commander & Forged Alliance Forever */
     { R"(\\(SupremeCommander|ForgedAlliance)\.exe$)", {{
@@ -944,7 +944,7 @@ namespace dxvk {
      * in mod New Vegas Reloaded. Nvidia path in  *
      * same mod use NvAPI_D3D9_StretchRectEx for  *
      * depth buffer resolves                      */
-    { R"(\\Fallout New Vegas.*\\(FalloutNV)?(Launcher)?\.exe$)", {{
+    { R"(\\Fallout( -)? New Vegas.*\\(FalloutNV)?(Launcher)?\.exe$)", {{
       { "d3d9.floatEmulation",            "Strict" },
       { "d3d9.hideNvidiaGpu",               "True" },
     }} },


### PR DESCRIPTION
The GOG release of Fallout: New Vegas uses a dash in the default installation directory. Also fixed a few alignment nits while I was at it.