### PR TITLE
[d3d11] Include all planes in subresource layout DepthPitch calculation.

### DIFF
--- a/src/d3d11/d3d11_texture.cpp
+++ b/src/d3d11/d3d11_texture.cpp
@@ -712,10 +712,11 @@ namespace dxvk {
 
         auto blockCount = util::computeBlockCount(extent, formatInfo->blockSize);
 
-        if (!result.RowPitch) {
-          result.RowPitch   = elementSize * blockCount.width;
-          result.DepthPitch = elementSize * blockCount.width * blockCount.height;
-        }
+        if (!result.RowPitch)
+          result.RowPitch = elementSize * blockCount.width;
+
+        if (!result.DepthPitch || formatInfo->flags.test(DxvkFormatFlag::MultiPlane))
+          result.DepthPitch += elementSize * blockCount.width * blockCount.height;
 
         VkDeviceSize size = elementSize * blockCount.width * blockCount.height * blockCount.depth;
 


### PR DESCRIPTION
Fixes a failure in Wine `mfplat` where `dxgi_surface_buffer_lock()` returns the incorrect buffer size because it uses `DepthPitch`.