### PR TITLE
Clean up FF PS

### DIFF
--- a/src/d3d9/d3d9_constant_buffer.cpp
+++ b/src/d3d9/d3d9_constant_buffer.cpp
@@ -195,7 +195,6 @@ namespace dxvk {
       case Kind::VSDynamicConstants:
         return VK_SHADER_STAGE_VERTEX_BIT;
 
-      case Kind::PSFixedFunction:
       case Kind::PSShared:
       case Kind::PSStaticConstants:
         return VK_SHADER_STAGE_FRAGMENT_BIT;
@@ -246,7 +245,6 @@ namespace dxvk {
     bool useCached = CbvType == Kind::VSClipPlanes
                   || CbvType == Kind::VSFixedFunction
                   || CbvType == Kind::VSVertexBlendData
-                  || CbvType == Kind::PSFixedFunction
                   || CbvType == Kind::PSShared
                   || CbvType == Kind::SpecData;
 

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -148,7 +148,6 @@ namespace dxvk {
     m_dirty.set(D3D9DeviceDirtyFlag::FFVertexShader);
     m_dirty.set(D3D9DeviceDirtyFlag::FFPixelShader);
     m_dirty.set(D3D9DeviceDirtyFlag::FFViewport);
-    m_dirty.set(D3D9DeviceDirtyFlag::FFPixelData);
     m_dirty.set(D3D9DeviceDirtyFlag::FFGlobalSpecular);
     m_dirty.set(D3D9DeviceDirtyFlag::SharedPixelShaderData);
     m_dirty.set(D3D9DeviceDirtyFlag::DepthBounds);
@@ -2452,7 +2451,7 @@ namespace dxvk {
           break;
 
         case D3DRS_TEXTUREFACTOR:
-          m_dirty.set(D3D9DeviceDirtyFlag::FFPixelData);
+          UpdatePushConstant<D3D9RenderStateItem::TextureFactor>();
           break;
 
         case D3DRS_DIFFUSEMATERIALSOURCE:
@@ -6183,6 +6182,10 @@ namespace dxvk {
 
       UpdatePushConstant<offsetof(D3D9RenderStateInfo, pointScaleC), sizeof(float)>(&scale);
     }
+    else if constexpr (Item == D3D9RenderStateItem::TextureFactor) {
+      uint32_t textureFactor = bit::cast<uint32_t>(rs[D3DRS_TEXTUREFACTOR]);
+      UpdatePushConstant<offsetof(D3D9RenderStateInfo, textureFactor), sizeof(uint32_t)>(&textureFactor);
+    }
     else
       Logger::warn("D3D9: Invalid push constant set to update.");
   }
@@ -8381,7 +8384,7 @@ namespace dxvk {
 
 
   void D3D9DeviceEx::UpdateFixedFunctionPS() {
-    if (unlikely(!m_dirty.test(D3D9DeviceDirtyFlag::FFPixelShader) && !m_dirty.test(D3D9DeviceDirtyFlag::FFPixelData)))
+    if (unlikely(!m_dirty.test(D3D9DeviceDirtyFlag::FFPixelShader)))
       return;
 
     // Shader...
@@ -8390,7 +8393,6 @@ namespace dxvk {
     if (m_dirty.test(D3D9DeviceDirtyFlag::FFPixelShader)) {
       // The flags are set based on the specialized shaders.
       m_dirty.clr(D3D9DeviceDirtyFlag::FFPixelShader);
-      m_dirty.set(D3D9DeviceDirtyFlag::FFPixelData);
 
       // Spec constants...
       uint32_t activeTextureStageCount;
@@ -8432,20 +8434,8 @@ namespace dxvk {
           dirty |= m_specInfo.set(static_cast<D3D9SpecConstantId>(D3D9SpecConstantId::SpecFFTextureStage0AlphaArg0 + i), 0u);
         }
       }
-      if (dirty) {
+      if (dirty)
         m_dirty.set(D3D9DeviceDirtyFlag::SpecializationEntries);
-      }
-    }
-
-    // Constants...
-    if (m_dirty.test(D3D9DeviceDirtyFlag::FFPixelData)) {
-      m_dirty.clr(D3D9DeviceDirtyFlag::FFPixelData);
-
-      auto& rs = m_state.renderStates;
-
-      auto data = GetConstantBuffer(CbvIndex::PSFixedFunction).AllocTyped<D3D9FixedFunctionPS>(1u);
-      DecodeD3DCOLOR(D3DCOLOR(rs[D3DRS_TEXTUREFACTOR]), data->textureFactor.data);
-      data->Key = key;
     }
   }
 
@@ -8653,7 +8643,7 @@ namespace dxvk {
     BindMultiSampleState();
 
     rs[D3DRS_TEXTUREFACTOR]       = 0xffffffff;
-    m_dirty.set(D3D9DeviceDirtyFlag::FFPixelData);
+    UpdatePushConstant<D3D9RenderStateItem::TextureFactor>();
 
     rs[D3DRS_DIFFUSEMATERIALSOURCE]  = D3DMCS_COLOR1;
     rs[D3DRS_SPECULARMATERIALSOURCE] = D3DMCS_COLOR2;

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -8311,129 +8311,116 @@ namespace dxvk {
   }
 
 
-  D3D9FFShaderKeyFS D3D9DeviceEx::BuildFFKeyFS() const {
-     // Used args for a given operation.
-    auto ArgsMask = [](DWORD Op) {
-      switch (Op) {
-        case D3DTOP_DISABLE:
-          return 0b000u; // No Args
-        case D3DTOP_SELECTARG1:
-        case D3DTOP_PREMODULATE:
-          return 0b010u; // Arg 1
-        case D3DTOP_SELECTARG2:
-          return 0b100u; // Arg 2
-        case D3DTOP_MULTIPLYADD:
-        case D3DTOP_LERP:
-          return 0b111u; // Arg 0, 1, 2
-        default:
-          return 0b110u; // Arg 1, 2
-      }
-    };
-
-    D3D9FFShaderKeyFS key;
-
-    uint32_t activeTextureStageCount = 0;
-    for (uint32_t i = 0; i < caps::TextureStageCount; i++) {
-      auto& stage = key.Stages[i].Contents;
-      auto& data  = m_state.textureStages[i];
-
-      // Subsequent stages do not occur if this is true.
-      if (data[DXVK_TSS_COLOROP] == D3DTOP_DISABLE)
-        break;
-
-      // If the stage is invalid (ie. no texture bound),
-      // this and all subsequent stages get disabled.
-      if (m_state.textures[i] == nullptr) {
-        if (((data[DXVK_TSS_COLORARG0] & D3DTA_SELECTMASK) == D3DTA_TEXTURE && (ArgsMask(data[DXVK_TSS_COLOROP]) & (1 << 0u)))
-         || ((data[DXVK_TSS_COLORARG1] & D3DTA_SELECTMASK) == D3DTA_TEXTURE && (ArgsMask(data[DXVK_TSS_COLOROP]) & (1 << 1u)))
-         || ((data[DXVK_TSS_COLORARG2] & D3DTA_SELECTMASK) == D3DTA_TEXTURE && (ArgsMask(data[DXVK_TSS_COLOROP]) & (1 << 2u))))
-          break;
-      }
-
-      stage.ColorOp = data[DXVK_TSS_COLOROP];
-      stage.AlphaOp = data[DXVK_TSS_ALPHAOP];
-
-      stage.ColorArg0 = data[DXVK_TSS_COLORARG0];
-      stage.ColorArg1 = data[DXVK_TSS_COLORARG1];
-      stage.ColorArg2 = data[DXVK_TSS_COLORARG2];
-
-      stage.AlphaArg0 = data[DXVK_TSS_ALPHAARG0];
-      stage.AlphaArg1 = data[DXVK_TSS_ALPHAARG1];
-      stage.AlphaArg2 = data[DXVK_TSS_ALPHAARG2];
-
-      stage.ResultIsTemp = data[DXVK_TSS_RESULTARG] == D3DTA_TEMP;
-
-      activeTextureStageCount = i + 1;
-    }
-
-    auto& stage0 = key.Stages[0].Contents;
-
-    if (stage0.ResultIsTemp &&
-        stage0.ColorOp != D3DTOP_DISABLE &&
-        stage0.AlphaOp == D3DTOP_DISABLE) {
-      stage0.AlphaOp   = D3DTOP_SELECTARG1;
-      stage0.AlphaArg1 = D3DTA_DIFFUSE;
-    }
-
-    // The last stage *always* writes to current.
-    if (activeTextureStageCount >= 1)
-      key.Stages[activeTextureStageCount - 1].Contents.ResultIsTemp = false;
-
-    return key;
-  }
-
-
   void D3D9DeviceEx::UpdateFixedFunctionPS() {
     if (unlikely(!m_dirty.test(D3D9DeviceDirtyFlag::FFPixelShader)))
       return;
-
-    // Shader...
-    D3D9FFShaderKeyFS key = BuildFFKeyFS();
 
     if (m_dirty.test(D3D9DeviceDirtyFlag::FFPixelShader)) {
       // The flags are set based on the specialized shaders.
       m_dirty.clr(D3D9DeviceDirtyFlag::FFPixelShader);
 
-      // Spec constants...
-      uint32_t activeTextureStageCount;
-      for (activeTextureStageCount = 0; activeTextureStageCount < caps::TextureStageCount; activeTextureStageCount++) {
-        auto& stage = key.Stages[activeTextureStageCount].Contents;
-        if (stage.ColorOp == D3DTOP_DISABLE)
-          break;
-      }
+      // Used args for a given operation.
+      auto usesArg = [](DWORD op, uint32_t arg) {
+        switch (op) {
+          case D3DTOP_DISABLE:
+            return false; // No Args
+          case D3DTOP_SELECTARG1:
+          case D3DTOP_PREMODULATE:
+            return arg == 1u; // Arg 1
+          case D3DTOP_SELECTARG2:
+            return arg == 2u; // Arg 2
+          case D3DTOP_MULTIPLYADD:
+          case D3DTOP_LERP:
+            return true; // Arg 0, 1, 2
+          default:
+            return arg > 0u; // Arg 1, 2
+        }
+      };
 
+      // Spec constants...
       const auto repackArg = [](uint32_t arg) {
         return (arg & 0b111u) | ((arg & 0b110000u) >> 1u);
       };
 
-      uint32_t lastActiveTextureStage = std::max(activeTextureStageCount, 1u) - 1u; // Subtract 1 to make it fit 3 bits
-      bool dirty = m_specInfo.set<D3D9SpecConstantId::SpecFFLastActiveTextureStage>(lastActiveTextureStage);
-      constexpr uint32_t perTextureStageSpecConsts = static_cast<uint32_t>(D3D9SpecConstantId::SpecFFTextureStage1ColorOp) - static_cast<uint32_t>(D3D9SpecConstantId::SpecFFTextureStage0ColorOp);
+      constexpr uint32_t perTextureStageSpecConsts = uint32_t(D3D9SpecConstantId::SpecFFTextureStage1ColorOp) - uint32_t(D3D9SpecConstantId::SpecFFTextureStage0ColorOp);
+      bool dirty = false;
+
+      bool stageActive = true;
+      uint32_t lastActiveTextureStage = 0u;
+
       for (uint32_t i = 0; i < caps::TextureStageCount; i++) {
-        if (i <= activeTextureStageCount) {
-          dirty |= m_specInfo.set(static_cast<D3D9SpecConstantId>(D3D9SpecConstantId::SpecFFTextureStage0ColorOp + perTextureStageSpecConsts * i), key.Stages[i].Contents.ColorOp);
-          dirty |= m_specInfo.set(static_cast<D3D9SpecConstantId>(D3D9SpecConstantId::SpecFFTextureStage0ColorArg1 + perTextureStageSpecConsts * i), repackArg(key.Stages[i].Contents.ColorArg1));
-          dirty |= m_specInfo.set(static_cast<D3D9SpecConstantId>(D3D9SpecConstantId::SpecFFTextureStage0ColorArg2 + perTextureStageSpecConsts * i), repackArg(key.Stages[i].Contents.ColorArg2));
-          dirty |= m_specInfo.set(static_cast<D3D9SpecConstantId>(D3D9SpecConstantId::SpecFFTextureStage0AlphaOp + perTextureStageSpecConsts * i), key.Stages[i].Contents.AlphaOp);
-          dirty |= m_specInfo.set(static_cast<D3D9SpecConstantId>(D3D9SpecConstantId::SpecFFTextureStage0AlphaArg1 + perTextureStageSpecConsts * i), repackArg(key.Stages[i].Contents.AlphaArg1));
-          dirty |= m_specInfo.set(static_cast<D3D9SpecConstantId>(D3D9SpecConstantId::SpecFFTextureStage0AlphaArg2 + perTextureStageSpecConsts * i), repackArg(key.Stages[i].Contents.AlphaArg2));
-          dirty |= m_specInfo.set(static_cast<D3D9SpecConstantId>(D3D9SpecConstantId::SpecFFTextureStage0ResultIsTemp + perTextureStageSpecConsts * i), key.Stages[i].Contents.ResultIsTemp);
+        auto& data  = m_state.textureStages[i];
+
+        // All subsequent stages are disabled too following the first disabled stage.
+        uint32_t colorOp = data[DXVK_TSS_COLOROP];
+        if (colorOp == D3DTOP_DISABLE)
+          stageActive = false;
+
+        // If the stage is invalid (ie. it's set to sample a texture and none is bound),
+        // this and all subsequent stages get disabled.
+        if (m_state.textures[i] == nullptr) {
+          // Strip modifiers from arguments
+          uint32_t pureColorArg1 = data[DXVK_TSS_COLORARG1] & D3DTA_SELECTMASK;
+          uint32_t pureColorArg2 = data[DXVK_TSS_COLORARG2] & D3DTA_SELECTMASK;
+          uint32_t pureColorArg0 = data[DXVK_TSS_COLORARG0] & D3DTA_SELECTMASK;
+
+          if ((pureColorArg0 == D3DTA_TEXTURE && usesArg(data[DXVK_TSS_COLOROP], 0u))
+           || (pureColorArg1 == D3DTA_TEXTURE && usesArg(data[DXVK_TSS_COLOROP], 1u))
+           || (pureColorArg2 == D3DTA_TEXTURE && usesArg(data[DXVK_TSS_COLOROP], 2u)))
+            stageActive = false;
+        }
+
+        if (stageActive) {
+          lastActiveTextureStage = i;
+
+          bool resultIsTemp = data[DXVK_TSS_RESULTARG] == D3DTA_TEMP;
+          uint32_t colorArg1 = data[DXVK_TSS_COLORARG1];
+          uint32_t colorArg2 = data[DXVK_TSS_COLORARG2];
+          uint32_t colorArg0 = data[DXVK_TSS_COLORARG0];
+          uint32_t alphaOp = data[DXVK_TSS_ALPHAOP];
+          uint32_t alphaArg1 = data[DXVK_TSS_ALPHAARG1];
+          uint32_t alphaArg2 = data[DXVK_TSS_ALPHAARG2];
+          uint32_t alphaArg0 = data[DXVK_TSS_ALPHAARG0];
+
+          if (i == 0
+            && resultIsTemp
+            && colorOp != D3DTOP_DISABLE
+            && alphaOp == D3DTOP_DISABLE) {
+            alphaOp   = D3DTOP_SELECTARG1;
+            alphaArg1 = D3DTA_DIFFUSE;
+          }
+
+          dirty |= m_specInfo.set(D3D9SpecConstantId(D3D9SpecConstantId::SpecFFTextureStage0ColorOp + perTextureStageSpecConsts * i), colorOp);
+          dirty |= m_specInfo.set(D3D9SpecConstantId(D3D9SpecConstantId::SpecFFTextureStage0ColorArg1 + perTextureStageSpecConsts * i), repackArg(colorArg1));
+          dirty |= m_specInfo.set(D3D9SpecConstantId(D3D9SpecConstantId::SpecFFTextureStage0ColorArg2 + perTextureStageSpecConsts * i), repackArg(colorArg2));
+          dirty |= m_specInfo.set(D3D9SpecConstantId(D3D9SpecConstantId::SpecFFTextureStage0AlphaOp + perTextureStageSpecConsts * i), alphaOp);
+          dirty |= m_specInfo.set(D3D9SpecConstantId(D3D9SpecConstantId::SpecFFTextureStage0AlphaArg1 + perTextureStageSpecConsts * i), repackArg(alphaArg1));
+          dirty |= m_specInfo.set(D3D9SpecConstantId(D3D9SpecConstantId::SpecFFTextureStage0AlphaArg2 + perTextureStageSpecConsts * i), repackArg(alphaArg2));
+          dirty |= m_specInfo.set(D3D9SpecConstantId(D3D9SpecConstantId::SpecFFTextureStage0ResultIsTemp + perTextureStageSpecConsts * i), resultIsTemp);
           // Color arg0 and alpha arg0 for all stages are packed after all the other FF spec consts
-          dirty |= m_specInfo.set(static_cast<D3D9SpecConstantId>(D3D9SpecConstantId::SpecFFTextureStage0ColorArg0 + i), repackArg(key.Stages[i].Contents.ColorArg0));
-          dirty |= m_specInfo.set(static_cast<D3D9SpecConstantId>(D3D9SpecConstantId::SpecFFTextureStage0AlphaArg0 + i), repackArg(key.Stages[i].Contents.AlphaArg0));
+          dirty |= m_specInfo.set(D3D9SpecConstantId(D3D9SpecConstantId::SpecFFTextureStage0ColorArg0 + i), repackArg(colorArg0));
+          dirty |= m_specInfo.set(D3D9SpecConstantId(D3D9SpecConstantId::SpecFFTextureStage0AlphaArg0 + i), repackArg(alphaArg0));
         } else {
-          dirty |= m_specInfo.set(static_cast<D3D9SpecConstantId>(D3D9SpecConstantId::SpecFFTextureStage0ColorOp + perTextureStageSpecConsts * i), 0);
-          dirty |= m_specInfo.set(static_cast<D3D9SpecConstantId>(D3D9SpecConstantId::SpecFFTextureStage0ColorArg1 + perTextureStageSpecConsts * i), 0);
-          dirty |= m_specInfo.set(static_cast<D3D9SpecConstantId>(D3D9SpecConstantId::SpecFFTextureStage0ColorArg2 + perTextureStageSpecConsts * i), 0);
-          dirty |= m_specInfo.set(static_cast<D3D9SpecConstantId>(D3D9SpecConstantId::SpecFFTextureStage0AlphaOp + perTextureStageSpecConsts * i), 0);
-          dirty |= m_specInfo.set(static_cast<D3D9SpecConstantId>(D3D9SpecConstantId::SpecFFTextureStage0AlphaArg1 + perTextureStageSpecConsts * i), 0);
-          dirty |= m_specInfo.set(static_cast<D3D9SpecConstantId>(D3D9SpecConstantId::SpecFFTextureStage0AlphaArg2 + perTextureStageSpecConsts * i), 0);
-          dirty |= m_specInfo.set(static_cast<D3D9SpecConstantId>(D3D9SpecConstantId::SpecFFTextureStage0ResultIsTemp + perTextureStageSpecConsts * i), 0);
+          // The last stage *always* writes to current.
+          if (i != 0u)
+            dirty |= m_specInfo.set(D3D9SpecConstantId(D3D9SpecConstantId::SpecFFTextureStage0ResultIsTemp + perTextureStageSpecConsts * (i - 1u)), false);
+
+          // Set all of it to 0 to avoid unnecessary bloat
+          dirty |= m_specInfo.set(D3D9SpecConstantId(D3D9SpecConstantId::SpecFFTextureStage0ColorOp + perTextureStageSpecConsts * i), 0);
+          dirty |= m_specInfo.set(D3D9SpecConstantId(D3D9SpecConstantId::SpecFFTextureStage0ColorArg1 + perTextureStageSpecConsts * i), 0);
+          dirty |= m_specInfo.set(D3D9SpecConstantId(D3D9SpecConstantId::SpecFFTextureStage0ColorArg2 + perTextureStageSpecConsts * i), 0);
+          dirty |= m_specInfo.set(D3D9SpecConstantId(D3D9SpecConstantId::SpecFFTextureStage0AlphaOp + perTextureStageSpecConsts * i), 0);
+          dirty |= m_specInfo.set(D3D9SpecConstantId(D3D9SpecConstantId::SpecFFTextureStage0AlphaArg1 + perTextureStageSpecConsts * i), 0);
+          dirty |= m_specInfo.set(D3D9SpecConstantId(D3D9SpecConstantId::SpecFFTextureStage0AlphaArg2 + perTextureStageSpecConsts * i), 0);
+          dirty |= m_specInfo.set(D3D9SpecConstantId(D3D9SpecConstantId::SpecFFTextureStage0ResultIsTemp + perTextureStageSpecConsts * i), 0);
           // Color arg0 and alpha arg0 for all stages are packed after all the other FF spec consts
-          dirty |= m_specInfo.set(static_cast<D3D9SpecConstantId>(D3D9SpecConstantId::SpecFFTextureStage0ColorArg0 + i), 0u);
-          dirty |= m_specInfo.set(static_cast<D3D9SpecConstantId>(D3D9SpecConstantId::SpecFFTextureStage0AlphaArg0 + i), 0u);
+          dirty |= m_specInfo.set(D3D9SpecConstantId(D3D9SpecConstantId::SpecFFTextureStage0ColorArg0 + i), 0u);
+          dirty |= m_specInfo.set(D3D9SpecConstantId(D3D9SpecConstantId::SpecFFTextureStage0AlphaArg0 + i), 0u);
         }
       }
+
+      dirty |= m_specInfo.set<D3D9SpecConstantId::SpecFFLastActiveTextureStage>(lastActiveTextureStage);
+
       if (dirty)
         m_dirty.set(D3D9DeviceDirtyFlag::SpecializationEntries);
     }

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -1454,7 +1454,6 @@ namespace dxvk {
     void UpdateFogModeSpec(bool fogEnabled, D3DFOGMODE vertexFogMode, D3DFOGMODE pixelFogMode);
 
     D3D9FFShaderKeyVS BuildFFKeyVS(D3D9FF_VertexBlendMode vertexBlendMode, bool indexedVertexBlend, uint32_t lightCount) const;
-    D3D9FFShaderKeyFS BuildFFKeyFS() const;
 
     void BindSpecConstants();
 

--- a/src/d3d9/d3d9_fixed_function.cpp
+++ b/src/d3d9/d3d9_fixed_function.cpp
@@ -83,14 +83,6 @@ namespace dxvk {
     specConstantBufferBinding.access = VK_ACCESS_UNIFORM_READ_BIT;
     specConstantBufferBinding.flags.set(DxvkDescriptorFlag::UniformBuffer);
 
-    auto& fixedFunctionDataBinding = bindings.emplace_back();
-    fixedFunctionDataBinding.set             = CbvSet;
-    fixedFunctionDataBinding.binding         = D3D9ShaderResourceMapping::CbvIndex::PSFixedFunction;
-    fixedFunctionDataBinding.resourceIndex   = D3D9ShaderResourceMapping::CbvIndex::PSFixedFunction;
-    fixedFunctionDataBinding.descriptorType  = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
-    fixedFunctionDataBinding.access          = VK_ACCESS_UNIFORM_READ_BIT;
-    fixedFunctionDataBinding.flags.set(DxvkDescriptorFlag::UniformBuffer);
-
     auto& sharedDataBinding = bindings.emplace_back();
     sharedDataBinding.set             = CbvSet;
     sharedDataBinding.binding         = D3D9ShaderResourceMapping::CbvIndex::PSShared;

--- a/src/d3d9/d3d9_shader.h
+++ b/src/d3d9/d3d9_shader.h
@@ -57,9 +57,8 @@ namespace dxvk {
       VSVertexBlendData       = 5u,
       VSStaticConstants       = 6u,
       VSDynamicConstants      = 7u,
-      PSFixedFunction         = 11u,
-      PSShared                = 12u,
-      PSStaticConstants       = 13u,
+      PSShared                = 11u,
+      PSStaticConstants       = 12u,
       SpecData                = 20u,
 
       Count

--- a/src/d3d9/d3d9_state.h
+++ b/src/d3d9/d3d9_state.h
@@ -47,6 +47,8 @@ namespace dxvk {
     float pointScaleA  = 1.0f;
     float pointScaleB  = 0.0f;
     float pointScaleC  = 0.0f;
+
+    uint32_t textureFactor = 0u;
   };
 
   enum class D3D9RenderStateItem {
@@ -62,6 +64,8 @@ namespace dxvk {
     PointScaleA,
     PointScaleB,
     PointScaleC,
+
+    TextureFactor,
 
     Count
   };
@@ -222,11 +226,6 @@ namespace dxvk {
     }
 
     D3D9FFShaderStage Stages[caps::TextureStageCount];
-  };
-
-  struct D3D9FixedFunctionPS {
-    Vector4 textureFactor;
-    D3D9FFShaderKeyFS Key;
   };
 
   enum D3D9SharedPSStages {

--- a/src/d3d9/d3d9_state.h
+++ b/src/d3d9/d3d9_state.h
@@ -193,41 +193,6 @@ namespace dxvk {
   static constexpr uint32_t D3D9MaxVertexBlendTransformsHw = 8u;
   static constexpr uint32_t D3D9MaxVertexBlendTransformsSw = 256u;
 
-  struct D3D9FFShaderStage {
-    union {
-      struct {
-        uint32_t     ColorOp   : 5;
-        uint32_t     ColorArg0 : 6;
-        uint32_t     ColorArg1 : 6;
-        uint32_t     ColorArg2 : 6;
-
-        uint32_t     AlphaOp   : 5;
-        uint32_t     AlphaArg0 : 6;
-        uint32_t     AlphaArg1 : 6;
-        uint32_t     AlphaArg2 : 6;
-
-        uint32_t     ResultIsTemp : 1;
-      } Contents;
-
-      uint32_t Primitive[2];
-    };
-  };
-
-  struct D3D9FFShaderKeyFS {
-    D3D9FFShaderKeyFS() {
-      // memcmp safety
-      std::memset(Stages, 0, sizeof(Stages));
-
-      // Normalize this. DISABLE != 0.
-      for (uint32_t i = 0; i < caps::TextureStageCount; i++) {
-        Stages[i].Contents.ColorOp = D3DTOP_DISABLE;
-        Stages[i].Contents.AlphaOp = D3DTOP_DISABLE;
-      }
-    }
-
-    D3D9FFShaderStage Stages[caps::TextureStageCount];
-  };
-
   enum D3D9SharedPSStages {
     D3D9SharedPSStages_Constant,
     D3D9SharedPSStages_BumpEnvMat0,

--- a/src/d3d9/shaders/d3d9_fixed_function_common.glsl
+++ b/src/d3d9/shaders/d3d9_fixed_function_common.glsl
@@ -22,6 +22,8 @@ struct D3D9RenderStateInfo {
     float pointScaleA;
     float pointScaleB;
     float pointScaleC;
+
+    uint textureFactor;
 };
 
 
@@ -48,8 +50,7 @@ spirv_instruction(set = "GLSL.std.450", id = 81) vec4 spvNClamp(vec4, vec4, vec4
 #define CBV_VS_FIXED_FUNCTION   4
 #define CBV_VS_VERTEX_BLEND     5
 
-#define CBV_PS_FIXED_FUNCTION   11
-#define CBV_PS_SHARED           12
+#define CBV_PS_SHARED           11
 
 #define CBV_SPEC_DATA           20
 
@@ -363,4 +364,8 @@ bool specBool(uint specConstIdx, uint bitOffset) {
 
 bool specBool(uint specConstIdx) {
     return specUint(specConstIdx) != 0u;
+}
+
+vec4 decodeD3DColor(uint color) {
+    return unpackUnorm4x8(color).bgra;
 }

--- a/src/d3d9/shaders/d3d9_fixed_function_frag.glsl
+++ b/src/d3d9/shaders/d3d9_fixed_function_frag.glsl
@@ -33,15 +33,6 @@ const uint MaxSharedPushDataSize = 64;
 
 #include "d3d9_fixed_function_common.glsl"
 
-struct D3D9FFTextureStage {
-    uint Primitive[2];
-};
-
-struct D3D9FixedFunctionPS {
-    vec4 textureFactor;
-    D3D9FFTextureStage Stages[8];
-};
-
 struct D3D9SharedPSStage {
     float Constant[4];
     float BumpEnvMat[2][2];
@@ -110,11 +101,6 @@ const uint VK_COMPARE_OP_GREATER_OR_EQUAL = 6;
 const uint VK_COMPARE_OP_ALWAYS           = 7;
 
 const uint PerTextureStageSpecConsts = SpecFFTextureStage1ColorOp - SpecFFTextureStage0ColorOp;
-
-layout(set = CBV_SET, binding = CBV_PS_FIXED_FUNCTION, scalar, row_major)
-uniform ShaderData {
-    D3D9FixedFunctionPS data;
-};
 
 layout(set = CBV_SET, binding = CBV_PS_SHARED, scalar, row_major)
 uniform SharedData {
@@ -307,7 +293,7 @@ vec4 readArgValue(uint stage, uint arg, vec4 current, vec4 temp, vec4 textureVal
             reg = textureVal;
             break;
         case D3DTA_TFACTOR:
-            reg = data.textureFactor;
+            reg = decodeD3DColor(rs.textureFactor);
             break;
     }
 
@@ -394,7 +380,7 @@ vec4 calculateTextureStage(uint op, vec4 dst, const TextureStageArgumentValues a
             return mix(arg.arg2, arg.arg1, textureVal.aaaa);
 
         case D3DTOP_BLENDFACTORALPHA:
-            return mix(arg.arg2, arg.arg1, data.textureFactor.aaaa);
+            return mix(arg.arg2, arg.arg1, decodeD3DColor(rs.textureFactor).aaaa);
 
         case D3DTOP_BLENDTEXTUREALPHAPM:
             return saturate(fma(arg.arg2, complement(textureVal.aaaa), arg.arg1));

--- a/src/d3d9/shaders/d3d9_fixed_function_frag.glsl
+++ b/src/d3d9/shaders/d3d9_fixed_function_frag.glsl
@@ -134,39 +134,6 @@ layout(set = SRV_SET, binding = SRV_PS_BASE) uniform texture3D t3d[TextureStageC
 
 layout(set = SAMPLER_SET, binding = 0) uniform sampler sampler_heap[];
 
-
-// Functions to extract information from the packed texture stages
-uint colorOp(uint stageIndex) {
-    return bitfieldExtract(data.Stages[stageIndex].Primitive[0], 0, 5);
-}
-uint colorArg0(uint stageIndex) {
-    return bitfieldExtract(data.Stages[stageIndex].Primitive[0], 5, 6);
-}
-uint colorArg1(uint stageIndex) {
-    return bitfieldExtract(data.Stages[stageIndex].Primitive[0], 11, 6);
-}
-uint colorArg2(uint stageIndex) {
-    return bitfieldExtract(data.Stages[stageIndex].Primitive[0], 17, 6);
-}
-
-uint alphaOp(uint stageIndex) {
-    return bitfieldExtract(data.Stages[stageIndex].Primitive[0], 23, 5);
-}
-uint alphaArg0(uint stageIndex) {
-    return bitfieldExtract(data.Stages[stageIndex].Primitive[1], 0, 6);
-}
-uint alphaArg1(uint stageIndex) {
-    return bitfieldExtract(data.Stages[stageIndex].Primitive[1], 6, 6);
-}
-uint alphaArg2(uint stageIndex) {
-    return bitfieldExtract(data.Stages[stageIndex].Primitive[1], 12, 6);
-}
-
-bool resultIsTemp(uint stageIndex) {
-    return bitfieldExtract(data.Stages[stageIndex].Primitive[1], 18, 1) != 0;
-}
-
-
 vec4 calculateFog(vec4 vPos, vec4 oColor) {
     vec3 fogColor = vec3(rs.fogColor[0], rs.fogColor[1], rs.fogColor[2]);
     float fogScale = rs.fogScale;
@@ -261,7 +228,7 @@ vec4 sampleTexture(uint stage, vec4 texcoord, vec4 previousStageTextureVal) {
 
     uint previousStageColorOp = 0;
     if (stage > 0) {
-        previousStageColorOp = specIsOptimized() ? specUint(SpecFFTextureStage0ColorOp + PerTextureStageSpecConsts * (stage - 1)) : colorOp(stage - 1);
+        previousStageColorOp = specUint(SpecFFTextureStage0ColorOp + PerTextureStageSpecConsts * (stage - 1));
     }
 
     if (stage != 0 && (
@@ -577,28 +544,28 @@ TextureStageState runTextureStage(uint stage, TextureStageState state) {
         return state;
     }
 
-    const uint colorOp = specIsOptimized() ? specUint(SpecFFTextureStage0ColorOp + PerTextureStageSpecConsts * stage) : colorOp(stage);
+    const uint colorOp = specUint(SpecFFTextureStage0ColorOp + PerTextureStageSpecConsts * stage);
 
     // This cancels all subsequent stages.
     if (colorOp == D3DTOP_DISABLE)
         return state;
 
-    const bool resultIsTemp = specIsOptimized() ? specBool(SpecFFTextureStage0ResultIsTemp + PerTextureStageSpecConsts * stage) : resultIsTemp(stage);
+    const bool resultIsTemp = specBool(SpecFFTextureStage0ResultIsTemp + PerTextureStageSpecConsts * stage);
     vec4 dst = resultIsTemp ? state.temp : state.current;
 
-    const uint alphaOp = specIsOptimized() ? specUint(SpecFFTextureStage0AlphaOp + PerTextureStageSpecConsts * stage) : alphaOp(stage);
+    const uint alphaOp = specUint(SpecFFTextureStage0AlphaOp + PerTextureStageSpecConsts * stage);
 
     const TextureStageArguments colorArgs = {
         // Color arg0 and alpha arg0 for all stages are packed after all the other FF spec consts
-        specIsOptimized() ? repackArg(specUint(SpecFFTextureStage0ColorArg0 + stage))                             : colorArg0(stage),
-        specIsOptimized() ? repackArg(specUint(SpecFFTextureStage0ColorArg1 + PerTextureStageSpecConsts * stage)) : colorArg1(stage),
-        specIsOptimized() ? repackArg(specUint(SpecFFTextureStage0ColorArg2 + PerTextureStageSpecConsts * stage)) : colorArg2(stage)
+        repackArg(specUint(SpecFFTextureStage0ColorArg0 + stage)),
+        repackArg(specUint(SpecFFTextureStage0ColorArg1 + PerTextureStageSpecConsts * stage)),
+        repackArg(specUint(SpecFFTextureStage0ColorArg2 + PerTextureStageSpecConsts * stage))
     };
     const TextureStageArguments alphaArgs = {
         // Color arg0 and alpha arg0 for all stages are packed after all the other FF spec consts
-        specIsOptimized() ? repackArg(specUint(SpecFFTextureStage0AlphaArg0 + stage))                             : alphaArg0(stage),
-        specIsOptimized() ? repackArg(specUint(SpecFFTextureStage0AlphaArg1 + PerTextureStageSpecConsts * stage)) : alphaArg1(stage),
-        specIsOptimized() ? repackArg(specUint(SpecFFTextureStage0AlphaArg2 + PerTextureStageSpecConsts * stage)) : alphaArg2(stage)
+        repackArg(specUint(SpecFFTextureStage0AlphaArg0 + stage)),
+        repackArg(specUint(SpecFFTextureStage0AlphaArg1 + PerTextureStageSpecConsts * stage)),
+        repackArg(specUint(SpecFFTextureStage0AlphaArg2 + PerTextureStageSpecConsts * stage))
     };
 
     vec4 textureVal = vec4(0.0f, 0.0f, 0.0f, 1.0f);


### PR DESCRIPTION
- Remove the FF PS Data CBV and move the `textureFactor` into push constants
- `textureFactor` is the only remaining thing we need from that CBV
- Remove the `FFPixelData` dirty flag, as we no longer need it
- Remove the special fallback and just rely on the spec const fallback
- Remove the 'key' and set the spec constants directly