### PR TITLE
Misc stuff

### DIFF
--- a/dxvk.conf
+++ b/dxvk.conf
@@ -70,6 +70,7 @@
 
 # dxgi.maxFrameLatency = 0
 # d3d9.maxFrameLatency = 0
+# dxvk.maxFrameLatency = 0
 
 
 # Enables frame rate limiter. The main purpose of this is to work around

--- a/src/d3d9/d3d9_options.cpp
+++ b/src/d3d9/d3d9_options.cpp
@@ -42,7 +42,8 @@ namespace dxvk {
     this->hideAmdGpu                    = config.getOption<Tristate>    ("d3d9.hideAmdGpu",                    Tristate::Auto) == Tristate::True;
     this->hideIntelGpu                  = config.getOption<Tristate>    ("d3d9.hideIntelGpu",                  Tristate::True) == Tristate::True;
     this->maxFrameLatency               = config.getOption<int32_t>     ("d3d9.maxFrameLatency",               0);
-    this->maxFrameRate                  = config.getOption<int32_t>     ("d3d9.maxFrameRate",                  0);
+    this->maxFrameRate                  = config.getOption<int32_t>     ("dxvk.maxFrameRate",
+                                          config.getOption<int32_t>     ("d3d9.maxFrameRate",                  0));
     this->presentInterval               = config.getOption<int32_t>     ("d3d9.presentInterval",               -1);
     this->shaderModel                   = config.getOption<int32_t>     ("d3d9.shaderModel",                   3u);
     this->dpiAware                      = config.getOption<bool>        ("d3d9.dpiAware",                      true);
@@ -77,10 +78,10 @@ namespace dxvk {
     this->extraFrontbuffer              = config.getOption<bool>        ("d3d9.extraFrontbuffer",              false);
 
     // D3D8 options
-    this->drefScaling                   = config.getOption<int32_t>     ("d3d8.scaleDref",                     0);
+    this->drefScaling = config.getOption<int32_t>("d3d8.scaleDref", 0);
 
     // Clamp the shader model value between 0 and 3
-    this->shaderModel    = dxvk::clamp(this->shaderModel, 0u, 3u);
+    this->shaderModel = dxvk::clamp(this->shaderModel, 0u, 3u);
     // Clamp LOD bias so that people don't abuse this in unintended ways
     this->samplerLodBias = dxvk::fclamp(this->samplerLodBias, -2.0f, 1.0f);
 

--- a/src/dxgi/dxgi_options.cpp
+++ b/src/dxgi/dxgi_options.cpp
@@ -90,7 +90,8 @@ namespace dxvk {
     this->maxDeviceMemory = VkDeviceSize(config.getOption<int32_t>("dxgi.maxDeviceMemory", 0)) << 20;
     this->maxSharedMemory = VkDeviceSize(config.getOption<int32_t>("dxgi.maxSharedMemory", 0)) << 20;
 
-    this->maxFrameRate     = config.getOption<int32_t>("dxgi.maxFrameRate", 0);
+    this->maxFrameRate     = config.getOption<int32_t>("dxvk.maxFrameRate",
+                             config.getOption<int32_t>("dxgi.maxFrameRate", 0));
     this->syncInterval     = config.getOption<int32_t>("dxgi.syncInterval", -1);
     this->forceRefreshRate = config.getOption<int32_t>("dxgi.forceRefreshRate", 0u);
 

--- a/src/dxvk/dxvk_shader_cache.cpp
+++ b/src/dxvk/dxvk_shader_cache.cpp
@@ -227,6 +227,21 @@ namespace dxvk {
       m_lut.insert_or_assign(k, e);
     }
 
+    auto cacheSize = m_binFile.size();;
+
+    std::stringstream message;
+    message << "Cache: " << m_lut.size() << " shaders (";
+
+    if (cacheSize >= (1ull << 20)) {
+      auto mib = (10ull * cacheSize) >> 20;
+      message << (mib / 10ull) << "." << (mib % 10ull) << " MB";
+    } else {
+      message << (cacheSize >> 10u) << " kB";
+    }
+
+    message << ")";
+
+    Logger::info(message.str());
     return true;
   }
 


### PR DESCRIPTION
Adds a `dxvk.maxFrameRate` option that takes precedence over the two API-specific variants (and thus, app profiles). Supersedes #5611.

Also shows the current size of the shader cache on startup.