### PR TITLE
Optimize D3D9 input layout binding

### DIFF
--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -7732,23 +7732,22 @@ namespace dxvk {
         cStreamsInstanced = m_vbSlotTracking.instanced,
         cStreamFreq       = streamFreq
       ] (DxvkContext* ctx) {
-        cIaState.streamsInstanced = cStreamsInstanced;
-        cIaState.streamsUsed      = 0;
-
         const auto& elements = cVertexDecl->GetElements();
 
-        std::array<DxvkVertexInput, 2 * caps::InputRegisterCount> attrList = { };
-        std::array<DxvkVertexInput, 2 * caps::InputRegisterCount> bindList = { };
-        std::array<uint32_t, 2 * caps::InputRegisterCount> vertexSizes = { };
+        // Fixed-function can have a lot of attributes...
+        std::array<DxvkVertexInput, caps::InputRegisterCount * 2u> attrList;
+        std::array<DxvkVertexInput, caps::MaxStreams + 1u> bindList;
+        std::array<uint16_t,        caps::MaxStreams + 1u> vertexSizes = { };
 
-        uint32_t attrMask = 0;
         uint32_t bindMask = 0;
 
         const auto& isgn = cVertexShader != nullptr
           ? GetCommonShader(cVertexShader)->GetInputSignature()
           : GetFixedFunctionIsgn();
 
-        for (uint32_t i = 0; i < isgn.size(); i++) {
+        uint32_t attrCount = isgn.size();
+
+        for (uint32_t i = 0; i < attrCount; i++) {
           const auto& shaderElementSemantic = isgn[i];
 
           DxvkVertexAttribute attrib = { };
@@ -7758,7 +7757,10 @@ namespace dxvk {
           attrib.offset   = 0;
 
           for (const auto& element : elements) {
-            dxbc_spv::sm3::Semantic elementSemantic = { static_cast<dxbc_spv::sm3::SemanticUsage>(element.Usage), element.UsageIndex };
+            dxbc_spv::sm3::Semantic elementSemantic = {};
+            elementSemantic.usage = dxbc_spv::sm3::SemanticUsage(element.Usage);
+            elementSemantic.index = element.UsageIndex;
+
             if (elementSemantic.usage == dxbc_spv::sm3::SemanticUsage::ePositionT)
               elementSemantic.usage = dxbc_spv::sm3::SemanticUsage::ePosition;
 
@@ -7767,7 +7769,7 @@ namespace dxvk {
               attrib.format  = DecodeDecltype(D3DDECLTYPE(element.Type));
               attrib.offset  = element.Offset;
 
-              cIaState.streamsUsed |= 1u << attrib.binding;
+              bindMask |= 1u << attrib.binding;
               break;
             }
           }
@@ -7775,37 +7777,45 @@ namespace dxvk {
           attrList[i] = DxvkVertexInput(attrib);
 
           vertexSizes[attrib.binding] = std::max(vertexSizes[attrib.binding],
-            uint32_t(attrib.offset + lookupFormatInfo(attrib.format)->elementSize));
-
-          DxvkVertexBinding binding = { };
-          binding.binding = attrib.binding;
-          binding.extent = vertexSizes[attrib.binding];
-
-          uint32_t instanceData = cStreamFreq[binding.binding % caps::MaxStreams];
-
-          if (instanceData & D3DSTREAMSOURCE_INSTANCEDATA) {
-            binding.divisor = instanceData & 0x7FFFFF; // Remove instance packed-in flags in the data.
-            binding.inputRate = VK_VERTEX_INPUT_RATE_INSTANCE;
-          }
-          else {
-            binding.divisor = 0u;
-            binding.inputRate = VK_VERTEX_INPUT_RATE_VERTEX;
-          }
-
-          bindList[binding.binding] = DxvkVertexInput(binding);
-
-          attrMask |= 1u << i;
-          bindMask |= 1u << binding.binding;
+            uint16_t(attrib.offset + lookupFormatInfo(attrib.format)->elementSize));
         }
 
-        // Compact the attribute and binding lists to filter
-        // out attributes and bindings not used by the shader
-        uint32_t attrCount = CompactSparseList(attrList.data(), attrMask);
-        uint32_t bindCount = CompactSparseList(bindList.data(), bindMask);
+        // Set up compacted bindings for all streams referenced by the
+        // attributes, including a dummy null binding if necessary.
+        uint32_t bindCount = 0u;
+
+        for (auto i : bit::BitMask(bindMask)) {
+          DxvkVertexBinding binding = { };
+          binding.binding = i;
+          binding.extent = vertexSizes[i];
+
+          if (likely(i < NullStreamIdx)) {
+            uint32_t instanceData = cStreamFreq[binding.binding % caps::MaxStreams];
+
+            if (instanceData & D3DSTREAMSOURCE_INSTANCEDATA) {
+              // Remove instance packed-in flags in the data.
+              binding.divisor = instanceData & 0x7fffffu;
+              binding.inputRate = VK_VERTEX_INPUT_RATE_INSTANCE;
+            } else {
+              binding.divisor = 0u;
+              binding.inputRate = VK_VERTEX_INPUT_RATE_VERTEX;
+            }
+          } else {
+            // Dummy binding, just fetch the same null value
+            binding.divisor = 0u;
+            binding.inputRate = VK_VERTEX_INPUT_RATE_INSTANCE;
+          }
+
+          bindList[bindCount++] = DxvkVertexInput(binding);
+        }
 
         ctx->setInputLayout(
           attrCount, attrList.data(),
           bindCount, bindList.data());
+
+        // Write feedback. This is only used on the CS thread.
+        cIaState.streamsInstanced = cStreamsInstanced;
+        cIaState.streamsUsed = bindMask;
       });
     }
   }

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -7720,15 +7720,15 @@ namespace dxvk {
         streamFreq[i] = m_state.streamFreq[i];
 
       Com<D3D9VertexDecl,   false> vertexDecl = m_state.vertexDecl;
-      Com<D3D9VertexShader, false> vertexShader;
 
-      if (UseProgrammableVS())
-        vertexShader = m_state.vertexShader;
+      const auto& inputSignature = UseProgrammableVS()
+        ? GetCommonShader(m_state.vertexShader)->GetInputSignature()
+        : GetFixedFunctionIsgn();
 
       EmitCs([
         &cIaState         = m_iaState,
         cVertexDecl       = std::move(vertexDecl),
-        cVertexShader     = std::move(vertexShader),
+        cInputSignature   = inputSignature,
         cStreamsInstanced = m_vbSlotTracking.instanced,
         cStreamFreq       = streamFreq
       ] (DxvkContext* ctx) {
@@ -7740,15 +7740,10 @@ namespace dxvk {
         std::array<uint16_t,        caps::MaxStreams + 1u> vertexSizes = { };
 
         uint32_t bindMask = 0;
-
-        const auto& isgn = cVertexShader != nullptr
-          ? GetCommonShader(cVertexShader)->GetInputSignature()
-          : GetFixedFunctionIsgn();
-
-        uint32_t attrCount = isgn.size();
+        uint32_t attrCount = cInputSignature.size();
 
         for (uint32_t i = 0; i < attrCount; i++) {
-          const auto& shaderElementSemantic = isgn[i];
+          const auto& shaderElementSemantic = cInputSignature.get(i);
 
           DxvkVertexAttribute attrib = { };
           attrib.location = i;

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -7707,66 +7707,67 @@ namespace dxvk {
   void D3D9DeviceEx::BindInputLayout() {
     m_dirty.clr(D3D9DeviceDirtyFlag::InputLayout);
 
-    if (m_state.vertexDecl == nullptr) {
-      EmitCs([&cIaState = m_iaState] (DxvkContext* ctx) {
-        cIaState.streamsUsed = 0;
-        ctx->setInputLayout(0, nullptr, 0, nullptr);
-      });
-    }
-    else {
+    if (likely(m_state.vertexDecl)) {
       std::array<uint32_t, caps::MaxStreams> streamFreq;
 
       for (uint32_t i = 0; i < caps::MaxStreams; i++)
         streamFreq[i] = m_state.streamFreq[i];
 
-      Com<D3D9VertexDecl,   false> vertexDecl = m_state.vertexDecl;
+      const auto& vertexElements = m_state.vertexDecl->GetElements();
 
       const auto& inputSignature = UseProgrammableVS()
         ? GetCommonShader(m_state.vertexShader)->GetInputSignature()
         : GetFixedFunctionIsgn();
 
-      EmitCs([
+      auto elementCount = vertexElements.size();
+      auto elementData = EmitCsCmd<D3DVERTEXELEMENT9>(elementCount, [
         &cIaState         = m_iaState,
-        cVertexDecl       = std::move(vertexDecl),
         cInputSignature   = inputSignature,
         cStreamsInstanced = m_vbSlotTracking.instanced,
         cStreamFreq       = streamFreq
-      ] (DxvkContext* ctx) {
-        const auto& elements = cVertexDecl->GetElements();
-
-        // Fixed-function can have a lot of attributes...
-        std::array<DxvkVertexInput, caps::InputRegisterCount * 2u> attrList;
-        std::array<DxvkVertexInput, caps::MaxStreams + 1u> bindList;
-        std::array<uint16_t,        caps::MaxStreams + 1u> vertexSizes = { };
-
-        uint32_t bindMask = 0;
+      ] (DxvkContext* ctx, const D3DVERTEXELEMENT9* elements, uint32_t elementCount) {
         uint32_t attrCount = cInputSignature.size();
 
+        // Map each vertex declaration entry to an attribute
+        std::array<uint8_t, caps::InputRegisterCount * 2u> attrMap;
+        std::fill(attrMap.begin(), attrMap.end(), 0xffu);
+
+        for (uint32_t i = 0u; i < elementCount; i++) {
+          dxbc_spv::sm3::Semantic elementSemantic = {};
+          elementSemantic.usage = dxbc_spv::sm3::SemanticUsage(elements[i].Usage);
+          elementSemantic.index = elements[i].UsageIndex;
+
+          if (elementSemantic.usage == dxbc_spv::sm3::SemanticUsage::ePositionT)
+            elementSemantic.usage = dxbc_spv::sm3::SemanticUsage::ePosition;
+
+          uint32_t index = cInputSignature.find(elementSemantic);
+
+          if (index < attrCount)
+            attrMap[index] = uint8_t(i);
+        }
+
+        // Fixed-function can have a lot of attributes...
+        std::array<DxvkVertexInput, caps::InputRegisterCount * 2u> attrList = {};
+        std::array<DxvkVertexInput, caps::MaxStreams + 1u> bindList = {};
+        std::array<uint16_t,        caps::MaxStreams + 1u> vertexSizes = {};
+
+        uint32_t bindMask = 0;
+
         for (uint32_t i = 0; i < attrCount; i++) {
-          const auto& shaderElementSemantic = cInputSignature.get(i);
-
-          DxvkVertexAttribute attrib = { };
+          DxvkVertexAttribute attrib = {};
           attrib.location = i;
-          attrib.binding  = NullStreamIdx;
-          attrib.format   = VK_FORMAT_R32G32B32A32_SFLOAT;
-          attrib.offset   = 0;
 
-          for (const auto& element : elements) {
-            dxbc_spv::sm3::Semantic elementSemantic = {};
-            elementSemantic.usage = dxbc_spv::sm3::SemanticUsage(element.Usage);
-            elementSemantic.index = element.UsageIndex;
+          if (likely(attrMap[i] < elementCount)) {
+            const auto& element = elements[attrMap[i]];
+            attrib.binding = uint32_t(element.Stream);
+            attrib.format = DecodeDecltype(D3DDECLTYPE(element.Type));
+            attrib.offset = element.Offset;
 
-            if (elementSemantic.usage == dxbc_spv::sm3::SemanticUsage::ePositionT)
-              elementSemantic.usage = dxbc_spv::sm3::SemanticUsage::ePosition;
-
-            if (elementSemantic == shaderElementSemantic) {
-              attrib.binding = uint32_t(element.Stream);
-              attrib.format  = DecodeDecltype(D3DDECLTYPE(element.Type));
-              attrib.offset  = element.Offset;
-
-              bindMask |= 1u << attrib.binding;
-              break;
-            }
+            bindMask |= 1u << attrib.binding;
+          } else {
+            attrib.binding = NullStreamIdx;
+            attrib.format = VK_FORMAT_R32G32B32A32_SFLOAT;
+            attrib.offset = 0;
           }
 
           attrList[i] = DxvkVertexInput(attrib);
@@ -7811,6 +7812,14 @@ namespace dxvk {
         // Write feedback. This is only used on the CS thread.
         cIaState.streamsInstanced = cStreamsInstanced;
         cIaState.streamsUsed = bindMask;
+      });
+
+      for (uint32_t i = 0u; i < elementCount; i++)
+        elementData[i] = vertexElements[i];
+    } else {
+      EmitCs([&cIaState = m_iaState] (DxvkContext* ctx) {
+        cIaState.streamsUsed = 0;
+        ctx->setInputLayout(0, nullptr, 0, nullptr);
       });
     }
   }

--- a/src/d3d9/d3d9_fixed_function.cpp
+++ b/src/d3d9/d3d9_fixed_function.cpp
@@ -146,18 +146,18 @@ namespace dxvk {
   static inline D3D9InputSignature CreateFixedFunctionIsgn() {
     D3D9InputSignature ffIsgn;
 
-    ffIsgn.push_back(dxbc_spv::sm3::Semantic { dxbc_spv::sm3::SemanticUsage::ePosition, 0u });
-    ffIsgn.push_back(dxbc_spv::sm3::Semantic { dxbc_spv::sm3::SemanticUsage::eNormal, 0u });
-    ffIsgn.push_back(dxbc_spv::sm3::Semantic { dxbc_spv::sm3::SemanticUsage::ePosition, 1u });
-    ffIsgn.push_back(dxbc_spv::sm3::Semantic { dxbc_spv::sm3::SemanticUsage::eNormal, 1u });
+    ffIsgn.add(dxbc_spv::sm3::Semantic { dxbc_spv::sm3::SemanticUsage::ePosition, 0u });
+    ffIsgn.add(dxbc_spv::sm3::Semantic { dxbc_spv::sm3::SemanticUsage::eNormal, 0u });
+    ffIsgn.add(dxbc_spv::sm3::Semantic { dxbc_spv::sm3::SemanticUsage::ePosition, 1u });
+    ffIsgn.add(dxbc_spv::sm3::Semantic { dxbc_spv::sm3::SemanticUsage::eNormal, 1u });
     for (uint32_t i = 0u; i < 8u; i++)
-      ffIsgn.push_back(dxbc_spv::sm3::Semantic { dxbc_spv::sm3::SemanticUsage::eTexCoord, i });
-    ffIsgn.push_back(dxbc_spv::sm3::Semantic { dxbc_spv::sm3::SemanticUsage::eColor, 0u });
-    ffIsgn.push_back(dxbc_spv::sm3::Semantic { dxbc_spv::sm3::SemanticUsage::eColor, 1u });
-    ffIsgn.push_back(dxbc_spv::sm3::Semantic { dxbc_spv::sm3::SemanticUsage::eFog, 0u });
-    ffIsgn.push_back(dxbc_spv::sm3::Semantic { dxbc_spv::sm3::SemanticUsage::ePointSize, 0u });
-    ffIsgn.push_back(dxbc_spv::sm3::Semantic { dxbc_spv::sm3::SemanticUsage::eBlendWeight, 0u });
-    ffIsgn.push_back(dxbc_spv::sm3::Semantic { dxbc_spv::sm3::SemanticUsage::eBlendIndices, 0u });
+      ffIsgn.add(dxbc_spv::sm3::Semantic { dxbc_spv::sm3::SemanticUsage::eTexCoord, i });
+    ffIsgn.add(dxbc_spv::sm3::Semantic { dxbc_spv::sm3::SemanticUsage::eColor, 0u });
+    ffIsgn.add(dxbc_spv::sm3::Semantic { dxbc_spv::sm3::SemanticUsage::eColor, 1u });
+    ffIsgn.add(dxbc_spv::sm3::Semantic { dxbc_spv::sm3::SemanticUsage::eFog, 0u });
+    ffIsgn.add(dxbc_spv::sm3::Semantic { dxbc_spv::sm3::SemanticUsage::ePointSize, 0u });
+    ffIsgn.add(dxbc_spv::sm3::Semantic { dxbc_spv::sm3::SemanticUsage::eBlendWeight, 0u });
+    ffIsgn.add(dxbc_spv::sm3::Semantic { dxbc_spv::sm3::SemanticUsage::eBlendIndices, 0u });
 
     return ffIsgn;
   }

--- a/src/d3d9/d3d9_shader_analysis.cpp
+++ b/src/d3d9/d3d9_shader_analysis.cpp
@@ -310,7 +310,7 @@ namespace dxvk {
     }
 
     if (registerType == RegisterType::eInput && GetShaderInfo().getType() == ShaderType::eVertex) {
-      m_inputSignature.push_back(Semantic { dcl.getSemanticUsage(), dcl.getSemanticIndex() });
+      m_inputSignature.add(Semantic { dcl.getSemanticUsage(), dcl.getSemanticIndex() });
       return true;
     }
 

--- a/src/d3d9/d3d9_shader_analysis.h
+++ b/src/d3d9/d3d9_shader_analysis.h
@@ -39,7 +39,64 @@ struct D3D9ShaderConstantsInfo {
 
 using D3D9RenderTargetMask = uint8_t;
 using D3D9SamplerMask      = uint32_t;
-using D3D9InputSignature   = small_vector<dxbc_spv::sm3::Semantic, 16u>;
+
+/**
+ * \brief Packed semantic
+ *
+ * Extremely compact representation of a semantic
+ * that can be used for look-up purposes.
+ */
+struct D3D9PackedSemantic {
+  D3D9PackedSemantic() = default;
+
+  explicit D3D9PackedSemantic(dxbc_spv::sm3::Semantic semantic)
+  : usage(uint8_t(semantic.usage))
+  , index(uint8_t(semantic.index)) { }
+
+  explicit operator dxbc_spv::sm3::Semantic() const {
+    dxbc_spv::sm3::Semantic semantic = {};
+    semantic.usage = dxbc_spv::sm3::SemanticUsage(usage);
+    semantic.index = index;
+    return semantic;
+  }
+
+  uint8_t usage : 4u;
+  uint8_t index : 4u;
+};
+
+/**
+ * \brief Input signature
+ *
+ * Fixed-size structure that stores the semantic that
+ * corresponds to any given vertex shader inputs.
+ */
+class D3D9InputSignature {
+
+public:
+
+  uint32_t size() const {
+    return m_size;
+  }
+
+  D3D9PackedSemantic getPacked(uint32_t index) const {
+    return m_entries[index];
+  }
+
+  dxbc_spv::sm3::Semantic get(uint32_t index) const {
+    return dxbc_spv::sm3::Semantic(getPacked(index));
+  }
+
+  void add(dxbc_spv::sm3::Semantic semantic) {
+    dxbc_spv_assert(semantic.index < 16u);
+    m_entries.at(m_size++) = D3D9PackedSemantic(semantic);
+  }
+
+private:
+
+  uint8_t                             m_size = 0u;
+  std::array<D3D9PackedSemantic, 31u> m_entries = {};
+
+};
 
 class D3D9ShaderAnalysis {
 

--- a/src/d3d9/d3d9_shader_analysis.h
+++ b/src/d3d9/d3d9_shader_analysis.h
@@ -49,6 +49,9 @@ using D3D9SamplerMask      = uint32_t;
 struct D3D9PackedSemantic {
   D3D9PackedSemantic() = default;
 
+  explicit D3D9PackedSemantic(uint8_t packed)
+  : usage(packed), index(packed >> 4u) { }
+
   explicit D3D9PackedSemantic(dxbc_spv::sm3::Semantic semantic)
   : usage(uint8_t(semantic.usage))
   , index(uint8_t(semantic.index)) { }
@@ -58,6 +61,10 @@ struct D3D9PackedSemantic {
     semantic.usage = dxbc_spv::sm3::SemanticUsage(usage);
     semantic.index = index;
     return semantic;
+  }
+
+  explicit operator uint8_t() const {
+    return uint8_t(usage) | (uint8_t(index) << 4u);
   }
 
   uint8_t usage : 4u;
@@ -71,30 +78,90 @@ struct D3D9PackedSemantic {
  * corresponds to any given vertex shader inputs.
  */
 class D3D9InputSignature {
-
+  // Abuse last element as the element count so that we
+  // can fit the entire structure into two SSE registers
+  static constexpr size_t SizeIndex = 31u;
 public:
 
+  D3D9InputSignature() {
+    // Populate with 'invalid' semantics
+    for (size_t i = 0u; i < SizeIndex; i++)
+      m_entries[i] = 0xffu;
+  }
+
+  /**
+   * \brief Number of valid entries in the signature
+   * \returns Number of signature entries
+   */
   uint32_t size() const {
-    return m_size;
+    return m_entries[SizeIndex];
   }
 
+  /**
+   * \brief Retrieves packed representation of a semantic
+   *
+   * \param [in] index Input register index
+   * \returns Semantic bound to the given register
+   */
   D3D9PackedSemantic getPacked(uint32_t index) const {
-    return m_entries[index];
+    return D3D9PackedSemantic(m_entries[index]);
   }
 
+  /**
+   * \brief Retrieves semantic for a given register
+   *
+   * \param [in] index Input register index
+   * \returns Semantic bound to the given register
+   */
   dxbc_spv::sm3::Semantic get(uint32_t index) const {
     return dxbc_spv::sm3::Semantic(getPacked(index));
   }
 
+  /**
+   * \brief Adds an input register with a given semantic
+   * \param [in] semantic Semantic to add
+   */
   void add(dxbc_spv::sm3::Semantic semantic) {
     dxbc_spv_assert(semantic.index < 16u);
-    m_entries.at(m_size++) = D3D9PackedSemantic(semantic);
+
+    auto index = m_entries[SizeIndex]++;
+    m_entries.at(index) = uint8_t(D3D9PackedSemantic(semantic));
+  }
+
+  /**
+   * \brief Finds input register for a given semantic
+   *
+   * Returns an out-of-bounds index if no register
+   * uses the given semantic.
+   * \param [in] semantic Semantic to find
+   * \returns Register index, if any, for given semantic
+   */
+  uint32_t find(dxbc_spv::sm3::Semantic semantic) const {
+    auto packed = uint8_t(D3D9PackedSemantic(semantic));
+
+    #if defined(DXVK_ARCH_X86) && (defined(__GNUC__) || defined(__clang__) || defined(_MSC_VER))
+    __m128i compareMask = _mm_set1_epi32(uint32_t(packed) * 0x01010101u);
+
+    __m128i eq0 = _mm_cmpeq_epi8(compareMask, _mm_loadu_si128(reinterpret_cast<const __m128i*>(&m_entries[ 0u])));
+    __m128i eq1 = _mm_cmpeq_epi8(compareMask, _mm_loadu_si128(reinterpret_cast<const __m128i*>(&m_entries[16u])));
+
+    uint32_t bits0 = _mm_movemask_epi8(eq0);
+    uint32_t bits1 = _mm_movemask_epi8(eq1);
+
+    return bit::tzcnt(bits0 | (bits1 << 16u));
+    #else
+    for (uint32_t i = 0u; i < SizeIndex; i++) {
+      if (m_entries[i] == packed)
+        return i;
+    }
+
+    return m_entries.size();
+    #endif
   }
 
 private:
 
-  uint8_t                             m_size = 0u;
-  std::array<D3D9PackedSemantic, 31u> m_entries = {};
+  std::array<uint8_t, SizeIndex + 1u> m_entries = {};
 
 };
 

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -2737,18 +2737,30 @@ namespace dxvk {
     const DxvkVertexInput*     attributes,
           uint32_t             bindingCount,
     const DxvkVertexInput*     bindings) {
-    m_flags.set(
-      DxvkContextFlag::GpDirtyPipelineState,
-      DxvkContextFlag::GpDirtyVertexBuffers);
+    // Avoiding redundant input layout setups from the front-end can be
+    // hard, but at least avoid rebinding the pipeline redundantly.
+    bool dirty = m_state.gp.state.il.attributeCount() != attributeCount
+              || m_state.gp.state.il.bindingCount() != bindingCount;
 
     for (uint32_t i = 0; i < bindingCount; i++) {
-      auto binding = bindings[i].binding();
+      auto newBinding = bindings[i].binding();
 
-      m_state.gp.state.ilBindings[i] = DxvkIlBinding(
-        binding.binding, 0,
-        binding.inputRate,
-        binding.divisor);
-      m_state.vi.vertexExtents[i] = binding.extent;
+      if (!dirty) {
+        auto oldExtent = m_state.vi.vertexExtents[i];
+        auto oldBinding = m_state.gp.state.ilBindings[i];
+
+        dirty = oldBinding.binding() != newBinding.binding
+             || oldBinding.inputRate() != newBinding.inputRate
+             || oldBinding.divisor() != newBinding.divisor
+             || oldExtent != newBinding.extent;
+      }
+
+      if (dirty) {
+        m_state.gp.state.ilBindings[i] = DxvkIlBinding(
+          newBinding.binding, 0, newBinding.inputRate,
+          newBinding.divisor);
+        m_state.vi.vertexExtents[i] = newBinding.extent;
+      }
     }
 
     for (uint32_t i = bindingCount; i < m_state.gp.state.il.bindingCount(); i++) {
@@ -2757,19 +2769,33 @@ namespace dxvk {
     }
 
     for (uint32_t i = 0; i < attributeCount; i++) {
-      auto attribute = attributes[i].attribute();
+      auto newAttribute = attributes[i].attribute();
 
-      m_state.gp.state.ilAttributes[i] = DxvkIlAttribute(
-        attribute.location,
-        attribute.binding,
-        attribute.format,
-        attribute.offset);
+      if (!dirty) {
+        auto oldAttribute = m_state.gp.state.ilAttributes[i];
+
+        dirty = oldAttribute.location() != newAttribute.location
+             || oldAttribute.binding() != newAttribute.binding
+             || oldAttribute.format() != newAttribute.format
+             || oldAttribute.offset() != newAttribute.offset;
+      }
+
+      if (dirty) {
+        m_state.gp.state.ilAttributes[i] = DxvkIlAttribute(
+          newAttribute.location, newAttribute.binding,
+          newAttribute.format,   newAttribute.offset);
+      }
     }
 
     for (uint32_t i = attributeCount; i < m_state.gp.state.il.attributeCount(); i++)
       m_state.gp.state.ilAttributes[i] = DxvkIlAttribute();
 
     m_state.gp.state.il = DxvkIlInfo(attributeCount, bindingCount);
+
+    if (dirty) {
+      m_flags.set(DxvkContextFlag::GpDirtyPipelineState,
+                  DxvkContextFlag::GpDirtyVertexBuffers);
+    }
   }
 
 


### PR DESCRIPTION
Turns out this code path is surprisingly hot in some games, soooo nested loops and atomic refcounts aren't the greatest idea ever.

Not the biggest perf improvement in the world, but saves 1-2% of CPU time in some games, esp. when bound by the CS thread.