### PR TITLE
Implement support for PUSH_ADDRESS constant buffer bindings

### DIFF
--- a/src/d3d9/d3d9_shader.cpp
+++ b/src/d3d9/d3d9_shader.cpp
@@ -401,11 +401,10 @@ namespace dxvk {
     dxbc_spv::ir::SsaDef emitSpecConstantCbv() {
       using namespace dxbc_spv;
 
-      auto result = m_builder.add(ir::Op::DclCbv(
-        ir::Type(ir::ScalarType::eU32).addArrayDimension(DxvkLimits::MaxNumSpecConstants),
-        m_entryPoint, 0u, uint32_t(D3D9IrCbvIndex::SpecData), 1u));
-      m_builder.add(ir::Op::DebugName(result, "spec_data"));
-
+      auto specDataType = ir::Type(ir::ScalarType::eU32).addArrayDimension(DxvkLimits::MaxNumSpecConstants);
+      auto result = m_builder.add(ir::Op::DclCbv(specDataType, m_entryPoint,
+        0u, uint32_t(D3D9IrCbvIndex::SpecData), 1u).setFlags(ir::OpFlag::eInBounds));
+      m_builder.add(ir::Op::DebugName(result, "specData"));
       return result;
     }
 
@@ -428,7 +427,8 @@ namespace dxvk {
         m_specCbv = emitSpecConstantCbv();
 
       auto cbvDescriptor = m_builder.add(ir::Op::DescriptorLoad(ir::ScalarType::eCbv, m_specCbv, m_builder.makeConstant(0u)));
-      auto cbvLoad = m_builder.add(ir::Op::BufferLoad(ir::ScalarType::eU32, cbvDescriptor, m_builder.makeConstant(layout.dwordOffset), 4u));
+      auto cbvLoad = m_builder.add(ir::Op::BufferLoad(ir::ScalarType::eU32, cbvDescriptor,
+        m_builder.makeConstant(layout.dwordOffset), 4u).setFlags(ir::OpFlag::eInBounds));
 
       auto dword = m_builder.add(ir::Op::Select(ir::ScalarType::eU32, m_specSelector, specDef, cbvLoad));
 
@@ -716,7 +716,8 @@ namespace dxvk {
 
       if (!m_clipPlaneCbv) {
         m_clipPlaneCbv = m_builder.add(ir::Op::DclCbv(clipCbvType,
-          m_entryPoint, 0u, uint32_t(D3D9IrCbvIndex::VsClipping), 1u));
+          m_entryPoint, 0u, uint32_t(D3D9IrCbvIndex::VsClipping), 1u)
+          .setFlags(ir::OpFlag::eInBounds));
         m_builder.add(ir::Op::DebugName(m_clipPlaneCbv, "clipPlanes"));
       }
 
@@ -740,8 +741,8 @@ namespace dxvk {
               ir::ScalarType::eCbv, m_clipPlaneCbv, m_builder.makeConstant(0u)));
             auto index = m_builder.makeConstant(i - uint32_t(ir::LegacyClipPlaneLayout::eClipPlane0));
 
-            resultOp.addOperand(m_builder.addBefore(ref, ir::Op::BufferLoad(
-              clipCbvType.getSubType(0u), descriptor, index, 16u)));
+            resultOp.addOperand(m_builder.addBefore(ref, ir::Op::BufferLoad(clipCbvType.getSubType(0u),
+              descriptor, index, 16u).setFlags(ir::OpFlag::eInBounds)));
           } break;
         }
       }
@@ -900,7 +901,8 @@ namespace dxvk {
 
       if (!m_textureStageCbv) {
         m_textureStageCbv = m_builder.add(ir::Op::DclCbv(textureStageCbvType,
-          m_entryPoint, 0u, uint32_t(D3D9IrCbvIndex::PsTextureStages), 1u));
+          m_entryPoint, 0u, uint32_t(D3D9IrCbvIndex::PsTextureStages), 1u)
+          .setFlags(ir::OpFlag::eInBounds));
 
         m_builder.add(ir::Op::DebugName(m_textureStageCbv, "textureStages"));
         m_builder.add(ir::Op::DebugMemberName(m_textureStageCbv, 0u, "constant"));
@@ -936,7 +938,8 @@ namespace dxvk {
         // Members in this struct are naturally aligned
         resultOp.addOperand(m_builder.addBefore(ref, ir::Op::BufferLoad(
           textureStageCbvType.getBaseType(member), descriptor, address,
-          textureStageCbvType.getBaseType(member).byteSize())));
+          textureStageCbvType.getBaseType(member).byteSize())
+          .setFlags(ir::OpFlag::eInBounds)));
       }
 
       return m_builder.addBefore(ref, std::move(resultOp));

--- a/src/dxvk/dxvk_device.cpp
+++ b/src/dxvk/dxvk_device.cpp
@@ -808,6 +808,12 @@ namespace dxvk {
         DxvkShaderCompileFlag::LowerF32toF16);
     }
 
+    // On AMD, push constant BDA will not be worse than going through a descriptor
+    if (m_adapter->matchesDriver(VK_DRIVER_ID_MESA_RADV)
+     || m_adapter->matchesDriver(VK_DRIVER_ID_AMD_OPEN_SOURCE)
+     || m_adapter->matchesDriver(VK_DRIVER_ID_AMD_PROPRIETARY))
+      m_shaderOptions.flags.set(DxvkShaderCompileFlag::LowerInBoundsCbvToBda);
+
     // Converting unsigned integers to float should return an unsigned float,
     // but Nvidia drivers prior to 580 don't agree
     if (m_adapter->matchesDriver(VK_DRIVER_ID_NVIDIA_PROPRIETARY, Version(), Version(580u, 0u, 0u)))
@@ -881,6 +887,9 @@ namespace dxvk {
 
     if (m_features.khrShaderFloatControls2.shaderFloatControls2)
       m_shaderOptions.spirv.set(DxvkShaderSpirvFlag::SupportsFloatControls2);
+
+    if (canUseDescriptorHeap())
+      m_shaderOptions.spirv.set(DxvkShaderSpirvFlag::SupportsDescriptorHeap);
 
     // Set up resource indexing flags
     if (m_features.core.features.shaderUniformBufferArrayDynamicIndexing &&

--- a/src/dxvk/dxvk_pipelayout.cpp
+++ b/src/dxvk/dxvk_pipelayout.cpp
@@ -365,6 +365,21 @@ namespace dxvk {
         pushIndex.heapArrayStride = m_device->getDescriptorProperties().getDescriptorTypeInfo(bindingInfo.descriptorType).size;
       }
     }
+
+    for (uint32_t i = 0u; i < key.getVaBindingCount(); i++) {
+      auto bindingInfo = key.getVaBinding(i);
+
+      auto& entry = m_mapping.mappings.emplace_back();
+      entry.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_AND_BINDING_MAPPING_EXT;
+      entry.descriptorSet = DxvkDescriptorSets::Virtual;
+      entry.firstBinding = bindingInfo.binding;
+      entry.bindingCount = 1u;
+      entry.resourceMask = VK_SPIRV_RESOURCE_TYPE_UNIFORM_BUFFER_BIT_EXT
+                         | VK_SPIRV_RESOURCE_TYPE_READ_ONLY_STORAGE_BUFFER_BIT_EXT
+                         | VK_SPIRV_RESOURCE_TYPE_READ_WRITE_STORAGE_BUFFER_BIT_EXT;
+      entry.source = VK_DESCRIPTOR_MAPPING_SOURCE_PUSH_ADDRESS_EXT;
+      entry.sourceData.pushAddressOffset = bindingInfo.vaOffset;
+    }
   }
 
 
@@ -460,11 +475,13 @@ namespace dxvk {
     auto setLayouts = buildDescriptorSetLayouts(type, flags, setInfos, builder, manager);
 
     // Create the actual pipeline layout
+    auto& layout = m_layouts[uint32_t(type)];
+
     DxvkPipelineLayoutKey key(type, flags, builder.getStageMask(),
       pushDataBlocks.size(), pushDataBlocks.data(),
-      setLayouts.size(), setLayouts.data());
+      setLayouts.size(), setLayouts.data(),
+      layout.vaBindings.size(), layout.vaBindings.data());
 
-    auto& layout = m_layouts[uint32_t(type)];
     layout.layout = manager->createPipelineLayout(key);
   }
 
@@ -563,6 +580,8 @@ namespace dxvk {
 
     auto& layout = m_layouts[uint32_t(type)];
 
+    uint32_t virtualBindingCount = 0u;
+
     // Generate descriptor set layout keys from all bindings
     std::array<DxvkDescriptorSetLayoutKey, MaxSets> setLayoutKeys = { };
 
@@ -582,9 +601,13 @@ namespace dxvk {
         auto bindingIndex = setLayoutKeys[set].add(DxvkDescriptorSetLayoutBinding(binding));
         dstMapping = DxvkShaderBinding(binding.getStageMask(), realSet, bindingIndex);
 
-        layout.bindingMap.addBinding(srcMapping, dstMapping);
         layout.setStateMasks[set] |= computeStateMask(binding);
+      } else {
+        dstMapping = DxvkShaderBinding(binding.getStageMask(),
+          DxvkDescriptorSets::Virtual, virtualBindingCount++);
       }
+
+      layout.bindingMap.addBinding(srcMapping, dstMapping);
 
       if (binding.getDescriptorCount()) {
         if (binding.usesDescriptor()) {

--- a/src/dxvk/dxvk_pipelayout.h
+++ b/src/dxvk/dxvk_pipelayout.h
@@ -85,6 +85,10 @@ namespace dxvk {
 
     // Maximum number of descriptor sets per layout
     static constexpr uint32_t SetCount                  = 2u;
+
+    // Virtual descriptor set index, only used for mapping purposes
+    // on the descriptor heap path. Not backed by actual descriptors.
+    static constexpr uint32_t Virtual                   = 15u;
   };
 
 
@@ -971,6 +975,25 @@ namespace dxvk {
 
 
   /**
+   * \brief Binding to push address mapping
+   *
+   * Can be used as a descriptor heap fast path for certain resources.
+   */
+  struct DxvkPipelineLayoutVaBinding {
+    uint16_t binding  = 0u;
+    uint16_t vaOffset = 0u;
+
+    bool eq(const DxvkPipelineLayoutVaBinding& other) const {
+      return binding == other.binding && vaOffset == other.vaOffset;
+    }
+
+    size_t hash() const {
+      return size_t(binding) | (size_t(vaOffset) << 16u);
+    }
+  };
+
+
+  /**
    * \brief Pipeline layout key
    *
    * Used to look up pipeline layout objects. Stores a reference to the
@@ -980,7 +1003,7 @@ namespace dxvk {
    * unique as well.
    */
   class DxvkPipelineLayoutKey {
-
+    static constexpr uint32_t MaxVaBindings = MaxTotalPushDataSize / sizeof(VkDeviceAddress);
   public:
 
     constexpr static uint32_t MaxSets = uint32_t(DxvkDescriptorSets::SetCount);
@@ -1000,12 +1023,17 @@ namespace dxvk {
             uint32_t                  pushDataBlockCount,
       const DxvkPushDataBlock*        pushDataBlocks,
             uint32_t                  setCount,
-      const DxvkDescriptorSetLayout** setLayouts)
+      const DxvkDescriptorSetLayout** setLayouts,
+            uint32_t                  vaBindingCount,
+      const DxvkShaderDescriptor*     vaBindings)
     : m_type          (type),
       m_flags         (flags),
       m_stages        (uint8_t(stageMask)) {
       for (uint32_t i = 0u; i < pushDataBlockCount; i++)
         addPushData(pushDataBlocks[i]);
+
+      for (uint32_t i = 0u; i < vaBindingCount; i++)
+        addVaBinding(vaBindings[i]);
 
       setDescriptorSetLayouts(setCount, setLayouts);
     }
@@ -1048,6 +1076,18 @@ namespace dxvk {
         m_pushMask |= 1u << index;
         m_pushData[index].merge(block);
       }
+    }
+
+    /**
+     * \brief Adds a VA binding
+     *
+     * The binding must use the virtual set index.
+     * \param [in] binding Binding to add
+     */
+    void addVaBinding(const DxvkShaderDescriptor& binding) {
+      auto& va = m_vaBindings.at(m_vaCount++);
+      va.binding = binding.getBinding();
+      va.vaOffset = binding.getBlockOffset();
     }
 
     /**
@@ -1136,6 +1176,24 @@ namespace dxvk {
     }
 
     /**
+     * \brief Queries VA binding mapping count
+     * \returns Number of VA binding mappings
+     */
+    uint32_t getVaBindingCount() const {
+      return m_vaCount;
+    }
+
+    /**
+     * \brief Queries VA binding info
+     *
+     * \param [in] index VA binding index
+     * \returns Mapping info for the given binding
+     */
+    DxvkPipelineLayoutVaBinding getVaBinding(uint32_t index) const {
+      return m_vaBindings[index];
+    }
+
+    /**
      * \brief Checks for equality
      *
      * \param [in] other Pipeline layout key to compare to
@@ -1146,13 +1204,17 @@ namespace dxvk {
              && m_flags     == other.m_flags
              && m_stages    == other.m_stages
              && m_pushMask  == other.m_pushMask
-             && m_setCount  == other.m_setCount;
+             && m_setCount  == other.m_setCount
+             && m_vaCount   == other.m_vaCount;
 
       for (auto i : bit::BitMask(uint32_t(m_pushMask)))
         eq &= m_pushData[i].eq(other.m_pushData[i]);
 
       for (uint32_t i = 0; i < m_setCount && eq; i++)
         eq = m_sets[i] == other.m_sets[i];
+
+      for (uint32_t i = 0; i < m_vaCount && eq; i++)
+        eq = m_vaBindings[i].eq(other.m_vaBindings[i]);
 
       return eq;
     }
@@ -1166,14 +1228,18 @@ namespace dxvk {
       hash.add(uint16_t(m_type));
       hash.add(m_flags.raw());
       hash.add(m_stages);
-      hash.add(m_setCount);
       hash.add(m_pushMask);
+      hash.add(m_setCount);
+      hash.add(m_vaCount);
 
       for (auto i : bit::BitMask(uint32_t(m_pushMask)))
         hash.add(m_pushData[i].hash());
 
       for (uint32_t i = 0; i < m_setCount; i++)
         hash.add(reinterpret_cast<uintptr_t>(m_sets[i]));
+
+      for (uint32_t i = 0; i < m_vaCount; i++)
+        hash.add(m_vaBindings[i].hash());
 
       return hash;
     }
@@ -1185,8 +1251,10 @@ namespace dxvk {
     uint8_t                 m_stages    = 0u;
     uint8_t                 m_pushMask  = 0u;
     uint8_t                 m_setCount  = 0u;
+    uint8_t                 m_vaCount   = 0u;
 
     std::array<DxvkPushDataBlock, DxvkPushDataBlock::MaxBlockCount> m_pushData = { };
+    std::array<DxvkPipelineLayoutVaBinding, MaxVaBindings> m_vaBindings = { };
 
     std::array<const DxvkDescriptorSetLayout*, MaxSets> m_sets = { };
 

--- a/src/dxvk/dxvk_shader.h
+++ b/src/dxvk/dxvk_shader.h
@@ -83,6 +83,8 @@ namespace dxvk {
     LowerConstantArrays         = 11u,
     /// Whether to enable semantic-based I/O interface matching
     SemanticIo                  = 12u,
+    /// Whether to explicitly use BDA for fully-bound constant buffers.
+    LowerInBoundsCbvToBda       = 13u,
   };
 
   using DxvkShaderCompileFlags = Flags<DxvkShaderCompileFlag>;
@@ -132,6 +134,8 @@ namespace dxvk {
     /// Whether dynamic non-uniform resource indexing is
     /// supported. Only applies to typed resources.
     SupportsResourceIndexing    = 20u,
+    /// Whether descriptor heap is used as the binding model.
+    SupportsDescriptorHeap      = 21u,
   };
 
   using DxvkShaderSpirvFlags = Flags<DxvkShaderSpirvFlag>;

--- a/src/dxvk/dxvk_shader_ir.cpp
+++ b/src/dxvk/dxvk_shader_ir.cpp
@@ -265,6 +265,7 @@ namespace dxvk {
       }
 
       rewriteSamplers();
+      rewriteConstantBuffers();
       rewriteUavCounters();
 
       if (m_sharedPushDataOffset) {
@@ -311,6 +312,10 @@ namespace dxvk {
     }
 
   private:
+
+    struct CbvInfo {
+      dxbc_spv::ir::SsaDef cbv = { };
+    };
 
     struct SamplerInfo {
       dxbc_spv::ir::SsaDef sampler = { };
@@ -372,6 +377,7 @@ namespace dxvk {
 
     uint32_t                      m_sharedPushDataOffset = 0u;
 
+    small_vector<CbvInfo,         16u>  m_cbv;
     small_vector<SamplerInfo,     16u>  m_samplers;
     small_vector<UavCounterInfo,  64u>  m_uavCounters;
 
@@ -478,25 +484,8 @@ namespace dxvk {
 
 
     dxbc_spv::ir::Builder::iterator handleCbv(dxbc_spv::ir::Builder::iterator op) {
-      auto regSpace = uint32_t(op->getOperand(1u));
-      auto regIndex = uint32_t(op->getOperand(2u));
-      auto regCount = uint32_t(op->getOperand(3u));
-
-      DxvkBindingInfo binding = { };
-      binding.set = DxvkShaderResourceMapping::setIndexForType(dxbc_spv::ir::ScalarType::eCbv);
-      binding.binding = regIndex;
-      binding.resourceIndex = m_shader.determineResourceIndex(m_stage,
-        dxbc_spv::ir::ScalarType::eCbv, regSpace, regIndex);
-      binding.descriptorType = determineDescriptorType(*op);
-      binding.descriptorCount = regCount;
-      binding.access = VK_ACCESS_UNIFORM_READ_BIT;
-
-      if (binding.descriptorType != VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER)
-        binding.access = VK_ACCESS_SHADER_READ_BIT;
-
-      binding.flags.set(DxvkDescriptorFlag::UniformBuffer);
-
-      addBinding(binding);
+      auto& e = m_cbv.emplace_back();
+      e.cbv = op->getDef();
       return ++op;
     }
 
@@ -918,6 +907,119 @@ namespace dxvk {
       }
 
       return m_builder.iter(m_builder.remove(op->getDef()));
+    }
+
+
+    void rewriteCbvUseAsBda(const dxbc_spv::ir::Op& cbv, const dxbc_spv::ir::Type& type, const dxbc_spv::ir::Op& use) {
+      // Replace descriptor load with push data load and pointer instruction
+      auto load = m_builder.addBefore(use.getDef(), dxbc_spv::ir::Op::PushDataLoad(
+        dxbc_spv::ir::ScalarType::eU64, cbv.getDef(), dxbc_spv::ir::SsaDef()));
+
+      m_builder.rewriteOp(use.getDef(), dxbc_spv::ir::Op::Pointer(
+        type, load, dxbc_spv::ir::UavFlag::eReadOnly));
+
+      // Replace all buffer loads with memory loads
+      small_vector<dxbc_spv::ir::SsaDef, 256u> uses;
+      m_builder.getUses(use.getDef(), uses);
+
+      for (auto use : uses) {
+        const auto& useOp = m_builder.getOp(use);
+
+        if (useOp.getOpCode() == dxbc_spv::ir::OpCode::eBufferLoad) {
+          dxbc_spv::ir::Op newOp(dxbc_spv::ir::OpCode::eMemoryLoad, useOp.getType());
+
+          for (uint32_t i = 0u; i < useOp.getOperandCount(); i++)
+            newOp.addOperand(useOp.getOperand(i));
+
+          newOp.setFlags(useOp.getFlags());
+          m_builder.rewriteOp(use, std::move(newOp));
+        }
+      }
+    }
+
+
+    void rewriteCbvAsBda(const dxbc_spv::ir::Op& cbv, uint32_t pushDataOffset) {
+      // Replace all descriptor loads with a push data load and conversion to
+      // pointer, and in turn replace all buffer loads with raw memory loads
+      small_vector<dxbc_spv::ir::SsaDef, 16u> uses;
+      m_builder.getUses(cbv.getDef(), uses);
+
+      // Rewrite CBV declaration as a 64-bit push data declaration.
+      // Keeps the debug name intact.
+      auto cbvType = cbv.getType();
+      auto entryPoint = dxbc_spv::ir::SsaDef(cbv.getOperand(0u));
+
+      m_builder.rewriteOp(cbv.getDef(), dxbc_spv::ir::Op::DclPushData(
+        dxbc_spv::ir::ScalarType::eU64, entryPoint, pushDataOffset, m_stage));
+
+      for (auto use : uses) {
+        const auto& useOp = m_builder.getOp(use);
+
+        switch (useOp.getOpCode()) {
+          case dxbc_spv::ir::OpCode::eDescriptorLoad: {
+            rewriteCbvUseAsBda(cbv, cbvType, useOp);
+          } break;
+
+          case dxbc_spv::ir::OpCode::eDebugName:
+            break;
+
+          case dxbc_spv::ir::OpCode::eDebugMemberName: {
+            // Can't do much with member names here
+            m_builder.remove(use);
+          } break;
+
+          default:
+            dxbc_spv_unreachable();
+            break;
+        }
+      }
+    }
+
+
+    void rewriteConstantBuffers() {
+      for (const auto& e : m_cbv) {
+        const auto& op = m_builder.getOp(e.cbv);
+
+        auto regSpace = uint32_t(op.getOperand(1u));
+        auto regIndex = uint32_t(op.getOperand(2u));
+        auto regCount = uint32_t(op.getOperand(3u));
+
+        DxvkBindingInfo binding = { };
+        binding.set = DxvkShaderResourceMapping::setIndexForType(dxbc_spv::ir::ScalarType::eCbv);
+        binding.binding = regIndex;
+        binding.resourceIndex = m_shader.determineResourceIndex(m_stage,
+          dxbc_spv::ir::ScalarType::eCbv, regSpace, regIndex);
+        binding.descriptorType = determineDescriptorType(op);
+        binding.descriptorCount = regCount;
+        binding.access = VK_ACCESS_UNIFORM_READ_BIT;
+
+        if (binding.descriptorType != VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER)
+          binding.access = VK_ACCESS_SHADER_READ_BIT;
+
+        binding.flags.set(DxvkDescriptorFlag::UniformBuffer);
+
+        // If we can use BDA or push address mapping with at least the same
+        // level of performance as a constant buffer, rewrite the binding.
+        bool useHeap = m_info.options.spirv.test(DxvkShaderSpirvFlag::SupportsDescriptorHeap);
+        bool useBda = m_info.options.flags.test(DxvkShaderCompileFlag::LowerInBoundsCbvToBda);
+
+        if ((useHeap || useBda) && (op.getFlags() & dxbc_spv::ir::OpFlag::eInBounds)
+         && (m_localPushDataOffset + sizeof(uint64_t) <= MaxPerStagePushDataSize)) {
+          m_localPushDataAlign = std::max<uint32_t>(m_localPushDataAlign, sizeof(uint64_t));
+          m_localPushDataOffset = align(m_localPushDataOffset, m_localPushDataAlign);
+
+          binding.blockOffset = MaxSharedPushDataSize + m_localPushDataOffset;
+          binding.flags.set(DxvkDescriptorFlag::PushData);
+
+          if (!useHeap)
+            rewriteCbvAsBda(op, m_localPushDataOffset);
+
+          m_localPushDataResourceMask |= 0x3ull << (m_localPushDataOffset / sizeof(uint32_t));
+          m_localPushDataOffset += sizeof(uint64_t);
+        }
+
+        addBinding(binding);
+      }
     }
 
 


### PR DESCRIPTION
TL;DR is that if we have enough push data space available, and we don't need robustness (including null descriptors) for a given buffer binding, we can get away with a `PUSH_ADDRESS` binding (when using descriptor heap) or BDA (as a legacy AMD fallback) to save a few CPU *and* GPU cycles.

This probably won't do much on its own currently since it only really affects the spec constant fallback and clipping stuff in practice, but the idea is to rework D3D9 enough to extend it to statically indexed shader constants as well, and at that point we'd only really use descriptors at all for dynamically indexed float constants.

Sadly this cannot really be used in D3D11 land because we have no guarantees on what the app is actually going to bind where.