### PR TITLE
D3D9: Move image view type mismatch handling to the backend

### DIFF
--- a/src/d3d9/d3d9_common_texture.cpp
+++ b/src/d3d9/d3d9_common_texture.cpp
@@ -717,6 +717,7 @@ namespace dxvk {
     viewInfo.aspects   = lookupFormatInfo(viewInfo.format)->aspectMask;
     viewInfo.usage     = UsageFlags;
     viewInfo.viewType  = GetImageViewTypeFromResourceType(m_type, Layer);
+    viewInfo.allowTypeMismatch = !(UsageFlags & VK_IMAGE_USAGE_SAMPLED_BIT);
     viewInfo.mipIndex  = Lod;
     viewInfo.mipCount  = m_desc.MipLevels - Lod;
     viewInfo.layerIndex = Layer == AllLayers ? 0 : Layer;

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -3619,8 +3619,6 @@ namespace dxvk {
 
     if (usesProgrammableVS) {
       BindShader<D3D9ShaderType::VertexShader>(GetCommonShader(shader));
-
-      UpdateTextureTypeMismatchesForShader(newShader, VSShaderMasks().samplerMask, FirstVSSamplerSlot);
     } else if (wasUsingProgrammableVS) {
       m_dirty.set(D3D9DeviceDirtyFlag::FFVertexShader);
       BindFFUbershader<D3D9ShaderType::VertexShader>();
@@ -3973,8 +3971,6 @@ namespace dxvk {
     if (shader != nullptr) {
       BindShader<D3D9ShaderType::PixelShader>(newShader);
 
-      UpdateTextureTypeMismatchesForShader(newShader, newShaderMasks.samplerMask, 0);
-
       bool dirty = m_specInfo.set<D3D9SpecConstantId::SpecFFLastActiveTextureStage>(0u);
       constexpr uint32_t perTextureStageSpecConsts = static_cast<uint32_t>(D3D9SpecConstantId::SpecFFTextureStage1ColorOp) - static_cast<uint32_t>(D3D9SpecConstantId::SpecFFTextureStage0ColorOp);
       for (uint32_t i = 0; i < caps::TextureStageCount; i++) {
@@ -3996,12 +3992,6 @@ namespace dxvk {
     else {
       m_dirty.set(D3D9DeviceDirtyFlag::FFPixelShader);
       BindFFUbershader<D3D9ShaderType::PixelShader>();
-
-      // TODO: What fixed function textures are in use?
-      // Currently we are making all 8 of them as in use here.
-      // Fixed function always uses spec constants to decide the texture type.
-      m_textureSlotTracking.textureDirty |= newShaderMasks.samplerMask & m_textureSlotTracking.mismatchingTextureType;
-      m_textureSlotTracking.mismatchingTextureType &= ~newShaderMasks.samplerMask;
     }
 
     // Check whether the color output mask or the mask of the used samplers
@@ -6424,7 +6414,6 @@ namespace dxvk {
     m_textureSlotTracking.bound                  &= ~bit;
     m_textureSlotTracking.needsUpload            &= ~bit;
     m_textureSlotTracking.needsMipGen            &= ~bit;
-    m_textureSlotTracking.mismatchingTextureType &= ~bit;
 
     auto tex = GetCommonTexture(m_state.textures[index]);
 
@@ -6473,8 +6462,6 @@ namespace dxvk {
 
       if (unlikely(m_textureSlotTracking.fetch4SamplerState & bit))
         UpdateActiveFetch4(index);
-
-      UpdateTextureTypeMismatchesForTexture(index);
     } else {
       if (unlikely(m_textureSlotTracking.fetch4 & bit))
         UpdateActiveFetch4(index);
@@ -6704,72 +6691,6 @@ namespace dxvk {
       UploadManagedTexture(GetCommonTexture(m_state.textures[texIdx]));
 
     m_textureSlotTracking.needsUpload &= ~mask;
-  }
-
-
-  void D3D9DeviceEx::UpdateTextureTypeMismatchesForShader(const D3D9CommonShader* shader, uint32_t shaderSamplerMask, uint32_t shaderSamplerOffset) {
-    const uint32_t stageCorrectedShaderSamplerMask = shaderSamplerMask << shaderSamplerOffset;
-    if (unlikely(shader->GetInfo().getVersion().first < 2 || m_d3d9Options.forceSamplerTypeSpecConstants)) {
-      // SM 1 shaders don't define the texture type in the shader.
-      // We always use spec constants for those.
-      m_textureSlotTracking.textureDirty |= stageCorrectedShaderSamplerMask & m_textureSlotTracking.mismatchingTextureType;
-      m_textureSlotTracking.mismatchingTextureType &= ~stageCorrectedShaderSamplerMask;
-      return;
-    }
-
-    for (const uint32_t i : bit::BitMask(stageCorrectedShaderSamplerMask)) {
-      const D3D9CommonTexture* texture = GetCommonTexture(m_state.textures[i]);
-      if (unlikely(texture == nullptr)) {
-        // Unbound textures are not mismatching texture types
-        m_textureSlotTracking.textureDirty |= m_textureSlotTracking.mismatchingTextureType & (1 << i);
-        m_textureSlotTracking.mismatchingTextureType &= ~(1 << i);
-        continue;
-      }
-
-      VkImageViewType boundViewType  = D3D9CommonTexture::GetImageViewTypeFromResourceType(texture->GetType(), D3D9CommonTexture::AllLayers);
-      VkImageViewType shaderViewType = shader->GetImageViewType(i - shaderSamplerOffset);
-      if (unlikely(boundViewType != shaderViewType)) {
-        m_textureSlotTracking.textureDirty |= 1 << i;
-        m_textureSlotTracking.mismatchingTextureType |= 1 << i;
-      } else {
-        // The texture type is no longer mismatching, make sure we bind the texture now.
-        m_textureSlotTracking.textureDirty |= m_textureSlotTracking.mismatchingTextureType & (1 << i);
-        m_textureSlotTracking.mismatchingTextureType &= ~(1 << i);
-      }
-    }
-  }
-
-
-  void D3D9DeviceEx::UpdateTextureTypeMismatchesForTexture(uint32_t stateSampler) {
-    uint32_t shaderTextureIndex;
-    const D3D9CommonShader* shader;
-    if (likely(IsPSSampler(stateSampler))) {
-      shader = GetCommonShader(m_state.pixelShader);
-      shaderTextureIndex = stateSampler;
-    } else if (unlikely(IsVSSampler(stateSampler))) {
-      shader = GetCommonShader(m_state.vertexShader);
-      shaderTextureIndex = stateSampler - caps::MaxTexturesPS - 1;
-    } else {
-      // Do not type check the fixed function displacement map texture.
-      return;
-    }
-
-    if (unlikely(shader == nullptr || shader->GetInfo().getVersion().first < 2 || m_d3d9Options.forceSamplerTypeSpecConstants)) {
-      // This function only gets called by UpdateTextureBitmasks
-      // which clears the dirty and mismatching bits for the texture before anyway.
-      return;
-    }
-
-    const D3D9CommonTexture* tex = GetCommonTexture(m_state.textures[stateSampler]);
-    VkImageViewType boundViewType  = D3D9CommonTexture::GetImageViewTypeFromResourceType(tex->GetType(), D3D9CommonTexture::AllLayers);
-    VkImageViewType shaderViewType = shader->GetImageViewType(shaderTextureIndex);
-    // D3D9 does not have 1D textures. The value of VIEW_TYPE_1D is 0
-    // which is the default when there is no declaration for the type.
-    bool shaderUsesTexture = shaderViewType != VkImageViewType(0);
-    if (unlikely(boundViewType != shaderViewType && shaderUsesTexture)) {
-      const uint32_t samplerBit = 1u << stateSampler;
-      m_textureSlotTracking.mismatchingTextureType |= samplerBit;
-    }
   }
 
 
@@ -7586,8 +7507,8 @@ namespace dxvk {
 
 
   void D3D9DeviceEx::UndirtyTextures(uint32_t usedMask) {
-    const uint32_t activeMask   = usedMask &  (m_textureSlotTracking.bound & ~m_textureSlotTracking.mismatchingTextureType);
-    const uint32_t inactiveMask = usedMask & (~m_textureSlotTracking.bound | m_textureSlotTracking.mismatchingTextureType);
+    const uint32_t activeMask   = usedMask & m_textureSlotTracking.bound;
+    const uint32_t inactiveMask = usedMask & ~m_textureSlotTracking.bound;
 
     for (uint32_t i : bit::BitMask(activeMask))
       BindTexture(i);

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -124,9 +124,6 @@ namespace dxvk {
      * There's 3 texture types, so every texture/sampler slot uses 2 bits. */
     uint32_t textureType = 0;
 
-    /** Whether the type of the texture currently bound to each slot matches the texture type that the shader expects */
-    uint32_t mismatchingTextureType = 0;
-
     /** Whether projected texture lookup is enabled for each texture/sampler slot. This is only used for generating fixed function shaders. */
     uint32_t projected = 0;
 
@@ -937,42 +934,6 @@ namespace dxvk {
     void EmitFeedbackLoopBarriers();
 
     void UpdateActiveFetch4(uint32_t stateSampler);
-
-    /**
-     * @brief Sets the mismatching texture type bits for all samplers if necessary.
-     *
-     * This function will check all samplers the shader uses and set the  set the mismatching texture type bit for the given sampler if it does not
-     * match the texture type expected by the respective shader.
-     *
-     * It will *not* unset the bit if the texture type does match.
-     *
-     * @param stateSampler Sampler index (according to our internal way of storing samplers)
-     */
-
-     /**
-      * @brief Sets the mismatching texture type bits for all samplers if necessary.
-      *
-      * This function will check all samplers the shader uses and set the  set the mismatching texture type bit for the given sampler if it does not
-      * match the texture type expected by the shader.
-      *
-      * @param shader The shader
-      * @param shaderSamplerMask Mask of all samplers that the shader uses (according to our internal way of storing samplers)
-      * @param shaderSamplerOffset First index of the shader's samplers according to our internal way of storing samplers.
-      *                            Used to transform the sampler indices that are relative to the entire pipeline to ones relative to the shader.
-      */
-    void UpdateTextureTypeMismatchesForShader(const D3D9CommonShader* shader, uint32_t shaderSamplerMask, uint32_t shaderSamplerOffset);
-
-    /**
-     * @brief Sets the mismatching texture type bit for the given sampler.
-     *
-     * This function will set the mismatching texture type bit for the given sampler if it does not
-     * match the texture type expected by the respective shader.
-     *
-     * It will *not* unset the bit if the texture type does match.
-     *
-     * @param stateSampler Sampler index (according to our internal way of storing samplers)
-     */
-    void UpdateTextureTypeMismatchesForTexture(uint32_t stateSampler);
 
     void UploadManagedTexture(D3D9CommonTexture* pResource);
 

--- a/src/d3d9/d3d9_shader.h
+++ b/src/d3d9/d3d9_shader.h
@@ -135,8 +135,6 @@ namespace dxvk {
 
     dxbc_spv::sm3::ShaderInfo GetInfo() const { return m_analysis.GetShaderInfo(); }
 
-    VkImageViewType GetImageViewType(uint32_t samplerSlot) const { return m_analysis.GetImageViewType(samplerSlot); }
-
   private:
 
     D3D9ShaderAnalysis    m_analysis;

--- a/src/dxvk/dxvk_image.cpp
+++ b/src/dxvk/dxvk_image.cpp
@@ -719,11 +719,17 @@ namespace dxvk {
       VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT |
       VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT;
 
+    // If we're not allowed to reinterpret the view type, behave
+    // as-if no resource was bound at all
+    if (!m_key.allowTypeMismatch && type != m_key.viewType)
+      return nullptr;
+
     // Legalize view usage. We allow creating transfer-only view
     // objects so that some internal APIs can be more consistent.
     DxvkImageViewKey key = m_key;
     key.viewType = type;
     key.layout = getLayout();
+    key.allowTypeMismatch = VK_FALSE;
 
     if (!(key.usage & ViewUsage))
       return nullptr;

--- a/src/dxvk/dxvk_image.h
+++ b/src/dxvk/dxvk_image.h
@@ -323,6 +323,7 @@ namespace dxvk {
     DxvkImageViewKey        m_key       = { };
 
     uint32_t                m_version   = 0u;
+    uint32_t                m_types     = 0u;
 
     DxvkImageViewImageProperties m_properties = { };
 

--- a/src/dxvk/dxvk_memory.h
+++ b/src/dxvk/dxvk_memory.h
@@ -341,6 +341,9 @@ namespace dxvk {
     VkImageLayout layout = VK_IMAGE_LAYOUT_UNDEFINED;
     /// Aspect flags to include in this view
     VkImageAspectFlags aspects = 0u;
+    /// If true, allow reinterpreting the view type, otherwise
+    /// bind a null descriptor if the type does not match.
+    VkBool32 allowTypeMismatch = VK_TRUE;
     /// First mip
     uint8_t mipIndex = 0u;
     /// Number of mips
@@ -359,6 +362,7 @@ namespace dxvk {
       hash.add(uint32_t(format));
       hash.add(uint32_t(layout));
       hash.add(uint32_t(aspects));
+      hash.add(uint32_t(allowTypeMismatch));
       hash.add(uint32_t(mipIndex) | (uint32_t(mipCount) << 16));
       hash.add(uint32_t(layerIndex) | (uint32_t(layerCount) << 16));
       hash.add(uint32_t(packedSwizzle));
@@ -371,6 +375,7 @@ namespace dxvk {
           && format == other.format
           && layout == other.layout
           && aspects == other.aspects
+          && allowTypeMismatch == other.allowTypeMismatch
           && mipIndex == other.mipIndex
           && mipCount == other.mipCount
           && layerIndex == other.layerIndex


### PR DESCRIPTION
Ever since 2.7 we've had a fairly clean and simple path to supporting this by simply returning a null descriptor for incorrect view types, so we might as well do that and get rid of some bitmask tracking jank.

@K0bin please let me know if I missed anything here or if that's really just it™. I'm a bit unsure about the line 4003 change since I don't really know how all that texture binding stuff works, but I assume that we can generally just bind everything all the time now.

Render targets seem fairly uninteresting here since it's all gonna be 2D anyway.