### PR TITLE
[d3d9] Consolidate SWVP HUD

### DIFF
--- a/src/d3d9/d3d9_hud.cpp
+++ b/src/d3d9/d3d9_hud.cpp
@@ -47,38 +47,16 @@ namespace dxvk::hud {
     return position;
   }
 
-  HudSWVPShaders::HudSWVPShaders(D3D9DeviceEx* device)
-  : m_device        (device)
-  , m_swvpShaderCount ("") {}
-
-
-  void HudSWVPShaders::update(dxvk::high_resolution_clock::time_point time) {
-    m_swvpShaderCount = str::format(m_device->GetSWVPShaderCount());
-  }
-
-
-  HudPos HudSWVPShaders::render(
-    const Rc<DxvkCommandList>&ctx,
-    const HudPipelineKey&     key,
-    const HudOptions&         options,
-          HudRenderer&        renderer,
-          HudPos              position) {
-    position.y += 16;
-    renderer.drawText(16, position, 0xffc0ff00u, "SWVP Shaders:");
-    renderer.drawText(16, { position.x + 180, position.y }, 0xffffffffu, m_swvpShaderCount);
-
-    position.y += 8;
-    return position;
-  }
-
 
   HudSWVPState::HudSWVPState(D3D9DeviceEx* device)
-          : m_device          (device)
-          , m_isSWVPText ("") {}
+  : m_device(device)  {
 
+  }
 
 
   void HudSWVPState::update(dxvk::high_resolution_clock::time_point time) {
+    m_swvpShaderCount = str::format(m_device->GetSWVPShaderCount());
+
     if (m_device->IsSWVP()) {
       if (m_device->CanOnlySWVP()) {
         m_isSWVPText = "SWVP";
@@ -104,6 +82,10 @@ namespace dxvk::hud {
     position.y += 16;
     renderer.drawText(16, position, 0xffc0ff00u, "Vertex Processing:");
     renderer.drawText(16, { position.x + 240, position.y }, 0xffffffffu, m_isSWVPText);
+
+    position.y += 20;
+    renderer.drawText(16, position, 0xffc0ff00u, "SWVP Shaders:");
+    renderer.drawText(16, { position.x + 168, position.y }, 0xffffffffu, m_swvpShaderCount);
 
     position.y += 8;
     return position;

--- a/src/d3d9/d3d9_hud.h
+++ b/src/d3d9/d3d9_hud.h
@@ -43,33 +43,6 @@ namespace dxvk::hud {
   /**
    * \brief HUD item to display amount of generated SWVP shaders
    */
-  class HudSWVPShaders : public HudItem {
-
-  public:
-
-    HudSWVPShaders(D3D9DeviceEx* device);
-
-    void update(dxvk::high_resolution_clock::time_point time);
-
-    HudPos render(
-      const Rc<DxvkCommandList>&ctx,
-      const HudPipelineKey&     key,
-      const HudOptions&         options,
-            HudRenderer&        renderer,
-            HudPos              position);
-
-  private:
-
-    D3D9DeviceEx* m_device;
-
-    std::string m_swvpShaderCount;
-
-  };
-
-
-  /**
-   * \brief HUD item to whether or not we're in SWVP mode
-   */
   class HudSWVPState : public HudItem {
 
   public:
@@ -90,6 +63,7 @@ namespace dxvk::hud {
     D3D9DeviceEx* m_device;
 
     std::string m_isSWVPText;
+    std::string m_swvpShaderCount;
 
   };
 

--- a/src/d3d9/d3d9_swapchain.cpp
+++ b/src/d3d9/d3d9_swapchain.cpp
@@ -1084,7 +1084,6 @@ namespace dxvk {
       if (m_latencyTracking)
         m_latencyHud = hud->addItem<hud::HudLatencyItem>("latency", 4);
 
-      hud->addItem<hud::HudSWVPShaders>("swvp", -1, m_parent);
       hud->addItem<hud::HudSWVPState>("swvp", -1, m_parent);
 
 #ifdef D3D9_ALLOW_UNMAPPING


### PR DESCRIPTION
Don't really need two classes to display related stuff under the same `DXVK_HUD` item.