### PR TITLE
Rework D3D9 shader constant management

### DIFF
--- a/dxvk.conf
+++ b/dxvk.conf
@@ -629,14 +629,15 @@
 
 # Device Local Constant Buffers
 #
-# Enables using device local, host accessible memory for constant buffers in D3D9.
-# This tends to actually be slower for some reason on AMD,
-# and the exact same performance on NVIDIA.
+# Allows streaming shader constants and render state buffers into
+# VRAM, which may improve performance in GPU-bound scenarios.
 #
 # Supported values:
-# - True/False
+# - True: Always enable constant buffer streaming
+# - Auto: Only enable streaming on discrete GPUs
+# - False: Always disable streaming
 
-# d3d9.deviceLocalConstantBuffers = False
+# d3d9.deviceLocalConstantBuffers = Auto
 
 
 # Support cube texture depth formats

--- a/src/d3d11/d3d11_initializer.cpp
+++ b/src/d3d11/d3d11_initializer.cpp
@@ -121,9 +121,10 @@ namespace dxvk {
         cBuffer       = buffer,
         cStagingSlice = std::move(stagingSlice)
       ] (DxvkContext* ctx) {
-        ctx->uploadBuffer(cBuffer,
+        ctx->uploadBuffer(cBuffer, 0u,
           cStagingSlice.buffer(),
-          cStagingSlice.offset());
+          cStagingSlice.offset(),
+          cStagingSlice.length());
       });
     } else {
       m_transferCommands += 1;

--- a/src/d3d9/d3d9_constant_buffer.cpp
+++ b/src/d3d9/d3d9_constant_buffer.cpp
@@ -10,15 +10,14 @@ namespace dxvk {
 
   D3D9ConstantBuffer::D3D9ConstantBuffer(
           D3D9DeviceEx*         pDevice,
-          VkShaderStageFlags    Stages,
-          uint32_t              ResourceSlot,
-          VkDeviceSize          Size)
+          Kind                  CbvType)
   : m_device    (pDevice)
-  , m_binding   (ResourceSlot)
-  , m_usage     (VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT | VK_BUFFER_USAGE_STORAGE_BUFFER_BIT)
-  , m_stages    (Stages)
-  , m_size      (Size)
-  , m_align     (getAlignment(pDevice->GetDXVKDevice())) {
+  , m_kind      (CbvType)
+  , m_size      (DetermineSize(CbvType))
+  , m_usage     (DetermineUsage(pDevice, CbvType, m_size))
+  , m_stages    (DetermineStages(CbvType))
+  , m_align     (DetermineAlignment(pDevice, m_usage))
+  , m_memType   (DetermineMemoryType(CbvType)) {
 
   }
 
@@ -29,58 +28,46 @@ namespace dxvk {
 
 
   void* D3D9ConstantBuffer::Alloc(VkDeviceSize size) {
-    if (unlikely(m_buffer == nullptr))
-      m_slice = this->createBuffer();
+    if (unlikely(!m_cpuBuffer))
+      m_cpuSlice = createBuffer();
 
     size = align(size, m_align);
 
-    if (unlikely(m_offset + size > m_size)) {
-      m_slice = m_buffer->allocateStorage();
-      m_offset = 0;
+    if (m_offset + size > m_size) {
+      m_cpuSlice = m_cpuBuffer->allocateStorage();
 
       m_device->EmitCs([
-        cBuffer = m_buffer,
-        cSlice  = m_slice
+        cBinding  = uint32_t(m_kind),
+        cStages   = m_stages,
+        cBuffer   = m_cpuBuffer,
+        cSlice    = m_cpuSlice,
+        cSize     = size
       ] (DxvkContext* ctx) mutable {
         ctx->invalidateBuffer(cBuffer, std::move(cSlice));
+        ctx->bindUniformBufferRange(cStages, cBinding, 0u, cSize);
       });
+
+      m_offset = size;
+
+      return m_cpuSlice->mapPtr();
+    } else {
+      m_device->EmitCs([
+        cBinding  = uint32_t(m_kind),
+        cStages   = m_stages,
+        cOffset   = m_offset,
+        cSize     = size
+      ] (DxvkContext* ctx) {
+        ctx->bindUniformBufferRange(cStages, cBinding, cOffset, cSize);
+      });
+
+      void* mapPtr = reinterpret_cast<char*>(m_cpuSlice->mapPtr()) + m_offset;
+      m_offset += size;
+      return mapPtr;
     }
-
-    m_device->EmitCs([
-      cStages   = m_stages,
-      cBinding  = m_binding,
-      cOffset   = m_offset,
-      cLength   = size
-    ] (DxvkContext* ctx) {
-      ctx->bindUniformBufferRange(cStages, cBinding, cOffset, cLength);
-    });
-
-    void* mapPtr = reinterpret_cast<char*>(m_slice->mapPtr()) + m_offset;
-    m_offset += size;
-    return mapPtr;
-  }
-
-
-  void* D3D9ConstantBuffer::AllocSlice() {
-    if (unlikely(m_buffer == nullptr))
-      m_slice = this->createBuffer();
-    else
-      m_slice = m_buffer->allocateStorage();
-
-    m_device->EmitCs([
-      cBuffer = m_buffer,
-      cSlice  = m_slice
-    ] (DxvkContext* ctx) mutable {
-      ctx->invalidateBuffer(cBuffer, std::move(cSlice));
-    });
-
-    return m_slice->mapPtr();
   }
 
 
   Rc<DxvkResourceAllocation> D3D9ConstantBuffer::createBuffer() {
-    auto options = m_device->GetOptions();
-
     // Buffer usage and access flags don't make much of a difference
     // in the backend, so set both STORAGE and UNIFORM usage/access.
     DxvkBufferCreateInfo bufferInfo;
@@ -95,32 +82,121 @@ namespace dxvk {
     if (m_usage & VK_BUFFER_USAGE_STORAGE_BUFFER_BIT)
       bufferInfo.access |= VK_ACCESS_SHADER_READ_BIT;
 
-    VkMemoryPropertyFlags memoryFlags
-      = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT
-      | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
-
-    if (options->deviceLocalConstantBuffers)
-      memoryFlags |= VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
-
-    m_buffer = m_device->GetDXVKDevice()->createBuffer(bufferInfo, memoryFlags);
+    m_cpuBuffer = m_device->GetDXVKDevice()->createBuffer(bufferInfo, m_memType);
 
     m_device->EmitCs([
+      cBinding  = uint32_t(m_kind),
       cStages   = m_stages,
-      cBinding  = m_binding,
-      cSlice    = DxvkBufferSlice(m_buffer)
+      cSlice    = DxvkBufferSlice(m_cpuBuffer)
     ] (DxvkContext* ctx) mutable {
       ctx->bindUniformBuffer(cStages, cBinding, std::move(cSlice));
     });
 
-    return m_buffer->storage();
+    return m_cpuBuffer->storage();
   }
 
 
-  VkDeviceSize D3D9ConstantBuffer::getAlignment(const Rc<DxvkDevice>& device) const {
-    return std::max(std::max(std::max(VkDeviceSize(CACHE_LINE_SIZE),
-      device->properties().core.properties.limits.minUniformBufferOffsetAlignment),
-      device->properties().core.properties.limits.minStorageBufferOffsetAlignment),
-      device->properties().extRobustness2.robustUniformBufferAccessSizeAlignment);
+  VkDeviceSize D3D9ConstantBuffer::DetermineSize(
+          Kind                CbvType) {
+    switch (CbvType) {
+      case Kind::VSStaticConstants:
+      case Kind::VSDynamicConstants:
+      case Kind::PSStaticConstants:
+        return ShaderConstSize;
+
+      default:
+        return MiscSize;
+    }
+  }
+
+
+  VkBufferUsageFlags D3D9ConstantBuffer::DetermineUsage(
+          D3D9DeviceEx*       pDevice,
+          Kind                CbvType,
+          VkDeviceSize        Size) {
+    VkBufferUsageFlags usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
+
+    // SWVP vertex constant buffers can get bigger than the minimum required
+    // size for uniform buffers on some devices. Don't bother figuring out
+    // the layout, just always allow storage buffer fallback in that case.
+    if ((CbvType == Kind::VSStaticConstants || CbvType == Kind::VSDynamicConstants) && pDevice->CanSWVP())
+      usage |= VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
+
+    // Vertex blend is a bit special w.r.t. nonuniform indexing, so enable
+    // storage buffer usage there as well.
+    if (CbvType == Kind::VSVertexBlendData)
+      usage |= VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
+
+    return usage;
+  }
+
+
+  VkShaderStageFlags D3D9ConstantBuffer::DetermineStages(
+          Kind                CbvType) {
+    switch (CbvType) {
+      case Kind::VSClipPlanes:
+      case Kind::VSFixedFunction:
+      case Kind::VSVertexBlendData:
+      case Kind::VSStaticConstants:
+      case Kind::VSDynamicConstants:
+        return VK_SHADER_STAGE_VERTEX_BIT;
+
+      case Kind::PSFixedFunction:
+      case Kind::PSShared:
+      case Kind::PSStaticConstants:
+        return VK_SHADER_STAGE_FRAGMENT_BIT;
+
+      case Kind::SpecData:
+        return VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT;
+    }
+
+    return 0u;
+  }
+
+
+  VkDeviceSize D3D9ConstantBuffer::DetermineAlignment(
+          D3D9DeviceEx*       pDevice,
+          VkBufferUsageFlags  Usage) {
+    auto dxvkDevice = pDevice->GetDXVKDevice();
+
+    // At least a full cache line for CPU write perf
+    VkDeviceSize result = CACHE_LINE_SIZE;
+
+    // Check required offset alignment and robustness properties by usage.
+    // Some buffers do not require robustness, but don't bother with that.
+    // We will likely get no more than 64 bytes out of this anyway.
+    if (Usage & VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT) {
+      result = std::max(result, dxvkDevice->properties().core.properties.limits.minUniformBufferOffsetAlignment);
+      result = std::max(result, dxvkDevice->properties().extRobustness2.robustUniformBufferAccessSizeAlignment);
+    }
+
+    if (Usage & VK_BUFFER_USAGE_STORAGE_BUFFER_BIT) {
+      result = std::max(result, dxvkDevice->properties().core.properties.limits.minStorageBufferOffsetAlignment);
+      result = std::max(result, dxvkDevice->properties().extRobustness2.robustStorageBufferAccessSizeAlignment);
+    }
+
+    return result;
+  }
+
+
+  VkMemoryPropertyFlags D3D9ConstantBuffer::DetermineMemoryType(
+          Kind                CbvType) {
+    VkMemoryPropertyFlags flags = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
+
+    // Enable cached memory type for the miscellaneous buffers
+    // since we don't really optimize write patterns there.
+    // TODO fix that at some point.
+    bool useCached = CbvType == Kind::VSClipPlanes
+                  || CbvType == Kind::VSFixedFunction
+                  || CbvType == Kind::VSVertexBlendData
+                  || CbvType == Kind::PSFixedFunction
+                  || CbvType == Kind::PSShared
+                  || CbvType == Kind::SpecData;
+
+    if (useCached)
+      flags |= VK_MEMORY_PROPERTY_HOST_CACHED_BIT;
+
+    return flags;
   }
 
 }

--- a/src/d3d9/d3d9_constant_buffer.cpp
+++ b/src/d3d9/d3d9_constant_buffer.cpp
@@ -9,26 +9,13 @@ namespace dxvk {
 
 
   D3D9ConstantBuffer::D3D9ConstantBuffer(
-          D3D9DeviceEx*                              pDevice,
-          D3D9ShaderType                             ShaderStage,
-          D3D9ShaderResourceMapping::ConstantBuffers BufferType,
-          VkDeviceSize                               Size)
-  : D3D9ConstantBuffer(pDevice, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT | VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, GetShaderStage(ShaderStage),
-      D3D9ShaderResourceMapping::computeCbvBinding(ShaderStage, BufferType),
-      Size) {
-
-  }
-
-
-  D3D9ConstantBuffer::D3D9ConstantBuffer(
           D3D9DeviceEx*         pDevice,
-          VkBufferUsageFlags    Usage,
           VkShaderStageFlags    Stages,
           uint32_t              ResourceSlot,
           VkDeviceSize          Size)
   : m_device    (pDevice)
   , m_binding   (ResourceSlot)
-  , m_usage     (Usage)
+  , m_usage     (VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT | VK_BUFFER_USAGE_STORAGE_BUFFER_BIT)
   , m_stages    (Stages)
   , m_size      (Size)
   , m_align     (getAlignment(pDevice->GetDXVKDevice())) {

--- a/src/d3d9/d3d9_constant_buffer.cpp
+++ b/src/d3d9/d3d9_constant_buffer.cpp
@@ -29,7 +29,7 @@ namespace dxvk {
 
   void* D3D9ConstantBuffer::Alloc(VkDeviceSize size) {
     if (unlikely(!m_cpuBuffer))
-      m_cpuSlice = createBuffer();
+      m_cpuSlice = CreateBuffer();
 
     size = align(size, m_align);
 
@@ -37,18 +37,19 @@ namespace dxvk {
       m_cpuSlice = m_cpuBuffer->allocateStorage();
 
       m_device->EmitCs([
-        cBinding  = uint32_t(m_kind),
-        cStages   = m_stages,
-        cBuffer   = m_cpuBuffer,
-        cSlice    = m_cpuSlice,
-        cSize     = size
+        cBinding    = uint32_t(m_kind),
+        cStages     = m_stages,
+        cCpuBuffer  = m_cpuBuffer,
+        cCpuSlice   = m_cpuSlice,
+        cSize       = size
       ] (DxvkContext* ctx) mutable {
-        ctx->invalidateBuffer(cBuffer, std::move(cSlice));
+        ctx->invalidateBuffer(cCpuBuffer, std::move(cCpuSlice));
         ctx->bindUniformBufferRange(cStages, cBinding, 0u, cSize);
       });
 
-      m_offset = size;
+      SetupStreamCommand(0u, size, true);
 
+      m_offset = size;
       return m_cpuSlice->mapPtr();
     } else {
       m_device->EmitCs([
@@ -60,6 +61,8 @@ namespace dxvk {
         ctx->bindUniformBufferRange(cStages, cBinding, cOffset, cSize);
       });
 
+      SetupStreamCommand(m_offset, size, false);
+
       void* mapPtr = reinterpret_cast<char*>(m_cpuSlice->mapPtr()) + m_offset;
       m_offset += size;
       return mapPtr;
@@ -67,9 +70,9 @@ namespace dxvk {
   }
 
 
-  Rc<DxvkResourceAllocation> D3D9ConstantBuffer::createBuffer() {
-    // Buffer usage and access flags don't make much of a difference
-    // in the backend, so set both STORAGE and UNIFORM usage/access.
+  Rc<DxvkResourceAllocation> D3D9ConstantBuffer::CreateBuffer() {
+    auto dxvkDevice = m_device->GetDXVKDevice();
+
     DxvkBufferCreateInfo bufferInfo;
     bufferInfo.size   = align(m_size, m_align);
     bufferInfo.usage  = m_usage;
@@ -82,17 +85,67 @@ namespace dxvk {
     if (m_usage & VK_BUFFER_USAGE_STORAGE_BUFFER_BIT)
       bufferInfo.access |= VK_ACCESS_SHADER_READ_BIT;
 
-    m_cpuBuffer = m_device->GetDXVKDevice()->createBuffer(bufferInfo, m_memType);
+    if (m_useDma) {
+      // Create the CPU buffer as a pure staging buffer
+      auto cpuInfo = bufferInfo;
+      cpuInfo.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
+      cpuInfo.stages = VK_PIPELINE_STAGE_TRANSFER_BIT;
+      cpuInfo.access = VK_ACCESS_TRANSFER_READ_BIT;
+
+      m_cpuBuffer = dxvkDevice->createBuffer(cpuInfo, m_memType);
+
+      // Create the GPU buffer as the actual uniform buffer
+      auto gpuInfo = bufferInfo;
+      gpuInfo.usage |= VK_BUFFER_USAGE_TRANSFER_DST_BIT;
+      gpuInfo.stages |= VK_PIPELINE_STAGE_TRANSFER_BIT;
+      gpuInfo.access |= VK_ACCESS_TRANSFER_WRITE_BIT;
+
+      m_gpuBuffer = dxvkDevice->createBuffer(gpuInfo, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+    } else {
+      // Create a single buffer for both CPU writes and GPU reads
+      m_cpuBuffer = dxvkDevice->createBuffer(bufferInfo, m_memType);
+      m_gpuBuffer = m_cpuBuffer;
+    }
 
     m_device->EmitCs([
       cBinding  = uint32_t(m_kind),
       cStages   = m_stages,
-      cSlice    = DxvkBufferSlice(m_cpuBuffer)
+      cSlice    = DxvkBufferSlice(m_gpuBuffer)
     ] (DxvkContext* ctx) mutable {
       ctx->bindUniformBuffer(cStages, cBinding, std::move(cSlice));
     });
 
     return m_cpuBuffer->storage();
+  }
+
+
+  void D3D9ConstantBuffer::SetupStreamCommand(
+          VkDeviceSize        Offset,
+          VkDeviceSize        Size,
+          bool                Discard) {
+    if (!m_useDma)
+      return;
+
+    if (m_streamCmd && !Discard) {
+      // Simply adjust the data size for the existing command
+      m_streamCmd->size = Offset + Size - m_streamCmd->offset;
+    } else {
+      // Need to discard GPU buffer as well so that we can safely
+      // use the asynchronous transfer queue for uploads.
+      m_streamCmd = m_device->EmitCsCmd<StreamCommand>(1u, [
+        cCpuBuffer = m_cpuBuffer,
+        cGpuBuffer = m_gpuBuffer,
+        cDiscard   = Discard
+      ] (DxvkContext* ctx, const StreamCommand* cmd, uint32_t) {
+        if (cDiscard)
+          ctx->invalidateBuffer(cGpuBuffer, cGpuBuffer->allocateStorage());
+
+        ctx->uploadBuffer(cGpuBuffer, cmd->offset, cCpuBuffer, cmd->offset, cmd->size);
+      });
+
+      m_streamCmd->offset = Offset;
+      m_streamCmd->size = Size;
+    }
   }
 
 

--- a/src/d3d9/d3d9_constant_buffer.cpp
+++ b/src/d3d9/d3d9_constant_buffer.cpp
@@ -261,6 +261,10 @@ namespace dxvk {
           D3D9DeviceEx*       pDevice,
           Kind                CbvType) {
     auto dxvkDevice = pDevice->GetDXVKDevice();
+    auto option = pDevice->GetOptions()->deviceLocalConstantBuffers;
+
+    if (option != Tristate::Auto)
+      return option == Tristate::True;
 
     // No point whatsoever in streaming the spec data buffer to
     // VRAM since it won't be used most of the time anyway

--- a/src/d3d9/d3d9_constant_buffer.cpp
+++ b/src/d3d9/d3d9_constant_buffer.cpp
@@ -17,7 +17,8 @@ namespace dxvk {
   , m_usage     (DetermineUsage(pDevice, CbvType, m_size))
   , m_stages    (DetermineStages(CbvType))
   , m_align     (DetermineAlignment(pDevice, m_usage))
-  , m_memType   (DetermineMemoryType(CbvType)) {
+  , m_memType   (DetermineMemoryType(CbvType))
+  , m_useDma    (DetermineDmaUsage(pDevice, CbvType)) {
 
   }
 
@@ -253,6 +254,18 @@ namespace dxvk {
       flags |= VK_MEMORY_PROPERTY_HOST_CACHED_BIT;
 
     return flags;
+  }
+
+
+  bool D3D9ConstantBuffer::DetermineDmaUsage(
+          D3D9DeviceEx*       pDevice,
+          Kind                CbvType) {
+    auto dxvkDevice = pDevice->GetDXVKDevice();
+
+    // No point whatsoever in streaming the spec data buffer to
+    // VRAM since it won't be used most of the time anyway
+    return dxvkDevice->properties().core.properties.deviceType == VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU
+      && CbvType != Kind::SpecData;
   }
 
 }

--- a/src/d3d9/d3d9_constant_buffer.cpp
+++ b/src/d3d9/d3d9_constant_buffer.cpp
@@ -117,8 +117,8 @@ namespace dxvk {
 
 
   VkDeviceSize D3D9ConstantBuffer::getAlignment(const Rc<DxvkDevice>& device) const {
-    return std::max(std::max(
-      device->properties().core.properties.limits.minUniformBufferOffsetAlignment,
+    return std::max(std::max(std::max(VkDeviceSize(CACHE_LINE_SIZE),
+      device->properties().core.properties.limits.minUniformBufferOffsetAlignment),
       device->properties().core.properties.limits.minStorageBufferOffsetAlignment),
       device->properties().extRobustness2.robustUniformBufferAccessSizeAlignment);
   }

--- a/src/d3d9/d3d9_constant_buffer.cpp
+++ b/src/d3d9/d3d9_constant_buffer.cpp
@@ -148,6 +148,9 @@ namespace dxvk {
 
       case Kind::SpecData:
         return VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT;
+
+      case Kind::Count:
+        break;
     }
 
     return 0u;

--- a/src/d3d9/d3d9_constant_buffer.h
+++ b/src/d3d9/d3d9_constant_buffer.h
@@ -22,13 +22,6 @@ namespace dxvk {
 
     D3D9ConstantBuffer(
             D3D9DeviceEx*         pDevice,
-            D3D9ShaderType        ShaderStage,
-            D3D9ShaderResourceMapping::ConstantBuffers BufferType,
-            VkDeviceSize          Size);
-
-    D3D9ConstantBuffer(
-            D3D9DeviceEx*         pDevice,
-            VkBufferUsageFlags    Usage,
             VkShaderStageFlags    Stages,
             uint32_t              ResourceSlot,
             VkDeviceSize          Size);

--- a/src/d3d9/d3d9_constant_buffer.h
+++ b/src/d3d9/d3d9_constant_buffer.h
@@ -15,16 +15,17 @@ namespace dxvk {
    * \brief Constant buffer
    */
   class D3D9ConstantBuffer {
+    static constexpr VkDeviceSize ShaderConstSize = 1024ull << 10;
+    static constexpr VkDeviceSize MiscSize        =   64ull << 10;
 
+    using Kind = D3D9ShaderResourceMapping::CbvIndex;
   public:
 
     D3D9ConstantBuffer();
 
     D3D9ConstantBuffer(
             D3D9DeviceEx*         pDevice,
-            VkShaderStageFlags    Stages,
-            uint32_t              ResourceSlot,
-            VkDeviceSize          Size);
+            Kind                  CbvType);
 
     ~D3D9ConstantBuffer();
 
@@ -47,14 +48,6 @@ namespace dxvk {
     void* Alloc(VkDeviceSize size);
 
     /**
-     * \brief Allocates a full buffer slice
-     *
-     * This must not be called if \ref Alloc is used.
-     * \returns Map pointer of the allocated region
-     */
-    void* AllocSlice();
-
-    /**
      * \brief Allocates typed data
      *
      * \param [in] count Number of items to allocate
@@ -69,19 +62,37 @@ namespace dxvk {
 
     D3D9DeviceEx*         m_device  = nullptr;
 
-    uint32_t              m_binding = 0u;
+    Kind                  m_kind    = {};
+    VkDeviceSize          m_size    = 0ull;
     VkBufferUsageFlags    m_usage   = 0u;
     VkShaderStageFlags    m_stages  = 0u;
-    VkDeviceSize          m_size    = 0ull;
     VkDeviceSize          m_align   = 0ull;
+    VkMemoryPropertyFlags m_memType = 0u;
     VkDeviceSize          m_offset  = 0ull;
 
-    Rc<DxvkBuffer>        m_buffer  = nullptr;
-    Rc<DxvkResourceAllocation> m_slice = nullptr;
+    Rc<DxvkBuffer>        m_cpuBuffer = nullptr;
+
+    Rc<DxvkResourceAllocation> m_cpuSlice = nullptr;
 
     Rc<DxvkResourceAllocation> createBuffer();
 
-    VkDeviceSize getAlignment(const Rc<DxvkDevice>& device) const;
+    static VkDeviceSize DetermineSize(
+            Kind                CbvType);
+
+    static VkBufferUsageFlags DetermineUsage(
+            D3D9DeviceEx*       pDevice,
+            Kind                CbvType,
+            VkDeviceSize        Size);
+
+    static VkShaderStageFlags DetermineStages(
+            Kind                CbvType);
+
+    static VkDeviceSize DetermineAlignment(
+            D3D9DeviceEx*       pDevice,
+            VkBufferUsageFlags  Usage);
+
+    static VkMemoryPropertyFlags DetermineMemoryType(
+            Kind                CbvType);
 
   };
 

--- a/src/d3d9/d3d9_constant_buffer.h
+++ b/src/d3d9/d3d9_constant_buffer.h
@@ -122,6 +122,10 @@ namespace dxvk {
     static VkMemoryPropertyFlags DetermineMemoryType(
             Kind                CbvType);
 
+    static bool DetermineDmaUsage(
+            D3D9DeviceEx*       pDevice,
+            Kind                CbvType);
+
   };
 
 }

--- a/src/d3d9/d3d9_constant_buffer.h
+++ b/src/d3d9/d3d9_constant_buffer.h
@@ -21,6 +21,11 @@ namespace dxvk {
     using Kind = D3D9ShaderResourceMapping::CbvIndex;
   public:
 
+    struct StreamCommand {
+      VkDeviceSize offset = 0u;
+      VkDeviceSize size = 0u;
+    };
+
     D3D9ConstantBuffer();
 
     D3D9ConstantBuffer(
@@ -42,6 +47,9 @@ namespace dxvk {
     /**
      * \brief Allocates a given amount of memory
      *
+     * \note: Requires that all data is written to the buffer before
+     * submitting the next set of commands to the CS chunk, otherwise
+     * the GPU may read stale data.
      * \param [in] size Number of bytes to allocate
      * \returns Map pointer of the allocated region
      */
@@ -58,6 +66,17 @@ namespace dxvk {
       return reinterpret_cast<T*>(Alloc(Count * sizeof(T)));
     }
 
+    /**
+     * \brief Resets current stream command
+     *
+     * This \e must unconditionally be called when the
+     * device's current CS chunk gets submitted to the
+     * worker to avoid accessing stale data.
+     */
+    void ResetStreamCommand() {
+      m_streamCmd = nullptr;
+    }
+
   private:
 
     D3D9DeviceEx*         m_device  = nullptr;
@@ -69,12 +88,21 @@ namespace dxvk {
     VkDeviceSize          m_align   = 0ull;
     VkMemoryPropertyFlags m_memType = 0u;
     VkDeviceSize          m_offset  = 0ull;
+    bool                  m_useDma  = false;
 
     Rc<DxvkBuffer>        m_cpuBuffer = nullptr;
+    Rc<DxvkBuffer>        m_gpuBuffer = nullptr;
 
     Rc<DxvkResourceAllocation> m_cpuSlice = nullptr;
 
-    Rc<DxvkResourceAllocation> createBuffer();
+    StreamCommand*        m_streamCmd = nullptr;
+
+    Rc<DxvkResourceAllocation> CreateBuffer();
+
+    void SetupStreamCommand(
+            VkDeviceSize        Offset,
+            VkDeviceSize        Size,
+            bool                Discard);
 
     static VkDeviceSize DetermineSize(
             Kind                CbvType);

--- a/src/d3d9/d3d9_constant_buffer.h
+++ b/src/d3d9/d3d9_constant_buffer.h
@@ -37,7 +37,7 @@ namespace dxvk {
     VkDeviceSize GetAlignment() const {
       return m_align;
     }
-    
+
     /**
      * \brief Allocates a given amount of memory
      *
@@ -53,6 +53,17 @@ namespace dxvk {
      * \returns Map pointer of the allocated region
      */
     void* AllocSlice();
+
+    /**
+     * \brief Allocates typed data
+     *
+     * \param [in] count Number of items to allocate
+     * \returns Allocated data slice
+     */
+    template<typename T>
+    T* AllocTyped(size_t Count) {
+      return reinterpret_cast<T*>(Alloc(Count * sizeof(T)));
+    }
 
   private:
 

--- a/src/d3d9/d3d9_constant_copy.cpp
+++ b/src/d3d9/d3d9_constant_copy.cpp
@@ -120,6 +120,32 @@ namespace dxvk {
   }
 
 
+  bool D3D9ConstantBufferLayout::eq(const D3D9ConstantBufferLayout& other) const {
+    bool eq = m_minCount == other.m_minCount
+           && m_maxCount == other.m_maxCount
+           && m_dynamicIndexing == other.m_dynamicIndexing
+           && m_ranges.size() == other.m_ranges.size();
+
+    for (size_t i = 0u; i < m_ranges.size() && eq; i++)
+      eq = m_ranges[i].eq(other.m_ranges[i]);
+
+    return eq;
+  }
+
+
+  size_t D3D9ConstantBufferLayout::hash() const {
+    DxvkHashState hash;
+
+    for (const auto& range : m_ranges)
+      hash.add(range.hash());
+
+    hash.add(m_minCount);
+    hash.add(m_maxCount);
+    hash.add(uint32_t(m_dynamicIndexing));
+    return hash;
+  }
+
+
   D3D9ConstantBufferCopy::D3D9ConstantBufferCopy() {
 
   }
@@ -136,6 +162,22 @@ namespace dxvk {
 
   D3D9ConstantBufferCopy::~D3D9ConstantBufferCopy() {
 
+  }
+
+
+  bool D3D9ConstantBufferCopy::eq(const D3D9ConstantBufferCopy& other) const {
+    return m_floatLayout.eq(other.m_floatLayout)
+        && m_intLayout.eq(other.m_intLayout)
+        && m_boolLayout.eq(other.m_boolLayout);
+  }
+
+
+  size_t D3D9ConstantBufferCopy::hash() const {
+    DxvkHashState hash;
+    hash.add(m_floatLayout.hash());
+    hash.add(m_intLayout.hash());
+    hash.add(m_boolLayout.hash());
+    return hash;
   }
 
 

--- a/src/d3d9/d3d9_constant_copy.cpp
+++ b/src/d3d9/d3d9_constant_copy.cpp
@@ -48,7 +48,12 @@ namespace dxvk {
     m_maxCount = dstIndex;
   }
 
-  D3D9ConstantBufferLayout::D3D9ConstantBufferLayout(uint32_t maxCount, uint32_t defLength, const uint32_t* defMask)
+  D3D9ConstantBufferLayout::D3D9ConstantBufferLayout(
+          uint32_t            maxCount,
+          uint32_t            defLength,
+    const uint32_t*           defMask,
+          size_t              defCount,
+    const D3D9ImmediateFloatConstant* defData)
   : m_minCount(0u), m_maxCount(maxCount), m_dynamicIndexing(true) {
     uint32_t defIndex = 0u;
     uint32_t dstIndex = 0u;
@@ -81,6 +86,8 @@ namespace dxvk {
 
         dstIndex = defRange.dstIndex + defRange.count;
         defIndex = defRange.srcIndex + defRange.count;
+
+        addConstantData(defRange, defCount, defData);
 
         m_minCount = std::max(m_minCount, dstIndex);
 
@@ -123,14 +130,33 @@ namespace dxvk {
   }
 
 
+  void D3D9ConstantBufferLayout::addConstantData(
+    const D3D9ConstantRange&          range,
+          size_t                      defCount,
+    const D3D9ImmediateFloatConstant* defData) {
+    for (uint32_t i = 0u; i < range.count; i++) {
+      for (uint32_t j = 0u; j < defCount; j++) {
+        if (defData[j].index == range.dstIndex + i) {
+          m_constantData.push_back(defData[j].value);
+          break;
+        }
+      }
+    }
+  }
+
+
   bool D3D9ConstantBufferLayout::eq(const D3D9ConstantBufferLayout& other) const {
-    bool eq = m_minCount == other.m_minCount
-           && m_maxCount == other.m_maxCount
-           && m_dynamicIndexing == other.m_dynamicIndexing
-           && m_ranges.size() == other.m_ranges.size();
+    bool eq = m_minCount            == other.m_minCount
+           && m_maxCount            == other.m_maxCount
+           && m_dynamicIndexing     == other.m_dynamicIndexing
+           && m_ranges.size()       == other.m_ranges.size()
+           && m_constantData.size() == other.m_constantData.size();
 
     for (size_t i = 0u; i < m_ranges.size() && eq; i++)
       eq = m_ranges[i].eq(other.m_ranges[i]);
+
+    for (size_t i = 0u; i < m_constantData.size() && eq; i++)
+      eq = !std::memcmp(&m_constantData[i], &other.m_constantData[i], sizeof(Vector4));
 
     return eq;
   }
@@ -141,6 +167,14 @@ namespace dxvk {
 
     for (const auto& range : m_ranges)
       hash.add(range.hash());
+
+    for (const auto& c : m_constantData) {
+      for (uint32_t i = 0u; i < 4u; i++) {
+        uint32_t dword = 0u;
+        std::memcpy(&dword, &c[i], sizeof(dword));
+        hash.add(dword);
+      }
+    }
 
     hash.add(m_minCount);
     hash.add(m_maxCount);
@@ -235,7 +269,9 @@ namespace dxvk {
       maxCount - std::min<uint32_t>(range.dstIndex, maxCount));
 
     // Need to select the correct source array
-    auto srcBuffer = range.isShaderDefined ? args.constFloatDef : args.constFloatApi;
+    auto srcBuffer = range.isShaderDefined
+      ? m_floatLayout.getShaderDefinedConstants()
+      : args.constFloatApi;
     auto srcPtr = reinterpret_cast<const Vector4*>(srcBuffer) + range.srcIndex;
 
     #if defined(DXVK_ARCH_X86) && (defined(__GNUC__) || defined(__clang__) || defined(_MSC_VER))

--- a/src/d3d9/d3d9_constant_copy.cpp
+++ b/src/d3d9/d3d9_constant_copy.cpp
@@ -1,0 +1,288 @@
+#include <cmath>
+
+#include "d3d9_constant_set.h"
+
+#include "../util/util_bit.h"
+
+namespace dxvk {
+
+  D3D9ConstantBufferLayout::D3D9ConstantBufferLayout() { }
+
+  D3D9ConstantBufferLayout::D3D9ConstantBufferLayout(uint32_t maxCount)
+  : m_minCount(maxCount), m_maxCount(maxCount) {
+    D3D9ConstantRange range = {};
+    range.dstIndex = 0u;
+    range.srcIndex = 0u;
+    range.count = maxCount;
+
+    addRange(range);
+  }
+
+  D3D9ConstantBufferLayout::D3D9ConstantBufferLayout(uint32_t useLength, const uint32_t* useMask) {
+    // Tightly pack accessed constants
+    uint32_t dstIndex = 0u;
+
+    for (uint32_t i = 0u; i < useLength; i++) {
+      uint32_t mask = useMask[i];
+
+      while (mask) {
+        uint32_t bitIndex = bit::tzcnt(mask);
+        uint32_t bitCount = bit::tzcnt(mask + (1u << bitIndex)) - bitIndex;
+
+        D3D9ConstantRange range = {};
+        range.dstIndex = dstIndex;
+        range.srcIndex = bitIndex + 32u * i;
+        range.count = bitCount;
+
+        addRange(range);
+        dstIndex += range.count;
+
+        mask &= -2u << (bitIndex + bitCount - 1u);
+      }
+    }
+
+    m_minCount = dstIndex;
+    m_maxCount = dstIndex;
+  }
+
+  D3D9ConstantBufferLayout::D3D9ConstantBufferLayout(uint32_t maxCount, uint32_t defLength, const uint32_t* defMask)
+  : m_minCount(0u), m_maxCount(maxCount), m_dynamicIndexing(true) {
+    uint32_t defIndex = 0u;
+    uint32_t dstIndex = 0u;
+
+    // More or less the inverse of the above logic. Keep all constants intact,
+    // but insert ranges for any constants that are shader-defined.
+    for (uint32_t i = 0u; i < defLength; i++) {
+      uint32_t mask = defMask[i];
+
+      while (mask) {
+        uint32_t bitIndex = bit::tzcnt(mask);
+        uint32_t bitCount = bit::tzcnt(mask + (1u << bitIndex)) - bitIndex;
+
+        uint32_t defRangeStart = bitIndex + 32u * i;
+
+        D3D9ConstantRange apiRange = {};
+        apiRange.dstIndex = dstIndex;
+        apiRange.srcIndex = dstIndex;
+        apiRange.count = defRangeStart - dstIndex;
+        apiRange.isDynamicallyIndexed = true;
+        addRange(apiRange);
+
+        D3D9ConstantRange defRange = {};
+        defRange.dstIndex = defRangeStart;
+        defRange.srcIndex = defIndex;
+        defRange.count = bitCount;
+        defRange.isDynamicallyIndexed = true;
+        defRange.isShaderDefined = true;
+        addRange(defRange);
+
+        dstIndex = defRange.dstIndex + defRange.count;
+        defIndex = defRange.srcIndex + defRange.count;
+
+        m_minCount = std::max(m_minCount, dstIndex);
+
+        mask &= -2u << (bitIndex + bitCount - 1u);
+      }
+    }
+
+    // Insert final range of constants
+    D3D9ConstantRange range = {};
+    range.dstIndex = dstIndex;
+    range.srcIndex = dstIndex;
+    range.count = maxCount - dstIndex;
+    range.isDynamicallyIndexed = true;
+
+    addRange(range);
+  }
+
+  D3D9ConstantBufferLayout::~D3D9ConstantBufferLayout() {
+
+  }
+
+  void D3D9ConstantBufferLayout::addRange(const D3D9ConstantRange& range) {
+    if (!range.count)
+      return;
+
+    // Merge with previous range if possible
+    if (!m_ranges.empty()) {
+      auto& last = m_ranges.back();
+
+      if (range.dstIndex == last.dstIndex + last.count
+       && range.srcIndex == last.srcIndex + last.count
+       && range.isDynamicallyIndexed == last.isDynamicallyIndexed
+       && range.isShaderDefined == last.isShaderDefined) {
+        last.count += range.count;
+        return;
+      }
+    }
+
+    m_ranges.push_back(range);
+  }
+
+
+  D3D9ConstantBufferCopy::D3D9ConstantBufferCopy() {
+
+  }
+
+
+  D3D9ConstantBufferCopy::D3D9ConstantBufferCopy(
+          D3D9ConstantBufferLayout Floats,
+          D3D9ConstantBufferLayout Ints,
+          D3D9ConstantBufferLayout Bools)
+  : m_floatLayout (std::move(Floats)),
+    m_intLayout   (std::move(Ints)),
+    m_boolLayout  (std::move(Bools)) { }
+
+
+  D3D9ConstantBufferCopy::~D3D9ConstantBufferCopy() {
+
+  }
+
+
+  void D3D9ConstantBufferCopy::copyConstantData(const D3D9ConstantBufferCopyArgs& args) const {
+    if (args.floatBufferSize) {
+      if (unlikely(args.flushNan))
+        writeFloatBuffer<true>(args);
+      else
+        writeFloatBuffer<false>(args);
+    }
+
+    if (args.intBufferSize)
+      writeIntBuffer(args);
+
+    if (args.boolBufferSize)
+      writeBoolBuffer(args);
+  }
+
+
+  template<bool FlushNan>
+  void D3D9ConstantBufferCopy::writeFloatBuffer(const D3D9ConstantBufferCopyArgs& args) const {
+    uint32_t writeCount = m_floatLayout.computeConstantCount(args.floatConstantCount);
+    uint32_t writeSize = writeCount * sizeof(Vector4);
+
+    for (uint32_t i = 0u; i < m_floatLayout.getRangeCount(); i++)
+      writeFloatRange<FlushNan>(args, m_floatLayout.getRange(i), writeCount);
+
+    pad16(args.floatBuffer, writeSize, args.floatBufferSize);
+  }
+
+
+  template<bool FlushNan>
+  void D3D9ConstantBufferCopy::writeFloatRange(const D3D9ConstantBufferCopyArgs& args, const D3D9ConstantRange& range, uint32_t maxCount) const {
+    // Need to clamp constant count for the last dynamically indexed range
+    auto dstPtr = reinterpret_cast<Vector4*>(args.floatBuffer) + range.dstIndex;
+    auto dstCount = std::min<uint32_t>(range.count,
+      maxCount - std::min<uint32_t>(range.dstIndex, maxCount));
+
+    // Need to select the correct source array
+    auto srcBuffer = range.isShaderDefined ? args.constFloatDef : args.constFloatApi;
+    auto srcPtr = reinterpret_cast<const Vector4*>(srcBuffer) + range.srcIndex;
+
+    #if defined(DXVK_ARCH_X86) && (defined(__GNUC__) || defined(__clang__) || defined(_MSC_VER))
+    uint32_t index = 0u;
+
+    while (index + 2u <= dstCount) {
+      auto src0 = _mm_loadu_ps(srcPtr[index + 0u].data);
+      auto src1 = _mm_loadu_ps(srcPtr[index + 1u].data);
+
+      if (FlushNan) {
+        src0 = _mm_and_ps(src0, _mm_cmpeq_ps(src0, src0));
+        src1 = _mm_and_ps(src1, _mm_cmpeq_ps(src1, src1));
+      }
+
+      _mm_stream_ps(dstPtr[index + 0u].data, src0);
+      _mm_stream_ps(dstPtr[index + 1u].data, src1);
+
+      index += 2u;
+    }
+
+    if (index < dstCount) {
+      auto src0 = _mm_loadu_ps(srcPtr[index].data);
+
+      if (FlushNan)
+        src0 = _mm_and_ps(src0, _mm_cmpeq_ps(src0, src0));
+
+      _mm_stream_ps(dstPtr[index].data, src0);
+    }
+    #else
+    for (uint32_t i = 0u; i < dstCount; i++) {
+      for (uint32_t j = 0u; j < 4u; j++) {
+        float f = srcPtr[i][j];
+
+        if (FlushNan)
+          f = std::isnan(f) ? 0.0f : f;
+
+        dstPtr[i][j] = f;
+      }
+    }
+    #endif
+  }
+
+
+  void D3D9ConstantBufferCopy::writeIntBuffer(const D3D9ConstantBufferCopyArgs& args) const {
+    uint32_t writeSize = m_intLayout.computeConstantCount(0u) * sizeof(Vector4i);
+
+    for (uint32_t i = 0u; i < m_intLayout.getRangeCount(); i++)
+      writeIntRange(args, m_intLayout.getRange(i));
+
+    pad16(args.intBuffer, writeSize, args.intBufferSize);
+  }
+
+
+  void D3D9ConstantBufferCopy::writeIntRange(const D3D9ConstantBufferCopyArgs& args, const D3D9ConstantRange& range) const {
+    #if defined(DXVK_ARCH_X86) && (defined(__GNUC__) || defined(__clang__) || defined(_MSC_VER))
+    auto dstPtr = reinterpret_cast<      __m128i*>(args.intBuffer) + range.dstIndex;
+    auto srcPtr = reinterpret_cast<const __m128i*>(args.constIntApi) + range.srcIndex;
+
+    for (uint32_t i = 0u; i < range.count; i++)
+      _mm_stream_si128(dstPtr + i, _mm_loadu_si128(srcPtr + i));
+    #else
+    std::memcpy(reinterpret_cast<Vector4i*>(args.intBuffer) + range.dstIndex,
+      args.constIntApi + range.srcIndex, range.count * sizeof(Vector4i));
+    #endif
+  }
+
+
+  void D3D9ConstantBufferCopy::writeBoolBuffer(const D3D9ConstantBufferCopyArgs& args) const {
+    uint32_t writeSize = m_boolLayout.computeConstantCount(0u) * sizeof(uint32_t);
+
+    for (uint32_t i = 0u; i < m_boolLayout.getRangeCount(); i++)
+      writeBoolRange(args, m_boolLayout.getRange(i));
+
+    pad16(args.boolBuffer, writeSize, args.boolBufferSize);
+  }
+
+
+  void D3D9ConstantBufferCopy::writeBoolRange(const D3D9ConstantBufferCopyArgs& args, const D3D9ConstantRange& range) const {
+    #if defined(DXVK_ARCH_X86) && (defined(__GNUC__) || defined(__clang__) || defined(_MSC_VER))
+    auto dstPtr = reinterpret_cast<      int*>(args.boolBuffer) + range.dstIndex;
+    auto srcPtr = reinterpret_cast<const int*>(args.constBoolApi) + range.srcIndex;
+
+    for (uint32_t i = 0u; i < range.count; i += 4u) {
+      auto data = _mm_loadu_si128(reinterpret_cast<const __m128i*>(srcPtr + i));
+      _mm_stream_si128(reinterpret_cast<__m128i*>(dstPtr + i), data);
+    }
+    #else
+    std::memcpy(reinterpret_cast<uint32_t*>(args.boolBuffer) + range.dstIndex,
+      args.constBoolApi + range.srcIndex, range.count * sizeof(uint32_t));
+    #endif
+  }
+
+
+  void D3D9ConstantBufferCopy::pad16(void* dst, size_t start, size_t end) {
+    if (start < end) {
+      #if defined(DXVK_ARCH_X86) && (defined(__GNUC__) || defined(__clang__) || defined(_MSC_VER))
+      auto dstPtr = reinterpret_cast<__m128i*>(reinterpret_cast<char*>(dst) + start);
+      auto dstCount = (end - start) / sizeof(*dstPtr);
+
+      __m128i zero = _mm_setzero_si128();
+
+      for (uint32_t i = 0u; i < dstCount; i++)
+        _mm_stream_si128(dstPtr + i, zero);
+      #else
+      std::memset(reinterpret_cast<char*>(dst) + start, 0, end - start);
+      #endif
+    }
+  }
+
+}

--- a/src/d3d9/d3d9_constant_copy.cpp
+++ b/src/d3d9/d3d9_constant_copy.cpp
@@ -6,6 +6,9 @@
 
 namespace dxvk {
 
+  dxvk::mutex D3D9ConstantBufferCopy::s_mutex;
+  std::unordered_set<D3D9ConstantBufferCopy, DxvkHash, DxvkEq> D3D9ConstantBufferCopy::s_layouts;
+
   D3D9ConstantBufferLayout::D3D9ConstantBufferLayout() { }
 
   D3D9ConstantBufferLayout::D3D9ConstantBufferLayout(uint32_t maxCount)
@@ -152,16 +155,31 @@ namespace dxvk {
 
 
   D3D9ConstantBufferCopy::D3D9ConstantBufferCopy(
-          D3D9ConstantBufferLayout Floats,
-          D3D9ConstantBufferLayout Ints,
-          D3D9ConstantBufferLayout Bools)
-  : m_floatLayout (std::move(Floats)),
-    m_intLayout   (std::move(Ints)),
-    m_boolLayout  (std::move(Bools)) { }
+          D3D9ConstantBufferLayout floats,
+          D3D9ConstantBufferLayout ints,
+          D3D9ConstantBufferLayout bools)
+  : m_floatLayout (std::move(floats)),
+    m_intLayout   (std::move(ints)),
+    m_boolLayout  (std::move(bools)) { }
 
 
   D3D9ConstantBufferCopy::~D3D9ConstantBufferCopy() {
 
+  }
+
+
+  const D3D9ConstantBufferCopy* D3D9ConstantBufferCopy::getOrCreate(
+          D3D9ConstantBufferLayout floats,
+          D3D9ConstantBufferLayout ints,
+          D3D9ConstantBufferLayout bools) {
+    std::lock_guard lock(s_mutex);
+
+    auto entry = s_layouts.emplace(
+      std::move(floats),
+      std::move(ints),
+      std::move(bools));
+
+    return &(*entry.first);
   }
 
 

--- a/src/d3d9/d3d9_constant_copy.h
+++ b/src/d3d9/d3d9_constant_copy.h
@@ -37,6 +37,24 @@ namespace dxvk {
      *  shader defined data rather than API state.
      *  Only useful with dynamic indexing. */
     bool isShaderDefined = false;
+
+    bool eq(const D3D9ConstantRange& other) const {
+      return dstIndex             == other.dstIndex
+          && srcIndex             == other.srcIndex
+          && count                == other.count
+          && isDynamicallyIndexed == other.isDynamicallyIndexed
+          && isShaderDefined      == other.isShaderDefined;
+    }
+
+    size_t hash() const {
+      DxvkHashState hash;
+      hash.add(dstIndex);
+      hash.add(srcIndex);
+      hash.add(count);
+      hash.add(uint32_t(isDynamicallyIndexed));
+      hash.add(uint32_t(isShaderDefined));
+      return hash;
+    }
   };
 
 
@@ -133,6 +151,20 @@ namespace dxvk {
 
       return std::nullopt;
     }
+
+    /**
+     * \brief Checks whether two layouts fully match
+     *
+     * Two identical layouts can use the same constant buffers.
+     * \param [in] other The other layout to check
+     * \returns \c true if both layouts are identical
+     */
+    bool eq(const D3D9ConstantBufferLayout& other) const;
+
+    /**
+     * \brief Computes layout hash
+     */
+    size_t hash() const;
 
   private:
 
@@ -239,6 +271,14 @@ namespace dxvk {
      * \param [in] Args Constant pointers and copy parameters
      */
     void copyConstantData(const D3D9ConstantBufferCopyArgs& args) const;
+
+    /**
+     * \brief Checks whether two layouts fully match
+     * \returns \c true if both layouts are identical
+     */
+    bool eq(const D3D9ConstantBufferCopy& other) const;
+
+    size_t hash() const;
 
   private:
 

--- a/src/d3d9/d3d9_constant_copy.h
+++ b/src/d3d9/d3d9_constant_copy.h
@@ -235,9 +235,9 @@ namespace dxvk {
     D3D9ConstantBufferCopy();
 
     D3D9ConstantBufferCopy(
-            D3D9ConstantBufferLayout Floats,
-            D3D9ConstantBufferLayout Ints,
-            D3D9ConstantBufferLayout Bools);
+            D3D9ConstantBufferLayout floats,
+            D3D9ConstantBufferLayout ints,
+            D3D9ConstantBufferLayout bools);
 
     ~D3D9ConstantBufferCopy();
 
@@ -280,11 +280,29 @@ namespace dxvk {
 
     size_t hash() const;
 
+    /**
+     * \brief Retrieves globally unique constant buffer layout
+     *
+     * The returned pointer will never be invalidated, and this function
+     * will return the same pointer for compatible constant layouts.
+     * \param [in] floats Float constant layout
+     * \param [in] ints Integer constant layout
+     * \param [in] bools Boolean constant layout
+     * \returns Pointer to unique layout
+     */
+    static const D3D9ConstantBufferCopy* getOrCreate(
+            D3D9ConstantBufferLayout floats,
+            D3D9ConstantBufferLayout ints,
+            D3D9ConstantBufferLayout bools);
+
   private:
 
     D3D9ConstantBufferLayout m_floatLayout  = {};
     D3D9ConstantBufferLayout m_intLayout    = {};
     D3D9ConstantBufferLayout m_boolLayout   = {};
+
+    static dxvk::mutex s_mutex;
+    static std::unordered_set<D3D9ConstantBufferCopy, DxvkHash, DxvkEq> s_layouts;
 
     template<bool FlushNan>
     void writeFloatBuffer(const D3D9ConstantBufferCopyArgs& args) const;

--- a/src/d3d9/d3d9_constant_copy.h
+++ b/src/d3d9/d3d9_constant_copy.h
@@ -1,0 +1,267 @@
+#pragma once
+
+#include <optional>
+
+#include "../util/util_small_vector.h"
+#include "../util/util_vector.h"
+
+namespace dxvk {
+
+  /**
+   * \brief Constant type
+   */
+  enum class D3D9ConstantType {
+    Float,
+    Int,
+    Bool
+  };
+
+  /**
+   * \brief Constant range
+   *
+   * Used to set up the exact layout of a constant buffer.
+   * Constant indices for booleans must actually be given
+   * in units of dwords rather than bits.
+   */
+  struct D3D9ConstantRange {
+    /** Constant index in buffer */
+    uint16_t dstIndex = 0u;
+    /** Constant index in API state */
+    uint16_t srcIndex = 0u;
+    /** Number of constants to copy. */
+    uint16_t count = 0u;
+    /** Whether this constant range is
+     *  dynamically indexed (float only) */
+    bool isDynamicallyIndexed = false;
+    /** Whether this constant range is sourced from
+     *  shader defined data rather than API state.
+     *  Only useful with dynamic indexing. */
+    bool isShaderDefined = false;
+  };
+
+
+  /**
+   * \brief Constant layout builder
+   */
+  class D3D9ConstantBufferLayout {
+
+  public:
+
+    D3D9ConstantBufferLayout();
+
+    /**
+     * \brief Builds trivial constant layout containing a set number of constants
+     *
+     * Assumes static indexing, and will not try to pack any gaps.
+     * \param [in] maxCount Maximum available constant count
+     */
+    D3D9ConstantBufferLayout(uint32_t maxCount);
+
+    /**
+     * \brief Builds constant layout for static indexing
+     *
+     * \param [in] useLength Number of dwords in the constant mask
+     * \param [in] useMask Bit mask of constants accessed by the shader
+     */
+    D3D9ConstantBufferLayout(uint32_t useLength, const uint32_t* useMask);
+
+    /**
+     * \brief Builds constant layout for dynamic indexing
+     *
+     * \param [in] maxCount Maximum available constant count
+     * \param [in] defLength Number of dwords in shader-defined constant mask
+     * \param [in] defMask Bit mask of shader-defined constants
+     */
+    D3D9ConstantBufferLayout(uint32_t maxCount, uint32_t defLength, const uint32_t* defMask);
+
+    ~D3D9ConstantBufferLayout();
+
+    /**
+     * \brief Queries number of constant ranges
+     * \returns Constant range count
+     */
+    uint32_t getRangeCount() const {
+      return uint32_t(m_ranges.size());
+    }
+
+    /**
+     * \brief Queries specific constant range
+     *
+     * \param [in] index Range index
+     * \returns Given constant range
+     */
+    D3D9ConstantRange getRange(uint32_t index) const {
+      return m_ranges[index];
+    }
+
+    /**
+     * \brief Computes required constant count in buffer
+     *
+     * Multiply by constant size to get required buffer allocation size in bytes.
+     * \param [in] valueCount Number of API constants with a non-default value.
+     *    Useful to reduce the amount of memory used and copied for dynamic indexing
+     *    if we can rely on robustness, but may be ignored or overridden if we do
+     *    need to copy more data.
+     * \returns Number of constants required
+     */
+    uint32_t computeConstantCount(uint32_t valueCount) const {
+      return std::clamp(valueCount, m_minCount, m_maxCount);
+    }
+
+    /**
+     * \brief Checks whether the layout is dynamically indexed
+     * \returns \c true for dynamically indexed layouts
+     */
+    bool isDynamicallyIndexed() const {
+      return m_dynamicIndexing;
+    }
+
+    /**
+     * \brief Looks up remapped constant index by source index
+     *
+     * Only useful for statically indexed constant ranges.
+     * \param [in] srcIndex Source constant index
+     * \returns Constant index in buffer, if found
+     */
+    std::optional<uint32_t> findConstant(uint32_t srcIndex) const {
+      if (!m_dynamicIndexing) {
+        for (const auto& e : m_ranges) {
+          if (srcIndex >= e.srcIndex && srcIndex < e.srcIndex + e.count)
+            return std::make_optional(e.dstIndex + (srcIndex - e.srcIndex));
+        }
+      }
+
+      return std::nullopt;
+    }
+
+  private:
+
+    small_vector<D3D9ConstantRange, 16u> m_ranges;
+
+    uint32_t m_minCount = 0u;
+    uint32_t m_maxCount = 0u;
+
+    bool m_dynamicIndexing = false;
+
+    void addRange(const D3D9ConstantRange& range);
+
+  };
+
+
+  /**
+   * \brief Required constant buffer sizes
+   *
+   * All sizes are given in bytes.
+   */
+  struct D3D9ConstantBufferSizes {
+    uint32_t floatBufferSize  = 0u;
+    uint32_t intBufferSize    = 0u;
+    uint32_t boolBufferSize   = 0u;
+  };
+
+
+  /**
+   * \brief Constant buffer copy arguments
+   *
+   * Points to buffer storage and source constants.
+   */
+  struct D3D9ConstantBufferCopyArgs {
+    /** Pointer and size of float constant buffer */
+    void* floatBuffer = nullptr;
+    size_t floatBufferSize = 0u;
+    /** Number of non-default API float constants */
+    uint32_t floatConstantCount = 0u;
+    /** Whether to replace NaN floats with 0.0 */
+    bool flushNan = false;
+    /** Pointer and size of integer constant buffer */
+    void* intBuffer = nullptr;
+    size_t intBufferSize = 0u;
+    /** Pointer and size of bool constant buffer. For HWVP
+     *  shaders, this shoud be ignored and set to null. */
+    void* boolBuffer = nullptr;
+    size_t boolBufferSize = 0u;
+    /** Pointer to API-defined float constants */
+    const Vector4* constFloatApi = nullptr;
+    /** Pointer to shader-defined float constants */
+    const Vector4* constFloatDef = nullptr;
+    /** Pointer to API-defined integer constants */
+    const Vector4i* constIntApi = nullptr;
+    /** Pointer to API-defined boolean constants */
+    const uint32_t* constBoolApi = nullptr;
+  };
+
+
+  /**
+   * \brief Per-shader constant copy helper
+   *
+   * Allows efficiently copying shader constants to a constant buffer.
+   */
+  class D3D9ConstantBufferCopy {
+
+  public:
+
+    D3D9ConstantBufferCopy();
+
+    D3D9ConstantBufferCopy(
+            D3D9ConstantBufferLayout Floats,
+            D3D9ConstantBufferLayout Ints,
+            D3D9ConstantBufferLayout Bools);
+
+    ~D3D9ConstantBufferCopy();
+
+    /**
+     * \brief Retrieces constant layouts of a given type
+     */
+    const D3D9ConstantBufferLayout& getLayout(D3D9ConstantType type) const {
+      if (type == D3D9ConstantType::Float)
+        return m_floatLayout;
+      if (type == D3D9ConstantType::Int)
+        return m_intLayout;
+      return m_boolLayout;
+    }
+
+    /**
+     * \brief Computes amount of data to allocate and write
+     *
+     * \param [in] FloatCount Float count for dynamic indexing
+     * \returns Required constant buffer sizes for each type, in bytes
+     */
+    D3D9ConstantBufferSizes getAllocationSizes(uint32_t floatCount) const{
+      D3D9ConstantBufferSizes result = {};
+      result.floatBufferSize = m_floatLayout.computeConstantCount(floatCount) * sizeof(Vector4);
+      result.intBufferSize = m_intLayout.computeConstantCount(0u) * sizeof(Vector4i);
+      result.boolBufferSize = m_boolLayout.computeConstantCount(0u) * sizeof(uint32_t);
+      return result;
+    }
+
+    /**
+     * \brief Copies constant data to allocated buffers
+     * \param [in] Args Constant pointers and copy parameters
+     */
+    void copyConstantData(const D3D9ConstantBufferCopyArgs& args) const;
+
+  private:
+
+    D3D9ConstantBufferLayout m_floatLayout  = {};
+    D3D9ConstantBufferLayout m_intLayout    = {};
+    D3D9ConstantBufferLayout m_boolLayout   = {};
+
+    template<bool FlushNan>
+    void writeFloatBuffer(const D3D9ConstantBufferCopyArgs& args) const;
+
+    template<bool FlushNan>
+    void writeFloatRange(const D3D9ConstantBufferCopyArgs& args, const D3D9ConstantRange& range, uint32_t maxCount) const;
+
+    void writeIntBuffer(const D3D9ConstantBufferCopyArgs& args) const;
+
+    void writeIntRange(const D3D9ConstantBufferCopyArgs& args, const D3D9ConstantRange& range) const;
+
+    void writeBoolBuffer(const D3D9ConstantBufferCopyArgs& args) const;
+
+    void writeBoolRange(const D3D9ConstantBufferCopyArgs& args, const D3D9ConstantRange& range) const;
+
+    static void pad16(void* dst, size_t start, size_t end);
+
+  };
+
+}

--- a/src/d3d9/d3d9_constant_copy.h
+++ b/src/d3d9/d3d9_constant_copy.h
@@ -16,6 +16,11 @@ namespace dxvk {
     Bool
   };
 
+  struct D3D9ImmediateFloatConstant {
+    uint32_t index;
+    Vector4 value;
+  };
+
   /**
    * \brief Constant range
    *
@@ -89,8 +94,14 @@ namespace dxvk {
      * \param [in] maxCount Maximum available constant count
      * \param [in] defLength Number of dwords in shader-defined constant mask
      * \param [in] defMask Bit mask of shader-defined constants
+     * \param [in] defData Actual shader-defined constant data
      */
-    D3D9ConstantBufferLayout(uint32_t maxCount, uint32_t defLength, const uint32_t* defMask);
+    D3D9ConstantBufferLayout(
+            uint32_t            maxCount,
+            uint32_t            defLength,
+      const uint32_t*           defMask,
+            size_t              defCount,
+      const D3D9ImmediateFloatConstant* defData);
 
     ~D3D9ConstantBufferLayout();
 
@@ -153,6 +164,14 @@ namespace dxvk {
     }
 
     /**
+     * \brief Retrieves shader-defined constants
+     * \returns Shader-defined constants, if any
+     */
+    const Vector4* getShaderDefinedConstants() const {
+      return m_constantData.data();
+    }
+
+    /**
      * \brief Checks whether two layouts fully match
      *
      * Two identical layouts can use the same constant buffers.
@@ -169,6 +188,7 @@ namespace dxvk {
   private:
 
     small_vector<D3D9ConstantRange, 16u> m_ranges;
+    small_vector<Vector4, 16u> m_constantData;
 
     uint32_t m_minCount = 0u;
     uint32_t m_maxCount = 0u;
@@ -176,6 +196,11 @@ namespace dxvk {
     bool m_dynamicIndexing = false;
 
     void addRange(const D3D9ConstantRange& range);
+
+    void addConstantData(
+      const D3D9ConstantRange&          range,
+            size_t                      defCount,
+      const D3D9ImmediateFloatConstant* defData);
 
   };
 

--- a/src/d3d9/d3d9_constant_set.h
+++ b/src/d3d9/d3d9_constant_set.h
@@ -30,15 +30,8 @@ namespace dxvk {
     uint32_t bConsts[1];
   };
 
-  struct D3D9SwvpConstantBuffers {
-    D3D9ConstantBuffer        intBuffer;
-    D3D9ConstantBuffer        boolBuffer;
-  };
-
   struct D3D9ConstantSets {
     D3D9ConstantLayout        layout;
-    D3D9SwvpConstantBuffers   swvp;
-    D3D9ConstantBuffer        buffer;
     D3D9ShaderConstantsInfo   shaderConstantsInfo;
     bool                      dirty = true;
     uint32_t                  changedFloatCount = 0u;

--- a/src/d3d9/d3d9_constant_set.h
+++ b/src/d3d9/d3d9_constant_set.h
@@ -2,6 +2,7 @@
 
 #include "d3d9_caps.h"
 #include "d3d9_constant_buffer.h"
+#include "d3d9_constant_copy.h"
 #include "d3d9_constant_layout.h"
 
 #include "../util/util_vector.h"
@@ -9,12 +10,6 @@
 #include <cstdint>
 
 namespace dxvk {
-
-  enum class D3D9ConstantType {
-    Float,
-    Int,
-    Bool
-  };
 
   // We make an assumption later based on the packing of this struct for copying.
   struct D3D9ShaderConstantsVSSoftware {

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -8203,6 +8203,13 @@ namespace dxvk {
         StartRegister, pConstantData, Count);
     }
 
+    // Only mark constants as dirty if any of the actual data has changed
+    bool anyConstantDirty = UpdateStateConstants<ShaderType, ConstantType, T>(
+      &m_state, StartRegister, pConstantData, Count);
+
+    if (unlikely(!anyConstantDirty))
+      return D3D_OK;
+
     D3D9ConstantSets& constSet = m_consts[uint32_t(ShaderType)];
 
     if (ConstantType == D3D9ConstantType::Float) {
@@ -8220,9 +8227,6 @@ namespace dxvk {
       // Bool constants are only backed by memory for SWVP vertex shaders
       constSet.dirty |= StartRegister < constSet.shaderConstantsInfo.boolCount && CanSWVP();
     }
-
-    UpdateStateConstants<ShaderType, ConstantType, T>(&m_state,
-      StartRegister, pConstantData, Count, false);
 
     return D3D_OK;
   }

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -96,9 +96,6 @@ namespace dxvk {
     if (!(BehaviorFlags & D3DCREATE_FPU_PRESERVE))
       SetupFPU();
 
-    // Check for VK_EXT_graphics_pipeline_libraries
-    m_usingGraphicsPipelines = dxvkDevice->features().extGraphicsPipelineLibrary.graphicsPipelineLibrary;
-
     // Check for VK_EXT_depth_bias_control and set up initial state
     m_depthBiasRepresentation = { VK_DEPTH_BIAS_REPRESENTATION_LEAST_REPRESENTABLE_VALUE_FORMAT_EXT, false };
     if (dxvkDevice->features().extDepthBiasControl.depthBiasControl) {
@@ -6036,14 +6033,12 @@ namespace dxvk {
         ? sizeof(D3D9FixedFunctionVertexBlendDataSW)
         : sizeof(D3D9FixedFunctionVertexBlendDataHW));
 
-    // Allocate constant buffer for values that would otherwise get passed as spec constants for fast-linked pipelines to use.
-    if (m_usingGraphicsPipelines) {
-      m_specBuffer = D3D9ConstantBuffer(this,
-        VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT,
-        VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT,
-        D3D9ShaderResourceMapping::getSpecConstantBufferSlot(),
-        D3D9SpecializationInfo::UBOSize);
-    }
+    // Allocate constant buffer for dynamic spec constants, needed for GPL
+    m_specBuffer = D3D9ConstantBuffer(this,
+      VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT,
+      VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT,
+      D3D9ShaderResourceMapping::getSpecConstantBufferSlot(),
+      D3D9SpecializationInfo::UBOSize);
   }
 
 
@@ -9338,11 +9333,10 @@ namespace dxvk {
     });
 
     // Write spec constants into buffer for fast-linked pipelines to use it.
-    if (m_usingGraphicsPipelines) {
-      // TODO: Make uploading specialization information less naive.
-      auto mapPtr = m_specBuffer.AllocSlice();
-      memcpy(mapPtr, m_specInfo.data.data(), D3D9SpecializationInfo::UBOSize);
-    }
+    // TODO get rid of the fallback buffer and rework everything to use push
+    // data instead.
+    auto mapPtr = m_specBuffer.AllocSlice();
+    memcpy(mapPtr, m_specInfo.data.data(), D3D9SpecializationInfo::UBOSize);
 
     m_dirty.clr(D3D9DeviceDirtyFlag::SpecializationEntries);
   }

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -5986,38 +5986,15 @@ namespace dxvk {
 
 
   void D3D9DeviceEx::CreateConstantBuffers() {
-    constexpr VkDeviceSize DefaultConstantBufferSize = 1024ull << 10;
-
-    m_psStaticConstants = D3D9ConstantBuffer(this, VK_SHADER_STAGE_FRAGMENT_BIT,
-      D3D9ShaderResourceMapping::CbvIndex::PSStaticConstants, DefaultConstantBufferSize);
-
-    m_vsStaticConstants = D3D9ConstantBuffer(this, VK_SHADER_STAGE_VERTEX_BIT,
-      D3D9ShaderResourceMapping::CbvIndex::VSStaticConstants, DefaultConstantBufferSize);
-
-    m_vsDynamicConstants = D3D9ConstantBuffer(this, VK_SHADER_STAGE_VERTEX_BIT,
-      D3D9ShaderResourceMapping::CbvIndex::VSDynamicConstants, DefaultConstantBufferSize);
-
-    m_vsClipPlanes = D3D9ConstantBuffer(this, VK_SHADER_STAGE_VERTEX_BIT,
-      D3D9ShaderResourceMapping::CbvIndex::VSClipPlanes,
-      caps::MaxClipPlanes * sizeof(D3D9ClipPlane));
-
-    m_vsFixedFunction = D3D9ConstantBuffer(this, VK_SHADER_STAGE_VERTEX_BIT,
-      D3D9ShaderResourceMapping::CbvIndex::VSFixedFunction, sizeof(D3D9FixedFunctionVS));
-
-    m_psFixedFunction = D3D9ConstantBuffer(this, VK_SHADER_STAGE_FRAGMENT_BIT,
-      D3D9ShaderResourceMapping::CbvIndex::PSFixedFunction, sizeof(D3D9FixedFunctionPS));
-
-    m_psShared = D3D9ConstantBuffer(this, VK_SHADER_STAGE_FRAGMENT_BIT,
-      D3D9ShaderResourceMapping::CbvIndex::PSShared, sizeof(D3D9SharedPS));
-
-    m_vsVertexBlend = D3D9ConstantBuffer(this, VK_SHADER_STAGE_VERTEX_BIT,
-      D3D9ShaderResourceMapping::CbvIndex::VSVertexBlendData, CanSWVP()
-        ? sizeof(D3D9FixedFunctionVertexBlendDataSW)
-        : sizeof(D3D9FixedFunctionVertexBlendDataHW));
-
-    // Constant buffer for dynamic spec constants, needed for GPL pipelines
-    m_specBuffer = D3D9ConstantBuffer(this, VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT,
-      D3D9ShaderResourceMapping::CbvIndex::SpecData, D3D9SpecializationInfo::UBOSize);
+    m_psStaticConstants = D3D9ConstantBuffer(this, D3D9ShaderResourceMapping::CbvIndex::PSStaticConstants);
+    m_vsStaticConstants = D3D9ConstantBuffer(this, D3D9ShaderResourceMapping::CbvIndex::VSStaticConstants);
+    m_vsDynamicConstants = D3D9ConstantBuffer(this, D3D9ShaderResourceMapping::CbvIndex::VSDynamicConstants);
+    m_vsClipPlanes = D3D9ConstantBuffer(this, D3D9ShaderResourceMapping::CbvIndex::VSClipPlanes);
+    m_vsFixedFunction = D3D9ConstantBuffer(this, D3D9ShaderResourceMapping::CbvIndex::VSFixedFunction);
+    m_psFixedFunction = D3D9ConstantBuffer(this, D3D9ShaderResourceMapping::CbvIndex::PSFixedFunction);
+    m_psShared = D3D9ConstantBuffer(this, D3D9ShaderResourceMapping::CbvIndex::PSShared);
+    m_vsVertexBlend = D3D9ConstantBuffer(this, D3D9ShaderResourceMapping::CbvIndex::VSVertexBlendData);
+    m_specBuffer = D3D9ConstantBuffer(this, D3D9ShaderResourceMapping::CbvIndex::SpecData);
   }
 
 

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -96,42 +96,6 @@ namespace dxvk {
     if (!(BehaviorFlags & D3DCREATE_FPU_PRESERVE))
       SetupFPU();
 
-    // Check if VK_EXT_robustness2 is supported, so we can optimize the number of constants we need to copy.
-    // Also check the required alignments.
-    const bool supportsRobustness2 = m_dxvkDevice->features().extRobustness2.robustBufferAccess2;
-    bool useRobustConstantAccess = supportsRobustness2;
-    D3D9ConstantSets& vsConstSet = m_consts[uint32_t(D3D9ShaderType::VertexShader)];
-    D3D9ConstantSets& psConstSet = m_consts[uint32_t(D3D9ShaderType::PixelShader)];
-    if (useRobustConstantAccess) {
-      m_robustSSBOAlignment = m_dxvkDevice->properties().extRobustness2.robustStorageBufferAccessSizeAlignment;
-      m_robustUBOAlignment  = m_dxvkDevice->properties().extRobustness2.robustUniformBufferAccessSizeAlignment;
-      if (canSWVP) {
-        const uint32_t floatBufferAlignment =
-          vsConstSet.layout.totalSize() < m_dxvkShaderOptions.maxUniformBufferSize
-          ? m_robustSSBOAlignment
-          : m_robustUBOAlignment;
-
-        useRobustConstantAccess &= vsConstSet.layout.floatSize() % floatBufferAlignment == 0;
-        useRobustConstantAccess &= vsConstSet.layout.intSize() % m_robustUBOAlignment == 0;
-        useRobustConstantAccess &= vsConstSet.layout.bitmaskSize() % m_robustUBOAlignment == 0;
-      } else {
-        useRobustConstantAccess &= vsConstSet.layout.totalSize() % m_robustUBOAlignment == 0;
-      }
-      useRobustConstantAccess &= psConstSet.layout.totalSize() % m_robustUBOAlignment == 0;
-    }
-
-    if (!useRobustConstantAccess) {
-      // Disable optimized constant copies, we always have to copy all constants.
-      vsConstSet.changedFloatCount = vsConstSet.layout.floatCount;
-      vsConstSet.changedIntCount   = vsConstSet.layout.intCount;
-      vsConstSet.changedBoolCount  = vsConstSet.layout.boolCount;
-      psConstSet.changedFloatCount = psConstSet.layout.floatCount;
-
-      if (supportsRobustness2) {
-        Logger::warn("Disabling robust constant buffer access because of alignment.");
-      }
-    }
-
     // Check for VK_EXT_graphics_pipeline_libraries
     m_usingGraphicsPipelines = dxvkDevice->features().extGraphicsPipelineLibrary.graphicsPipelineLibrary;
 

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -3556,10 +3556,14 @@ namespace dxvk {
     if (shader == m_state.vertexShader.ptr())
       return D3D_OK;
 
+    auto* oldShader = GetCommonShader(m_state.vertexShader);
     auto* newShader = GetCommonShader(shader);
 
+    auto oldLayout = oldShader ? oldShader->GetConstantLayout() : nullptr;
+    auto newLayout = newShader ? newShader->GetConstantLayout() : nullptr;
+
     auto& vsConstants = m_consts[uint32_t(D3D9ShaderType::VertexShader)];
-    vsConstants.dirty = true;
+    vsConstants.dirty |= oldLayout != newLayout;
     vsConstants.shaderConstantsInfo = newShader ? newShader->GetConstantsInfo() : D3D9ShaderConstantsInfo();
 
     const bool wasUsingProgrammableVS = UseProgrammableVS();
@@ -3901,10 +3905,14 @@ namespace dxvk {
     if (shader == m_state.pixelShader.ptr())
       return D3D_OK;
 
+    auto* oldShader = GetCommonShader(m_state.pixelShader);
     auto* newShader = GetCommonShader(shader);
 
+    auto oldLayout = oldShader ? oldShader->GetConstantLayout() : nullptr;
+    auto newLayout = newShader ? newShader->GetConstantLayout() : nullptr;
+
     auto& psConstants = m_consts[uint32_t(D3D9ShaderType::PixelShader)];
-    psConstants.dirty = true;
+    psConstants.dirty |= oldLayout != newLayout;
     psConstants.shaderConstantsInfo = newShader ? newShader->GetConstantsInfo() : D3D9ShaderConstantsInfo();
 
     const D3D9ShaderMasks oldShaderMasks = PSShaderMasks();

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -6029,11 +6029,10 @@ namespace dxvk {
     }
 
     // Set up and perform the actual data copy
-    D3D9ConstantBufferCopyArgs copyArgs = {};
-    copyArgs.floatConstantCount = dynamicFloatCount;
-    copyArgs.flushNan = m_d3d9Options.d3d9FloatEmulation == D3D9FloatEmulation::Enabled;
-
     if (staticSize) {
+      D3D9ConstantBufferCopyArgs copyArgs = {};
+      copyArgs.flushNan = m_d3d9Options.d3d9FloatEmulation == D3D9FloatEmulation::Enabled;
+
       // Allocate storage for statically indexed constants
       auto& buffer = GetConstantBuffer(ShaderType == D3D9ShaderType::VertexShader
         ? CbvIndex::VSStaticConstants
@@ -6056,9 +6055,24 @@ namespace dxvk {
       // Pad last block so we always write full cache lines
       copyArgs.boolBuffer = reinterpret_cast<char*>(staticData) + staticOffset;
       copyArgs.boolBufferSize = staticSize - staticOffset;
+
+      if (ShaderType == D3D9ShaderType::VertexShader) {
+        copyArgs.constFloatApi = m_state.vsConsts->fConsts;
+        copyArgs.constIntApi = m_state.vsConsts->iConsts;
+        copyArgs.constBoolApi = m_state.vsConsts->bConsts;
+      } else {
+        copyArgs.constFloatApi = m_state.psConsts->fConsts;
+        copyArgs.constIntApi = m_state.psConsts->iConsts;
+      }
+
+      layout->copyConstantData(copyArgs);
     }
 
     if (dynamicSize) {
+      D3D9ConstantBufferCopyArgs copyArgs = {};
+      copyArgs.floatConstantCount = dynamicFloatCount;
+      copyArgs.flushNan = m_d3d9Options.d3d9FloatEmulation == D3D9FloatEmulation::Enabled;
+
       // Allocate storage for dynamically indexed floats. Pad this
       // to the full allocation size as well so we write everything.
       auto& buffer = GetConstantBuffer(CbvIndex::VSDynamicConstants);
@@ -6066,18 +6080,10 @@ namespace dxvk {
 
       copyArgs.floatBuffer = buffer.Alloc(dynamicSize);
       copyArgs.floatBufferSize = dynamicSize;
-    }
-
-    if (ShaderType == D3D9ShaderType::VertexShader) {
       copyArgs.constFloatApi = m_state.vsConsts->fConsts;
-      copyArgs.constIntApi = m_state.vsConsts->iConsts;
-      copyArgs.constBoolApi = m_state.vsConsts->bConsts;
-    } else {
-      copyArgs.constFloatApi = m_state.psConsts->fConsts;
-      copyArgs.constIntApi = m_state.psConsts->iConsts;
-    }
 
-    layout->copyConstantData(copyArgs);
+      layout->copyConstantData(copyArgs);
+    }
 
     constants.dirty = false;
   }

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -5986,23 +5986,7 @@ namespace dxvk {
 
 
   void D3D9DeviceEx::CreateConstantBuffers() {
-    constexpr VkDeviceSize DefaultConstantBufferSize  = 1024ull << 10;
-    constexpr VkDeviceSize SmallConstantBufferSize    =   64ull << 10;
-
-    auto& vsConst = m_consts[uint32_t(D3D9ShaderType::VertexShader)];
-    auto& psConst = m_consts[uint32_t(D3D9ShaderType::PixelShader)];
-
-    vsConst.buffer = D3D9ConstantBuffer(this, VK_SHADER_STAGE_VERTEX_BIT,
-      D3D9ShaderResourceMapping::CbvIndex::VSConstantBuffer, DefaultConstantBufferSize);
-
-    vsConst.swvp.intBuffer = D3D9ConstantBuffer(this, VK_SHADER_STAGE_VERTEX_BIT,
-      D3D9ShaderResourceMapping::CbvIndex::VSIntConstantBuffer, SmallConstantBufferSize);
-
-    vsConst.swvp.boolBuffer = D3D9ConstantBuffer(this, VK_SHADER_STAGE_VERTEX_BIT,
-      D3D9ShaderResourceMapping::CbvIndex::VSBoolConstantBuffer, SmallConstantBufferSize);
-
-    psConst.buffer = D3D9ConstantBuffer(this, VK_SHADER_STAGE_FRAGMENT_BIT,
-      D3D9ShaderResourceMapping::CbvIndex::PSConstantBuffer, DefaultConstantBufferSize);
+    constexpr VkDeviceSize DefaultConstantBufferSize = 1024ull << 10;
 
     m_psStaticConstants = D3D9ConstantBuffer(this, VK_SHADER_STAGE_FRAGMENT_BIT,
       D3D9ShaderResourceMapping::CbvIndex::PSStaticConstants, DefaultConstantBufferSize);

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -5986,15 +5986,8 @@ namespace dxvk {
 
 
   void D3D9DeviceEx::CreateConstantBuffers() {
-    m_psStaticConstants = D3D9ConstantBuffer(this, D3D9ShaderResourceMapping::CbvIndex::PSStaticConstants);
-    m_vsStaticConstants = D3D9ConstantBuffer(this, D3D9ShaderResourceMapping::CbvIndex::VSStaticConstants);
-    m_vsDynamicConstants = D3D9ConstantBuffer(this, D3D9ShaderResourceMapping::CbvIndex::VSDynamicConstants);
-    m_vsClipPlanes = D3D9ConstantBuffer(this, D3D9ShaderResourceMapping::CbvIndex::VSClipPlanes);
-    m_vsFixedFunction = D3D9ConstantBuffer(this, D3D9ShaderResourceMapping::CbvIndex::VSFixedFunction);
-    m_psFixedFunction = D3D9ConstantBuffer(this, D3D9ShaderResourceMapping::CbvIndex::PSFixedFunction);
-    m_psShared = D3D9ConstantBuffer(this, D3D9ShaderResourceMapping::CbvIndex::PSShared);
-    m_vsVertexBlend = D3D9ConstantBuffer(this, D3D9ShaderResourceMapping::CbvIndex::VSVertexBlendData);
-    m_specBuffer = D3D9ConstantBuffer(this, D3D9ShaderResourceMapping::CbvIndex::SpecData);
+    for (uint32_t i = 0u; i < m_constantBuffers.size(); i++)
+      m_constantBuffers[i] = D3D9ConstantBuffer(this, D3D9ShaderResourceMapping::CbvIndex(i));
   }
 
 
@@ -6042,8 +6035,9 @@ namespace dxvk {
 
     if (staticSize) {
       // Allocate storage for statically indexed constants
-      auto& buffer = ShaderType == D3D9ShaderType::VertexShader
-        ? m_vsStaticConstants : m_psStaticConstants;
+      auto& buffer = GetConstantBuffer(ShaderType == D3D9ShaderType::VertexShader
+        ? CbvIndex::VSStaticConstants
+        : CbvIndex::PSStaticConstants);
       staticSize = align(staticSize, buffer.GetAlignment());
 
       auto staticData = buffer.Alloc(staticSize);
@@ -6067,9 +6061,10 @@ namespace dxvk {
     if (dynamicSize) {
       // Allocate storage for dynamically indexed floats. Pad this
       // to the full allocation size as well so we write everything.
-      dynamicSize = align(dynamicSize, m_vsDynamicConstants.GetAlignment());
+      auto& buffer = GetConstantBuffer(CbvIndex::VSDynamicConstants);
+      dynamicSize = align(dynamicSize, buffer.GetAlignment());
 
-      copyArgs.floatBuffer = m_vsDynamicConstants.Alloc(dynamicSize);
+      copyArgs.floatBuffer = buffer.Alloc(dynamicSize);
       copyArgs.floatBufferSize = dynamicSize;
     }
 
@@ -6091,7 +6086,7 @@ namespace dxvk {
   void D3D9DeviceEx::UpdateClipPlanes() {
     m_dirty.clr(D3D9DeviceDirtyFlag::ClipPlanes);
 
-    auto dst = m_vsClipPlanes.AllocTyped<D3D9ClipPlane>(caps::MaxClipPlanes);
+    auto dst = GetConstantBuffer(CbvIndex::VSClipPlanes).AllocTyped<D3D9ClipPlane>(caps::MaxClipPlanes);
 
     uint32_t clipPlaneCount = 0u;
     for (uint32_t i = 0; i < caps::MaxClipPlanes; i++) {
@@ -7642,7 +7637,7 @@ namespace dxvk {
     if (unlikely(m_dirty.test(D3D9DeviceDirtyFlag::SharedPixelShaderData))) {
       m_dirty.clr(D3D9DeviceDirtyFlag::SharedPixelShaderData);
 
-      auto data = m_psShared.AllocTyped<D3D9SharedPS>(1u);
+      auto data = GetConstantBuffer(CbvIndex::PSShared).AllocTyped<D3D9SharedPS>(1u);
 
       for (uint32_t i = 0; i < caps::TextureStageCount; i++) {
         DecodeD3DCOLOR(D3DCOLOR(m_state.textureStages[i][DXVK_TSS_CONSTANT]), data->Stages[i].Constant);
@@ -8342,7 +8337,7 @@ namespace dxvk {
       auto WorldView    = m_state.transforms[GetTransformIndex(D3DTS_VIEW)] * m_state.transforms[GetTransformIndex(D3DTS_WORLD)];
       auto NormalMatrix = inverse(WorldView);
 
-      auto data = m_vsFixedFunction.AllocTyped<D3D9FixedFunctionVS>(1u);
+      auto data = GetConstantBuffer(CbvIndex::VSFixedFunction).AllocTyped<D3D9FixedFunctionVS>(1u);
       data->WorldView    = WorldView;
       data->NormalMatrix = NormalMatrix;
       data->InverseView  = transpose(inverse(m_state.transforms[GetTransformIndex(D3DTS_VIEW)]));
@@ -8376,7 +8371,7 @@ namespace dxvk {
         ? D3D9MaxVertexBlendTransformsSw
         : D3D9MaxVertexBlendTransformsHw;
 
-      auto data = m_vsVertexBlend.AllocTyped<Matrix4>(matrixCount);
+      auto data = GetConstantBuffer(CbvIndex::VSVertexBlendData).AllocTyped<Matrix4>(matrixCount);
 
       for (uint32_t i = 0; i < matrixCount; i++) {
         data[i] = m_state.transforms[GetTransformIndex(D3DTS_VIEW)] *
@@ -8521,7 +8516,7 @@ namespace dxvk {
 
       auto& rs = m_state.renderStates;
 
-      auto data = m_psFixedFunction.AllocTyped<D3D9FixedFunctionPS>(1u);
+      auto data = GetConstantBuffer(CbvIndex::PSFixedFunction).AllocTyped<D3D9FixedFunctionPS>(1u);
       DecodeD3DCOLOR(D3DCOLOR(rs[D3DRS_TEXTUREFACTOR]), data->textureFactor.data);
       data->Key = key;
     }
@@ -9227,7 +9222,7 @@ namespace dxvk {
     // Write spec constants into buffer for fast-linked pipelines to use it.
     // TODO get rid of the fallback buffer and rework everything to use push
     // data instead.
-    auto mapPtr = m_specBuffer.Alloc(sizeof(m_specInfo.data));
+    auto mapPtr = GetConstantBuffer(CbvIndex::SpecData).Alloc(sizeof(m_specInfo.data));
     memcpy(mapPtr, m_specInfo.data.data(), sizeof(m_specInfo.data));
 
     m_dirty.clr(D3D9DeviceDirtyFlag::SpecializationEntries);

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -6001,6 +6001,15 @@ namespace dxvk {
     psConst.buffer = D3D9ConstantBuffer(this, VK_SHADER_STAGE_FRAGMENT_BIT,
       D3D9ShaderResourceMapping::CbvIndex::PSConstantBuffer, DefaultConstantBufferSize);
 
+    m_psStaticConstants = D3D9ConstantBuffer(this, VK_SHADER_STAGE_FRAGMENT_BIT,
+      D3D9ShaderResourceMapping::CbvIndex::PSStaticConstants, DefaultConstantBufferSize);
+
+    m_vsStaticConstants = D3D9ConstantBuffer(this, VK_SHADER_STAGE_VERTEX_BIT,
+      D3D9ShaderResourceMapping::CbvIndex::VSStaticConstants, DefaultConstantBufferSize);
+
+    m_vsDynamicConstants = D3D9ConstantBuffer(this, VK_SHADER_STAGE_VERTEX_BIT,
+      D3D9ShaderResourceMapping::CbvIndex::VSDynamicConstants, DefaultConstantBufferSize);
+
     m_vsClipPlanes = D3D9ConstantBuffer(this, VK_SHADER_STAGE_VERTEX_BIT,
       D3D9ShaderResourceMapping::CbvIndex::VSClipPlanes,
       caps::MaxClipPlanes * sizeof(D3D9ClipPlane));

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -6040,7 +6040,7 @@ namespace dxvk {
       ? GetCommonShader(m_state.vertexShader)
       : GetCommonShader(m_state.pixelShader);
 
-    const auto& layout = shader->GetConstantLayout();
+    const auto* layout = shader->GetConstantLayout();
 
     // Dynamic indexing is only a thing in VS, so nope out on the PS path.
     uint32_t dynamicFloatCount = 0u;
@@ -6049,10 +6049,10 @@ namespace dxvk {
       dynamicFloatCount = constants.changedFloatCount;
 
     bool isDynamicallyIndexed = ShaderType == D3D9ShaderType::VertexShader
-      && layout.getLayout(D3D9ConstantType::Float).isDynamicallyIndexed();
+      && layout->getLayout(D3D9ConstantType::Float).isDynamicallyIndexed();
 
     // Compute amount of storage required for each constant type
-    auto dataSize = layout.getAllocationSizes(dynamicFloatCount);
+    auto dataSize = layout->getAllocationSizes(dynamicFloatCount);
 
     if (ShaderType == D3D9ShaderType::PixelShader)
       dataSize.boolBufferSize = 0u;
@@ -6117,7 +6117,7 @@ namespace dxvk {
       copyArgs.constIntApi = m_state.psConsts->iConsts;
     }
 
-    layout.copyConstantData(copyArgs);
+    layout->copyConstantData(copyArgs);
 
     constants.dirty = false;
   }

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -6034,6 +6034,100 @@ namespace dxvk {
   }
 
 
+  template<D3D9ShaderType ShaderType>
+  void D3D9DeviceEx::UpdateShaderConstants() {
+    auto& constants = m_consts[uint32_t(ShaderType)];
+
+    if (!constants.dirty)
+      return;
+
+    auto shader = ShaderType == D3D9ShaderType::VertexShader
+      ? GetCommonShader(m_state.vertexShader)
+      : GetCommonShader(m_state.pixelShader);
+
+    const auto& layout = shader->GetConstantLayout();
+
+    // Dynamic indexing is only a thing in VS, so nope out on the PS path.
+    uint32_t dynamicFloatCount = 0u;
+
+    if (ShaderType == D3D9ShaderType::VertexShader)
+      dynamicFloatCount = constants.changedFloatCount;
+
+    bool isDynamicallyIndexed = ShaderType == D3D9ShaderType::VertexShader
+      && layout.getLayout(D3D9ConstantType::Float).isDynamicallyIndexed();
+
+    // Compute amount of storage required for each constant type
+    auto dataSize = layout.getAllocationSizes(dynamicFloatCount);
+
+    if (ShaderType == D3D9ShaderType::PixelShader)
+      dataSize.boolBufferSize = 0u;
+
+    // Compute data layout of the respective buffers
+    auto staticSize = dataSize.boolBufferSize + dataSize.intBufferSize;
+    auto dynamicSize = dataSize.floatBufferSize;
+
+    if (!isDynamicallyIndexed) {
+      staticSize += dynamicSize;
+      dynamicSize = 0u;
+    }
+
+    // Set up and perform the actual data copy
+    D3D9ConstantBufferCopyArgs copyArgs = {};
+    copyArgs.floatConstantCount = dynamicFloatCount;
+    copyArgs.flushNan = m_d3d9Options.d3d9FloatEmulation == D3D9FloatEmulation::Enabled;
+
+    if (staticSize) {
+      // Allocate storage for statically indexed constants
+      auto& buffer = ShaderType == D3D9ShaderType::VertexShader
+        ? m_vsStaticConstants : m_psStaticConstants;
+      staticSize = align(staticSize, buffer.GetAlignment());
+
+      auto staticData = buffer.Alloc(staticSize);
+      auto staticOffset = 0u;
+
+      if (!dynamicSize) {
+        copyArgs.floatBuffer = reinterpret_cast<char*>(staticData) + staticOffset;
+        copyArgs.floatBufferSize = dataSize.floatBufferSize;
+        staticOffset += dataSize.floatBufferSize;
+      }
+
+      copyArgs.intBuffer = reinterpret_cast<char*>(staticData) + staticOffset;
+      copyArgs.intBufferSize = dataSize.intBufferSize;
+      staticOffset += dataSize.intBufferSize;
+
+      // Pad last block so we always write full cache lines
+      copyArgs.boolBuffer = reinterpret_cast<char*>(staticData) + staticOffset;
+      copyArgs.boolBufferSize = staticSize - staticOffset;
+    }
+
+    if (dynamicSize) {
+      // Allocate storage for dynamically indexed floats. Pad this
+      // to the full allocation size as well so we write everything.
+      dynamicSize = align(dynamicSize, m_vsDynamicConstants.GetAlignment());
+
+      copyArgs.floatBuffer = m_vsDynamicConstants.Alloc(dynamicSize);
+      copyArgs.floatBufferSize = dynamicSize;
+    }
+
+    if (ShaderType == D3D9ShaderType::VertexShader) {
+      // Need shader-defined constants for dynamic
+      // indexing, and boolean constants for SWVP.
+      copyArgs.constFloatApi = m_state.vsConsts->fConsts;
+      copyArgs.constFloatDef = shader->GetConstantData();
+      copyArgs.constIntApi = m_state.vsConsts->iConsts;
+      copyArgs.constBoolApi = m_state.vsConsts->bConsts;
+    } else {
+      // Don't need any of the above for PS, fast path
+      copyArgs.constFloatApi = m_state.psConsts->fConsts;
+      copyArgs.constIntApi = m_state.psConsts->iConsts;
+    }
+
+    layout.copyConstantData(copyArgs);
+
+    constants.dirty = false;
+  }
+
+
   inline void D3D9DeviceEx::UploadSoftwareConstantSet(const D3D9ShaderConstantsVSSoftware& Src, const D3D9ConstantLayout& Layout) {
     /*
      * SWVP raises the amount of constants by a lot.

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -3556,21 +3556,11 @@ namespace dxvk {
     if (shader == m_state.vertexShader.ptr())
       return D3D_OK;
 
-    auto* oldShader = GetCommonShader(m_state.vertexShader);
     auto* newShader = GetCommonShader(shader);
 
-    bool oldCopies = oldShader && oldShader->GetConstantsInfo().floatsAccessedDynamically;
-    bool newCopies = newShader && newShader->GetConstantsInfo().floatsAccessedDynamically;
-
-    m_consts[uint32_t(D3D9ShaderType::VertexShader)].dirty |= oldCopies || newCopies || !oldShader;
-    m_consts[uint32_t(D3D9ShaderType::VertexShader)].shaderConstantsInfo  = newShader ? newShader->GetConstantsInfo() : D3D9ShaderConstantsInfo();
-
-    if (newShader && oldShader) {
-      m_consts[uint32_t(D3D9ShaderType::VertexShader)].dirty
-        |= newShader->GetConstantsInfo().floatCount > oldShader->GetConstantsInfo().floatCount
-        || newShader->GetConstantsInfo().intCount > oldShader->GetConstantsInfo().intCount
-        || newShader->GetConstantsInfo().boolCount > oldShader->GetConstantsInfo().boolCount;
-    }
+    auto& vsConstants = m_consts[uint32_t(D3D9ShaderType::VertexShader)];
+    vsConstants.dirty = true;
+    vsConstants.shaderConstantsInfo = newShader ? newShader->GetConstantsInfo() : D3D9ShaderConstantsInfo();
 
     const bool wasUsingProgrammableVS = UseProgrammableVS();
 
@@ -3911,21 +3901,11 @@ namespace dxvk {
     if (shader == m_state.pixelShader.ptr())
       return D3D_OK;
 
-    auto* oldShader = GetCommonShader(m_state.pixelShader);
     auto* newShader = GetCommonShader(shader);
 
-    bool oldCopies = oldShader && oldShader->GetConstantsInfo().floatsAccessedDynamically;
-    bool newCopies = newShader && newShader->GetConstantsInfo().floatsAccessedDynamically;
-
-    m_consts[uint32_t(D3D9ShaderType::PixelShader)].dirty |= oldCopies || newCopies || !oldShader;
-    m_consts[uint32_t(D3D9ShaderType::PixelShader)].shaderConstantsInfo  = newShader ? newShader->GetConstantsInfo() : D3D9ShaderConstantsInfo();
-
-    if (newShader && oldShader) {
-      m_consts[uint32_t(D3D9ShaderType::PixelShader)].dirty
-        |= newShader->GetConstantsInfo().floatCount > oldShader->GetConstantsInfo().floatCount
-        || newShader->GetConstantsInfo().intCount > oldShader->GetConstantsInfo().intCount
-        || newShader->GetConstantsInfo().boolCount > oldShader->GetConstantsInfo().boolCount;
-    }
+    auto& psConstants = m_consts[uint32_t(D3D9ShaderType::PixelShader)];
+    psConstants.dirty = true;
+    psConstants.shaderConstantsInfo = newShader ? newShader->GetConstantsInfo() : D3D9ShaderConstantsInfo();
 
     const D3D9ShaderMasks oldShaderMasks = PSShaderMasks();
     m_state.pixelShader = shader;
@@ -8007,15 +7987,13 @@ namespace dxvk {
     m_state.vsConsts->bConsts[idx] &= ~mask;
     m_state.vsConsts->bConsts[idx] |= bits & mask;
 
-    m_consts[uint32_t(D3D9ShaderType::VertexShader)].dirty = true;
+    m_consts[uint32_t(D3D9ShaderType::VertexShader)].dirty |= CanSWVP();
   }
 
 
   void D3D9DeviceEx::SetPixelBoolBitfield(uint32_t idx, uint32_t mask, uint32_t bits) {
     m_state.psConsts->bConsts[idx] &= ~mask;
     m_state.psConsts->bConsts[idx] |= bits & mask;
-
-    m_consts[uint32_t(D3D9ShaderType::PixelShader)].dirty = true;
   }
 
 
@@ -8192,73 +8170,59 @@ namespace dxvk {
   }
 
 
-  template <
-    D3D9ShaderType   ShaderType,
-    D3D9ConstantType ConstantType,
-    typename         T>
-    HRESULT D3D9DeviceEx::SetShaderConstants(
-            UINT  StartRegister,
-      const T*    pConstantData,
-            UINT  Count) {
-    const     uint32_t regCountHardware = DetermineHardwareRegCount<ShaderType, ConstantType>();
-    constexpr uint32_t regCountSoftware = DetermineSoftwareRegCount<ShaderType, ConstantType>();
+  template<D3D9ShaderType ShaderType, D3D9ConstantType ConstantType, typename T>
+  HRESULT D3D9DeviceEx::SetShaderConstants(
+          UINT  StartRegister,
+    const T*    pConstantData,
+          UINT  Count) {
+    uint32_t maxRegCount = DetermineSoftwareRegCount<ShaderType, ConstantType>();
 
     // Error out in case of StartRegister + Count overflow
-    if (unlikely(StartRegister > std::numeric_limits<uint32_t>::max() - Count))
+    if (unlikely(StartRegister > maxRegCount) || unlikely(Count > maxRegCount - StartRegister))
       return D3DERR_INVALIDCALL;
 
-    if (unlikely(StartRegister + Count > regCountSoftware))
-      return D3DERR_INVALIDCALL;
-
-    Count = UINT(
-      std::max<INT>(
-        std::clamp<INT>(Count + StartRegister, 0, regCountHardware) - INT(StartRegister),
-        0));
-
-    if (unlikely(Count == 0))
+    if (unlikely(!Count))
       return D3D_OK;
 
-    if (unlikely(pConstantData == nullptr))
+    // Clamp count to the maximum that we are going to access in shaders.
+    // For PS or SWVP VS, constant counts won't change, so skip.
+    if (ShaderType == D3D9ShaderType::VertexShader && likely(!CanSWVP())) {
+      maxRegCount = DetermineHardwareRegCount<ShaderType, ConstantType>();
+
+      if (unlikely(StartRegister >= maxRegCount))
+        return D3D_OK;
+
+      Count = std::min(maxRegCount - StartRegister, Count);
+    }
+
+    if (unlikely(!pConstantData))
       return D3DERR_INVALIDCALL;
 
-    if (unlikely(ShouldRecord()))
+    if (unlikely(ShouldRecord())) {
       return m_recorder->SetShaderConstants<ShaderType, ConstantType, T>(
-        StartRegister,
-        pConstantData,
-        Count);
+        StartRegister, pConstantData, Count);
+    }
 
     D3D9ConstantSets& constSet = m_consts[uint32_t(ShaderType)];
 
-    if constexpr (ConstantType == D3D9ConstantType::Float) {
-      constSet.changedFloatCount = std::max(constSet.changedFloatCount, StartRegister + Count);
-    } else if constexpr (ConstantType == D3D9ConstantType::Int && ShaderType == D3D9ShaderType::VertexShader) {
-      // We only track changed int constants for vertex shaders (and it's only used when the device uses the SWVP UBO layout).
-      // Pixel shaders (and vertex shaders on HWVP devices) always copy all int constants into the same UBO as the float constants
-      constSet.changedIntCount = std::max(constSet.changedIntCount, StartRegister + Count);
-    } else  if constexpr (ConstantType == D3D9ConstantType::Bool && ShaderType == D3D9ShaderType::VertexShader) {
-      // We only track changed bool constants for vertex shaders (and it's only used when the device uses the SWVP UBO layout).
-      // Pixel shaders (and vertex shaders on HWVP devices) always put all bool constants into a single spec constant.
-      constSet.changedBoolCount = std::max(constSet.changedBoolCount, StartRegister + Count);
+    if (ConstantType == D3D9ConstantType::Float) {
+      // Check whether the constant range has any effect on the bound shader.
+      // Also update the dynamic float count for vertex shaders, which is used
+      // to reduce the number of constants copied with dynamic indexing.q
+      constSet.dirty |= StartRegister < constSet.shaderConstantsInfo.floatCount;
+
+      if (ShaderType == D3D9ShaderType::VertexShader)
+        constSet.changedFloatCount = std::max(constSet.changedFloatCount, StartRegister + Count);
+    } else if (ConstantType == D3D9ConstantType::Int) {
+      // Same logic as above except we need to check against the used integer count.
+      constSet.dirty |= StartRegister < constSet.shaderConstantsInfo.intCount;
+    } else if (ConstantType == D3D9ConstantType::Bool && ShaderType == D3D9ShaderType::VertexShader) {
+      // Bool constants are only backed by memory for SWVP vertex shaders
+      constSet.dirty |= StartRegister < constSet.shaderConstantsInfo.boolCount && CanSWVP();
     }
 
-    if constexpr (ConstantType != D3D9ConstantType::Bool) {
-      uint32_t count = ConstantType == D3D9ConstantType::Float
-        ? constSet.shaderConstantsInfo.floatCount
-        : constSet.shaderConstantsInfo.intCount;
-
-      constSet.dirty |= StartRegister < count;
-    } else if constexpr (ShaderType == D3D9ShaderType::VertexShader) {
-      if (unlikely(CanSWVP())) {
-        constSet.dirty |= StartRegister < constSet.shaderConstantsInfo.boolCount;
-      }
-    }
-
-    UpdateStateConstants<ShaderType, ConstantType, T>(
-      &m_state,
-      StartRegister,
-      pConstantData,
-      Count,
-      m_d3d9Options.d3d9FloatEmulation == D3D9FloatEmulation::Enabled);
+    UpdateStateConstants<ShaderType, ConstantType, T>(&m_state,
+      StartRegister, pConstantData, Count, false);
 
     return D3D_OK;
   }

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -3364,10 +3364,10 @@ namespace dxvk {
       args.viewportH = -float(m_state.viewport.Height);
 
       ctx->bindShader<VK_SHADER_STAGE_GEOMETRY_BIT>(std::move(shader));
-      ctx->bindResourceBufferView(VK_SHADER_STAGE_GEOMETRY_BIT, D3D9ShaderResourceMapping::getSWVPBufferSlot(), std::move(bufferView));
+      ctx->bindResourceBufferView(VK_SHADER_STAGE_GEOMETRY_BIT, D3D9ShaderResourceMapping::getSwvpBufferIndex(), std::move(bufferView));
       ctx->pushData(VK_SHADER_STAGE_GEOMETRY_BIT, 0u, sizeof(args), &args);
       ctx->draw(1u, &draw);
-      ctx->bindResourceBufferView(VK_SHADER_STAGE_GEOMETRY_BIT, D3D9ShaderResourceMapping::getSWVPBufferSlot(), nullptr);
+      ctx->bindResourceBufferView(VK_SHADER_STAGE_GEOMETRY_BIT, D3D9ShaderResourceMapping::getSwvpBufferIndex(), nullptr);
       ctx->bindShader<VK_SHADER_STAGE_GEOMETRY_BIT>(nullptr);
     });
 
@@ -5986,59 +5986,42 @@ namespace dxvk {
     constexpr VkDeviceSize DefaultConstantBufferSize  = 1024ull << 10;
     constexpr VkDeviceSize SmallConstantBufferSize    =   64ull << 10;
 
-    m_consts[uint32_t(D3D9ShaderType::VertexShader)].buffer = D3D9ConstantBuffer(this,
-      D3D9ShaderType::VertexShader,
-      D3D9ShaderResourceMapping::ConstantBuffers::VSConstantBuffer,
-      DefaultConstantBufferSize);
+    auto& vsConst = m_consts[uint32_t(D3D9ShaderType::VertexShader)];
+    auto& psConst = m_consts[uint32_t(D3D9ShaderType::PixelShader)];
 
-    m_consts[uint32_t(D3D9ShaderType::VertexShader)].swvp.intBuffer = D3D9ConstantBuffer(this,
-      D3D9ShaderType::VertexShader,
-      D3D9ShaderResourceMapping::ConstantBuffers::VSIntConstantBuffer,
-      SmallConstantBufferSize);
+    vsConst.buffer = D3D9ConstantBuffer(this, VK_SHADER_STAGE_VERTEX_BIT,
+      D3D9ShaderResourceMapping::CbvIndex::VSConstantBuffer, DefaultConstantBufferSize);
 
-    m_consts[uint32_t(D3D9ShaderType::VertexShader)].swvp.boolBuffer = D3D9ConstantBuffer(this,
-      D3D9ShaderType::VertexShader,
-      D3D9ShaderResourceMapping::ConstantBuffers::VSBoolConstantBuffer,
-      SmallConstantBufferSize);
+    vsConst.swvp.intBuffer = D3D9ConstantBuffer(this, VK_SHADER_STAGE_VERTEX_BIT,
+      D3D9ShaderResourceMapping::CbvIndex::VSIntConstantBuffer, SmallConstantBufferSize);
 
-    m_consts[uint32_t(D3D9ShaderType::PixelShader)].buffer = D3D9ConstantBuffer(this,
-      D3D9ShaderType::PixelShader,
-      D3D9ShaderResourceMapping::ConstantBuffers::PSConstantBuffer,
-      DefaultConstantBufferSize);
+    vsConst.swvp.boolBuffer = D3D9ConstantBuffer(this, VK_SHADER_STAGE_VERTEX_BIT,
+      D3D9ShaderResourceMapping::CbvIndex::VSBoolConstantBuffer, SmallConstantBufferSize);
 
-    m_vsClipPlanes = D3D9ConstantBuffer(this,
-      D3D9ShaderType::VertexShader,
-      D3D9ShaderResourceMapping::ConstantBuffers::VSClipPlanes,
+    psConst.buffer = D3D9ConstantBuffer(this, VK_SHADER_STAGE_FRAGMENT_BIT,
+      D3D9ShaderResourceMapping::CbvIndex::PSConstantBuffer, DefaultConstantBufferSize);
+
+    m_vsClipPlanes = D3D9ConstantBuffer(this, VK_SHADER_STAGE_VERTEX_BIT,
+      D3D9ShaderResourceMapping::CbvIndex::VSClipPlanes,
       caps::MaxClipPlanes * sizeof(D3D9ClipPlane));
 
-    m_vsFixedFunction = D3D9ConstantBuffer(this,
-      D3D9ShaderType::VertexShader,
-      D3D9ShaderResourceMapping::ConstantBuffers::VSFixedFunction,
-      sizeof(D3D9FixedFunctionVS));
+    m_vsFixedFunction = D3D9ConstantBuffer(this, VK_SHADER_STAGE_VERTEX_BIT,
+      D3D9ShaderResourceMapping::CbvIndex::VSFixedFunction, sizeof(D3D9FixedFunctionVS));
 
-    m_psFixedFunction = D3D9ConstantBuffer(this,
-      D3D9ShaderType::PixelShader,
-      D3D9ShaderResourceMapping::ConstantBuffers::PSFixedFunction,
-      sizeof(D3D9FixedFunctionPS));
+    m_psFixedFunction = D3D9ConstantBuffer(this, VK_SHADER_STAGE_FRAGMENT_BIT,
+      D3D9ShaderResourceMapping::CbvIndex::PSFixedFunction, sizeof(D3D9FixedFunctionPS));
 
-    m_psShared = D3D9ConstantBuffer(this,
-      D3D9ShaderType::PixelShader,
-      D3D9ShaderResourceMapping::ConstantBuffers::PSShared,
-      sizeof(D3D9SharedPS));
+    m_psShared = D3D9ConstantBuffer(this, VK_SHADER_STAGE_FRAGMENT_BIT,
+      D3D9ShaderResourceMapping::CbvIndex::PSShared, sizeof(D3D9SharedPS));
 
-    m_vsVertexBlend = D3D9ConstantBuffer(this,
-      D3D9ShaderType::VertexShader,
-      D3D9ShaderResourceMapping::ConstantBuffers::VSVertexBlendData,
-      CanSWVP()
+    m_vsVertexBlend = D3D9ConstantBuffer(this, VK_SHADER_STAGE_VERTEX_BIT,
+      D3D9ShaderResourceMapping::CbvIndex::VSVertexBlendData, CanSWVP()
         ? sizeof(D3D9FixedFunctionVertexBlendDataSW)
         : sizeof(D3D9FixedFunctionVertexBlendDataHW));
 
-    // Allocate constant buffer for dynamic spec constants, needed for GPL
-    m_specBuffer = D3D9ConstantBuffer(this,
-      VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT,
-      VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT,
-      D3D9ShaderResourceMapping::getSpecConstantBufferSlot(),
-      D3D9SpecializationInfo::UBOSize);
+    // Constant buffer for dynamic spec constants, needed for GPL pipelines
+    m_specBuffer = D3D9ConstantBuffer(this, VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT,
+      D3D9ShaderResourceMapping::CbvIndex::SpecData, D3D9SpecializationInfo::UBOSize);
   }
 
 

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -6114,8 +6114,7 @@ namespace dxvk {
   void D3D9DeviceEx::UpdateClipPlanes() {
     m_dirty.clr(D3D9DeviceDirtyFlag::ClipPlanes);
 
-    auto mapPtr = m_vsClipPlanes.AllocSlice();
-    auto dst = reinterpret_cast<D3D9ClipPlane*>(mapPtr);
+    auto dst = m_vsClipPlanes.AllocTyped<D3D9ClipPlane>(caps::MaxClipPlanes);
 
     uint32_t clipPlaneCount = 0u;
     for (uint32_t i = 0; i < caps::MaxClipPlanes; i++) {
@@ -7666,8 +7665,7 @@ namespace dxvk {
     if (unlikely(m_dirty.test(D3D9DeviceDirtyFlag::SharedPixelShaderData))) {
       m_dirty.clr(D3D9DeviceDirtyFlag::SharedPixelShaderData);
 
-      auto mapPtr = m_psShared.AllocSlice();
-      D3D9SharedPS* data = reinterpret_cast<D3D9SharedPS*>(mapPtr);
+      auto data = m_psShared.AllocTyped<D3D9SharedPS>(1u);
 
       for (uint32_t i = 0; i < caps::TextureStageCount; i++) {
         DecodeD3DCOLOR(D3DCOLOR(m_state.textureStages[i][DXVK_TSS_CONSTANT]), data->Stages[i].Constant);
@@ -8364,12 +8362,10 @@ namespace dxvk {
     if (m_dirty.test(D3D9DeviceDirtyFlag::FFVertexData)) {
       m_dirty.clr(D3D9DeviceDirtyFlag::FFVertexData);
 
-      auto mapPtr = m_vsFixedFunction.AllocSlice();
-
       auto WorldView    = m_state.transforms[GetTransformIndex(D3DTS_VIEW)] * m_state.transforms[GetTransformIndex(D3DTS_WORLD)];
       auto NormalMatrix = inverse(WorldView);
 
-      D3D9FixedFunctionVS* data = reinterpret_cast<D3D9FixedFunctionVS*>(mapPtr);
+      auto data = m_vsFixedFunction.AllocTyped<D3D9FixedFunctionVS>(1u);
       data->WorldView    = WorldView;
       data->NormalMatrix = NormalMatrix;
       data->InverseView  = transpose(inverse(m_state.transforms[GetTransformIndex(D3DTS_VIEW)]));
@@ -8399,15 +8395,16 @@ namespace dxvk {
     if (m_dirty.test(D3D9DeviceDirtyFlag::FFVertexBlend) && vertexBlendMode == D3D9FF_VertexBlendMode_Normal) {
       m_dirty.clr(D3D9DeviceDirtyFlag::FFVertexBlend);
 
-      auto mapPtr = m_vsVertexBlend.AllocSlice();
-      auto UploadVertexBlendData = [&](auto data) {
-        for (uint32_t i = 0; i < std::size(data->WorldView); i++)
-          data->WorldView[i] = m_state.transforms[GetTransformIndex(D3DTS_VIEW)] * m_state.transforms[GetTransformIndex(D3DTS_WORLDMATRIX(i))];
-      };
+      uint32_t matrixCount = m_isSWVP && indexedVertexBlend
+        ? D3D9MaxVertexBlendTransformsSw
+        : D3D9MaxVertexBlendTransformsHw;
 
-      (m_isSWVP && indexedVertexBlend)
-        ? UploadVertexBlendData(reinterpret_cast<D3D9FixedFunctionVertexBlendDataSW*>(mapPtr))
-        : UploadVertexBlendData(reinterpret_cast<D3D9FixedFunctionVertexBlendDataHW*>(mapPtr));
+      auto data = m_vsVertexBlend.AllocTyped<Matrix4>(matrixCount);
+
+      for (uint32_t i = 0; i < matrixCount; i++) {
+        data[i] = m_state.transforms[GetTransformIndex(D3DTS_VIEW)] *
+          m_state.transforms[GetTransformIndex(D3DTS_WORLDMATRIX(i))];
+      }
     }
   }
 
@@ -8545,11 +8542,10 @@ namespace dxvk {
     if (m_dirty.test(D3D9DeviceDirtyFlag::FFPixelData)) {
       m_dirty.clr(D3D9DeviceDirtyFlag::FFPixelData);
 
-      auto mapPtr = m_psFixedFunction.AllocSlice();
       auto& rs = m_state.renderStates;
 
-      D3D9FixedFunctionPS* data = reinterpret_cast<D3D9FixedFunctionPS*>(mapPtr);
-      DecodeD3DCOLOR((D3DCOLOR)rs[D3DRS_TEXTUREFACTOR], data->textureFactor.data);
+      auto data = m_psFixedFunction.AllocTyped<D3D9FixedFunctionPS>(1u);
+      DecodeD3DCOLOR(D3DCOLOR(rs[D3DRS_TEXTUREFACTOR]), data->textureFactor.data);
       data->Key = key;
     }
   }
@@ -9254,8 +9250,8 @@ namespace dxvk {
     // Write spec constants into buffer for fast-linked pipelines to use it.
     // TODO get rid of the fallback buffer and rework everything to use push
     // data instead.
-    auto mapPtr = m_specBuffer.AllocSlice();
-    memcpy(mapPtr, m_specInfo.data.data(), D3D9SpecializationInfo::UBOSize);
+    auto mapPtr = m_specBuffer.Alloc(sizeof(m_specInfo.data));
+    memcpy(mapPtr, m_specInfo.data.data(), sizeof(m_specInfo.data));
 
     m_dirty.clr(D3D9DeviceDirtyFlag::SpecializationEntries);
   }

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -6128,146 +6128,6 @@ namespace dxvk {
   }
 
 
-  inline void D3D9DeviceEx::UploadSoftwareConstantSet(const D3D9ShaderConstantsVSSoftware& Src, const D3D9ConstantLayout& Layout) {
-    /*
-     * SWVP raises the amount of constants by a lot.
-     * To avoid copying huge amounts of data for every draw call,
-     * we track the highest set constant and only use a buffer big enough
-     * to fit that. We rely on robustness to return 0 for OOB reads.
-    */
-
-    D3D9ConstantSets& constSet = m_consts[uint32_t(D3D9ShaderType::VertexShader)];
-
-    if (!constSet.dirty)
-      return;
-
-    constSet.dirty = false;
-
-    // If we statically know which is the last float constant accessed by the shader, we don't need to copy the rest.
-    uint32_t floatCount = constSet.changedFloatCount;
-    if (constSet.shaderConstantsInfo.floatsAccessedDynamically) {
-      // If the shader requires us to preserve shader defined constants,
-      // we copy those over. We need to adjust the amount of used floats accordingly.
-      auto shader = GetCommonShader(m_state.vertexShader);
-      floatCount = std::max(floatCount, shader->GetImmediateConstants().floatCount);
-    }
-    // If we statically know which is the last float constant accessed by the shader, we don't need to copy the rest.
-    floatCount = std::min(floatCount, constSet.shaderConstantsInfo.floatCount);
-
-    // Calculate data sizes for each constant type.
-    const uint32_t floatDataSize = floatCount * sizeof(Vector4);
-    const uint32_t intDataSize   = std::min(constSet.shaderConstantsInfo.intCount, constSet.changedIntCount) * sizeof(Vector4i);
-    const uint32_t boolDataSize  = divCeil(std::min(constSet.shaderConstantsInfo.boolCount, constSet.changedBoolCount), 32u) * uint32_t(sizeof(uint32_t));
-
-    // Max copy source size is 8192 * 16 => always aligned to any plausible value
-    // => we won't copy out of bounds
-    if (likely(floatDataSize != 0u)) {
-      auto mapPtr = CopySoftwareConstants(constSet.buffer, Src.fConsts, floatDataSize);
-
-      if (constSet.shaderConstantsInfo.floatsAccessedDynamically) {
-        // Copy shader defined constants over so they can be accessed
-        // with relative addressing.
-        Vector4* data = reinterpret_cast<Vector4*>(mapPtr);
-
-        const auto& shaderConsts = GetCommonShader(m_state.vertexShader)->GetImmediateConstants().floats;
-
-        for (const auto& constant : shaderConsts) {
-          if (constant.index < constSet.shaderConstantsInfo.floatCount)
-            data[constant.index] = constant.value;
-        }
-      }
-    }
-
-    // Max copy source size is 2048 * 16 => always aligned to any plausible value
-    // => we won't copy out of bounds
-    if (likely(intDataSize != 0u))
-      CopySoftwareConstants(constSet.swvp.intBuffer, Src.iConsts, intDataSize);
-
-    if (likely(boolDataSize != 0u))
-      CopySoftwareConstants(constSet.swvp.boolBuffer, Src.bConsts, boolDataSize);
-  }
-
-
-  inline void* D3D9DeviceEx::CopySoftwareConstants(D3D9ConstantBuffer& dstBuffer, const void* src, uint32_t size) {
-    uint32_t alignment = dstBuffer.GetAlignment();
-    size = std::max(size, alignment);
-    size = align(size, alignment);
-
-    auto mapPtr = dstBuffer.Alloc(size);
-    std::memcpy(mapPtr, src, size);
-    return mapPtr;
-  }
-
-
-  template <D3D9ShaderType ShaderStage, typename HardwareLayoutType, typename SoftwareLayoutType, typename ShaderType>
-  inline void D3D9DeviceEx::UploadConstantSet(const SoftwareLayoutType& Src, const D3D9ConstantLayout& Layout, const ShaderType& Shader) {
-    /*
-     * We just copy the float constants that have been set by the application and rely on robustness
-     * to return 0 on OOB reads.
-    */
-    D3D9ConstantSets& constSet = m_consts[uint32_t(ShaderStage)];
-
-    if (!constSet.dirty)
-      return;
-
-    constSet.dirty = false;
-
-    uint32_t floatCount = constSet.changedFloatCount;
-    if (constSet.shaderConstantsInfo.floatsAccessedDynamically) {
-      // If the shader requires us to preserve shader defined constants,
-      // we copy those over. We need to adjust the amount of used floats accordingly.
-      auto shader = GetCommonShader(Shader);
-      floatCount = std::max(floatCount, shader->GetImmediateConstants().floatCount);
-    }
-    // If we statically know which is the last float constant accessed by the shader, we don't need to copy the rest.
-    floatCount = std::min(floatCount, constSet.shaderConstantsInfo.floatCount);
-
-    // There are very few int constants, so we put those into the same buffer at the start.
-    // We always allocate memory for all possible int constants to make sure alignment works out.
-    const uint32_t intRange = caps::MaxOtherConstants * sizeof(Vector4i);
-    uint32_t floatDataSize = floatCount * sizeof(Vector4);
-    // Determine amount of floats and buffer size based on highest used float constant and alignment
-    const uint32_t alignment = constSet.buffer.GetAlignment();
-    const uint32_t bufferSize = align(std::max(floatDataSize + intRange, alignment), alignment);
-    floatDataSize = bufferSize - intRange;
-
-    void* mapPtr = constSet.buffer.Alloc(bufferSize);
-    auto* dst = reinterpret_cast<HardwareLayoutType*>(mapPtr);
-
-    const uint32_t intDataSize = constSet.shaderConstantsInfo.intCount * sizeof(Vector4i);
-    if (intDataSize != 0u)
-      std::memcpy(dst->iConsts, Src.iConsts, intDataSize);
-    if (floatDataSize != 0u)
-      std::memcpy(dst->fConsts, Src.fConsts, floatDataSize);
-
-    if (constSet.shaderConstantsInfo.floatsAccessedDynamically) {
-      // Copy shader defined constants over so they can be accessed
-      // with relative addressing.
-      Vector4* data = reinterpret_cast<Vector4*>(dst->fConsts);
-
-      const auto& shaderConsts = GetCommonShader(Shader)->GetImmediateConstants().floats;
-
-      for (const auto& constant : shaderConsts) {
-        if (constant.index < constSet.shaderConstantsInfo.floatCount)
-          data[constant.index] = constant.value;
-      }
-    }
-  }
-
-
-  template <D3D9ShaderType ShaderStage>
-  void D3D9DeviceEx::UploadConstants() {
-    if constexpr (ShaderStage == D3D9ShaderType::VertexShader) {
-      if (CanSWVP())
-        return UploadSoftwareConstantSet(m_state.vsConsts.get(), m_consts[uint32_t(ShaderStage)].layout);
-      else
-        return UploadConstantSet<ShaderStage, D3D9ShaderConstantsVSHardware>(m_state.vsConsts.get(), m_consts[uint32_t(ShaderStage)].layout, m_state.vertexShader);
-    } else {
-      return UploadConstantSet<ShaderStage, D3D9ShaderConstantsPS>(m_state.psConsts.get(), m_consts[uint32_t(ShaderStage)].layout, m_state.pixelShader);
-    }
-  }
-
-
   void D3D9DeviceEx::UpdateClipPlanes() {
     m_dirty.clr(D3D9DeviceDirtyFlag::ClipPlanes);
 
@@ -7753,7 +7613,7 @@ namespace dxvk {
       UpdateGlobalSpecular();
 
     if (likely(UseProgrammableVS())) {
-      UploadConstants<D3D9ShaderType::VertexShader>();
+      UpdateShaderConstants<D3D9ShaderType::VertexShader>();
 
       if (likely(!CanSWVP())) {
         UpdateVertexBoolSpec(
@@ -7772,7 +7632,7 @@ namespace dxvk {
 
     uint32_t projected = m_textureSlotTracking.projected;
     if (likely(UseProgrammablePS())) {
-      UploadConstants<D3D9ShaderType::PixelShader>();
+      UpdateShaderConstants<D3D9ShaderType::PixelShader>();
 
       const uint32_t psTextureMask = usedTextureMask & ((1u << caps::MaxTexturesPS) - 1u);
       const uint32_t fetch4        = m_textureSlotTracking.fetch4    & psTextureMask;

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -6105,14 +6105,10 @@ namespace dxvk {
     }
 
     if (ShaderType == D3D9ShaderType::VertexShader) {
-      // Need shader-defined constants for dynamic
-      // indexing, and boolean constants for SWVP.
       copyArgs.constFloatApi = m_state.vsConsts->fConsts;
-      copyArgs.constFloatDef = shader->GetConstantData();
       copyArgs.constIntApi = m_state.vsConsts->iConsts;
       copyArgs.constBoolApi = m_state.vsConsts->bConsts;
     } else {
-      // Don't need any of the above for PS, fast path
       copyArgs.constFloatApi = m_state.psConsts->fConsts;
       copyArgs.constIntApi = m_state.psConsts->iConsts;
     }

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -5891,6 +5891,11 @@ namespace dxvk {
     // can processe them before the first use.
     m_initializer->FlushCsChunk();
 
+    // Constant buffers may hold a pointer into the current chunk,
+    // reset that here so the data won't get overwritten.
+    for (auto& cbv : m_constantBuffers)
+      cbv.ResetStreamCommand();
+
     m_csSeqNum = m_csThread.dispatchChunk(std::move(chunk));
   }
 

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -5856,6 +5856,21 @@ namespace dxvk {
   }
 
 
+  const D3D9ConstantBufferCopy* D3D9DeviceEx::GetOrCreateConstantLayout(
+          D3D9ConstantBufferLayout  FloatLayout,
+          D3D9ConstantBufferLayout  IntLayout,
+          D3D9ConstantBufferLayout  BoolLayout) {
+    std::lock_guard lock(m_constantLayoutMutex);
+
+    auto entry = m_constantLayouts.emplace(
+      std::move(FloatLayout),
+      std::move(IntLayout),
+      std::move(BoolLayout));
+
+    return &(*entry.first);
+  }
+
+
   void D3D9DeviceEx::InjectCsChunk(
           DxvkCsChunkRef&&            Chunk,
           bool                        Synchronize) {

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -8046,7 +8046,8 @@ namespace dxvk {
 
     dxbc_spv::util::ByteReader reader(pShaderBytecode, std::numeric_limits<size_t>::max());
 
-    D3D9ShaderAnalysis analysis(reader, m_isSWVP);
+    D3D9ShaderAnalysis analysis(reader, CanSWVP());
+
     if (!analysis) {
       Logger::err("CreateShaderModule: Shader analysis prepass failed");
       return D3DERR_INVALIDCALL;

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -171,7 +171,7 @@ namespace dxvk {
     if (this_thread::isInModuleDetachment())
       return;
 
-    Flush();
+    ExecuteFlush(true);
     SynchronizeCsThread(DxvkCsThread::SynchronizeAll);
 
     if (m_annotation)
@@ -537,7 +537,7 @@ namespace dxvk {
       return hr;
     }
 
-    Flush();
+    ExecuteFlush(true);
     SynchronizeCsThread(DxvkCsThread::SynchronizeAll);
 
     if (m_d3d9Options.deferSurfaceCreation)
@@ -4909,7 +4909,7 @@ namespace dxvk {
       else {
         // Make sure pending commands using the resource get
         // executed on the the GPU if we have to wait for it
-        Flush();
+        ExecuteFlush(false);
         SynchronizeCsThread(SequenceNumber);
 
         m_dxvkDevice->waitForResource(Resource, access);
@@ -5900,7 +5900,7 @@ namespace dxvk {
     uint64_t submissionId = m_submissionFence->value();
 
     if (m_flushTracker.considerFlush(FlushType, chunkId, submissionId, 0u))
-      Flush();
+      ExecuteFlush(false);
   }
 
 
@@ -6211,11 +6211,10 @@ namespace dxvk {
   }
 
 
-  template <bool Synchronize9On12>
-  void D3D9DeviceEx::ExecuteFlush() {
+  void D3D9DeviceEx::ExecuteFlush(bool Synchronize9On12) {
     D3D9DeviceLock lock = LockDevice();
 
-    if constexpr (Synchronize9On12)
+    if (Synchronize9On12)
       m_submitStatus.result = VK_NOT_READY;
 
     // Update signaled staging buffer counter and signal the fence
@@ -6247,7 +6246,7 @@ namespace dxvk {
 
     // If necessary, block calling thread until the
     // Vulkan queue submission is performed.
-    if constexpr (Synchronize9On12)
+    if (Synchronize9On12)
       m_dxvkDevice->waitForSubmission(&m_submitStatus);
 
     // Notify the device that the context has been flushed,
@@ -6257,12 +6256,14 @@ namespace dxvk {
 
 
   void D3D9DeviceEx::Flush() {
-    ExecuteFlush<false>();
+    D3D9DeviceLock lock = LockDevice();
+    ExecuteFlush(false);
   }
 
 
   void D3D9DeviceEx::FlushAndSync9On12() {
-    ExecuteFlush<true>();
+    D3D9DeviceLock lock = LockDevice();
+    ExecuteFlush(true);
   }
 
 
@@ -7765,7 +7766,7 @@ namespace dxvk {
     // We should absolutely never hit this path in the real world.
     Logger::warn("Sampler pool exhausted, synchronizing with GPU.");
 
-    Flush();
+    ExecuteFlush(false);
     SynchronizeCsThread(DxvkCsThread::SynchronizeAll);
 
     uint64_t submissionId = m_submissionFence->value();
@@ -7978,7 +7979,7 @@ namespace dxvk {
     pQuery->NotifyEnd();
     if (unlikely(pQuery->IsEvent())) {
       pQuery->IsStalling()
-        ? Flush()
+        ? ExecuteFlush(false)
         : ConsiderFlush(GpuFlushType::ImplicitStrongHint);
     } else if (pQuery->IsStalling()) {
       ConsiderFlush(GpuFlushType::ImplicitWeakHint);
@@ -9053,7 +9054,7 @@ namespace dxvk {
     if (FAILED(hr))
       return hr;
 
-    Flush();
+    ExecuteFlush(false);
     SynchronizeCsThread(DxvkCsThread::SynchronizeAll);
 
     return D3D_OK;

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -1025,16 +1025,6 @@ namespace dxvk {
     template<D3D9ShaderType ShaderType>
     void UpdateShaderConstants();
 
-    inline void UploadSoftwareConstantSet(const D3D9ShaderConstantsVSSoftware& Src, const D3D9ConstantLayout& Layout);
-
-    inline void* CopySoftwareConstants(D3D9ConstantBuffer& dstBuffer, const void* src, uint32_t size);
-
-    template <D3D9ShaderType ShaderStage, typename HardwareLayoutType, typename SoftwareLayoutType, typename ShaderType>
-    inline void UploadConstantSet(const SoftwareLayoutType& Src, const D3D9ConstantLayout& Layout, const ShaderType& Shader);
-
-    template <D3D9ShaderType ShaderStage>
-    void UploadConstants();
-
     void UpdateClipPlanes();
 
     void UpdateGlobalSpecular();

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -1022,6 +1022,9 @@ namespace dxvk {
 
     void BindDepthBias();
 
+    template<D3D9ShaderType ShaderType>
+    void UpdateShaderConstants();
+
     inline void UploadSoftwareConstantSet(const D3D9ShaderConstantsVSSoftware& Src, const D3D9ConstantLayout& Layout);
 
     inline void* CopySoftwareConstants(D3D9ConstantBuffer& dstBuffer, const void* src, uint32_t size);

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -1660,7 +1660,6 @@ namespace dxvk {
 
     VkImageLayout                   m_hazardLayout = VK_IMAGE_LAYOUT_GENERAL;
 
-    bool                            m_usingGraphicsPipelines = false;
     uint32_t                        m_resetCtr = 0u;
 
     DxvkDepthBiasRepresentation     m_depthBiasRepresentation = { VK_DEPTH_BIAS_REPRESENTATION_LEAST_REPRESENTABLE_VALUE_FORMAT_EXT, false };

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -10,6 +10,7 @@
 #include "d3d9_multithread.h"
 #include "d3d9_adapter.h"
 #include "d3d9_constant_buffer.h"
+#include "d3d9_constant_copy.h"
 #include "d3d9_constant_set.h"
 #include "d3d9_mem.h"
 
@@ -31,6 +32,7 @@
 #include <vector>
 #include <type_traits>
 #include <unordered_map>
+#include <unordered_set>
 
 #include "../util/util_flush.h"
 #include "../util/util_lru.h"
@@ -1254,6 +1256,11 @@ namespace dxvk {
       return m_dxvkShaderOptions;
     }
 
+    const D3D9ConstantBufferCopy* GetOrCreateConstantLayout(
+            D3D9ConstantBufferLayout  FloatLayout,
+            D3D9ConstantBufferLayout  IntLayout,
+            D3D9ConstantBufferLayout  BoolLayout);
+
   private:
 
     template<bool AllowFlush = true, typename Cmd>
@@ -1692,6 +1699,10 @@ namespace dxvk {
 #ifdef D3D9_ALLOW_UNMAPPING
     lru_list<D3D9CommonTexture*>    m_mappedTextures;
 #endif
+
+    dxvk::mutex                     m_constantLayoutMutex;
+    std::unordered_set<D3D9ConstantBufferCopy,
+      DxvkHash, DxvkEq>             m_constantLayouts;
 
     // m_state should be declared last (i.e. freed first), because it
     // references objects that can call back into the device when freed.

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -225,6 +225,8 @@ namespace dxvk {
     friend class D3D9UserDefinedAnnotation;
     friend class DxvkD3D8Bridge;
     friend D3D9VkInteropDevice;
+
+    using CbvIndex = D3D9ShaderResourceMapping::CbvIndex;
   public:
 
     D3D9DeviceEx(
@@ -1551,6 +1553,10 @@ namespace dxvk {
         : FixedFunctionMask;
     }
 
+    D3D9ConstantBuffer& GetConstantBuffer(CbvIndex Index) {
+      return m_constantBuffers[uint32_t(Index)];
+    }
+
     GpuFlushType GetMaxFlushType() const;
 
     bool ValidateSharedTexture(
@@ -1594,17 +1600,7 @@ namespace dxvk {
 
     Rc<D3D9ShaderModuleSet>         m_shaderModules;
 
-    D3D9ConstantBuffer              m_vsClipPlanes;
-
-    D3D9ConstantBuffer              m_psStaticConstants;
-    D3D9ConstantBuffer              m_vsStaticConstants;
-    D3D9ConstantBuffer              m_vsDynamicConstants;
-
-    D3D9ConstantBuffer              m_vsFixedFunction;
-    D3D9ConstantBuffer              m_vsVertexBlend;
-    D3D9ConstantBuffer              m_psFixedFunction;
-    D3D9ConstantBuffer              m_psShared;
-    D3D9ConstantBuffer              m_specBuffer;
+    std::array<D3D9ConstantBuffer, CbvIndex::Count> m_constantBuffers;
 
     Rc<DxvkBuffer>                  m_upBuffer;
     VkDeviceSize                    m_upBufferOffset  = 0ull;

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -1294,8 +1294,7 @@ namespace dxvk {
       return m_resetCtr;
     }
 
-    template <bool Synchronize9On12>
-    void ExecuteFlush();
+    void ExecuteFlush(bool Synchronize9On12);
 
     void DetermineConstantLayouts(bool canSWVP);
 

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -1344,8 +1344,7 @@ namespace dxvk {
     }
 
     // So we don't do OOB.
-    template <D3D9ShaderType   ShaderType,
-              D3D9ConstantType ConstantType>
+    template <D3D9ShaderType ShaderType, D3D9ConstantType ConstantType>
     inline static constexpr uint32_t DetermineSoftwareRegCount() {
       constexpr bool isVS = ShaderType == D3D9ShaderType::VertexShader;
 
@@ -1358,16 +1357,15 @@ namespace dxvk {
     }
 
     // So we don't copy more than we need.
-    template <D3D9ShaderType   ShaderType,
-              D3D9ConstantType ConstantType>
+    template<D3D9ShaderType ShaderType, D3D9ConstantType ConstantType>
     inline uint32_t DetermineHardwareRegCount() const {
-      const auto& layout = m_consts[uint32_t(ShaderType)].layout;
+      constexpr bool isVS = ShaderType == D3D9ShaderType::VertexShader;
 
       switch (ConstantType) {
         default:
-        case D3D9ConstantType::Float:  return layout.floatCount;
-        case D3D9ConstantType::Int:    return layout.intCount;
-        case D3D9ConstantType::Bool:   return layout.boolCount;
+        case D3D9ConstantType::Float:  return isVS ? caps::MaxFloatConstantsVS : caps::MaxSM3FloatConstantsPS;
+        case D3D9ConstantType::Int:    return caps::MaxOtherConstants;
+        case D3D9ConstantType::Bool:   return caps::MaxOtherConstants;
       }
     }
 

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -1599,6 +1599,10 @@ namespace dxvk {
 
     D3D9ConstantBuffer              m_vsClipPlanes;
 
+    D3D9ConstantBuffer              m_psStaticConstants;
+    D3D9ConstantBuffer              m_vsStaticConstants;
+    D3D9ConstantBuffer              m_vsDynamicConstants;
+
     D3D9ConstantBuffer              m_vsFixedFunction;
     D3D9ConstantBuffer              m_vsVertexBlend;
     D3D9ConstantBuffer              m_psFixedFunction;

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -1278,6 +1278,25 @@ namespace dxvk {
       }
     }
 
+    template<typename M, bool AllowFlush = true, typename Cmd>
+    M* EmitCsCmd(size_t count, Cmd&& command) {
+      auto csData = m_csChunk->pushCmd<M, Cmd>(command, count);
+
+      if (unlikely(!csData)) {
+        EmitCsChunk(std::move(m_csChunk));
+        m_csChunk = AllocCsChunk();
+
+        if constexpr (AllowFlush)
+          ConsiderFlush(GpuFlushType::ImplicitWeakHint);
+
+        // We must record this command after the potential
+        // flush since the caller may still access the data
+        csData = m_csChunk->pushCmd<M, Cmd>(command, count);
+      }
+
+      return reinterpret_cast<M*>(csData->first());
+    }
+
     void EmitCsChunk(DxvkCsChunkRef&& chunk);
 
     void FlushCsChunk() {

--- a/src/d3d9/d3d9_fixed_function.cpp
+++ b/src/d3d9/d3d9_fixed_function.cpp
@@ -27,45 +27,34 @@ namespace dxvk {
   Rc<DxvkShader> D3D9FFShaderModuleSet::buildVs() {
     small_vector<DxvkBindingInfo, 4> bindings = {};
 
-    constexpr uint32_t specConstantBufferBindingId = D3D9ShaderResourceMapping::getSpecConstantBufferSlot();
-
     auto& specConstantBufferBinding = bindings.emplace_back();
-    specConstantBufferBinding.set = 0u;
-    specConstantBufferBinding.binding        = specConstantBufferBindingId;
-    specConstantBufferBinding.resourceIndex  = specConstantBufferBindingId;
+    specConstantBufferBinding.set            = CbvSet;
+    specConstantBufferBinding.binding        = D3D9ShaderResourceMapping::CbvIndex::SpecData;
+    specConstantBufferBinding.resourceIndex  = D3D9ShaderResourceMapping::CbvIndex::SpecData;
     specConstantBufferBinding.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
     specConstantBufferBinding.access = VK_ACCESS_UNIFORM_READ_BIT;
     specConstantBufferBinding.flags.set(DxvkDescriptorFlag::UniformBuffer);
 
-    constexpr uint32_t fixedFunctionDataBindingId = D3D9ShaderResourceMapping::computeCbvBinding(
-      D3D9ShaderType::VertexShader, D3D9ShaderResourceMapping::ConstantBuffers::VSFixedFunction);
-
     auto& fixedFunctionDataBinding = bindings.emplace_back();
-    fixedFunctionDataBinding.set             = 0u;
-    fixedFunctionDataBinding.binding         = fixedFunctionDataBindingId;
-    fixedFunctionDataBinding.resourceIndex   = fixedFunctionDataBindingId;
+    fixedFunctionDataBinding.set             = CbvSet;
+    fixedFunctionDataBinding.binding         = D3D9ShaderResourceMapping::CbvIndex::VSFixedFunction;
+    fixedFunctionDataBinding.resourceIndex   = D3D9ShaderResourceMapping::CbvIndex::VSFixedFunction;
     fixedFunctionDataBinding.descriptorType  = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
     fixedFunctionDataBinding.access          = VK_ACCESS_UNIFORM_READ_BIT;
     fixedFunctionDataBinding.flags.set(DxvkDescriptorFlag::UniformBuffer);
 
-    constexpr uint32_t vertexBlendBindingId = D3D9ShaderResourceMapping::computeCbvBinding(
-      D3D9ShaderType::VertexShader, D3D9ShaderResourceMapping::ConstantBuffers::VSVertexBlendData);
-
     auto& vertexBlendBinding = bindings.emplace_back();
-    vertexBlendBinding.set             = 0u;
-    vertexBlendBinding.binding         = vertexBlendBindingId;
-    vertexBlendBinding.resourceIndex   = vertexBlendBindingId;
+    vertexBlendBinding.set             = CbvSet;
+    vertexBlendBinding.binding         = D3D9ShaderResourceMapping::CbvIndex::VSVertexBlendData;
+    vertexBlendBinding.resourceIndex   = D3D9ShaderResourceMapping::CbvIndex::VSVertexBlendData;
     vertexBlendBinding.descriptorType  = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
     vertexBlendBinding.access          = VK_ACCESS_SHADER_READ_BIT;
     vertexBlendBinding.flags.set(DxvkDescriptorFlag::UniformBuffer);
 
-    constexpr uint32_t clipPlanesBindingId = D3D9ShaderResourceMapping::computeCbvBinding(
-      D3D9ShaderType::VertexShader, D3D9ShaderResourceMapping::ConstantBuffers::VSClipPlanes);
-
     auto& clipPlanesBinding = bindings.emplace_back();
-    clipPlanesBinding.set             = 0u;
-    clipPlanesBinding.binding         = clipPlanesBindingId;
-    clipPlanesBinding.resourceIndex   = clipPlanesBindingId;
+    clipPlanesBinding.set             = CbvSet;
+    clipPlanesBinding.binding         = D3D9ShaderResourceMapping::CbvIndex::VSClipPlanes;
+    clipPlanesBinding.resourceIndex   = D3D9ShaderResourceMapping::CbvIndex::VSClipPlanes;
     clipPlanesBinding.descriptorType  = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
     clipPlanesBinding.access          = VK_ACCESS_UNIFORM_READ_BIT;
     clipPlanesBinding.flags.set(DxvkDescriptorFlag::UniformBuffer);
@@ -86,46 +75,38 @@ namespace dxvk {
   Rc<DxvkShader> D3D9FFShaderModuleSet::buildFs(D3D9DeviceEx* pDevice) {
     small_vector<DxvkBindingInfo, 12> bindings = {};
 
-    constexpr uint32_t specConstantBufferBindingId = D3D9ShaderResourceMapping::getSpecConstantBufferSlot();
-
     auto& specConstantBufferBinding = bindings.emplace_back();
-    specConstantBufferBinding.set = 0u;
-    specConstantBufferBinding.binding        = specConstantBufferBindingId;
-    specConstantBufferBinding.resourceIndex  = specConstantBufferBindingId;
+    specConstantBufferBinding.set            = CbvSet;
+    specConstantBufferBinding.binding        = D3D9ShaderResourceMapping::CbvIndex::SpecData;
+    specConstantBufferBinding.resourceIndex  = D3D9ShaderResourceMapping::CbvIndex::SpecData;
     specConstantBufferBinding.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
     specConstantBufferBinding.access = VK_ACCESS_UNIFORM_READ_BIT;
     specConstantBufferBinding.flags.set(DxvkDescriptorFlag::UniformBuffer);
 
-    constexpr uint32_t fixedFunctionDataBindingId = D3D9ShaderResourceMapping::computeCbvBinding(
-      D3D9ShaderType::PixelShader, D3D9ShaderResourceMapping::ConstantBuffers::PSFixedFunction);
-
     auto& fixedFunctionDataBinding = bindings.emplace_back();
-    fixedFunctionDataBinding.set             = 0u;
-    fixedFunctionDataBinding.binding         = fixedFunctionDataBindingId;
-    fixedFunctionDataBinding.resourceIndex   = fixedFunctionDataBindingId;
+    fixedFunctionDataBinding.set             = CbvSet;
+    fixedFunctionDataBinding.binding         = D3D9ShaderResourceMapping::CbvIndex::PSFixedFunction;
+    fixedFunctionDataBinding.resourceIndex   = D3D9ShaderResourceMapping::CbvIndex::PSFixedFunction;
     fixedFunctionDataBinding.descriptorType  = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
     fixedFunctionDataBinding.access          = VK_ACCESS_UNIFORM_READ_BIT;
     fixedFunctionDataBinding.flags.set(DxvkDescriptorFlag::UniformBuffer);
 
-    constexpr uint32_t sharedDataBindingId = D3D9ShaderResourceMapping::computeCbvBinding(
-      D3D9ShaderType::PixelShader, D3D9ShaderResourceMapping::ConstantBuffers::PSShared);
-
     auto& sharedDataBinding = bindings.emplace_back();
-    sharedDataBinding.set             = 0u;
-    sharedDataBinding.binding         = sharedDataBindingId;
-    sharedDataBinding.resourceIndex   = sharedDataBindingId;
+    sharedDataBinding.set             = CbvSet;
+    sharedDataBinding.binding         = D3D9ShaderResourceMapping::CbvIndex::PSShared;
+    sharedDataBinding.resourceIndex   = D3D9ShaderResourceMapping::CbvIndex::PSShared;
     sharedDataBinding.descriptorType  = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
     sharedDataBinding.access          = VK_ACCESS_SHADER_READ_BIT;
     sharedDataBinding.flags.set(DxvkDescriptorFlag::UniformBuffer);
 
-    constexpr uint32_t textureBindingId = D3D9ShaderResourceMapping::computeTextureBinding(D3D9ShaderType::PixelShader, 0u);
+    uint32_t textureBindingId = D3D9ShaderResourceMapping::computeTextureBinding(D3D9ShaderType::PixelShader, 0u);
 
     auto& textureBinding = bindings.emplace_back();
-    textureBinding.set             = 0u;
+    textureBinding.set             = SrvSet;
     textureBinding.binding         = textureBindingId;
     textureBinding.resourceIndex   = textureBindingId;
     textureBinding.descriptorType  = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
-    textureBinding.access       = VK_ACCESS_SHADER_READ_BIT;
+    textureBinding.access          = VK_ACCESS_SHADER_READ_BIT;
     textureBinding.descriptorCount = caps::TextureStageCount;
 
     for (uint32_t i = 0; i < caps::TextureStageCount; i++) {
@@ -153,7 +134,7 @@ namespace dxvk {
     info.sharedPushData = DxvkPushDataBlock(0u, sizeof(D3D9RenderStateInfo), 4u, 0u);
     info.localPushData = DxvkPushDataBlock(VK_SHADER_STAGE_FRAGMENT_BIT, GetPushSamplerOffset(0u),
       samplerDwordCount * sizeof(uint32_t), sizeof(uint32_t), (1u << samplerDwordCount) - 1u);
-    info.samplerHeap = DxvkShaderBinding(VK_SHADER_STAGE_FRAGMENT_BIT, 1u, 0u);
+    info.samplerHeap = DxvkShaderBinding(VK_SHADER_STAGE_FRAGMENT_BIT, SamplerSet, 0u);
     info.debugName = "FF FS";
 
     return pDevice->GetOptions()->forceSampleRateShading

--- a/src/d3d9/d3d9_fixed_function.h
+++ b/src/d3d9/d3d9_fixed_function.h
@@ -30,7 +30,9 @@ namespace dxvk {
   constexpr uint32_t TCIMask   = 0b111 << TCIOffset;
 
   class D3D9FFShaderModuleSet : public RcObject {
-
+    static constexpr uint32_t SamplerSet = 0u;
+    static constexpr uint32_t SrvSet = 1u;
+    static constexpr uint32_t CbvSet = 2u;
   public:
 
     D3D9FFShaderModuleSet() = delete;

--- a/src/d3d9/d3d9_multithread.cpp
+++ b/src/d3d9/d3d9_multithread.cpp
@@ -2,8 +2,14 @@
 
 namespace dxvk {
 
-  D3D9Multithread::D3D9Multithread(
-          BOOL                  Protected)
-    : m_protected( Protected ) { }
+  D3D9DeviceLock D3D9Multithread::LockContested(uint32_t threadId) {
+    // Spin until we can take ownership of the lock.
+    sync::spin(2000, [this, threadId] {
+      uint32_t expected = 0u;
+      return m_owner.compare_exchange_weak(expected, threadId, std::memory_order_acquire);
+    });
+
+    return D3D9DeviceLock(*this);
+  }
 
 }

--- a/src/d3d9/d3d9_multithread.h
+++ b/src/d3d9/d3d9_multithread.h
@@ -4,34 +4,27 @@
 
 namespace dxvk {
 
+  class D3D9Multithread;
+
   /**
-   * \brief Device lock
-   *
-   * Lightweight RAII wrapper that implements
-   * a subset of the functionality provided by
-   * \c std::unique_lock, with the goal of being
-   * cheaper to construct and destroy.
+   * \brief Scoped device lock
    */
   class D3D9DeviceLock {
 
   public:
 
-    D3D9DeviceLock()
-      : m_mutex(nullptr) { }
+    D3D9DeviceLock() { }
 
-    D3D9DeviceLock(sync::RecursiveSpinlock& mutex)
-      : m_mutex(&mutex) {
-      mutex.lock();
-    }
+    D3D9DeviceLock(D3D9Multithread& mutex)
+    : m_mutex(&mutex) { }
 
     D3D9DeviceLock(D3D9DeviceLock&& other)
-      : m_mutex(other.m_mutex) {
+    : m_mutex(other.m_mutex) {
       other.m_mutex = nullptr;
     }
 
     D3D9DeviceLock& operator = (D3D9DeviceLock&& other) {
-      if (m_mutex)
-        m_mutex->unlock();
+      Unlock();
 
       m_mutex = other.m_mutex;
       other.m_mutex = nullptr;
@@ -39,13 +32,14 @@ namespace dxvk {
     }
 
     ~D3D9DeviceLock() {
-      if (m_mutex != nullptr)
-        m_mutex->unlock();
+      Unlock();
     }
 
   private:
 
-    sync::RecursiveSpinlock* m_mutex;
+    D3D9Multithread* m_mutex = nullptr;
+
+    void Unlock();
 
   };
 
@@ -54,24 +48,54 @@ namespace dxvk {
    * \brief D3D9 context lock
    */
   class D3D9Multithread {
+    static constexpr uint32_t InvalidTid = -1u;
 
+    friend D3D9DeviceLock;
   public:
 
-    D3D9Multithread(
-      BOOL                  Protected);
+    D3D9Multithread(BOOL Protected)
+    : m_protected(Protected) { }
 
+    /**
+     * \brief Acquires lock
+     *
+     * If the calling thread already owns the lock, this will return
+     * an empty lock guard and rely entirely on proper scoping.
+     * \returns Lock guard
+     */
     D3D9DeviceLock AcquireLock() {
-      return m_protected
-        ? D3D9DeviceLock(m_mutex)
-        : D3D9DeviceLock();
+      if (likely(!m_protected))
+        return D3D9DeviceLock();
+
+      uint32_t expected = 0u;
+      uint32_t threadId = dxvk::this_thread::get_id();
+
+      if (likely(m_owner.compare_exchange_weak(expected, threadId, std::memory_order_acquire)))
+        return D3D9DeviceLock(*this);
+
+      if (expected == threadId)
+        return D3D9DeviceLock();
+
+      return LockContested(threadId);
     }
 
   private:
 
-    BOOL            m_protected;
+    alignas(CACHE_LINE_SIZE)
+    std::atomic<uint32_t>   m_owner     = { 0u };
+    BOOL                    m_protected = false;
 
-    sync::RecursiveSpinlock m_mutex;
+    D3D9DeviceLock LockContested(uint32_t threadId);
+
+    void Unlock() {
+      m_owner.store(0u, std::memory_order_release);
+    }
 
   };
+
+  inline void D3D9DeviceLock::Unlock() {
+    if (m_mutex)
+      m_mutex->Unlock();
+  }
 
 }

--- a/src/d3d9/d3d9_options.cpp
+++ b/src/d3d9/d3d9_options.cpp
@@ -64,7 +64,7 @@ namespace dxvk {
     this->allowDiscard                  = config.getOption<bool>        ("d3d9.allowDiscard",                  true);
     this->enumerateByDisplays           = config.getOption<bool>        ("d3d9.enumerateByDisplays",           true);
     this->cachedWriteOnlyBuffers        = config.getOption<bool>        ("d3d9.cachedWriteOnlyBuffers",          false);
-    this->deviceLocalConstantBuffers    = config.getOption<bool>        ("d3d9.deviceLocalConstantBuffers",    false);
+    this->deviceLocalConstantBuffers    = config.getOption<Tristate>    ("d3d9.deviceLocalConstantBuffers",    Tristate::Auto);
     this->allowDirectBufferMapping      = config.getOption<bool>        ("d3d9.allowDirectBufferMapping",      true);
     this->forceDrawTimeBufferUpload     = config.getOption<bool>        ("d3d9.forceDrawTimeBufferUpload",     false);
     this->seamlessCubes                 = config.getOption<bool>        ("d3d9.seamlessCubes",                 false);

--- a/src/d3d9/d3d9_options.h
+++ b/src/d3d9/d3d9_options.h
@@ -123,7 +123,7 @@ namespace dxvk {
     bool cachedWriteOnlyBuffers;
 
     /// Use device local memory for constant buffers.
-    bool deviceLocalConstantBuffers;
+    Tristate deviceLocalConstantBuffers;
 
     /// Disable direct buffer mapping
     bool allowDirectBufferMapping;

--- a/src/d3d9/d3d9_shader.cpp
+++ b/src/d3d9/d3d9_shader.cpp
@@ -10,17 +10,6 @@
 
 namespace dxvk {
 
-  enum class D3D9IrCbvIndex : uint32_t {
-    SpecData        = 0u,
-    VsClipping      = 1u,
-    PsTextureStages = 2u,
-    ConstFloat      = 3u,
-    ConstInt        = 4u,
-    ConstBool       = 5u,
-    ConstStatic     = 6u,
-    ConstDynamic    = 7u,
-  };
-
   class D3D9ShaderLowerLegacyInputPass {
 
   public:
@@ -235,6 +224,10 @@ namespace dxvk {
       if (!totalCount)
         return;
 
+      uint32_t regIndex = m_shaderStage == ir::ShaderStage::eVertex
+        ? D3D9ShaderResourceMapping::CbvIndex::VSStaticConstants
+        : D3D9ShaderResourceMapping::CbvIndex::PSStaticConstants;
+
       m_firstConstInt = constantCountF;
       m_firstConstBool = constantCountF + constantCountI;
 
@@ -245,7 +238,7 @@ namespace dxvk {
         auto cbvType = ir::Type();
 
         m_staticCbv = m_builder.add(ir::Op::DclCbv(cbvType, m_entryPoint,
-          0u, uint32_t(D3D9IrCbvIndex::ConstStatic), 1u).setFlags(ir::OpFlag::eInBounds));
+          0u, regIndex, 1u).setFlags(ir::OpFlag::eInBounds));
 
         if (!layoutF.isDynamicallyIndexed())
           emitStaticConstantRanges(ir::BuiltIn::eLegacyConstFloat, m_staticCbv, cbvType, layoutF);
@@ -269,7 +262,7 @@ namespace dxvk {
         auto cbvType = ir::Type(ir::ScalarType::eU32, 4u).addArrayDimension(vec4Count);
 
         m_staticCbv = m_builder.add(ir::Op::DclCbv(cbvType, m_entryPoint,
-          0u, uint32_t(D3D9IrCbvIndex::ConstStatic), 1u).setFlags(ir::OpFlag::eInBounds));
+          0u, regIndex, 1u).setFlags(ir::OpFlag::eInBounds));
         m_builder.add(ir::Op::DebugName(m_staticCbv, "c"));
       }
     }
@@ -287,7 +280,7 @@ namespace dxvk {
       auto cbvType = ir::Type(ir::ScalarType::eF32, 4u).addArrayDimension(cbvSize);
 
       m_dynamicCbv = m_builder.add(ir::Op::DclCbv(cbvType, m_entryPoint,
-        0u, uint32_t(D3D9IrCbvIndex::ConstDynamic), 1u));
+        0u, D3D9ShaderResourceMapping::CbvIndex::VSDynamicConstants, 1u));
       m_builder.add(ir::Op::DebugName(m_dynamicCbv, "cF"));
     }
 
@@ -569,7 +562,7 @@ namespace dxvk {
 
       auto specDataType = ir::Type(ir::ScalarType::eU32).addArrayDimension(DxvkLimits::MaxNumSpecConstants);
       auto result = m_builder.add(ir::Op::DclCbv(specDataType, m_entryPoint,
-        0u, uint32_t(D3D9IrCbvIndex::SpecData), 1u).setFlags(ir::OpFlag::eInBounds));
+        0u, D3D9ShaderResourceMapping::CbvIndex::SpecData, 1u).setFlags(ir::OpFlag::eInBounds));
       m_builder.add(ir::Op::DebugName(result, "specData"));
       return result;
     }
@@ -782,7 +775,7 @@ namespace dxvk {
 
       if (!m_clipPlaneCbv) {
         m_clipPlaneCbv = m_builder.add(ir::Op::DclCbv(clipCbvType,
-          m_entryPoint, 0u, uint32_t(D3D9IrCbvIndex::VsClipping), 1u)
+          m_entryPoint, 0u, D3D9ShaderResourceMapping::CbvIndex::VSClipPlanes, 1u)
           .setFlags(ir::OpFlag::eInBounds));
         m_builder.add(ir::Op::DebugName(m_clipPlaneCbv, "clipPlanes"));
       }
@@ -967,7 +960,7 @@ namespace dxvk {
 
       if (!m_textureStageCbv) {
         m_textureStageCbv = m_builder.add(ir::Op::DclCbv(textureStageCbvType,
-          m_entryPoint, 0u, uint32_t(D3D9IrCbvIndex::PsTextureStages), 1u)
+          m_entryPoint, 0u, D3D9ShaderResourceMapping::CbvIndex::PSShared, 1u)
           .setFlags(ir::OpFlag::eInBounds));
 
         m_builder.add(ir::Op::DebugName(m_textureStageCbv, "textureStages"));
@@ -1078,35 +1071,7 @@ namespace dxvk {
 
       switch (type) {
         case dxbc_spv::ir::ScalarType::eCbv:
-          switch (D3D9IrCbvIndex(regIndex)) {
-            case D3D9IrCbvIndex::SpecData:
-              return D3D9ShaderResourceMapping::CbvIndex::SpecData;
-
-            case D3D9IrCbvIndex::VsClipping:
-              return D3D9ShaderResourceMapping::CbvIndex::VSClipPlanes;
-
-            case D3D9IrCbvIndex::PsTextureStages:
-              return D3D9ShaderResourceMapping::CbvIndex::PSShared;
-
-            case D3D9IrCbvIndex::ConstFloat:
-              return shaderType == D3D9ShaderType::PixelShader
-                ? D3D9ShaderResourceMapping::CbvIndex::PSConstantBuffer
-                : D3D9ShaderResourceMapping::CbvIndex::VSConstantBuffer;
-
-            case D3D9IrCbvIndex::ConstInt:
-              return D3D9ShaderResourceMapping::CbvIndex::VSIntConstantBuffer;
-
-            case D3D9IrCbvIndex::ConstBool:
-              return D3D9ShaderResourceMapping::CbvIndex::VSBoolConstantBuffer;
-
-            case D3D9IrCbvIndex::ConstStatic:
-              return shaderType == D3D9ShaderType::PixelShader
-                ? D3D9ShaderResourceMapping::CbvIndex::PSStaticConstants
-                : D3D9ShaderResourceMapping::CbvIndex::VSStaticConstants;
-
-            case D3D9IrCbvIndex::ConstDynamic:
-              return D3D9ShaderResourceMapping::CbvIndex::VSDynamicConstants;
-          } break;
+          return regIndex;
 
         case dxbc_spv::ir::ScalarType::eSrv:
         case dxbc_spv::ir::ScalarType::eSampler:

--- a/src/d3d9/d3d9_shader.cpp
+++ b/src/d3d9/d3d9_shader.cpp
@@ -1074,27 +1074,24 @@ namespace dxvk {
         case dxbc_spv::ir::ScalarType::eCbv:
           switch (D3D9IrCbvIndex(regIndex)) {
             case D3D9IrCbvIndex::SpecData:
-              return D3D9ShaderResourceMapping::getSpecConstantBufferSlot();
+              return D3D9ShaderResourceMapping::CbvIndex::SpecData;
 
             case D3D9IrCbvIndex::VsClipping:
-              return D3D9ShaderResourceMapping::computeCbvBinding(shaderType,
-                D3D9ShaderResourceMapping::ConstantBuffers::VSClipPlanes);
+              return D3D9ShaderResourceMapping::CbvIndex::VSClipPlanes;
 
             case D3D9IrCbvIndex::PsTextureStages:
-              return D3D9ShaderResourceMapping::computeCbvBinding(shaderType,
-                D3D9ShaderResourceMapping::ConstantBuffers::PSShared);
+              return D3D9ShaderResourceMapping::CbvIndex::PSShared;
 
             case D3D9IrCbvIndex::ConstFloat:
-              return D3D9ShaderResourceMapping::computeCbvBinding(shaderType,
-                D3D9ShaderResourceMapping::ConstantBuffers::VSFloatConstantBuffer);
+              return shaderType == D3D9ShaderType::PixelShader
+                ? D3D9ShaderResourceMapping::CbvIndex::PSConstantBuffer
+                : D3D9ShaderResourceMapping::CbvIndex::VSConstantBuffer;
 
             case D3D9IrCbvIndex::ConstInt:
-              return D3D9ShaderResourceMapping::computeCbvBinding(shaderType,
-                D3D9ShaderResourceMapping::ConstantBuffers::VSIntConstantBuffer);
+              return D3D9ShaderResourceMapping::CbvIndex::VSIntConstantBuffer;
 
             case D3D9IrCbvIndex::ConstBool:
-              return D3D9ShaderResourceMapping::computeCbvBinding(shaderType,
-                D3D9ShaderResourceMapping::ConstantBuffers::VSBoolConstantBuffer);
+              return D3D9ShaderResourceMapping::CbvIndex::VSBoolConstantBuffer;
           } break;
 
         case dxbc_spv::ir::ScalarType::eSrv:

--- a/src/d3d9/d3d9_shader.cpp
+++ b/src/d3d9/d3d9_shader.cpp
@@ -17,6 +17,8 @@ namespace dxvk {
     ConstFloat      = 3u,
     ConstInt        = 4u,
     ConstBool       = 5u,
+    ConstStatic     = 6u,
+    ConstDynamic    = 7u,
   };
 
   class D3D9ShaderLowerLegacyInputPass {
@@ -34,6 +36,9 @@ namespace dxvk {
 
       std::tie(m_entryPoint, m_shaderStage) = findEntryPoint();
       dxbc_spv_assert(m_entryPoint);
+
+      setupStaticCbv();
+      setupDynamicCbv();
 
       dxvk::small_vector<ir::SsaDef, 32u> inputs;
 
@@ -83,9 +88,16 @@ namespace dxvk {
     dxbc_spv::ir::SsaDef      m_entryPoint = {};
     dxbc_spv::ir::SsaDef      m_specSelector = {};
     dxbc_spv::ir::SsaDef      m_specCbv = {};
-    dxbc_spv::ir::SsaDef      m_mergedCbv = {};
     dxbc_spv::ir::SsaDef      m_clipPlaneCbv = {};
     dxbc_spv::ir::SsaDef      m_textureStageCbv = {};
+
+    dxbc_spv::ir::SsaDef      m_mergedCbv = {};
+
+    dxbc_spv::ir::SsaDef      m_staticCbv = {};
+    dxbc_spv::ir::SsaDef      m_dynamicCbv = {};
+
+    uint32_t                  m_firstConstInt  = 0u;
+    uint32_t                  m_firstConstBool = 0u;
 
     dxbc_spv::ir::SsaDef      m_fogPushData = {};
     dxbc_spv::ir::SsaDef      m_alphaTestPushData = {};
@@ -107,89 +119,234 @@ namespace dxvk {
       return {};
     }
 
+    dxbc_spv::ir::SsaDef findDeclarationForBuiltIn(dxbc_spv::ir::BuiltIn builtIn) {
+      using namespace dxbc_spv;
+
+      for (auto iter = m_builder.getDeclarations().first;
+                iter != m_builder.getDeclarations().second; iter++) {
+        if (iter->getOpCode() == ir::OpCode::eDclInputBuiltIn
+         && builtIn == ir::BuiltIn(iter->getOperand(iter->getFirstLiteralOperandIndex())))
+          return iter->getDef();
+      }
+
+      return ir::SsaDef();
+    }
+
+    void emitStaticConstantRanges(
+            dxbc_spv::ir::BuiltIn     builtIn,
+            dxbc_spv::ir::SsaDef      cbv,
+            dxbc_spv::ir::Type&       cbvType,
+      const D3D9ConstantBufferLayout& layout) {
+      using namespace dxbc_spv;
+
+      auto decl = m_builder.getOp(findDeclarationForBuiltIn(builtIn));
+
+      if (!decl)
+        return;
+
+      auto type = decl.getType().getBaseType(0u);
+
+      for (uint32_t i = 0u; i < layout.getRangeCount(); i++) {
+        const auto& range = layout.getRange(i);
+
+        for (uint32_t n = 0u; n < range.count; n++) {
+          uint32_t memberIndex = cbvType.getStructMemberCount();
+          cbvType.addStructMember(type);
+
+          auto debugName = getDebugName(decl, range.srcIndex + n);
+
+          if (debugName) {
+            m_builder.rewriteOp(debugName, ir::Op(m_builder.getOp(debugName))
+              .setOperand(0u, cbv)
+              .setOperand(1u, memberIndex));
+          } else {
+            std::string name;
+
+            switch (builtIn) {
+              case ir::BuiltIn::eLegacyConstBool: name = str::format("b", range.srcIndex + n); break;
+              case ir::BuiltIn::eLegacyConstInt:  name = str::format("i", range.srcIndex + n); break;
+              default: name = str::format("c", range.srcIndex + n); break;
+            }
+
+            m_builder.add(ir::Op::DebugMemberName(cbv, memberIndex, name.c_str()));
+          }
+        }
+      }
+    }
+
+    void fixupStaticCbvDebugName() {
+      // If the static buffer only has one struct member, any OpDebugMemberName
+      // instruction will not apply properly, so just set it as the debug name
+      // for the constant buffer itself.
+      using namespace dxbc_spv;
+
+      const auto& op = m_builder.getOp(m_staticCbv);
+
+      if (op.getType().getStructMemberCount() != 1u)
+        return;
+
+      ir::Op debugName = {};
+
+      small_vector<ir::SsaDef, 4u> uses;
+      m_builder.getUses(op.getDef(), uses);
+
+      for (auto use : uses) {
+        const auto& useOp = m_builder.getOp(use);
+
+        switch (useOp.getOpCode()) {
+          case ir::OpCode::eDebugName:
+            m_builder.remove(use);
+            break;
+
+          case ir::OpCode::eDebugMemberName: {
+            if (!uint32_t(useOp.getOperand(1u)))
+              debugName = useOp;
+
+            m_builder.remove(use);
+          } break;
+
+          default:
+            break;
+        }
+      }
+
+      if (debugName) {
+        auto name = debugName.getLiteralString(2u);
+        m_builder.add(ir::Op::DebugName(m_staticCbv, name.c_str()));
+      }
+    }
+
+    void setupStaticCbv() {
+      using namespace dxbc_spv;
+
+      const auto& layoutB = m_analysis.GetConstantLayout().getLayout(D3D9ConstantType::Bool);
+      const auto& layoutI = m_analysis.GetConstantLayout().getLayout(D3D9ConstantType::Int);
+      const auto& layoutF = m_analysis.GetConstantLayout().getLayout(D3D9ConstantType::Float);
+
+      auto constantCountF = 0u;
+      auto constantCountI = layoutI.computeConstantCount(0u);
+      auto constantCountB = layoutB.computeConstantCount(0u);
+
+      if (!layoutF.isDynamicallyIndexed())
+        constantCountF = layoutF.computeConstantCount(0u);
+
+      uint32_t totalCount = constantCountF + constantCountI + constantCountB;
+
+      if (!totalCount)
+        return;
+
+      m_firstConstInt = constantCountF;
+      m_firstConstBool = constantCountF + constantCountI;
+
+      if (totalCount <= ir::Type::MaxStructMembers && !constantCountB) {
+        // Put floats first, then integer constants, then bools. Emit a dummy CBV
+        // declaration first so we can accumulate type info and add debug names,
+        // then fix it up later with the proper type.
+        auto cbvType = ir::Type();
+
+        m_staticCbv = m_builder.add(ir::Op::DclCbv(cbvType, m_entryPoint,
+          0u, uint32_t(D3D9IrCbvIndex::ConstStatic), 1u).setFlags(ir::OpFlag::eInBounds));
+
+        if (!layoutF.isDynamicallyIndexed())
+          emitStaticConstantRanges(ir::BuiltIn::eLegacyConstFloat, m_staticCbv, cbvType, layoutF);
+
+        emitStaticConstantRanges(ir::BuiltIn::eLegacyConstInt, m_staticCbv, cbvType, layoutI);
+        emitStaticConstantRanges(ir::BuiltIn::eLegacyConstBool, m_staticCbv, cbvType, layoutB);
+
+        m_builder.rewriteOp(m_staticCbv, ir::Op(m_builder.getOp(m_staticCbv)).setType(std::move(cbvType)));
+        m_builder.add(ir::Op::DebugName(m_staticCbv, "c"));
+
+        fixupStaticCbvDebugName();
+      } else {
+        // SWVP fallback. Just emit everything as a dword array that we can
+        // dynamically index into, which will be needed for booleans.
+        uint32_t boolCount = layoutB.computeConstantCount(0u);
+        uint32_t vec4Count = layoutI.computeConstantCount(0u) + align(boolCount, 4u) / 4u;
+
+        if (!layoutF.isDynamicallyIndexed())
+          vec4Count += layoutF.computeConstantCount(0u);
+
+        auto cbvType = ir::Type(ir::ScalarType::eU32, 4u).addArrayDimension(vec4Count);
+
+        m_staticCbv = m_builder.add(ir::Op::DclCbv(cbvType, m_entryPoint,
+          0u, uint32_t(D3D9IrCbvIndex::ConstStatic), 1u).setFlags(ir::OpFlag::eInBounds));
+        m_builder.add(ir::Op::DebugName(m_staticCbv, "c"));
+      }
+    }
+
+    void setupDynamicCbv() {
+      using namespace dxbc_spv;
+
+      const auto& layout = m_analysis.GetConstantLayout().getLayout(D3D9ConstantType::Float);
+
+      if (!layout.isDynamicallyIndexed())
+        return;
+
+      // Trivial, just emit a float vector array with the maximum required size.
+      auto cbvSize = layout.computeConstantCount(-1u);
+      auto cbvType = ir::Type(ir::ScalarType::eF32, 4u).addArrayDimension(cbvSize);
+
+      m_dynamicCbv = m_builder.add(ir::Op::DclCbv(cbvType, m_entryPoint,
+        0u, uint32_t(D3D9IrCbvIndex::ConstDynamic), 1u));
+      m_builder.add(ir::Op::DebugName(m_dynamicCbv, "cF"));
+    }
+
     void lowerLegacyConstInput(const dxbc_spv::ir::Op& decl, dxbc_spv::ir::BuiltIn builtIn) {
       using namespace dxbc_spv;
 
-      // Declare constant buffer for given constant type
-      ir::SsaDef cbv = { };
+      // Check which layout to use for constant mappings
+      bool isFloat = builtIn == ir::BuiltIn::eLegacyConstFloat;
 
-      uint32_t indexOffset = 0u;
+      const auto& layout = m_analysis.GetConstantLayout().getLayout(
+        isFloat ? D3D9ConstantType::Float : D3D9ConstantType::Int);
 
-      if (m_options.isSWVP && m_shaderStage == ir::ShaderStage::eVertex) {
-        cbv = emitConstantCbv(decl, builtIn);
-      } else {
-        if (!m_mergedCbv)
-          m_mergedCbv = emitMergedConstantCbv();
-
-        cbv = m_mergedCbv;
-
-        if (builtIn == ir::BuiltIn::eLegacyConstFloat)
-          indexOffset = caps::MaxOtherConstants;
-      }
-
-      if (!cbv)
-        return;
-
-      // Replace all input loads with equivalent constant buffer loads,
-      // and apply the constant index offset when using the merged buffer.
+      // We already emitted all the constant buffers that we might need.
+      // Replace all input loads with loads from the relevant buffer.
       dxvk::small_vector<ir::SsaDef, 256u> uses;
       m_builder.getUses(decl.getDef(), uses);
 
       for (auto use : uses) {
         const auto& useOp = m_builder.getOp(use);
 
-        switch (useOp.getOpCode()) {
-          case ir::OpCode::eInputLoad: {
-            const auto& addressOp = m_builder.getOpForOperand(useOp, 1u);
-            auto address = addressOp.getDef();
+        if (useOp.getOpCode() == ir::OpCode::eInputLoad) {
+          const auto& addressOp = m_builder.getOpForOperand(useOp, 1u);
 
-            if (indexOffset) {
-              // Adjust index offset
-              if (addressOp.isConstant()) {
-                address = m_builder.add(ir::Op(addressOp).setOperand(0u,
-                  uint32_t(addressOp.getOperand(0u)) + indexOffset));
-              } else {
-                auto srcTy = addressOp.getType().getBaseType(0u);
-                auto dstTy = ir::BasicType(ir::ScalarType::eU32, srcTy.getVectorSize());
+          if (layout.isDynamicallyIndexed()) {
+            dxbc_spv_assert(isFloat);
+            dxbc_spv_assert(m_dynamicCbv);
 
-                auto offsetConst = ir::Op(ir::OpCode::eConstant, dstTy).addOperand(indexOffset);
+            // Trivially forward the load to the dynamically indexed buffer
+            auto cbvDescriptor = m_builder.addBefore(use, ir::Op::DescriptorLoad(
+              ir::ScalarType::eCbv, m_dynamicCbv, m_builder.makeConstant(0u)));
 
-                for (uint32_t i = 1u; i < dstTy.getVectorSize(); i++)
-                  offsetConst.addOperand(0u);
+            m_builder.rewriteOp(use, ir::Op::BufferLoad(useOp.getType(),
+              cbvDescriptor, addressOp.getDef(), useOp.getType().byteSize()));
+          } else {
+            // For compacted constants, we need to map the source constant
+            // to a member index in the static constant buffer struct.
+            dxbc_spv_assert(addressOp.isConstant());
+            dxbc_spv_assert(m_staticCbv);
 
-                address = m_builder.addBefore(use, ir::Op::ConsumeAs(dstTy, address));
-                address = m_builder.addBefore(use, ir::Op::IAdd(dstTy, address, m_builder.add(offsetConst)));
-              }
-            }
+            auto cbvDescriptor = m_builder.addBefore(use, ir::Op::DescriptorLoad(
+              ir::ScalarType::eCbv, m_staticCbv, m_builder.makeConstant(0u)));
 
-            // Emit actual buffer load using the adjusted address
-            auto descriptor = m_builder.addBefore(use, ir::Op::DescriptorLoad(
-              ir::ScalarType::eCbv, cbv, m_builder.makeConstant(0u)));
+            auto srcIndex = uint32_t(addressOp.getOperand(0u));
+            auto dstIndex = layout.findConstant(srcIndex);
 
-            // Merged CBV is annoying and may force us to load the
-            // wrong type if the CBV itself is arrayed.
-            auto loadType = useOp.getType();
+            dxbc_spv_assert(dstIndex);
 
-            if (m_builder.getOp(cbv).getType().isArrayType())
-              loadType = m_builder.getOp(cbv).getType().getBaseType(0u);
+            auto memberIndex = dstIndex.value_or(0u) + (isFloat ? 0u : m_firstConstInt);
+            auto memberType = m_builder.getOp(m_staticCbv).getType().getBaseType(memberIndex);
 
-            auto load = m_builder.addBefore(use, ir::Op::BufferLoad(
-              loadType, descriptor, address, 16u));
+            if (addressOp.getOperandCount() > 1u)
+              memberType = memberType.getBaseType();
 
-            if (useOp.getType() != loadType)
-              load = m_builder.addBefore(use, ir::Op::ConsumeAs(useOp.getType(), load));
+            auto newAddress = m_builder.add(ir::Op(addressOp).setOperand(0u, memberIndex));
 
-            m_builder.rewriteDef(use, load);
-          } break;
-
-          case ir::OpCode::eDebugName:
-          case ir::OpCode::eDebugMemberName: {
-            m_builder.remove(use);
-          } break;
-
-          default:
-            dxbc_spv_unreachable();
-            break;
+            auto bufferLoad = m_builder.addBefore(use, ir::Op::BufferLoad(memberType,
+              cbvDescriptor, newAddress, useOp.getType().byteSize()).setFlags(ir::OpFlag::eInBounds));
+            m_builder.rewriteOp(use, ir::Op::ConsumeAs(useOp.getType(), bufferLoad));
+          }
         }
       }
     }
@@ -197,10 +354,11 @@ namespace dxvk {
     void lowerLegacyConstBoolInput(const dxbc_spv::ir::Op& decl) {
       using namespace dxbc_spv;
 
-      // Bools are special: In HWVP, we simply map them tp 16 bits of spec
-      // data, in SWVP we need to load them from an actual constant buffer.
-      // Build helper function to actually fetch a single boolean from the
-      // source.
+      // Bools are special: In HWVP, we simply map them tp 16 bits of spec data,
+      // in SWVP we need to load them from an actual constant buffer. Build helper
+      // function to actually fetch a single boolean from the source.
+      const auto& layout = m_analysis.GetConstantLayout()->getLayout(D3D9ConstantType::Bool);
+
       auto ref = m_builder.getCode().first->getDef();
 
       auto loadArg = m_builder.add(ir::Op::DclParam(ir::ScalarType::eU32));
@@ -211,7 +369,7 @@ namespace dxvk {
 
       auto cursor = m_builder.setCursor(loadFn);
 
-      if (!m_options.isSWVP) {
+      if (!layout.computeConstantCount(0u)) {
         // Build helper function to extract boolean from spec constant
         auto constIndex = m_builder.add(ir::Op::ParamLoad(ir::ScalarType::eU32, loadFn, loadArg));
 
@@ -225,25 +383,44 @@ namespace dxvk {
         result = m_builder.add(ir::Op::INe(ir::ScalarType::eBool, result, m_builder.makeConstant(0u)));
         m_builder.add(ir::Op::Return(ir::ScalarType::eBool, result));
       } else {
-        uint32_t bitCount = getUsedConstantCount(ir::BuiltIn::eLegacyConstBool)
-          .value_or(caps::MaxOtherConstantsSoftware);
-        uint32_t dwordCount = (bitCount + 31u) / 32u;
+        dxbc_spv_assert(m_staticCbv);
 
-        // Declare constant buffer as a dword array, one bit per constant
-        auto cbvType = ir::Type(ir::ScalarType::eU32).addArrayDimension(dwordCount);
-        auto cbvDef = m_builder.add(ir::Op::DclCbv(cbvType, m_entryPoint, 0u, uint32_t(D3D9IrCbvIndex::ConstBool), 1u));
-        m_builder.add(ir::Op::DebugName(cbvDef, "cB"));
-
+        // This is all extremely awful, but compilers should be able to constant-fold
+        // all the indices and optimize. We should basically never hit this, anyway.
         auto constIndex = m_builder.add(ir::Op::ParamLoad(ir::ScalarType::eU32, loadFn, loadArg));
-        auto dwordIndex = m_builder.add(ir::Op::UShr(ir::ScalarType::eU32, constIndex, m_builder.makeConstant(5u)));
-        auto dwordShift = m_builder.add(ir::Op::IAnd(ir::ScalarType::eU32, constIndex, m_builder.makeConstant(0x1fu)));
 
-        auto descriptor = m_builder.add(ir::Op::DescriptorLoad(ir::ScalarType::eCbv, cbvDef, m_builder.makeConstant(0u)));
-        auto dwordLoad = m_builder.add(ir::Op::BufferLoad(ir::ScalarType::eU32, descriptor, dwordIndex, 4u));
-        auto dwordMask = m_builder.add(ir::Op::IShl(ir::ScalarType::eU32, m_builder.makeConstant(1u), dwordShift));
+        auto cbvType = m_builder.getOp(m_staticCbv).getType().getBaseType(0u);
+        auto cbvDescriptor = m_builder.add(ir::Op::DescriptorLoad(ir::ScalarType::eCbv, m_staticCbv, m_builder.makeConstant(0u)));
 
-        auto result = m_builder.add(ir::Op::IAnd(ir::ScalarType::eU32, dwordLoad, dwordMask));
+        auto vectorIndex = m_builder.add(ir::Op::UShr(ir::ScalarType::eU32, constIndex, m_builder.makeConstant(7u)));
+        vectorIndex = m_builder.add(ir::Op::IAdd(ir::ScalarType::eU32, vectorIndex, m_builder.makeConstant(m_firstConstBool)));
+
+        auto vectorLoad = m_builder.add(ir::Op::BufferLoad(cbvType,
+          cbvDescriptor, vectorIndex, 16u).setFlags(ir::OpFlag::eInBounds));
+        vectorLoad = m_builder.add(ir::Op::ConsumeAs(ir::BasicType(ir::ScalarType::eU32, 4u), vectorLoad));
+
+        auto dwordIndex = m_builder.add(ir::Op::UBitExtract(ir::ScalarType::eU32,
+          constIndex, m_builder.makeConstant(5u), m_builder.makeConstant(2u)));
+
+        // Select correct dword from vector load
+        auto dword = m_builder.add(ir::Op::CompositeExtract(ir::ScalarType::eU32, vectorLoad, m_builder.makeConstant(0u)));
+
+        for (uint32_t i = 1u; i < 4u; i++) {
+          dword = m_builder.add(ir::Op::Select(ir::ScalarType::eU32,
+            m_builder.add(ir::Op::IEq(ir::ScalarType::eBool, dwordIndex, m_builder.makeConstant(i))),
+            m_builder.add(ir::Op::CompositeExtract(ir::ScalarType::eU32, vectorLoad, m_builder.makeConstant(i))),
+            dword));
+        }
+
+        // Test whether the requested bit is set in the bit mask
+        auto bitIndex = m_builder.add(ir::Op::UBitExtract(ir::ScalarType::eU32,
+          constIndex, m_builder.makeConstant(0u), m_builder.makeConstant(5u)));
+
+        auto dwordMask = m_builder.add(ir::Op::IShl(ir::ScalarType::eU32, m_builder.makeConstant(1u), bitIndex));
+
+        auto result = m_builder.add(ir::Op::IAnd(ir::ScalarType::eU32, dword, dwordMask));
         result = m_builder.add(ir::Op::INe(ir::ScalarType::eBool, result, m_builder.makeConstant(0u)));
+
         m_builder.add(ir::Op::Return(ir::ScalarType::eBool, result));
       }
 
@@ -258,23 +435,12 @@ namespace dxvk {
       for (auto use : uses) {
         const auto& useOp = m_builder.getOp(use);
 
-        switch (useOp.getOpCode()) {
-          case ir::OpCode::eInputLoad: {
-            const auto& addressOp = m_builder.getOpForOperand(useOp, 1u);
-            dxbc_spv_assert(addressOp.getType().isScalarType());
+        if (useOp.getOpCode() == ir::OpCode::eInputLoad) {
+          const auto& addressOp = m_builder.getOpForOperand(useOp, 1u);
+          dxbc_spv_assert(addressOp.getType().isScalarType());
 
-            auto address = m_builder.addBefore(use, ir::Op::ConsumeAs(ir::ScalarType::eU32, addressOp.getDef()));
-            m_builder.rewriteOp(use, ir::Op::FunctionCall(useOp.getType(), loadFn).addOperand(address));
-          } break;
-
-          case ir::OpCode::eDebugName:
-          case ir::OpCode::eDebugMemberName: {
-            m_builder.remove(use);
-          } break;
-
-          default:
-            dxbc_spv_unreachable();
-            break;
+          auto address = m_builder.addBefore(use, ir::Op::ConsumeAs(ir::ScalarType::eU32, addressOp.getDef()));
+          m_builder.rewriteOp(use, ir::Op::FunctionCall(useOp.getType(), loadFn).addOperand(address));
         }
       }
     }
@@ -507,106 +673,6 @@ namespace dxvk {
       using namespace dxbc_spv;
 
       return emitSpecConstantLoadIndexed(specConstant, name, ref, type, 0u, 0u, ir::SsaDef());
-    }
-
-    dxbc_spv::ir::SsaDef emitConstantCbv(const dxbc_spv::ir::Op& decl, dxbc_spv::ir::BuiltIn builtIn) {
-      using namespace dxbc_spv;
-
-      // Declare CBV as array if dynamically indexed, or as an actual
-      // structure if statically indexed so we can use debug names.
-      auto constantsUsed = getUsedConstantCount(builtIn);
-      auto constantCount = constantsUsed.value_or(decl.getType().getArraySize(0u));
-
-      if (!constantCount)
-        return ir::SsaDef();
-
-      ir::Type cbvType;
-
-      if (constantsUsed && constantCount < ir::Type::MaxStructMembers) {
-        auto baseType = decl.getType().getBaseType(0u);
-
-        for (uint32_t i = 0u; i < constantCount; i++)
-          cbvType.addStructMember(baseType);
-      } else {
-        cbvType = decl.getType().getBaseType(0u);
-        cbvType.addArrayDimension(constantCount);
-      }
-
-      auto cbvIndex = builtIn == ir::BuiltIn::eLegacyConstFloat
-        ? D3D9IrCbvIndex::ConstFloat
-        : D3D9IrCbvIndex::ConstInt;
-      auto cbv = m_builder.add(ir::Op::DclCbv(std::move(cbvType), m_entryPoint, 0u, uint32_t(cbvIndex), 1u));
-
-      if (constantsUsed && constantCount < ir::Type::MaxStructMembers)
-        copyConstantNames(cbv, 0u, constantCount, decl.getDef(), "c");
-
-      m_builder.add(ir::Op::DebugName(cbv, builtIn == ir::BuiltIn::eLegacyConstFloat ? "cF" : "cI"));
-      return cbv;
-    }
-
-    dxbc_spv::ir::SsaDef emitMergedConstantCbv() {
-      using namespace dxbc_spv;
-
-      // Count number of constants used by type. If any dynamic
-      // indexing is involved, either number will be undefined.
-      ir::SsaDef constInt = {};
-      ir::SsaDef constFloat = {};
-
-      auto numIntConstants = getUsedConstantCount(ir::BuiltIn::eLegacyConstInt);
-      auto numFloatConstants = getUsedConstantCount(ir::BuiltIn::eLegacyConstFloat);
-
-      auto [a, b] = m_builder.getDeclarations();
-
-      for (auto iter = a; iter != b; iter++) {
-        if (iter->getOpCode() == ir::OpCode::eDclInputBuiltIn) {
-          auto builtIn = ir::BuiltIn(iter->getOperand(iter->getFirstLiteralOperandIndex()));
-
-          if (builtIn == ir::BuiltIn::eLegacyConstFloat)
-            constFloat = iter->getDef();
-          else if (builtIn == ir::BuiltIn::eLegacyConstInt)
-            constInt = iter->getDef();
-        }
-      }
-
-      // No constants declared at all
-      if (!constInt && !constFloat)
-        return ir::SsaDef();
-
-      // Declare the merged buffer with a float type since that will be the
-      // most common access type. The merged buffer is not used in SWVP mode,
-      // so using the regular constant counts is fine here.
-      // TODO rework CBV binding to always keep int constants separate.
-      auto cbvInts = caps::MaxOtherConstants;
-      auto cbvFloats = numFloatConstants.value_or(m_shaderStage == ir::ShaderStage::eVertex
-        ? caps::MaxFloatConstantsVS : caps::MaxSM3FloatConstantsPS);
-
-      auto cbvConstants = cbvFloats + cbvInts;
-
-      // If there is no dynamic indexing going on, declare constants as
-      // individual members.
-      ir::Type cbvType = ir::Type(ir::ScalarType::eF32, 4u).addArrayDimension(cbvConstants);
-
-      if (numIntConstants && numFloatConstants) {
-        cbvType = ir::Type();
-
-        for (uint32_t i = 0u; i < caps::MaxOtherConstants; i++)
-          cbvType.addStructMember(ir::ScalarType::eI32, 4u);
-
-        for (uint32_t i = 0u; i < cbvFloats; i++)
-          cbvType.addStructMember(ir::ScalarType::eF32, 4u);
-      }
-
-      auto cbv = m_builder.add(ir::Op::DclCbv(std::move(cbvType),
-        m_entryPoint, 0u, uint32_t(D3D9IrCbvIndex::ConstFloat), 1u));
-      m_builder.add(ir::Op::DebugName(cbv, "c"));
-
-      // Copy debug names for individual constants if possible
-      if (numIntConstants && numFloatConstants) {
-        copyConstantNames(cbv, 0u, cbvInts, constInt, "i");
-        copyConstantNames(cbv, cbvInts, cbvFloats, constFloat, "c");
-      }
-
-      return cbv;
     }
 
     dxbc_spv::ir::SsaDef loadAlphaTestArgs(dxbc_spv::ir::SsaDef ref) {
@@ -958,66 +1024,6 @@ namespace dxvk {
 
       return ir::SsaDef();
     }
-
-    void copyConstantNames(
-            dxbc_spv::ir::SsaDef    dstDecl,
-            uint32_t                dstIndex,
-            uint32_t                dstCount,
-            dxbc_spv::ir::SsaDef    srcDecl,
-      const char*                   prefix) {
-      using namespace dxbc_spv;
-
-      auto memberCount = m_builder.getOp(dstDecl).getType().getStructMemberCount();
-
-      if (memberCount == 1u)
-        return;
-
-      dxvk::small_vector<ir::SsaDef, 272u> names;
-      dxvk::small_vector<ir::SsaDef, 256u> uses;
-      m_builder.getUses(srcDecl, uses);
-
-      // Assign dummy IDs to avoid assigning debug names for unused
-      // constants. Simply assign a 0 ID to mark constants as used.
-      names.resize(dstCount, dstDecl);
-
-      for (auto use : uses) {
-        const auto& useOp = m_builder.getOp(use);
-
-        if (useOp.getOpCode() == ir::OpCode::eInputLoad) {
-          const auto& addressOp = m_builder.getOpForOperand(useOp, 1u);
-          dxbc_spv_assert(addressOp.isConstant());
-
-          uint32_t index = uint32_t(addressOp.getOperand(0u));
-          dxbc_spv_assert(index < dstCount);
-
-          names[index] = ir::SsaDef();
-        }
-      }
-
-      // Copy existing debug names for indexed constants
-      for (auto use : uses) {
-        const auto& useOp = m_builder.getOp(use);
-
-        if (useOp.getOpCode() == ir::OpCode::eDebugMemberName) {
-          auto index = uint32_t(useOp.getOperand(useOp.getFirstLiteralOperandIndex()));
-
-          if (index < dstCount && index + dstIndex < memberCount && !names[index]) {
-            names[index] = m_builder.add(ir::Op(useOp)
-              .setOperand(0u, dstDecl)
-              .setOperand(1u, dstIndex + index));
-          }
-        }
-      }
-
-      // Assign fallback names for used constants that have no name
-      for (uint32_t i = 0u; i < dstCount && dstIndex + i < memberCount; i++) {
-        if (!names[i]) {
-          names[i] = m_builder.add(ir::Op::DebugMemberName(
-            dstDecl, dstIndex + i, str::format(prefix, i).c_str()));
-        }
-      }
-    }
-
   };
 
   class D3D9ShaderConverter : public DxvkIrShaderConverter {
@@ -1092,6 +1098,14 @@ namespace dxvk {
 
             case D3D9IrCbvIndex::ConstBool:
               return D3D9ShaderResourceMapping::CbvIndex::VSBoolConstantBuffer;
+
+            case D3D9IrCbvIndex::ConstStatic:
+              return shaderType == D3D9ShaderType::PixelShader
+                ? D3D9ShaderResourceMapping::CbvIndex::PSStaticConstants
+                : D3D9ShaderResourceMapping::CbvIndex::VSStaticConstants;
+
+            case D3D9IrCbvIndex::ConstDynamic:
+              return D3D9ShaderResourceMapping::CbvIndex::VSDynamicConstants;
           } break;
 
         case dxbc_spv::ir::ScalarType::eSrv:

--- a/src/d3d9/d3d9_shader.cpp
+++ b/src/d3d9/d3d9_shader.cpp
@@ -219,9 +219,9 @@ namespace dxvk {
     void setupStaticCbv() {
       using namespace dxbc_spv;
 
-      const auto& layoutB = m_analysis.GetConstantLayout().getLayout(D3D9ConstantType::Bool);
-      const auto& layoutI = m_analysis.GetConstantLayout().getLayout(D3D9ConstantType::Int);
-      const auto& layoutF = m_analysis.GetConstantLayout().getLayout(D3D9ConstantType::Float);
+      const auto& layoutB = m_analysis.GetConstantLayout()->getLayout(D3D9ConstantType::Bool);
+      const auto& layoutI = m_analysis.GetConstantLayout()->getLayout(D3D9ConstantType::Int);
+      const auto& layoutF = m_analysis.GetConstantLayout()->getLayout(D3D9ConstantType::Float);
 
       auto constantCountF = 0u;
       auto constantCountI = layoutI.computeConstantCount(0u);
@@ -277,7 +277,7 @@ namespace dxvk {
     void setupDynamicCbv() {
       using namespace dxbc_spv;
 
-      const auto& layout = m_analysis.GetConstantLayout().getLayout(D3D9ConstantType::Float);
+      const auto& layout = m_analysis.GetConstantLayout()->getLayout(D3D9ConstantType::Float);
 
       if (!layout.isDynamicallyIndexed())
         return;
@@ -297,7 +297,7 @@ namespace dxvk {
       // Check which layout to use for constant mappings
       bool isFloat = builtIn == ir::BuiltIn::eLegacyConstFloat;
 
-      const auto& layout = m_analysis.GetConstantLayout().getLayout(
+      const auto& layout = m_analysis.GetConstantLayout()->getLayout(
         isFloat ? D3D9ConstantType::Float : D3D9ConstantType::Int);
 
       // We already emitted all the constant buffers that we might need.

--- a/src/d3d9/d3d9_shader.h
+++ b/src/d3d9/d3d9_shader.h
@@ -107,7 +107,7 @@ namespace dxvk {
     }
 
     const D3D9ShaderConstantsInfo& GetConstantsInfo() const { return m_analysis.GetConstantsInfo(); }
-    const D3D9ImmediateConstants& GetImmediateConstants() const { return m_analysis.GetImmediateConstants(); }
+    const D3D9ImmediateConstantsInfo& GetImmediateConstants() const { return m_analysis.GetImmediateConstants(); }
 
     const D3D9ConstantBufferCopy* GetConstantLayout() const {
       return m_analysis.GetConstantLayout();

--- a/src/d3d9/d3d9_shader.h
+++ b/src/d3d9/d3d9_shader.h
@@ -113,6 +113,14 @@ namespace dxvk {
     const D3D9ShaderConstantsInfo& GetConstantsInfo() const { return m_analysis.GetConstantsInfo(); }
     const D3D9ImmediateConstants& GetImmediateConstants() const { return m_analysis.GetImmediateConstants(); }
 
+    const D3D9ConstantBufferCopy& GetConstantLayout() const {
+      return m_analysis.GetConstantLayout();
+    }
+
+    const Vector4* GetConstantData() const {
+      return m_analysis.GetShaderDefinedConstants();
+    }
+
     D3D9ShaderMasks GetShaderMask() const { return D3D9ShaderMasks{ m_analysis.GetSamplerMask(), m_analysis.GetRenderTargetMask() }; }
 
     dxbc_spv::sm3::ShaderInfo GetInfo() const { return m_analysis.GetShaderInfo(); }

--- a/src/d3d9/d3d9_shader.h
+++ b/src/d3d9/d3d9_shader.h
@@ -61,6 +61,8 @@ namespace dxvk {
       PSShared                = 12u,
       PSStaticConstants       = 13u,
       SpecData                = 20u,
+
+      Count
     };
 
     static constexpr uint32_t computeTextureBinding(D3D9ShaderType shaderType, uint32_t index) {

--- a/src/d3d9/d3d9_shader.h
+++ b/src/d3d9/d3d9_shader.h
@@ -58,9 +58,12 @@ namespace dxvk {
       VSClipPlanes            = 3u,
       VSFixedFunction         = 4u,
       VSVertexBlendData       = 5u,
+      VSStaticConstants       = 6u,
+      VSDynamicConstants      = 7u,
       PSConstantBuffer        = 10u,
       PSFixedFunction         = 11u,
       PSShared                = 12u,
+      PSStaticConstants       = 13u,
       SpecData                = 20u,
     };
 

--- a/src/d3d9/d3d9_shader.h
+++ b/src/d3d9/d3d9_shader.h
@@ -51,48 +51,27 @@ namespace dxvk {
    * indices for D3D9 binding slots.
    */
   struct D3D9ShaderResourceMapping {
-    enum ConstantBuffers : uint32_t {
-      VSConstantBuffer = 0,
-      VSFloatConstantBuffer = 0,
-      VSIntConstantBuffer = 1,
-      VSBoolConstantBuffer = 2,
-      VSClipPlanes     = 3,
-      VSFixedFunction  = 4,
-      VSVertexBlendData = 5,
-      VSCount,
-
-      PSConstantBuffer = 0,
-      PSFixedFunction  = 1,
-      PSShared         = 2,
-      PSCount
+    enum CbvIndex : uint32_t {
+      VSConstantBuffer        = 0u,
+      VSIntConstantBuffer     = 1u,
+      VSBoolConstantBuffer    = 2u,
+      VSClipPlanes            = 3u,
+      VSFixedFunction         = 4u,
+      VSVertexBlendData       = 5u,
+      PSConstantBuffer        = 10u,
+      PSFixedFunction         = 11u,
+      PSShared                = 12u,
+      SpecData                = 20u,
     };
 
-    static constexpr uint32_t computeCbvBinding(D3D9ShaderType shaderType, uint32_t index) {
-      const uint32_t stageOffset = (ConstantBuffers::VSCount + caps::MaxTexturesVS) * computeStageIndex(shaderType);
-      return index + stageOffset;
-    }
-
     static constexpr uint32_t computeTextureBinding(D3D9ShaderType shaderType, uint32_t index) {
-      const uint32_t stageIndex = computeStageIndex(shaderType);
-      const uint32_t stageOffset = (ConstantBuffers::VSCount + caps::MaxTexturesVS) * stageIndex;
-      return index + stageOffset
-        + (stageIndex == 1u
-          ? ConstantBuffers::PSCount
-          : ConstantBuffers::VSCount);
+      auto base = (shaderType == D3D9ShaderType::VertexShader) ? FirstVSSamplerSlot : 0u;
+      return base + index;
     }
 
-    static constexpr uint32_t computeStageIndex(D3D9ShaderType shaderType) {
-      return uint32_t(shaderType);
+    static constexpr uint32_t getSwvpBufferIndex() {
+      return caps::MaxTextures;
     }
-
-    static constexpr uint32_t getSWVPBufferSlot() {
-      return ConstantBuffers::VSCount + caps::MaxTexturesVS + ConstantBuffers::PSCount + caps::MaxTexturesPS + 1; // From last pixel shader slot, above.
-    }
-
-    static constexpr uint32_t getSpecConstantBufferSlot() {
-      return getSWVPBufferSlot() + 1;
-    }
-
   };
 
   /**

--- a/src/d3d9/d3d9_shader.h
+++ b/src/d3d9/d3d9_shader.h
@@ -113,7 +113,7 @@ namespace dxvk {
     const D3D9ShaderConstantsInfo& GetConstantsInfo() const { return m_analysis.GetConstantsInfo(); }
     const D3D9ImmediateConstants& GetImmediateConstants() const { return m_analysis.GetImmediateConstants(); }
 
-    const D3D9ConstantBufferCopy& GetConstantLayout() const {
+    const D3D9ConstantBufferCopy* GetConstantLayout() const {
       return m_analysis.GetConstantLayout();
     }
 

--- a/src/d3d9/d3d9_shader.h
+++ b/src/d3d9/d3d9_shader.h
@@ -52,15 +52,11 @@ namespace dxvk {
    */
   struct D3D9ShaderResourceMapping {
     enum CbvIndex : uint32_t {
-      VSConstantBuffer        = 0u,
-      VSIntConstantBuffer     = 1u,
-      VSBoolConstantBuffer    = 2u,
       VSClipPlanes            = 3u,
       VSFixedFunction         = 4u,
       VSVertexBlendData       = 5u,
       VSStaticConstants       = 6u,
       VSDynamicConstants      = 7u,
-      PSConstantBuffer        = 10u,
       PSFixedFunction         = 11u,
       PSShared                = 12u,
       PSStaticConstants       = 13u,

--- a/src/d3d9/d3d9_shader.h
+++ b/src/d3d9/d3d9_shader.h
@@ -117,10 +117,6 @@ namespace dxvk {
       return m_analysis.GetConstantLayout();
     }
 
-    const Vector4* GetConstantData() const {
-      return m_analysis.GetShaderDefinedConstants();
-    }
-
     D3D9ShaderMasks GetShaderMask() const { return D3D9ShaderMasks{ m_analysis.GetSamplerMask(), m_analysis.GetRenderTargetMask() }; }
 
     dxbc_spv::sm3::ShaderInfo GetInfo() const { return m_analysis.GetShaderInfo(); }

--- a/src/d3d9/d3d9_shader_analysis.cpp
+++ b/src/d3d9/d3d9_shader_analysis.cpp
@@ -40,13 +40,15 @@ namespace dxvk {
     // No real point in gathering bool masks here. For HWVP we have to
     // use a different mechanism anyway, and in SWVP mode we can just
     // use the entire bit array up to the highest accessed constant.
+    D3D9ImmediateConstantsData shaderDefs;
+
     ConstantMask constMaskF;
     ConstantMask constMaskI;
 
     while (parser) {
       dxbc_spv::sm3::Instruction instruction = parser.parseInstruction();
 
-      if (!instruction || !HandleInstruction(instruction, constMaskF, constMaskI))
+      if (!instruction || !HandleInstruction(instruction, constMaskF, constMaskI, shaderDefs))
         return false;
     }
 
@@ -57,18 +59,22 @@ namespace dxvk {
       // as a mask of defined constants as necessary
       constMaskF.clear();
 
-      for (size_t i = 0u; i < m_immediateConstants.floats.size(); i++)
-        setBit(constMaskF, m_immediateConstants.floats[i].index);
+      for (size_t i = 0u; i < shaderDefs.floats.size(); i++)
+        setBit(constMaskF, shaderDefs.floats[i].index);
     } else {
       // The compiler will always constant-fold inline constants that
       // are statically indexed, so there is no need to keep them around
-      for (size_t i = 0u; i < m_immediateConstants.floats.size(); i++)
-        clrBit(constMaskF, m_immediateConstants.floats[i].index);
+      for (size_t i = 0u; i < shaderDefs.floats.size(); i++)
+        clrBit(constMaskF, shaderDefs.floats[i].index);
     }
+
+    // Same for shader-defied floats, they will never be read from the buffer.
+    for (size_t i = 0u; i < shaderDefs.ints.size(); i++)
+      clrBit(constMaskI, shaderDefs.ints[i]);
 
     D3D9ConstantBufferLayout constLayoutF = m_constants.floatsAccessedDynamically
       ? D3D9ConstantBufferLayout(m_constants.floatCount, constMaskF.size(), constMaskF.data(),
-          m_immediateConstants.floats.size(), m_immediateConstants.floats.data())
+          shaderDefs.floats.size(), shaderDefs.floats.data())
       : D3D9ConstantBufferLayout(constMaskF.size(), constMaskF.data());
 
     D3D9ConstantBufferLayout constLayoutI(constMaskI.size(), constMaskI.data());
@@ -98,7 +104,8 @@ namespace dxvk {
   bool D3D9ShaderAnalysis::HandleInstruction(
     const dxbc_spv::sm3::Instruction&   op,
           ConstantMask&                 constMaskF,
-          ConstantMask&                 constMaskI) {
+          ConstantMask&                 constMaskI,
+          D3D9ImmediateConstantsData&   shaderDefs) {
     auto matrixSize = getMatrixSize(op.getOpCode());
 
     /* Determine whether we're accessing float constants dynamically
@@ -165,7 +172,7 @@ namespace dxvk {
       case OpCode::eDef:
       case OpCode::eDefI:
       case OpCode::eDefB:
-        if (!HandleDef(op))
+        if (!HandleDef(op, shaderDefs))
           return false;
         break;
 
@@ -200,7 +207,9 @@ namespace dxvk {
     return true;
   }
 
-  bool D3D9ShaderAnalysis::HandleDef(const Instruction& op) {
+  bool D3D9ShaderAnalysis::HandleDef(
+    const Instruction&                  op,
+          D3D9ImmediateConstantsData&   shaderDefs) {
     dxbc_spv_assert(op.hasDst());
     uint32_t index = op.getDst().getIndex();
 
@@ -214,9 +223,11 @@ namespace dxvk {
         imm.getImmediate<float>(0u), imm.getImmediate<float>(1u),
         imm.getImmediate<float>(2u), imm.getImmediate<float>(3u)
       };
-      m_immediateConstants.floats.push_back({ index, value });
+
+      shaderDefs.floats.push_back({ index, value });
     } else if (op.getOpCode() == OpCode::eDefI) {
       m_immediateConstants.intCount = std::max(m_immediateConstants.intCount, index + 1u);
+      shaderDefs.ints.push_back(index);
     } else if (op.getOpCode() == OpCode::eDefB) {
       m_immediateConstants.boolCount = std::max(m_immediateConstants.boolCount, index + 1u);
     } else {

--- a/src/d3d9/d3d9_shader_analysis.cpp
+++ b/src/d3d9/d3d9_shader_analysis.cpp
@@ -52,24 +52,13 @@ namespace dxvk {
 
     m_length = parser.getByteOffset();
 
-    // Sort immediate constants by index since the
-    // constant layout code relies on it
-    std::sort(m_immediateConstants.floats.begin(), m_immediateConstants.floats.end(),
-      [] (const D3D9ImmediateFloatConstant& a, const D3D9ImmediateFloatConstant& b) {
-        return a.index < b.index;
-      });
-
     if (m_constants.floatsAccessedDynamically) {
       // Repurpose float mask as shader-defined constant mask
       // as a mask of defined constants as necessary
-      m_defConstants.reserve(m_immediateConstants.floats.size());
-
       constMaskF.clear();
 
-      for (size_t i = 0u; i < m_immediateConstants.floats.size(); i++) {
+      for (size_t i = 0u; i < m_immediateConstants.floats.size(); i++)
         setBit(constMaskF, m_immediateConstants.floats[i].index);
-        m_defConstants.push_back(m_immediateConstants.floats[i].value);
-      }
     } else {
       // The compiler will always constant-fold inline constants that
       // are statically indexed, so there is no need to keep them around
@@ -78,7 +67,8 @@ namespace dxvk {
     }
 
     D3D9ConstantBufferLayout constLayoutF = m_constants.floatsAccessedDynamically
-      ? D3D9ConstantBufferLayout(m_constants.floatCount, constMaskF.size(), constMaskF.data())
+      ? D3D9ConstantBufferLayout(m_constants.floatCount, constMaskF.size(), constMaskF.data(),
+          m_immediateConstants.floats.size(), m_immediateConstants.floats.data())
       : D3D9ConstantBufferLayout(constMaskF.size(), constMaskF.data());
 
     D3D9ConstantBufferLayout constLayoutI(constMaskI.size(), constMaskI.data());

--- a/src/d3d9/d3d9_shader_analysis.cpp
+++ b/src/d3d9/d3d9_shader_analysis.cpp
@@ -91,8 +91,10 @@ namespace dxvk {
       constLayoutB = D3D9ConstantBufferLayout(align(dwordCount, 4u));
     }
 
-    m_constLayout = D3D9ConstantBufferCopy(std::move(constLayoutF),
-      std::move(constLayoutI), std::move(constLayoutB));
+    m_constLayout = D3D9ConstantBufferCopy::getOrCreate(
+      std::move(constLayoutF),
+      std::move(constLayoutI),
+      std::move(constLayoutB));
 
     // Shift up these sampler bits so we can just
     // do an or per-draw in the device.

--- a/src/d3d9/d3d9_shader_analysis.cpp
+++ b/src/d3d9/d3d9_shader_analysis.cpp
@@ -1,12 +1,13 @@
-#include <sm3/sm3_io_map.h>
+#include <algorithm>
+#include <utility>
 
 #include "../dxvk/dxvk_include.h"
 
+#include <sm3/sm3_io_map.h>
+
+#include "d3d9_fixed_function.h"
 #include "d3d9_shader_analysis.h"
 #include "d3d9_util.h"
-#include "d3d9_fixed_function.h"
-
-#include <utility>
 
 #include "../util/log/log.h"
 
@@ -29,20 +30,6 @@ namespace dxvk {
     }
   }
 
-  D3D9ShaderAnalysis::D3D9ShaderAnalysis(D3D9ShaderAnalysis&& other)
-    : m_isSWVP(other.m_isSWVP), m_length(other.m_length), m_shaderInfo(other.m_shaderInfo),
-      m_constants(other.m_constants), m_immediateConstants(std::move(other.m_immediateConstants)),
-      m_usedRTs(other.m_usedRTs), m_usedSamplers(other.m_usedSamplers), m_imageViewTypes(other.m_imageViewTypes),
-      m_flatShadingMask(other.m_flatShadingMask), m_inputSignature(std::move(other.m_inputSignature)) {
-    other.m_length = 0u;
-  }
-
-  D3D9ShaderAnalysis::D3D9ShaderAnalysis(const D3D9ShaderAnalysis& other)
-    : m_isSWVP(other.m_isSWVP), m_length(other.m_length), m_shaderInfo(other.m_shaderInfo),
-      m_constants(other.m_constants), m_immediateConstants(other.m_immediateConstants), m_usedRTs(other.m_usedRTs),
-      m_usedSamplers(other.m_usedSamplers), m_imageViewTypes(other.m_imageViewTypes),
-      m_flatShadingMask(other.m_flatShadingMask), m_inputSignature(other.m_inputSignature) { }
-
   bool D3D9ShaderAnalysis::RunAnalysis(Parser& parser) {
     if (!(m_shaderInfo = parser.getShaderInfo()))
       return false;
@@ -50,14 +37,62 @@ namespace dxvk {
     if (m_shaderInfo.getVersion().first == 1u && m_shaderInfo.getType() == dxbc_spv::sm3::ShaderType::ePixel)
       m_usedRTs = 0b1u;
 
+    // No real point in gathering bool masks here. For HWVP we have to
+    // use a different mechanism anyway, and in SWVP mode we can just
+    // use the entire bit array up to the highest accessed constant.
+    ConstantMask constMaskF;
+    ConstantMask constMaskI;
+
     while (parser) {
       dxbc_spv::sm3::Instruction instruction = parser.parseInstruction();
 
-      if (!instruction || !HandleInstruction(instruction))
+      if (!instruction || !HandleInstruction(instruction, constMaskF, constMaskI))
         return false;
     }
 
     m_length = parser.getByteOffset();
+
+    // Sort immediate constants by index since the
+    // constant layout code relies on it
+    std::sort(m_immediateConstants.floats.begin(), m_immediateConstants.floats.end(),
+      [] (const D3D9ImmediateFloatConstant& a, const D3D9ImmediateFloatConstant& b) {
+        return a.index < b.index;
+      });
+
+    if (m_constants.floatsAccessedDynamically) {
+      // Repurpose float mask as shader-defined constant mask
+      // as a mask of defined constants as necessary
+      m_defConstants.reserve(m_immediateConstants.floats.size());
+
+      constMaskF.clear();
+
+      for (size_t i = 0u; i < m_immediateConstants.floats.size(); i++) {
+        setBit(constMaskF, m_immediateConstants.floats[i].index);
+        m_defConstants.push_back(m_immediateConstants.floats[i].value);
+      }
+    } else {
+      // The compiler will always constant-fold inline constants that
+      // are statically indexed, so there is no need to keep them around
+      for (size_t i = 0u; i < m_immediateConstants.floats.size(); i++)
+        clrBit(constMaskF, m_immediateConstants.floats[i].index);
+    }
+
+    D3D9ConstantBufferLayout constLayoutF = m_constants.floatsAccessedDynamically
+      ? D3D9ConstantBufferLayout(m_constants.floatCount, constMaskF.size(), constMaskF.data())
+      : D3D9ConstantBufferLayout(constMaskF.size(), constMaskF.data());
+
+    D3D9ConstantBufferLayout constLayoutI(constMaskI.size(), constMaskI.data());
+    D3D9ConstantBufferLayout constLayoutB;
+
+    if (m_isSWVP) {
+      // Pad bool constants to a multiple of 16 bytes so we
+      // can trivially keep all the other constants aligned
+      uint32_t dwordCount = align(m_constants.boolCount, 32u) / 32u;
+      constLayoutB = D3D9ConstantBufferLayout(align(dwordCount, 4u));
+    }
+
+    m_constLayout = D3D9ConstantBufferCopy(std::move(constLayoutF),
+      std::move(constLayoutI), std::move(constLayoutB));
 
     // Shift up these sampler bits so we can just
     // do an or per-draw in the device.
@@ -68,7 +103,10 @@ namespace dxvk {
     return true;
   }
 
-  bool D3D9ShaderAnalysis::HandleInstruction(const Instruction& op) {
+  bool D3D9ShaderAnalysis::HandleInstruction(
+    const dxbc_spv::sm3::Instruction&   op,
+          ConstantMask&                 constMaskF,
+          ConstantMask&                 constMaskI) {
     auto matrixSize = getMatrixSize(op.getOpCode());
 
     /* Determine whether we're accessing float constants dynamically
@@ -79,17 +117,21 @@ namespace dxvk {
       auto registerType = src.getRegisterType();
 
       uint32_t index = src.getIndex();
+      uint32_t count = 1u;
 
       if (i && matrixSize)
-        index += matrixSize->second - 1u;
+        count = matrixSize->second;
 
       switch (registerType) {
         case RegisterType::eConstInt:
-          m_constants.intCount = std::max(m_constants.intCount, index + 1u);
+          m_constants.intCount = std::max(m_constants.intCount, index + count);
+
+          for (uint32_t j = 0u; j < count; j++)
+            setBit(constMaskI, index + j);
           break;
 
         case RegisterType::eConstBool: {
-          m_constants.boolCount = std::max(m_constants.boolCount, index + 1u);
+          m_constants.boolCount = std::max(m_constants.boolCount, index + count);
 
           if (!m_isSWVP) // SWVP raises the constant limit too high to use bit mask.
             m_constants.boolMask |= 1u << index;
@@ -99,7 +141,7 @@ namespace dxvk {
         case RegisterType::eConst2:
         case RegisterType::eConst3:
         case RegisterType::eConst4: {
-          m_constants.floatCount = std::max(m_constants.floatCount, index + 1u);
+          m_constants.floatCount = std::max(m_constants.floatCount, index + count);
 
           if (src.hasRelativeAddressing()) {
             uint32_t hwvpFloatConstantsCount = GetShaderInfo().getType() == ShaderType::ePixel ? MaxFloatConstantsPS : MaxFloatConstantsVS;
@@ -108,6 +150,12 @@ namespace dxvk {
               m_isSWVP ? MaxFloatConstantsSoftware : hwvpFloatConstantsCount);
 
             m_constants.floatsAccessedDynamically = true;
+          }
+
+          // Access mask is useless if we have dynamic indexing
+          if (!m_constants.floatsAccessedDynamically) {
+            for (uint32_t j = 0u; j < count; j++)
+              setBit(constMaskF, index + j);
           }
         } break;
 
@@ -292,41 +340,23 @@ namespace dxvk {
   }
 
 
-  D3D9ShaderAnalysis& D3D9ShaderAnalysis::operator=(const D3D9ShaderAnalysis& other) {
-    if (this == &other)
-      return *this;
+  void D3D9ShaderAnalysis::setBit(ConstantMask& mask, uint32_t bit) {
+    uint32_t index = bit / 32u;
+    uint32_t shift = bit % 32u;
 
-    m_isSWVP = other.m_isSWVP;
-    m_length = other.m_length;
-    m_shaderInfo = other.m_shaderInfo;
-    m_constants = other.m_constants;
-    m_immediateConstants = other.m_immediateConstants;
-    m_usedRTs = other.m_usedRTs;
-    m_usedSamplers = other.m_usedSamplers;
-    m_imageViewTypes = other.m_imageViewTypes;
-    m_flatShadingMask = other.m_flatShadingMask;
-    m_inputSignature = other.m_inputSignature;
+    if (index >= mask.size())
+      mask.resize(index + 1u);
 
-    return *this;
+    mask[index] |= 1u << shift;
   }
 
-  D3D9ShaderAnalysis& D3D9ShaderAnalysis::operator=(D3D9ShaderAnalysis&& other) {
-    if (this == &other)
-      return *this;
 
-    m_isSWVP = other.m_isSWVP;
-    m_length = other.m_length;
-    m_shaderInfo = other.m_shaderInfo;
-    m_constants = other.m_constants;
-    m_immediateConstants = std::move(other.m_immediateConstants);
-    m_usedRTs = other.m_usedRTs;
-    m_usedSamplers = other.m_usedSamplers;
-    m_imageViewTypes = other.m_imageViewTypes;
-    m_flatShadingMask = other.m_flatShadingMask;
-    m_inputSignature = std::move(other.m_inputSignature);
-    other.m_length = 0u;
+  void D3D9ShaderAnalysis::clrBit(ConstantMask& mask, uint32_t bit) {
+    uint32_t index = bit / 32u;
+    uint32_t shift = bit % 32u;
 
-    return *this;
+    if (index < mask.size())
+      mask[index] &= ~(1u << shift);
   }
 
 }

--- a/src/d3d9/d3d9_shader_analysis.h
+++ b/src/d3d9/d3d9_shader_analysis.h
@@ -83,7 +83,7 @@ public:
     return m_usedRTs;
   }
 
-  const D3D9ConstantBufferCopy& GetConstantLayout() const {
+  const D3D9ConstantBufferCopy* GetConstantLayout() const {
     return m_constLayout;
   }
 
@@ -135,8 +135,8 @@ private:
   dxbc_spv::sm3::ShaderInfo m_shaderInfo;
 
   D3D9ShaderConstantsInfo m_constants;
-  D3D9ConstantBufferCopy m_constLayout;
   D3D9ImmediateConstants m_immediateConstants;
+  const D3D9ConstantBufferCopy* m_constLayout;
 
   small_vector<Vector4, 16u> m_defConstants;
 

--- a/src/d3d9/d3d9_shader_analysis.h
+++ b/src/d3d9/d3d9_shader_analysis.h
@@ -16,11 +16,6 @@
 
 namespace dxvk {
 
-struct D3D9ImmediateFloatConstant {
-  uint32_t index;
-  Vector4 value;
-};
-
 using D3D9ImmediateFloatConstants = small_vector<D3D9ImmediateFloatConstant, 16u>;
 
 struct D3D9ImmediateConstants {
@@ -69,10 +64,6 @@ public:
 
   const D3D9ShaderConstantsInfo& GetConstantsInfo() const {
     return m_constants;
-  }
-
-  const Vector4* GetShaderDefinedConstants() const {
-    return m_defConstants.data();
   }
 
   const D3D9ImmediateConstants& GetImmediateConstants() const {
@@ -137,8 +128,6 @@ private:
   D3D9ShaderConstantsInfo m_constants;
   D3D9ImmediateConstants m_immediateConstants;
   const D3D9ConstantBufferCopy* m_constLayout;
-
-  small_vector<Vector4, 16u> m_defConstants;
 
   D3D9RenderTargetMask m_usedRTs = 0u;
 

--- a/src/d3d9/d3d9_shader_analysis.h
+++ b/src/d3d9/d3d9_shader_analysis.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "d3d9_constant_copy.h"
+
 #include "../util/util_vector.h"
 #include "../util/util_small_vector.h"
 
@@ -51,13 +53,11 @@ public:
 
   D3D9ShaderAnalysis(dxbc_spv::util::ByteReader code, bool isSWVP);
 
-  D3D9ShaderAnalysis(D3D9ShaderAnalysis&& other);
+  D3D9ShaderAnalysis(const D3D9ShaderAnalysis& other) = default;
+  D3D9ShaderAnalysis(D3D9ShaderAnalysis&& other) = default;
 
-  D3D9ShaderAnalysis(const D3D9ShaderAnalysis& other);
-
-  D3D9ShaderAnalysis& operator=(const D3D9ShaderAnalysis& other);
-
-  D3D9ShaderAnalysis& operator=(D3D9ShaderAnalysis&& other);
+  D3D9ShaderAnalysis& operator = (const D3D9ShaderAnalysis& other) = default;
+  D3D9ShaderAnalysis& operator = (D3D9ShaderAnalysis&& other) = default;
 
   dxbc_spv::sm3::ShaderInfo GetShaderInfo() const {
     return m_shaderInfo;
@@ -71,12 +71,20 @@ public:
     return m_constants;
   }
 
+  const Vector4* GetShaderDefinedConstants() const {
+    return m_defConstants.data();
+  }
+
   const D3D9ImmediateConstants& GetImmediateConstants() const {
     return m_immediateConstants;
   }
 
   D3D9RenderTargetMask GetRenderTargetMask() const {
     return m_usedRTs;
+  }
+
+  const D3D9ConstantBufferCopy& GetConstantLayout() const {
+    return m_constLayout;
   }
 
   D3D9SamplerMask GetSamplerMask() const {
@@ -103,9 +111,14 @@ public:
 
 private:
 
+  using ConstantMask = small_vector<uint32_t, 64u>;
+
   bool RunAnalysis(dxbc_spv::sm3::Parser& parser);
 
-  bool HandleInstruction(const dxbc_spv::sm3::Instruction& op);
+  bool HandleInstruction(
+    const dxbc_spv::sm3::Instruction&   op,
+          ConstantMask&                 constMaskF,
+          ConstantMask&                 constMaskI);
 
   bool HandleDef(const dxbc_spv::sm3::Instruction& op);
 
@@ -122,8 +135,10 @@ private:
   dxbc_spv::sm3::ShaderInfo m_shaderInfo;
 
   D3D9ShaderConstantsInfo m_constants;
-
+  D3D9ConstantBufferCopy m_constLayout;
   D3D9ImmediateConstants m_immediateConstants;
+
+  small_vector<Vector4, 16u> m_defConstants;
 
   D3D9RenderTargetMask m_usedRTs = 0u;
 
@@ -133,7 +148,11 @@ private:
 
   uint32_t m_flatShadingMask = 0u;
 
-  D3D9InputSignature m_inputSignature    = {};
+  D3D9InputSignature m_inputSignature = {};
+
+  static void setBit(ConstantMask& mask, uint32_t bit);
+
+  static void clrBit(ConstantMask& mask, uint32_t bit);
 
 };
 

--- a/src/d3d9/d3d9_shader_analysis.h
+++ b/src/d3d9/d3d9_shader_analysis.h
@@ -16,14 +16,15 @@
 
 namespace dxvk {
 
-using D3D9ImmediateFloatConstants = small_vector<D3D9ImmediateFloatConstant, 16u>;
+struct D3D9ImmediateConstantsData {
+  small_vector<D3D9ImmediateFloatConstant, 16u> floats;
+  small_vector<int16_t, 16u> ints;
+};
 
-struct D3D9ImmediateConstants {
+struct D3D9ImmediateConstantsInfo {
   uint32_t floatCount = 0u;
   uint32_t intCount   = 0u;
   uint32_t boolCount  = 0u;
-
-  D3D9ImmediateFloatConstants floats;
 };
 
 struct D3D9ShaderConstantsInfo {
@@ -66,7 +67,7 @@ public:
     return m_constants;
   }
 
-  const D3D9ImmediateConstants& GetImmediateConstants() const {
+  const D3D9ImmediateConstantsInfo& GetImmediateConstants() const {
     return m_immediateConstants;
   }
 
@@ -109,9 +110,12 @@ private:
   bool HandleInstruction(
     const dxbc_spv::sm3::Instruction&   op,
           ConstantMask&                 constMaskF,
-          ConstantMask&                 constMaskI);
+          ConstantMask&                 constMaskI,
+          D3D9ImmediateConstantsData&   shaderDefs);
 
-  bool HandleDef(const dxbc_spv::sm3::Instruction& op);
+  bool HandleDef(
+    const dxbc_spv::sm3::Instruction&   op,
+          D3D9ImmediateConstantsData&   shaderDefs);
 
   bool HandleTextureSample(const dxbc_spv::sm3::Instruction& op);
 
@@ -126,7 +130,7 @@ private:
   dxbc_spv::sm3::ShaderInfo m_shaderInfo;
 
   D3D9ShaderConstantsInfo m_constants;
-  D3D9ImmediateConstants m_immediateConstants;
+  D3D9ImmediateConstantsInfo m_immediateConstants;
   const D3D9ConstantBufferCopy* m_constLayout;
 
   D3D9RenderTargetMask m_usedRTs = 0u;

--- a/src/d3d9/d3d9_spec_constants.h
+++ b/src/d3d9/d3d9_spec_constants.h
@@ -135,8 +135,6 @@ namespace dxvk {
     // Spec const word 0 determines whether the other spec constants are used rather than the spec const UBO
     static constexpr uint32_t MaxSpecDwords = 17;
 
-    static constexpr size_t UBOSize = MaxSpecDwords * sizeof(uint32_t);
-
     static constexpr std::array<BitfieldPosition, SpecConstantCount> Layout{{
       { 0, 0, 32 },  // SamplerType
 

--- a/src/d3d9/d3d9_state.h
+++ b/src/d3d9/d3d9_state.h
@@ -412,55 +412,105 @@ namespace dxvk {
   using D3D9CapturableState = D3D9State<dynamic_item>;
   using D3D9DeviceState = D3D9State<static_item>;
 
-  template <
-    D3D9ShaderType   ShaderType,
-    D3D9ConstantType ConstantType,
-    typename         T,
-    typename         StateType>
-  HRESULT UpdateStateConstants(
+  template<D3D9ShaderType ShaderType, D3D9ConstantType ConstantType, typename T, typename StateType>
+  bool UpdateStateConstants(
           StateType*           pState,
           UINT                 StartRegister,
     const T*                   pConstantData,
-          UINT                 Count,
-          bool                 FloatEmu) {
-    auto UpdateHelper = [&] (auto& set) {
+          UINT                 Count) {
+    if constexpr (ConstantType == D3D9ConstantType::Bool) {
+      uint32_t* dstData = ShaderType == D3D9ShaderType::VertexShader
+        ? pState->vsConsts->bConsts
+        : pState->psConsts->bConsts;
+
+      for (uint32_t i = 0; i < Count; i++) {
+        const uint32_t constantIdx = StartRegister + i;
+        const uint32_t arrayIdx    = constantIdx / 32;
+        const uint32_t bitIdx      = constantIdx % 32;
+
+        const uint32_t bit = 1u << bitIdx;
+
+        dstData[arrayIdx] &= ~bit;
+
+        if (pConstantData[i])
+          dstData[arrayIdx] |= bit;
+      }
+
+      return true;
+    } else {
+      static_assert(sizeof(T) == 4u);
+
+      Vector4Base<T>* dstData = nullptr;
+
       if constexpr (ConstantType == D3D9ConstantType::Float) {
-
-        if (!FloatEmu) {
-          size_t size = Count * sizeof(Vector4);
-
-          std::memcpy(set->fConsts[StartRegister].data, pConstantData, size);
-        }
-        else {
-          for (UINT i = 0; i < Count; i++)
-            set->fConsts[StartRegister + i] = replaceNaN(pConstantData + (i * 4));
-        }
-      }
-      else if constexpr (ConstantType == D3D9ConstantType::Int) {
-        size_t size = Count * sizeof(Vector4i);
-
-        std::memcpy(set->iConsts[StartRegister].data, pConstantData, size);
-      }
-      else {
-        for (uint32_t i = 0; i < Count; i++) {
-          const uint32_t constantIdx = StartRegister + i;
-          const uint32_t arrayIdx    = constantIdx / 32;
-          const uint32_t bitIdx      = constantIdx % 32;
-
-          const uint32_t bit = 1u << bitIdx;
-
-          set->bConsts[arrayIdx] &= ~bit;
-          if (pConstantData[i])
-            set->bConsts[arrayIdx] |= bit;
-        }
+        dstData = ShaderType == D3D9ShaderType::VertexShader
+          ? pState->vsConsts->fConsts
+          : pState->psConsts->fConsts;
+      } else if constexpr (ConstantType == D3D9ConstantType::Int) {
+        dstData = ShaderType == D3D9ShaderType::VertexShader
+          ? pState->vsConsts->iConsts
+          : pState->psConsts->iConsts;
       }
 
-      return D3D_OK;
-    };
+      dstData += StartRegister;
 
-    return ShaderType == D3D9ShaderType::VertexShader
-      ? UpdateHelper(pState->vsConsts)
-      : UpdateHelper(pState->psConsts);
+      #if defined(DXVK_ARCH_X86) && (defined(__GNUC__) || defined(__clang__) || defined(_MSC_VER))
+      auto* dstPtr = reinterpret_cast<      __m128i*>(dstData);
+      auto* srcPtr = reinterpret_cast<const __m128i*>(pConstantData);
+
+      // In the first loop, find the first contant that has changed, if any, and
+      // only copy that. Basically a glorified memcmp. The idea is to give feedback
+      // to the caller on whether any constant values have changed.
+      bool dirty = false;
+
+      uint32_t index = 0u;
+
+      while (index < Count) {
+        __m128i srcData = _mm_loadu_si128(srcPtr + index);
+        __m128i dstData = _mm_loadu_si128(dstPtr + index);
+
+        __m128i eqMask = _mm_cmpeq_epi32(srcData, dstData);
+
+        dirty = _mm_movemask_epi8(eqMask) != 0xffff;
+        index += 1u;
+
+        if (dirty) {
+          _mm_storeu_si128(dstPtr + index - 1u, srcData);
+          break;
+        }
+      }
+
+      if (unlikely(!dirty))
+        return false;
+
+      // Once we know constants have changed, just copy the rest.
+      while (index + 2u <= Count) {
+        __m128i src0 = _mm_loadu_si128(srcPtr + index + 0u);
+        __m128i src1 = _mm_loadu_si128(srcPtr + index + 1u);
+
+        _mm_storeu_si128(dstPtr + index + 0u, src0);
+        _mm_storeu_si128(dstPtr + index + 1u, src1);
+
+        index += 2u;
+      }
+
+      if (index < Count) {
+        __m128i srcData = _mm_loadu_si128(srcPtr + index);
+        _mm_storeu_si128(dstPtr + index, srcData);
+      }
+
+      return true;
+      // If any mask bit is 0, a constant has changed
+      #else
+      size_t dataSize = Count * sizeof(*dstData);
+
+      if (!std::memcmp(&dstData->data, pConstantData, dataSize))
+        return false;
+
+      std::memcpy(&dstData->data, pConstantData, dataSize);
+      return true;
+      #endif
+    }
   }
 
   struct Direct3DState9 : public D3D9DeviceState {

--- a/src/d3d9/d3d9_state.h
+++ b/src/d3d9/d3d9_state.h
@@ -186,16 +186,8 @@ namespace dxvk {
     D3D9FFShaderKeyVSData Key;
   };
 
-
-  struct D3D9FixedFunctionVertexBlendDataHW {
-    Matrix4 WorldView[8];
-  };
-
-
-  struct D3D9FixedFunctionVertexBlendDataSW {
-    Matrix4 WorldView[256];
-  };
-
+  static constexpr uint32_t D3D9MaxVertexBlendTransformsHw = 8u;
+  static constexpr uint32_t D3D9MaxVertexBlendTransformsSw = 256u;
 
   struct D3D9FFShaderStage {
     union {

--- a/src/d3d9/d3d9_stateblock.h
+++ b/src/d3d9/d3d9_stateblock.h
@@ -368,15 +368,8 @@ namespace dxvk {
             setCaptures.bConsts.set(reg, true);
         }
 
-        UpdateStateConstants<
-          ShaderType,
-          ConstantType,
-          T>(
-            &m_state,
-            StartRegister,
-            pConstantData,
-            Count,
-            false);
+        UpdateStateConstants<ShaderType, ConstantType, T>(
+          &m_state, StartRegister, pConstantData, Count);
 
         return D3D_OK;
       };

--- a/src/d3d9/d3d9_swvp_emu.cpp
+++ b/src/d3d9/d3d9_swvp_emu.cpp
@@ -170,7 +170,7 @@ namespace dxvk {
       dxbc_spv_assert(stage == dxbc_spv::ir::ShaderStage::eGeometry);
       dxbc_spv_assert(type == dxbc_spv::ir::ScalarType::eUav && !regSpace && !regIndex);
 
-      return D3D9ShaderResourceMapping::getSWVPBufferSlot();
+      return D3D9ShaderResourceMapping::getSwvpBufferIndex();
     }
 
     void dumpSource(const std::string& path) const {

--- a/src/d3d9/meson.build
+++ b/src/d3d9/meson.build
@@ -25,6 +25,7 @@ d3d9_src = [
   'd3d9_format.cpp',
   'd3d9_common_texture.cpp',
   'd3d9_constant_buffer.cpp',
+  'd3d9_constant_copy.cpp',
   'd3d9_texture.cpp',
   'd3d9_surface.cpp',
   'd3d9_volume.cpp',

--- a/src/d3d9/shaders/d3d9_fixed_function_common.glsl
+++ b/src/d3d9/shaders/d3d9_fixed_function_common.glsl
@@ -35,10 +35,25 @@ spirv_instruction(set = "GLSL.std.450", id = 81) vec2 spvNClamp(vec2, vec2, vec2
 spirv_instruction(set = "GLSL.std.450", id = 81) vec3 spvNClamp(vec3, vec3, vec3);
 spirv_instruction(set = "GLSL.std.450", id = 81) vec4 spvNClamp(vec4, vec4, vec4);
 
+// Bindings have to match D3D9ShaderResourceMapping.
+// Set numbers are arbitrarily set in d3d9_fixed_function.cpp
+#define SAMPLER_SET             0
 
-// Dynamic "spec constants"
-// Binding has to match with getSpecConstantBufferSlot in d3d9_shader.h
-layout(set = 0, binding = 31, scalar) uniform SpecConsts {
+#define SRV_SET                 1
+#define SRV_PS_BASE             0
+
+#define CBV_SET                 2
+
+#define CBV_VS_CLIP_PLANES      3
+#define CBV_VS_FIXED_FUNCTION   4
+#define CBV_VS_VERTEX_BLEND     5
+
+#define CBV_PS_FIXED_FUNCTION   11
+#define CBV_PS_SHARED           12
+
+#define CBV_SPEC_DATA           20
+
+layout(set = CBV_SET, binding = CBV_SPEC_DATA, scalar) uniform SpecConsts {
     uint dynamicSpecConstDword[20];
 };
 

--- a/src/d3d9/shaders/d3d9_fixed_function_frag.glsl
+++ b/src/d3d9/shaders/d3d9_fixed_function_frag.glsl
@@ -111,32 +111,28 @@ const uint VK_COMPARE_OP_ALWAYS           = 7;
 
 const uint PerTextureStageSpecConsts = SpecFFTextureStage1ColorOp - SpecFFTextureStage0ColorOp;
 
-
-// Bindings have to match with D3D9ShaderResourceMapping in d3d9_shader.h
-// D3D9ShaderResourceMapping::computeCbvBinding(D3D9ShaderType::PixelShader,
-//         D3D9ShaderResourceMapping::ConstantBuffers::PSFixedFunction) = 11
-layout(set = 0, binding = 11, scalar, row_major) uniform ShaderData {
+layout(set = CBV_SET, binding = CBV_PS_FIXED_FUNCTION, scalar, row_major)
+uniform ShaderData {
     D3D9FixedFunctionPS data;
 };
 
-// Bindings have to match with D3D9ShaderResourceMapping in d3d9_shader.h
-// D3D9ShaderResourceMapping::computeCbvBinding(D3D9ShaderType::PixelShader,
-//         D3D9ShaderResourceMapping::ConstantBuffers::PSShared) = 12
-layout(set = 0, binding = 12, scalar, row_major) uniform SharedData {
+layout(set = CBV_SET, binding = CBV_PS_SHARED, scalar, row_major)
+uniform SharedData {
     D3D9SharedPS sharedData;
 };
 
-layout(push_constant, scalar, row_major) uniform RenderStates {
+layout(push_constant, scalar, row_major)
+uniform RenderStates {
     D3D9RenderStateInfo rs;
 
     layout(offset = MaxSharedPushDataSize) uint packedSamplerIndices[TextureStageCount / 2];
 };
 
-layout(set = 0, binding = 13) uniform texture2D t2d[TextureStageCount];
-layout(set = 0, binding = 13) uniform textureCube tcube[TextureStageCount];
-layout(set = 0, binding = 13) uniform texture3D t3d[TextureStageCount];
+layout(set = SRV_SET, binding = SRV_PS_BASE) uniform texture2D t2d[TextureStageCount];
+layout(set = SRV_SET, binding = SRV_PS_BASE) uniform textureCube tcube[TextureStageCount];
+layout(set = SRV_SET, binding = SRV_PS_BASE) uniform texture3D t3d[TextureStageCount];
 
-layout(set = 1, binding = 0) uniform sampler sampler_heap[];
+layout(set = SAMPLER_SET, binding = 0) uniform sampler sampler_heap[];
 
 
 // Functions to extract information from the packed texture stages

--- a/src/d3d9/shaders/d3d9_fixed_function_vert.vert
+++ b/src/d3d9/shaders/d3d9_fixed_function_vert.vert
@@ -129,30 +129,24 @@ const uint TCIOffset = 16;
 const uint TCIMask = (7 << TCIOffset);
 
 
-// Bindings have to match with D3D9ShaderResourceMapping in d3d9_shader.h
-// D3D9ShaderResourceMapping::computeCbvBinding(D3D9ShaderType::Vertex,
-//         D3D9ShaderResourceMapping::ConstantBuffers::VSFixedFunction) = 4
-layout(set = 0, binding = 4, scalar, row_major) uniform ShaderData {
+layout(set = CBV_SET, binding = CBV_VS_FIXED_FUNCTION, scalar, row_major)
+uniform ShaderData {
     D3D9FixedFunctionVS data;
 };
 
-layout(push_constant, scalar, row_major) uniform RenderStates {
-    D3D9RenderStateInfo rs;
-};
-
-// Bindings have to match with D3D9ShaderResourceMapping in d3d9_shader.h
-// D3D9ShaderResourceMapping::computeCbvBinding(D3D9ShaderType::Vertex,
-//         D3D9ShaderResourceMapping::ConstantBuffers::VSVertexBlendData) = 5
-layout(set = 0, binding = 5, std140, row_major) readonly buffer VertexBlendData {
+layout(set = CBV_SET, binding = CBV_VS_VERTEX_BLEND, std140, row_major)
+readonly buffer VertexBlendData {
     mat4 WorldViewArray[];
 };
 
-
-// Bindings have to match with D3D9ShaderResourceMapping in d3d9_shader.h
-// D3D9ShaderResourceMapping::computeCbvBinding(D3D9ShaderType::Vertex,
-//         D3D9ShaderResourceMapping::ConstantBuffers::VSClipPlanes) = 3
-layout(set = 0, binding = 3, std140) uniform ClipPlanes {
+layout(set = CBV_SET, binding = CBV_VS_CLIP_PLANES, std140)
+uniform ClipPlanes {
     vec4 clipPlanes[MaxClipPlaneCount];
+};
+
+layout(push_constant, scalar, row_major)
+uniform RenderStates {
+    D3D9RenderStateInfo rs;
 };
 
 

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -2607,10 +2607,12 @@ namespace dxvk {
   
   void DxvkContext::uploadBuffer(
     const Rc<DxvkBuffer>&           buffer,
+          VkDeviceSize              bufferOffset,
     const Rc<DxvkBuffer>&           source,
-          VkDeviceSize              sourceOffset) {
-    auto bufferSlice = buffer->getSliceInfo();
-    auto sourceSlice = source->getSliceInfo(sourceOffset, buffer->info().size);
+          VkDeviceSize              sourceOffset,
+          VkDeviceSize              size) {
+    auto bufferSlice = buffer->getSliceInfo(bufferOffset, size);
+    auto sourceSlice = source->getSliceInfo(sourceOffset, size);
 
     VkBufferCopy2 copyRegion = { VK_STRUCTURE_TYPE_BUFFER_COPY_2 };
     copyRegion.srcOffset = sourceSlice.offset;

--- a/src/dxvk/dxvk_context.h
+++ b/src/dxvk/dxvk_context.h
@@ -1024,16 +1024,20 @@ namespace dxvk {
     /**
      * \brief Uses transfer queue to initialize buffer
      *
-     * Always replaces the entire buffer. Only safe to use
-     * if the buffer is currently not in use by the GPU.
+     * Must only be use if the given buffer region is
+     * not currently in use by the GPU.
      * \param [in] buffer The buffer to initialize
+     * \param [in] bufferOffset Buffer offset
      * \param [in] source Staging buffer containing data
      * \param [in] sourceOffset Offset into staging buffer
+     * \param [in] size Number of bytes to copy
      */
     void uploadBuffer(
       const Rc<DxvkBuffer>&           buffer,
+            VkDeviceSize              bufferOffset,
       const Rc<DxvkBuffer>&           source,
-            VkDeviceSize              sourceOffset);
+            VkDeviceSize              sourceOffset,
+            VkDeviceSize              size);
     
     /**
      * \brief Uses transfer queue to initialize image


### PR DESCRIPTION
Besides getting rid of some legacy cruft, this compacts statically indexed shader constants in such a way that shaders only accessing `c180` through `c183` will now only allocate and copy 64 bytes of buffer memory instead of 2944 bytes. Hello Witcher 2.

Additionally, this leverages the new `PUSH_ADDRESS` support in the backend for statically indexed constant buffers, which means no more uniform buffer descriptors in most cases.

We also get proper debug names in shaders now if the shader defines `ctab`:
```glsl
layout(set = 1, binding = 6, std140) uniform c_buf {
    vec4 scale_matrix0;
    vec4 scale_matrix1;
    vec4 scene_fog_start;
    vec4 scene_fog_enabled;
    vec4 matrix_worldviewproj0;
    vec4 matrix_worldviewproj1;
    vec4 matrix_worldviewproj2;
    vec4 matrix_worldviewproj3;
    vec4 matrix_projinv2;
    vec4 c20;
} c;
```

Dynamically indexed VS floats get their own dedicated buffer now with more or less the same strategy as before, we only actually bind and upload constants that have a non-zero value. Looks like this in shader:

```glsl
layout(set = 1, binding = 6, std140) uniform light_count_buf {
    ivec4 m;
} light_count;

layout(set = 1, binding = 7, std140) uniform cF_buf {
    vec4 m[256];
} cF;
```

Dirty-tracking is *also* changed in such a way that `SetShaderConstant*` will actually check whether any of the constants have actually changed, this does save a fair bit of work in some cases especially when it affects shaders with dynamic floats. If anything, this could probably be made more granular to actually track dynamic and static buffers separately.

As for performance, somewhat disappointingly I'm not seeing much of an improvement in the handful of games that I tested, even though micro-benchmarking the time spent in `SetShaderConstants` and `UpdateShaderConstants` shows clear improvements.

That said, one *real* benefit (besides wasting slightly less memory) is that the descriptor copy worker does next to nothing now in many 32-bit D3D9 games because we no longer use actual descriptors for UBOs, at least on the descriptor heap path and on AMD. Another one is that RE6 no longer runs out of descriptor heap space.

Needs a lot of testing because this do be a lil scawy.