### PR TITLE
Rework D3D9 constant buffers

### DIFF
--- a/dxvk.conf
+++ b/dxvk.conf
@@ -629,14 +629,15 @@
 
 # Device Local Constant Buffers
 #
-# Enables using device local, host accessible memory for constant buffers in D3D9.
-# This tends to actually be slower for some reason on AMD,
-# and the exact same performance on NVIDIA.
+# Allows streaming shader constants and render state buffers into
+# VRAM, which may improve performance in GPU-bound scenarios.
 #
 # Supported values:
-# - True/False
+# - True: Always enable constant buffer streaming
+# - Auto: Only enable streaming on discrete GPUs
+# - False: Always disable streaming
 
-# d3d9.deviceLocalConstantBuffers = False
+# d3d9.deviceLocalConstantBuffers = Auto
 
 
 # Support cube texture depth formats

--- a/src/d3d11/d3d11_initializer.cpp
+++ b/src/d3d11/d3d11_initializer.cpp
@@ -121,9 +121,10 @@ namespace dxvk {
         cBuffer       = buffer,
         cStagingSlice = std::move(stagingSlice)
       ] (DxvkContext* ctx) {
-        ctx->uploadBuffer(cBuffer,
+        ctx->uploadBuffer(cBuffer, 0u,
           cStagingSlice.buffer(),
-          cStagingSlice.offset());
+          cStagingSlice.offset(),
+          cStagingSlice.length());
       });
     } else {
       m_transferCommands += 1;

--- a/src/d3d9/d3d9_constant_buffer.cpp
+++ b/src/d3d9/d3d9_constant_buffer.cpp
@@ -10,15 +10,14 @@ namespace dxvk {
 
   D3D9ConstantBuffer::D3D9ConstantBuffer(
           D3D9DeviceEx*         pDevice,
-          VkShaderStageFlags    Stages,
-          uint32_t              ResourceSlot,
-          VkDeviceSize          Size)
+          Kind                  CbvType)
   : m_device    (pDevice)
-  , m_binding   (ResourceSlot)
-  , m_usage     (VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT | VK_BUFFER_USAGE_STORAGE_BUFFER_BIT)
-  , m_stages    (Stages)
-  , m_size      (Size)
-  , m_align     (getAlignment(pDevice->GetDXVKDevice())) {
+  , m_kind      (CbvType)
+  , m_size      (DetermineSize(CbvType))
+  , m_usage     (DetermineUsage(pDevice, CbvType, m_size))
+  , m_stages    (DetermineStages(CbvType))
+  , m_align     (DetermineAlignment(pDevice, m_usage))
+  , m_memType   (DetermineMemoryType(CbvType)) {
 
   }
 
@@ -29,58 +28,46 @@ namespace dxvk {
 
 
   void* D3D9ConstantBuffer::Alloc(VkDeviceSize size) {
-    if (unlikely(m_buffer == nullptr))
-      m_slice = this->createBuffer();
+    if (unlikely(!m_cpuBuffer))
+      m_cpuSlice = createBuffer();
 
     size = align(size, m_align);
 
-    if (unlikely(m_offset + size > m_size)) {
-      m_slice = m_buffer->allocateStorage();
-      m_offset = 0;
+    if (m_offset + size > m_size) {
+      m_cpuSlice = m_cpuBuffer->allocateStorage();
 
       m_device->EmitCs([
-        cBuffer = m_buffer,
-        cSlice  = m_slice
+        cBinding  = uint32_t(m_kind),
+        cStages   = m_stages,
+        cBuffer   = m_cpuBuffer,
+        cSlice    = m_cpuSlice,
+        cSize     = size
       ] (DxvkContext* ctx) mutable {
         ctx->invalidateBuffer(cBuffer, std::move(cSlice));
+        ctx->bindUniformBufferRange(cStages, cBinding, 0u, cSize);
       });
+
+      m_offset = size;
+
+      return m_cpuSlice->mapPtr();
+    } else {
+      m_device->EmitCs([
+        cBinding  = uint32_t(m_kind),
+        cStages   = m_stages,
+        cOffset   = m_offset,
+        cSize     = size
+      ] (DxvkContext* ctx) {
+        ctx->bindUniformBufferRange(cStages, cBinding, cOffset, cSize);
+      });
+
+      void* mapPtr = reinterpret_cast<char*>(m_cpuSlice->mapPtr()) + m_offset;
+      m_offset += size;
+      return mapPtr;
     }
-
-    m_device->EmitCs([
-      cStages   = m_stages,
-      cBinding  = m_binding,
-      cOffset   = m_offset,
-      cLength   = size
-    ] (DxvkContext* ctx) {
-      ctx->bindUniformBufferRange(cStages, cBinding, cOffset, cLength);
-    });
-
-    void* mapPtr = reinterpret_cast<char*>(m_slice->mapPtr()) + m_offset;
-    m_offset += size;
-    return mapPtr;
-  }
-
-
-  void* D3D9ConstantBuffer::AllocSlice() {
-    if (unlikely(m_buffer == nullptr))
-      m_slice = this->createBuffer();
-    else
-      m_slice = m_buffer->allocateStorage();
-
-    m_device->EmitCs([
-      cBuffer = m_buffer,
-      cSlice  = m_slice
-    ] (DxvkContext* ctx) mutable {
-      ctx->invalidateBuffer(cBuffer, std::move(cSlice));
-    });
-
-    return m_slice->mapPtr();
   }
 
 
   Rc<DxvkResourceAllocation> D3D9ConstantBuffer::createBuffer() {
-    auto options = m_device->GetOptions();
-
     // Buffer usage and access flags don't make much of a difference
     // in the backend, so set both STORAGE and UNIFORM usage/access.
     DxvkBufferCreateInfo bufferInfo;
@@ -95,32 +82,121 @@ namespace dxvk {
     if (m_usage & VK_BUFFER_USAGE_STORAGE_BUFFER_BIT)
       bufferInfo.access |= VK_ACCESS_SHADER_READ_BIT;
 
-    VkMemoryPropertyFlags memoryFlags
-      = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT
-      | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
-
-    if (options->deviceLocalConstantBuffers)
-      memoryFlags |= VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
-
-    m_buffer = m_device->GetDXVKDevice()->createBuffer(bufferInfo, memoryFlags);
+    m_cpuBuffer = m_device->GetDXVKDevice()->createBuffer(bufferInfo, m_memType);
 
     m_device->EmitCs([
+      cBinding  = uint32_t(m_kind),
       cStages   = m_stages,
-      cBinding  = m_binding,
-      cSlice    = DxvkBufferSlice(m_buffer)
+      cSlice    = DxvkBufferSlice(m_cpuBuffer)
     ] (DxvkContext* ctx) mutable {
       ctx->bindUniformBuffer(cStages, cBinding, std::move(cSlice));
     });
 
-    return m_buffer->storage();
+    return m_cpuBuffer->storage();
   }
 
 
-  VkDeviceSize D3D9ConstantBuffer::getAlignment(const Rc<DxvkDevice>& device) const {
-    return std::max(std::max(std::max(VkDeviceSize(CACHE_LINE_SIZE),
-      device->properties().core.properties.limits.minUniformBufferOffsetAlignment),
-      device->properties().core.properties.limits.minStorageBufferOffsetAlignment),
-      device->properties().extRobustness2.robustUniformBufferAccessSizeAlignment);
+  VkDeviceSize D3D9ConstantBuffer::DetermineSize(
+          Kind                CbvType) {
+    switch (CbvType) {
+      case Kind::VSStaticConstants:
+      case Kind::VSDynamicConstants:
+      case Kind::PSStaticConstants:
+        return ShaderConstSize;
+
+      default:
+        return MiscSize;
+    }
+  }
+
+
+  VkBufferUsageFlags D3D9ConstantBuffer::DetermineUsage(
+          D3D9DeviceEx*       pDevice,
+          Kind                CbvType,
+          VkDeviceSize        Size) {
+    VkBufferUsageFlags usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
+
+    // SWVP vertex constant buffers can get bigger than the minimum required
+    // size for uniform buffers on some devices. Don't bother figuring out
+    // the layout, just always allow storage buffer fallback in that case.
+    if ((CbvType == Kind::VSStaticConstants || CbvType == Kind::VSDynamicConstants) && pDevice->CanSWVP())
+      usage |= VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
+
+    // Vertex blend is a bit special w.r.t. nonuniform indexing, so enable
+    // storage buffer usage there as well.
+    if (CbvType == Kind::VSVertexBlendData)
+      usage |= VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
+
+    return usage;
+  }
+
+
+  VkShaderStageFlags D3D9ConstantBuffer::DetermineStages(
+          Kind                CbvType) {
+    switch (CbvType) {
+      case Kind::VSClipPlanes:
+      case Kind::VSFixedFunction:
+      case Kind::VSVertexBlendData:
+      case Kind::VSStaticConstants:
+      case Kind::VSDynamicConstants:
+        return VK_SHADER_STAGE_VERTEX_BIT;
+
+      case Kind::PSFixedFunction:
+      case Kind::PSShared:
+      case Kind::PSStaticConstants:
+        return VK_SHADER_STAGE_FRAGMENT_BIT;
+
+      case Kind::SpecData:
+        return VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT;
+    }
+
+    return 0u;
+  }
+
+
+  VkDeviceSize D3D9ConstantBuffer::DetermineAlignment(
+          D3D9DeviceEx*       pDevice,
+          VkBufferUsageFlags  Usage) {
+    auto dxvkDevice = pDevice->GetDXVKDevice();
+
+    // At least a full cache line for CPU write perf
+    VkDeviceSize result = CACHE_LINE_SIZE;
+
+    // Check required offset alignment and robustness properties by usage.
+    // Some buffers do not require robustness, but don't bother with that.
+    // We will likely get no more than 64 bytes out of this anyway.
+    if (Usage & VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT) {
+      result = std::max(result, dxvkDevice->properties().core.properties.limits.minUniformBufferOffsetAlignment);
+      result = std::max(result, dxvkDevice->properties().extRobustness2.robustUniformBufferAccessSizeAlignment);
+    }
+
+    if (Usage & VK_BUFFER_USAGE_STORAGE_BUFFER_BIT) {
+      result = std::max(result, dxvkDevice->properties().core.properties.limits.minStorageBufferOffsetAlignment);
+      result = std::max(result, dxvkDevice->properties().extRobustness2.robustStorageBufferAccessSizeAlignment);
+    }
+
+    return result;
+  }
+
+
+  VkMemoryPropertyFlags D3D9ConstantBuffer::DetermineMemoryType(
+          Kind                CbvType) {
+    VkMemoryPropertyFlags flags = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
+
+    // Enable cached memory type for the miscellaneous buffers
+    // since we don't really optimize write patterns there.
+    // TODO fix that at some point.
+    bool useCached = CbvType == Kind::VSClipPlanes
+                  || CbvType == Kind::VSFixedFunction
+                  || CbvType == Kind::VSVertexBlendData
+                  || CbvType == Kind::PSFixedFunction
+                  || CbvType == Kind::PSShared
+                  || CbvType == Kind::SpecData;
+
+    if (useCached)
+      flags |= VK_MEMORY_PROPERTY_HOST_CACHED_BIT;
+
+    return flags;
   }
 
 }

--- a/src/d3d9/d3d9_constant_buffer.cpp
+++ b/src/d3d9/d3d9_constant_buffer.cpp
@@ -29,7 +29,7 @@ namespace dxvk {
 
   void* D3D9ConstantBuffer::Alloc(VkDeviceSize size) {
     if (unlikely(!m_cpuBuffer))
-      m_cpuSlice = createBuffer();
+      m_cpuSlice = CreateBuffer();
 
     size = align(size, m_align);
 
@@ -37,18 +37,19 @@ namespace dxvk {
       m_cpuSlice = m_cpuBuffer->allocateStorage();
 
       m_device->EmitCs([
-        cBinding  = uint32_t(m_kind),
-        cStages   = m_stages,
-        cBuffer   = m_cpuBuffer,
-        cSlice    = m_cpuSlice,
-        cSize     = size
+        cBinding    = uint32_t(m_kind),
+        cStages     = m_stages,
+        cCpuBuffer  = m_cpuBuffer,
+        cCpuSlice   = m_cpuSlice,
+        cSize       = size
       ] (DxvkContext* ctx) mutable {
-        ctx->invalidateBuffer(cBuffer, std::move(cSlice));
+        ctx->invalidateBuffer(cCpuBuffer, std::move(cCpuSlice));
         ctx->bindUniformBufferRange(cStages, cBinding, 0u, cSize);
       });
 
-      m_offset = size;
+      SetupStreamCommand(0u, size, true);
 
+      m_offset = size;
       return m_cpuSlice->mapPtr();
     } else {
       m_device->EmitCs([
@@ -60,6 +61,8 @@ namespace dxvk {
         ctx->bindUniformBufferRange(cStages, cBinding, cOffset, cSize);
       });
 
+      SetupStreamCommand(m_offset, size, false);
+
       void* mapPtr = reinterpret_cast<char*>(m_cpuSlice->mapPtr()) + m_offset;
       m_offset += size;
       return mapPtr;
@@ -67,9 +70,9 @@ namespace dxvk {
   }
 
 
-  Rc<DxvkResourceAllocation> D3D9ConstantBuffer::createBuffer() {
-    // Buffer usage and access flags don't make much of a difference
-    // in the backend, so set both STORAGE and UNIFORM usage/access.
+  Rc<DxvkResourceAllocation> D3D9ConstantBuffer::CreateBuffer() {
+    auto dxvkDevice = m_device->GetDXVKDevice();
+
     DxvkBufferCreateInfo bufferInfo;
     bufferInfo.size   = align(m_size, m_align);
     bufferInfo.usage  = m_usage;
@@ -82,17 +85,67 @@ namespace dxvk {
     if (m_usage & VK_BUFFER_USAGE_STORAGE_BUFFER_BIT)
       bufferInfo.access |= VK_ACCESS_SHADER_READ_BIT;
 
-    m_cpuBuffer = m_device->GetDXVKDevice()->createBuffer(bufferInfo, m_memType);
+    if (m_useDma) {
+      // Create the CPU buffer as a pure staging buffer
+      auto cpuInfo = bufferInfo;
+      cpuInfo.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
+      cpuInfo.stages = VK_PIPELINE_STAGE_TRANSFER_BIT;
+      cpuInfo.access = VK_ACCESS_TRANSFER_READ_BIT;
+
+      m_cpuBuffer = dxvkDevice->createBuffer(cpuInfo, m_memType);
+
+      // Create the GPU buffer as the actual uniform buffer
+      auto gpuInfo = bufferInfo;
+      gpuInfo.usage |= VK_BUFFER_USAGE_TRANSFER_DST_BIT;
+      gpuInfo.stages |= VK_PIPELINE_STAGE_TRANSFER_BIT;
+      gpuInfo.access |= VK_ACCESS_TRANSFER_WRITE_BIT;
+
+      m_gpuBuffer = dxvkDevice->createBuffer(gpuInfo, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+    } else {
+      // Create a single buffer for both CPU writes and GPU reads
+      m_cpuBuffer = dxvkDevice->createBuffer(bufferInfo, m_memType);
+      m_gpuBuffer = m_cpuBuffer;
+    }
 
     m_device->EmitCs([
       cBinding  = uint32_t(m_kind),
       cStages   = m_stages,
-      cSlice    = DxvkBufferSlice(m_cpuBuffer)
+      cSlice    = DxvkBufferSlice(m_gpuBuffer)
     ] (DxvkContext* ctx) mutable {
       ctx->bindUniformBuffer(cStages, cBinding, std::move(cSlice));
     });
 
     return m_cpuBuffer->storage();
+  }
+
+
+  void D3D9ConstantBuffer::SetupStreamCommand(
+          VkDeviceSize        Offset,
+          VkDeviceSize        Size,
+          bool                Discard) {
+    if (!m_useDma)
+      return;
+
+    if (m_streamCmd && !Discard) {
+      // Simply adjust the data size for the existing command
+      m_streamCmd->size = Offset + Size - m_streamCmd->offset;
+    } else {
+      // Need to discard GPU buffer as well so that we can safely
+      // use the asynchronous transfer queue for uploads.
+      m_streamCmd = m_device->EmitCsCmd<StreamCommand>(1u, [
+        cCpuBuffer = m_cpuBuffer,
+        cGpuBuffer = m_gpuBuffer,
+        cDiscard   = Discard
+      ] (DxvkContext* ctx, const StreamCommand* cmd, uint32_t) {
+        if (cDiscard)
+          ctx->invalidateBuffer(cGpuBuffer, cGpuBuffer->allocateStorage());
+
+        ctx->uploadBuffer(cGpuBuffer, cmd->offset, cCpuBuffer, cmd->offset, cmd->size);
+      });
+
+      m_streamCmd->offset = Offset;
+      m_streamCmd->size = Size;
+    }
   }
 
 

--- a/src/d3d9/d3d9_constant_buffer.cpp
+++ b/src/d3d9/d3d9_constant_buffer.cpp
@@ -261,6 +261,10 @@ namespace dxvk {
           D3D9DeviceEx*       pDevice,
           Kind                CbvType) {
     auto dxvkDevice = pDevice->GetDXVKDevice();
+    auto option = pDevice->GetOptions()->deviceLocalConstantBuffers;
+
+    if (option != Tristate::Auto)
+      return option == Tristate::True;
 
     // No point whatsoever in streaming the spec data buffer to
     // VRAM since it won't be used most of the time anyway

--- a/src/d3d9/d3d9_constant_buffer.cpp
+++ b/src/d3d9/d3d9_constant_buffer.cpp
@@ -17,7 +17,8 @@ namespace dxvk {
   , m_usage     (DetermineUsage(pDevice, CbvType, m_size))
   , m_stages    (DetermineStages(CbvType))
   , m_align     (DetermineAlignment(pDevice, m_usage))
-  , m_memType   (DetermineMemoryType(CbvType)) {
+  , m_memType   (DetermineMemoryType(CbvType))
+  , m_useDma    (DetermineDmaUsage(pDevice, CbvType)) {
 
   }
 
@@ -253,6 +254,18 @@ namespace dxvk {
       flags |= VK_MEMORY_PROPERTY_HOST_CACHED_BIT;
 
     return flags;
+  }
+
+
+  bool D3D9ConstantBuffer::DetermineDmaUsage(
+          D3D9DeviceEx*       pDevice,
+          Kind                CbvType) {
+    auto dxvkDevice = pDevice->GetDXVKDevice();
+
+    // No point whatsoever in streaming the spec data buffer to
+    // VRAM since it won't be used most of the time anyway
+    return dxvkDevice->properties().core.properties.deviceType == VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU
+      && CbvType != Kind::SpecData;
   }
 
 }

--- a/src/d3d9/d3d9_constant_buffer.cpp
+++ b/src/d3d9/d3d9_constant_buffer.cpp
@@ -148,6 +148,9 @@ namespace dxvk {
 
       case Kind::SpecData:
         return VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT;
+
+      case Kind::Count:
+        break;
     }
 
     return 0u;

--- a/src/d3d9/d3d9_constant_buffer.h
+++ b/src/d3d9/d3d9_constant_buffer.h
@@ -15,16 +15,17 @@ namespace dxvk {
    * \brief Constant buffer
    */
   class D3D9ConstantBuffer {
+    static constexpr VkDeviceSize ShaderConstSize = 1024ull << 10;
+    static constexpr VkDeviceSize MiscSize        =   64ull << 10;
 
+    using Kind = D3D9ShaderResourceMapping::CbvIndex;
   public:
 
     D3D9ConstantBuffer();
 
     D3D9ConstantBuffer(
             D3D9DeviceEx*         pDevice,
-            VkShaderStageFlags    Stages,
-            uint32_t              ResourceSlot,
-            VkDeviceSize          Size);
+            Kind                  CbvType);
 
     ~D3D9ConstantBuffer();
 
@@ -47,14 +48,6 @@ namespace dxvk {
     void* Alloc(VkDeviceSize size);
 
     /**
-     * \brief Allocates a full buffer slice
-     *
-     * This must not be called if \ref Alloc is used.
-     * \returns Map pointer of the allocated region
-     */
-    void* AllocSlice();
-
-    /**
      * \brief Allocates typed data
      *
      * \param [in] count Number of items to allocate
@@ -69,19 +62,37 @@ namespace dxvk {
 
     D3D9DeviceEx*         m_device  = nullptr;
 
-    uint32_t              m_binding = 0u;
+    Kind                  m_kind    = {};
+    VkDeviceSize          m_size    = 0ull;
     VkBufferUsageFlags    m_usage   = 0u;
     VkShaderStageFlags    m_stages  = 0u;
-    VkDeviceSize          m_size    = 0ull;
     VkDeviceSize          m_align   = 0ull;
+    VkMemoryPropertyFlags m_memType = 0u;
     VkDeviceSize          m_offset  = 0ull;
 
-    Rc<DxvkBuffer>        m_buffer  = nullptr;
-    Rc<DxvkResourceAllocation> m_slice = nullptr;
+    Rc<DxvkBuffer>        m_cpuBuffer = nullptr;
+
+    Rc<DxvkResourceAllocation> m_cpuSlice = nullptr;
 
     Rc<DxvkResourceAllocation> createBuffer();
 
-    VkDeviceSize getAlignment(const Rc<DxvkDevice>& device) const;
+    static VkDeviceSize DetermineSize(
+            Kind                CbvType);
+
+    static VkBufferUsageFlags DetermineUsage(
+            D3D9DeviceEx*       pDevice,
+            Kind                CbvType,
+            VkDeviceSize        Size);
+
+    static VkShaderStageFlags DetermineStages(
+            Kind                CbvType);
+
+    static VkDeviceSize DetermineAlignment(
+            D3D9DeviceEx*       pDevice,
+            VkBufferUsageFlags  Usage);
+
+    static VkMemoryPropertyFlags DetermineMemoryType(
+            Kind                CbvType);
 
   };
 

--- a/src/d3d9/d3d9_constant_buffer.h
+++ b/src/d3d9/d3d9_constant_buffer.h
@@ -122,6 +122,10 @@ namespace dxvk {
     static VkMemoryPropertyFlags DetermineMemoryType(
             Kind                CbvType);
 
+    static bool DetermineDmaUsage(
+            D3D9DeviceEx*       pDevice,
+            Kind                CbvType);
+
   };
 
 }

--- a/src/d3d9/d3d9_constant_buffer.h
+++ b/src/d3d9/d3d9_constant_buffer.h
@@ -21,6 +21,11 @@ namespace dxvk {
     using Kind = D3D9ShaderResourceMapping::CbvIndex;
   public:
 
+    struct StreamCommand {
+      VkDeviceSize offset = 0u;
+      VkDeviceSize size = 0u;
+    };
+
     D3D9ConstantBuffer();
 
     D3D9ConstantBuffer(
@@ -42,6 +47,9 @@ namespace dxvk {
     /**
      * \brief Allocates a given amount of memory
      *
+     * \note: Requires that all data is written to the buffer before
+     * submitting the next set of commands to the CS chunk, otherwise
+     * the GPU may read stale data.
      * \param [in] size Number of bytes to allocate
      * \returns Map pointer of the allocated region
      */
@@ -58,6 +66,17 @@ namespace dxvk {
       return reinterpret_cast<T*>(Alloc(Count * sizeof(T)));
     }
 
+    /**
+     * \brief Resets current stream command
+     *
+     * This \e must unconditionally be called when the
+     * device's current CS chunk gets submitted to the
+     * worker to avoid accessing stale data.
+     */
+    void ResetStreamCommand() {
+      m_streamCmd = nullptr;
+    }
+
   private:
 
     D3D9DeviceEx*         m_device  = nullptr;
@@ -69,12 +88,21 @@ namespace dxvk {
     VkDeviceSize          m_align   = 0ull;
     VkMemoryPropertyFlags m_memType = 0u;
     VkDeviceSize          m_offset  = 0ull;
+    bool                  m_useDma  = false;
 
     Rc<DxvkBuffer>        m_cpuBuffer = nullptr;
+    Rc<DxvkBuffer>        m_gpuBuffer = nullptr;
 
     Rc<DxvkResourceAllocation> m_cpuSlice = nullptr;
 
-    Rc<DxvkResourceAllocation> createBuffer();
+    StreamCommand*        m_streamCmd = nullptr;
+
+    Rc<DxvkResourceAllocation> CreateBuffer();
+
+    void SetupStreamCommand(
+            VkDeviceSize        Offset,
+            VkDeviceSize        Size,
+            bool                Discard);
 
     static VkDeviceSize DetermineSize(
             Kind                CbvType);

--- a/src/d3d9/d3d9_constant_buffer.h
+++ b/src/d3d9/d3d9_constant_buffer.h
@@ -37,7 +37,7 @@ namespace dxvk {
     VkDeviceSize GetAlignment() const {
       return m_align;
     }
-    
+
     /**
      * \brief Allocates a given amount of memory
      *
@@ -53,6 +53,17 @@ namespace dxvk {
      * \returns Map pointer of the allocated region
      */
     void* AllocSlice();
+
+    /**
+     * \brief Allocates typed data
+     *
+     * \param [in] count Number of items to allocate
+     * \returns Allocated data slice
+     */
+    template<typename T>
+    T* AllocTyped(size_t Count) {
+      return reinterpret_cast<T*>(Alloc(Count * sizeof(T)));
+    }
 
   private:
 

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -5986,38 +5986,15 @@ namespace dxvk {
 
 
   void D3D9DeviceEx::CreateConstantBuffers() {
-    constexpr VkDeviceSize DefaultConstantBufferSize = 1024ull << 10;
-
-    m_psStaticConstants = D3D9ConstantBuffer(this, VK_SHADER_STAGE_FRAGMENT_BIT,
-      D3D9ShaderResourceMapping::CbvIndex::PSStaticConstants, DefaultConstantBufferSize);
-
-    m_vsStaticConstants = D3D9ConstantBuffer(this, VK_SHADER_STAGE_VERTEX_BIT,
-      D3D9ShaderResourceMapping::CbvIndex::VSStaticConstants, DefaultConstantBufferSize);
-
-    m_vsDynamicConstants = D3D9ConstantBuffer(this, VK_SHADER_STAGE_VERTEX_BIT,
-      D3D9ShaderResourceMapping::CbvIndex::VSDynamicConstants, DefaultConstantBufferSize);
-
-    m_vsClipPlanes = D3D9ConstantBuffer(this, VK_SHADER_STAGE_VERTEX_BIT,
-      D3D9ShaderResourceMapping::CbvIndex::VSClipPlanes,
-      caps::MaxClipPlanes * sizeof(D3D9ClipPlane));
-
-    m_vsFixedFunction = D3D9ConstantBuffer(this, VK_SHADER_STAGE_VERTEX_BIT,
-      D3D9ShaderResourceMapping::CbvIndex::VSFixedFunction, sizeof(D3D9FixedFunctionVS));
-
-    m_psFixedFunction = D3D9ConstantBuffer(this, VK_SHADER_STAGE_FRAGMENT_BIT,
-      D3D9ShaderResourceMapping::CbvIndex::PSFixedFunction, sizeof(D3D9FixedFunctionPS));
-
-    m_psShared = D3D9ConstantBuffer(this, VK_SHADER_STAGE_FRAGMENT_BIT,
-      D3D9ShaderResourceMapping::CbvIndex::PSShared, sizeof(D3D9SharedPS));
-
-    m_vsVertexBlend = D3D9ConstantBuffer(this, VK_SHADER_STAGE_VERTEX_BIT,
-      D3D9ShaderResourceMapping::CbvIndex::VSVertexBlendData, CanSWVP()
-        ? sizeof(D3D9FixedFunctionVertexBlendDataSW)
-        : sizeof(D3D9FixedFunctionVertexBlendDataHW));
-
-    // Constant buffer for dynamic spec constants, needed for GPL pipelines
-    m_specBuffer = D3D9ConstantBuffer(this, VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT,
-      D3D9ShaderResourceMapping::CbvIndex::SpecData, D3D9SpecializationInfo::UBOSize);
+    m_psStaticConstants = D3D9ConstantBuffer(this, D3D9ShaderResourceMapping::CbvIndex::PSStaticConstants);
+    m_vsStaticConstants = D3D9ConstantBuffer(this, D3D9ShaderResourceMapping::CbvIndex::VSStaticConstants);
+    m_vsDynamicConstants = D3D9ConstantBuffer(this, D3D9ShaderResourceMapping::CbvIndex::VSDynamicConstants);
+    m_vsClipPlanes = D3D9ConstantBuffer(this, D3D9ShaderResourceMapping::CbvIndex::VSClipPlanes);
+    m_vsFixedFunction = D3D9ConstantBuffer(this, D3D9ShaderResourceMapping::CbvIndex::VSFixedFunction);
+    m_psFixedFunction = D3D9ConstantBuffer(this, D3D9ShaderResourceMapping::CbvIndex::PSFixedFunction);
+    m_psShared = D3D9ConstantBuffer(this, D3D9ShaderResourceMapping::CbvIndex::PSShared);
+    m_vsVertexBlend = D3D9ConstantBuffer(this, D3D9ShaderResourceMapping::CbvIndex::VSVertexBlendData);
+    m_specBuffer = D3D9ConstantBuffer(this, D3D9ShaderResourceMapping::CbvIndex::SpecData);
   }
 
 

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -6029,11 +6029,10 @@ namespace dxvk {
     }
 
     // Set up and perform the actual data copy
-    D3D9ConstantBufferCopyArgs copyArgs = {};
-    copyArgs.floatConstantCount = dynamicFloatCount;
-    copyArgs.flushNan = m_d3d9Options.d3d9FloatEmulation == D3D9FloatEmulation::Enabled;
-
     if (staticSize) {
+      D3D9ConstantBufferCopyArgs copyArgs = {};
+      copyArgs.flushNan = m_d3d9Options.d3d9FloatEmulation == D3D9FloatEmulation::Enabled;
+
       // Allocate storage for statically indexed constants
       auto& buffer = GetConstantBuffer(ShaderType == D3D9ShaderType::VertexShader
         ? CbvIndex::VSStaticConstants
@@ -6056,9 +6055,24 @@ namespace dxvk {
       // Pad last block so we always write full cache lines
       copyArgs.boolBuffer = reinterpret_cast<char*>(staticData) + staticOffset;
       copyArgs.boolBufferSize = staticSize - staticOffset;
+
+      if (ShaderType == D3D9ShaderType::VertexShader) {
+        copyArgs.constFloatApi = m_state.vsConsts->fConsts;
+        copyArgs.constIntApi = m_state.vsConsts->iConsts;
+        copyArgs.constBoolApi = m_state.vsConsts->bConsts;
+      } else {
+        copyArgs.constFloatApi = m_state.psConsts->fConsts;
+        copyArgs.constIntApi = m_state.psConsts->iConsts;
+      }
+
+      layout->copyConstantData(copyArgs);
     }
 
     if (dynamicSize) {
+      D3D9ConstantBufferCopyArgs copyArgs = {};
+      copyArgs.floatConstantCount = dynamicFloatCount;
+      copyArgs.flushNan = m_d3d9Options.d3d9FloatEmulation == D3D9FloatEmulation::Enabled;
+
       // Allocate storage for dynamically indexed floats. Pad this
       // to the full allocation size as well so we write everything.
       auto& buffer = GetConstantBuffer(CbvIndex::VSDynamicConstants);
@@ -6066,18 +6080,10 @@ namespace dxvk {
 
       copyArgs.floatBuffer = buffer.Alloc(dynamicSize);
       copyArgs.floatBufferSize = dynamicSize;
-    }
-
-    if (ShaderType == D3D9ShaderType::VertexShader) {
       copyArgs.constFloatApi = m_state.vsConsts->fConsts;
-      copyArgs.constIntApi = m_state.vsConsts->iConsts;
-      copyArgs.constBoolApi = m_state.vsConsts->bConsts;
-    } else {
-      copyArgs.constFloatApi = m_state.psConsts->fConsts;
-      copyArgs.constIntApi = m_state.psConsts->iConsts;
-    }
 
-    layout->copyConstantData(copyArgs);
+      layout->copyConstantData(copyArgs);
+    }
 
     constants.dirty = false;
   }

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -5986,15 +5986,8 @@ namespace dxvk {
 
 
   void D3D9DeviceEx::CreateConstantBuffers() {
-    m_psStaticConstants = D3D9ConstantBuffer(this, D3D9ShaderResourceMapping::CbvIndex::PSStaticConstants);
-    m_vsStaticConstants = D3D9ConstantBuffer(this, D3D9ShaderResourceMapping::CbvIndex::VSStaticConstants);
-    m_vsDynamicConstants = D3D9ConstantBuffer(this, D3D9ShaderResourceMapping::CbvIndex::VSDynamicConstants);
-    m_vsClipPlanes = D3D9ConstantBuffer(this, D3D9ShaderResourceMapping::CbvIndex::VSClipPlanes);
-    m_vsFixedFunction = D3D9ConstantBuffer(this, D3D9ShaderResourceMapping::CbvIndex::VSFixedFunction);
-    m_psFixedFunction = D3D9ConstantBuffer(this, D3D9ShaderResourceMapping::CbvIndex::PSFixedFunction);
-    m_psShared = D3D9ConstantBuffer(this, D3D9ShaderResourceMapping::CbvIndex::PSShared);
-    m_vsVertexBlend = D3D9ConstantBuffer(this, D3D9ShaderResourceMapping::CbvIndex::VSVertexBlendData);
-    m_specBuffer = D3D9ConstantBuffer(this, D3D9ShaderResourceMapping::CbvIndex::SpecData);
+    for (uint32_t i = 0u; i < m_constantBuffers.size(); i++)
+      m_constantBuffers[i] = D3D9ConstantBuffer(this, D3D9ShaderResourceMapping::CbvIndex(i));
   }
 
 
@@ -6042,8 +6035,9 @@ namespace dxvk {
 
     if (staticSize) {
       // Allocate storage for statically indexed constants
-      auto& buffer = ShaderType == D3D9ShaderType::VertexShader
-        ? m_vsStaticConstants : m_psStaticConstants;
+      auto& buffer = GetConstantBuffer(ShaderType == D3D9ShaderType::VertexShader
+        ? CbvIndex::VSStaticConstants
+        : CbvIndex::PSStaticConstants);
       staticSize = align(staticSize, buffer.GetAlignment());
 
       auto staticData = buffer.Alloc(staticSize);
@@ -6067,9 +6061,10 @@ namespace dxvk {
     if (dynamicSize) {
       // Allocate storage for dynamically indexed floats. Pad this
       // to the full allocation size as well so we write everything.
-      dynamicSize = align(dynamicSize, m_vsDynamicConstants.GetAlignment());
+      auto& buffer = GetConstantBuffer(CbvIndex::VSDynamicConstants);
+      dynamicSize = align(dynamicSize, buffer.GetAlignment());
 
-      copyArgs.floatBuffer = m_vsDynamicConstants.Alloc(dynamicSize);
+      copyArgs.floatBuffer = buffer.Alloc(dynamicSize);
       copyArgs.floatBufferSize = dynamicSize;
     }
 
@@ -6091,7 +6086,7 @@ namespace dxvk {
   void D3D9DeviceEx::UpdateClipPlanes() {
     m_dirty.clr(D3D9DeviceDirtyFlag::ClipPlanes);
 
-    auto dst = m_vsClipPlanes.AllocTyped<D3D9ClipPlane>(caps::MaxClipPlanes);
+    auto dst = GetConstantBuffer(CbvIndex::VSClipPlanes).AllocTyped<D3D9ClipPlane>(caps::MaxClipPlanes);
 
     uint32_t clipPlaneCount = 0u;
     for (uint32_t i = 0; i < caps::MaxClipPlanes; i++) {
@@ -7642,7 +7637,7 @@ namespace dxvk {
     if (unlikely(m_dirty.test(D3D9DeviceDirtyFlag::SharedPixelShaderData))) {
       m_dirty.clr(D3D9DeviceDirtyFlag::SharedPixelShaderData);
 
-      auto data = m_psShared.AllocTyped<D3D9SharedPS>(1u);
+      auto data = GetConstantBuffer(CbvIndex::PSShared).AllocTyped<D3D9SharedPS>(1u);
 
       for (uint32_t i = 0; i < caps::TextureStageCount; i++) {
         DecodeD3DCOLOR(D3DCOLOR(m_state.textureStages[i][DXVK_TSS_CONSTANT]), data->Stages[i].Constant);
@@ -8342,7 +8337,7 @@ namespace dxvk {
       auto WorldView    = m_state.transforms[GetTransformIndex(D3DTS_VIEW)] * m_state.transforms[GetTransformIndex(D3DTS_WORLD)];
       auto NormalMatrix = inverse(WorldView);
 
-      auto data = m_vsFixedFunction.AllocTyped<D3D9FixedFunctionVS>(1u);
+      auto data = GetConstantBuffer(CbvIndex::VSFixedFunction).AllocTyped<D3D9FixedFunctionVS>(1u);
       data->WorldView    = WorldView;
       data->NormalMatrix = NormalMatrix;
       data->InverseView  = transpose(inverse(m_state.transforms[GetTransformIndex(D3DTS_VIEW)]));
@@ -8376,7 +8371,7 @@ namespace dxvk {
         ? D3D9MaxVertexBlendTransformsSw
         : D3D9MaxVertexBlendTransformsHw;
 
-      auto data = m_vsVertexBlend.AllocTyped<Matrix4>(matrixCount);
+      auto data = GetConstantBuffer(CbvIndex::VSVertexBlendData).AllocTyped<Matrix4>(matrixCount);
 
       for (uint32_t i = 0; i < matrixCount; i++) {
         data[i] = m_state.transforms[GetTransformIndex(D3DTS_VIEW)] *
@@ -8521,7 +8516,7 @@ namespace dxvk {
 
       auto& rs = m_state.renderStates;
 
-      auto data = m_psFixedFunction.AllocTyped<D3D9FixedFunctionPS>(1u);
+      auto data = GetConstantBuffer(CbvIndex::PSFixedFunction).AllocTyped<D3D9FixedFunctionPS>(1u);
       DecodeD3DCOLOR(D3DCOLOR(rs[D3DRS_TEXTUREFACTOR]), data->textureFactor.data);
       data->Key = key;
     }
@@ -9227,7 +9222,7 @@ namespace dxvk {
     // Write spec constants into buffer for fast-linked pipelines to use it.
     // TODO get rid of the fallback buffer and rework everything to use push
     // data instead.
-    auto mapPtr = m_specBuffer.Alloc(sizeof(m_specInfo.data));
+    auto mapPtr = GetConstantBuffer(CbvIndex::SpecData).Alloc(sizeof(m_specInfo.data));
     memcpy(mapPtr, m_specInfo.data.data(), sizeof(m_specInfo.data));
 
     m_dirty.clr(D3D9DeviceDirtyFlag::SpecializationEntries);

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -6114,8 +6114,7 @@ namespace dxvk {
   void D3D9DeviceEx::UpdateClipPlanes() {
     m_dirty.clr(D3D9DeviceDirtyFlag::ClipPlanes);
 
-    auto mapPtr = m_vsClipPlanes.AllocSlice();
-    auto dst = reinterpret_cast<D3D9ClipPlane*>(mapPtr);
+    auto dst = m_vsClipPlanes.AllocTyped<D3D9ClipPlane>(caps::MaxClipPlanes);
 
     uint32_t clipPlaneCount = 0u;
     for (uint32_t i = 0; i < caps::MaxClipPlanes; i++) {
@@ -7666,8 +7665,7 @@ namespace dxvk {
     if (unlikely(m_dirty.test(D3D9DeviceDirtyFlag::SharedPixelShaderData))) {
       m_dirty.clr(D3D9DeviceDirtyFlag::SharedPixelShaderData);
 
-      auto mapPtr = m_psShared.AllocSlice();
-      D3D9SharedPS* data = reinterpret_cast<D3D9SharedPS*>(mapPtr);
+      auto data = m_psShared.AllocTyped<D3D9SharedPS>(1u);
 
       for (uint32_t i = 0; i < caps::TextureStageCount; i++) {
         DecodeD3DCOLOR(D3DCOLOR(m_state.textureStages[i][DXVK_TSS_CONSTANT]), data->Stages[i].Constant);
@@ -8364,12 +8362,10 @@ namespace dxvk {
     if (m_dirty.test(D3D9DeviceDirtyFlag::FFVertexData)) {
       m_dirty.clr(D3D9DeviceDirtyFlag::FFVertexData);
 
-      auto mapPtr = m_vsFixedFunction.AllocSlice();
-
       auto WorldView    = m_state.transforms[GetTransformIndex(D3DTS_VIEW)] * m_state.transforms[GetTransformIndex(D3DTS_WORLD)];
       auto NormalMatrix = inverse(WorldView);
 
-      D3D9FixedFunctionVS* data = reinterpret_cast<D3D9FixedFunctionVS*>(mapPtr);
+      auto data = m_vsFixedFunction.AllocTyped<D3D9FixedFunctionVS>(1u);
       data->WorldView    = WorldView;
       data->NormalMatrix = NormalMatrix;
       data->InverseView  = transpose(inverse(m_state.transforms[GetTransformIndex(D3DTS_VIEW)]));
@@ -8399,15 +8395,16 @@ namespace dxvk {
     if (m_dirty.test(D3D9DeviceDirtyFlag::FFVertexBlend) && vertexBlendMode == D3D9FF_VertexBlendMode_Normal) {
       m_dirty.clr(D3D9DeviceDirtyFlag::FFVertexBlend);
 
-      auto mapPtr = m_vsVertexBlend.AllocSlice();
-      auto UploadVertexBlendData = [&](auto data) {
-        for (uint32_t i = 0; i < std::size(data->WorldView); i++)
-          data->WorldView[i] = m_state.transforms[GetTransformIndex(D3DTS_VIEW)] * m_state.transforms[GetTransformIndex(D3DTS_WORLDMATRIX(i))];
-      };
+      uint32_t matrixCount = m_isSWVP && indexedVertexBlend
+        ? D3D9MaxVertexBlendTransformsSw
+        : D3D9MaxVertexBlendTransformsHw;
 
-      (m_isSWVP && indexedVertexBlend)
-        ? UploadVertexBlendData(reinterpret_cast<D3D9FixedFunctionVertexBlendDataSW*>(mapPtr))
-        : UploadVertexBlendData(reinterpret_cast<D3D9FixedFunctionVertexBlendDataHW*>(mapPtr));
+      auto data = m_vsVertexBlend.AllocTyped<Matrix4>(matrixCount);
+
+      for (uint32_t i = 0; i < matrixCount; i++) {
+        data[i] = m_state.transforms[GetTransformIndex(D3DTS_VIEW)] *
+          m_state.transforms[GetTransformIndex(D3DTS_WORLDMATRIX(i))];
+      }
     }
   }
 
@@ -8545,11 +8542,10 @@ namespace dxvk {
     if (m_dirty.test(D3D9DeviceDirtyFlag::FFPixelData)) {
       m_dirty.clr(D3D9DeviceDirtyFlag::FFPixelData);
 
-      auto mapPtr = m_psFixedFunction.AllocSlice();
       auto& rs = m_state.renderStates;
 
-      D3D9FixedFunctionPS* data = reinterpret_cast<D3D9FixedFunctionPS*>(mapPtr);
-      DecodeD3DCOLOR((D3DCOLOR)rs[D3DRS_TEXTUREFACTOR], data->textureFactor.data);
+      auto data = m_psFixedFunction.AllocTyped<D3D9FixedFunctionPS>(1u);
+      DecodeD3DCOLOR(D3DCOLOR(rs[D3DRS_TEXTUREFACTOR]), data->textureFactor.data);
       data->Key = key;
     }
   }
@@ -9254,8 +9250,8 @@ namespace dxvk {
     // Write spec constants into buffer for fast-linked pipelines to use it.
     // TODO get rid of the fallback buffer and rework everything to use push
     // data instead.
-    auto mapPtr = m_specBuffer.AllocSlice();
-    memcpy(mapPtr, m_specInfo.data.data(), D3D9SpecializationInfo::UBOSize);
+    auto mapPtr = m_specBuffer.Alloc(sizeof(m_specInfo.data));
+    memcpy(mapPtr, m_specInfo.data.data(), sizeof(m_specInfo.data));
 
     m_dirty.clr(D3D9DeviceDirtyFlag::SpecializationEntries);
   }

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -5891,6 +5891,11 @@ namespace dxvk {
     // can processe them before the first use.
     m_initializer->FlushCsChunk();
 
+    // Constant buffers may hold a pointer into the current chunk,
+    // reset that here so the data won't get overwritten.
+    for (auto& cbv : m_constantBuffers)
+      cbv.ResetStreamCommand();
+
     m_csSeqNum = m_csThread.dispatchChunk(std::move(chunk));
   }
 

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -225,6 +225,8 @@ namespace dxvk {
     friend class D3D9UserDefinedAnnotation;
     friend class DxvkD3D8Bridge;
     friend D3D9VkInteropDevice;
+
+    using CbvIndex = D3D9ShaderResourceMapping::CbvIndex;
   public:
 
     D3D9DeviceEx(
@@ -1551,6 +1553,10 @@ namespace dxvk {
         : FixedFunctionMask;
     }
 
+    D3D9ConstantBuffer& GetConstantBuffer(CbvIndex Index) {
+      return m_constantBuffers[uint32_t(Index)];
+    }
+
     GpuFlushType GetMaxFlushType() const;
 
     bool ValidateSharedTexture(
@@ -1594,17 +1600,7 @@ namespace dxvk {
 
     Rc<D3D9ShaderModuleSet>         m_shaderModules;
 
-    D3D9ConstantBuffer              m_vsClipPlanes;
-
-    D3D9ConstantBuffer              m_psStaticConstants;
-    D3D9ConstantBuffer              m_vsStaticConstants;
-    D3D9ConstantBuffer              m_vsDynamicConstants;
-
-    D3D9ConstantBuffer              m_vsFixedFunction;
-    D3D9ConstantBuffer              m_vsVertexBlend;
-    D3D9ConstantBuffer              m_psFixedFunction;
-    D3D9ConstantBuffer              m_psShared;
-    D3D9ConstantBuffer              m_specBuffer;
+    std::array<D3D9ConstantBuffer, CbvIndex::Count> m_constantBuffers;
 
     Rc<DxvkBuffer>                  m_upBuffer;
     VkDeviceSize                    m_upBufferOffset  = 0ull;

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -1278,6 +1278,25 @@ namespace dxvk {
       }
     }
 
+    template<typename M, bool AllowFlush = true, typename Cmd>
+    M* EmitCsCmd(size_t count, Cmd&& command) {
+      auto csData = m_csChunk->pushCmd<M, Cmd>(command, count);
+
+      if (unlikely(!csData)) {
+        EmitCsChunk(std::move(m_csChunk));
+        m_csChunk = AllocCsChunk();
+
+        if constexpr (AllowFlush)
+          ConsiderFlush(GpuFlushType::ImplicitWeakHint);
+
+        // We must record this command after the potential
+        // flush since the caller may still access the data
+        csData = m_csChunk->pushCmd<M, Cmd>(command, count);
+      }
+
+      return reinterpret_cast<M*>(csData->first());
+    }
+
     void EmitCsChunk(DxvkCsChunkRef&& chunk);
 
     void FlushCsChunk() {

--- a/src/d3d9/d3d9_options.cpp
+++ b/src/d3d9/d3d9_options.cpp
@@ -64,7 +64,7 @@ namespace dxvk {
     this->allowDiscard                  = config.getOption<bool>        ("d3d9.allowDiscard",                  true);
     this->enumerateByDisplays           = config.getOption<bool>        ("d3d9.enumerateByDisplays",           true);
     this->cachedWriteOnlyBuffers        = config.getOption<bool>        ("d3d9.cachedWriteOnlyBuffers",          false);
-    this->deviceLocalConstantBuffers    = config.getOption<bool>        ("d3d9.deviceLocalConstantBuffers",    false);
+    this->deviceLocalConstantBuffers    = config.getOption<Tristate>    ("d3d9.deviceLocalConstantBuffers",    Tristate::Auto);
     this->allowDirectBufferMapping      = config.getOption<bool>        ("d3d9.allowDirectBufferMapping",      true);
     this->forceDrawTimeBufferUpload     = config.getOption<bool>        ("d3d9.forceDrawTimeBufferUpload",     false);
     this->seamlessCubes                 = config.getOption<bool>        ("d3d9.seamlessCubes",                 false);

--- a/src/d3d9/d3d9_options.h
+++ b/src/d3d9/d3d9_options.h
@@ -123,7 +123,7 @@ namespace dxvk {
     bool cachedWriteOnlyBuffers;
 
     /// Use device local memory for constant buffers.
-    bool deviceLocalConstantBuffers;
+    Tristate deviceLocalConstantBuffers;
 
     /// Disable direct buffer mapping
     bool allowDirectBufferMapping;

--- a/src/d3d9/d3d9_shader.h
+++ b/src/d3d9/d3d9_shader.h
@@ -61,6 +61,8 @@ namespace dxvk {
       PSShared                = 12u,
       PSStaticConstants       = 13u,
       SpecData                = 20u,
+
+      Count
     };
 
     static constexpr uint32_t computeTextureBinding(D3D9ShaderType shaderType, uint32_t index) {

--- a/src/d3d9/d3d9_spec_constants.h
+++ b/src/d3d9/d3d9_spec_constants.h
@@ -135,8 +135,6 @@ namespace dxvk {
     // Spec const word 0 determines whether the other spec constants are used rather than the spec const UBO
     static constexpr uint32_t MaxSpecDwords = 17;
 
-    static constexpr size_t UBOSize = MaxSpecDwords * sizeof(uint32_t);
-
     static constexpr std::array<BitfieldPosition, SpecConstantCount> Layout{{
       { 0, 0, 32 },  // SamplerType
 

--- a/src/d3d9/d3d9_state.h
+++ b/src/d3d9/d3d9_state.h
@@ -186,16 +186,8 @@ namespace dxvk {
     D3D9FFShaderKeyVSData Key;
   };
 
-
-  struct D3D9FixedFunctionVertexBlendDataHW {
-    Matrix4 WorldView[8];
-  };
-
-
-  struct D3D9FixedFunctionVertexBlendDataSW {
-    Matrix4 WorldView[256];
-  };
-
+  static constexpr uint32_t D3D9MaxVertexBlendTransformsHw = 8u;
+  static constexpr uint32_t D3D9MaxVertexBlendTransformsSw = 256u;
 
   struct D3D9FFShaderStage {
     union {

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -2607,10 +2607,12 @@ namespace dxvk {
   
   void DxvkContext::uploadBuffer(
     const Rc<DxvkBuffer>&           buffer,
+          VkDeviceSize              bufferOffset,
     const Rc<DxvkBuffer>&           source,
-          VkDeviceSize              sourceOffset) {
-    auto bufferSlice = buffer->getSliceInfo();
-    auto sourceSlice = source->getSliceInfo(sourceOffset, buffer->info().size);
+          VkDeviceSize              sourceOffset,
+          VkDeviceSize              size) {
+    auto bufferSlice = buffer->getSliceInfo(bufferOffset, size);
+    auto sourceSlice = source->getSliceInfo(sourceOffset, size);
 
     VkBufferCopy2 copyRegion = { VK_STRUCTURE_TYPE_BUFFER_COPY_2 };
     copyRegion.srcOffset = sourceSlice.offset;

--- a/src/dxvk/dxvk_context.h
+++ b/src/dxvk/dxvk_context.h
@@ -1024,16 +1024,20 @@ namespace dxvk {
     /**
      * \brief Uses transfer queue to initialize buffer
      *
-     * Always replaces the entire buffer. Only safe to use
-     * if the buffer is currently not in use by the GPU.
+     * Must only be use if the given buffer region is
+     * not currently in use by the GPU.
      * \param [in] buffer The buffer to initialize
+     * \param [in] bufferOffset Buffer offset
      * \param [in] source Staging buffer containing data
      * \param [in] sourceOffset Offset into staging buffer
+     * \param [in] size Number of bytes to copy
      */
     void uploadBuffer(
       const Rc<DxvkBuffer>&           buffer,
+            VkDeviceSize              bufferOffset,
       const Rc<DxvkBuffer>&           source,
-            VkDeviceSize              sourceOffset);
+            VkDeviceSize              sourceOffset,
+            VkDeviceSize              size);
     
     /**
      * \brief Uses transfer queue to initialize image


### PR DESCRIPTION
Based on #5686, hence the draft.

The TL;DR here is that instead of reading constant buffers directly from system memory, we instead create one system memory buffer and one `DEVICE_LOCAL` buffer and essentially stream all constant data into VRAM using the transfer queue. This gives me a small (~3%) improvement in Witcher 2 when GPU-bound, and is certainly better than tanking CPU-bound perf by 20% when writing directly into HVV.

Of course, this is only done on discrete GPUs, no point on doing extra copies on integrated.

The fixed-function constant buffers etc are also allocated in `CACHED` memory now because the write patterns suck.