### PR TITLE
Clean up small push data and D3D11 render state lowering

### DIFF
--- a/src/d3d11/d3d11_context.cpp
+++ b/src/d3d11/d3d11_context.cpp
@@ -3435,22 +3435,24 @@ namespace dxvk {
 
   template<typename ContextType>
   void D3D11CommonContext<ContextType>::ApplyRasterizerSampleCount() {
-    uint32_t sampleCount = m_state.om.sampleCount;
+    D3D11BuiltInPushData pushData = {};
+    pushData.maxTessFactor = m_maxTessFactor;
+    pushData.sampleCount = m_state.om.sampleCount;
 
-    if (unlikely(!sampleCount)) {
-      sampleCount = m_state.rs.state
+    if (unlikely(!pushData.sampleCount)) {
+      pushData.sampleCount = m_state.rs.state
         ? m_state.rs.state->Desc().ForcedSampleCount
         : 0u;
 
-      if (!sampleCount)
-        sampleCount = 1u;
+      if (!pushData.sampleCount)
+        pushData.sampleCount = 1u;
     }
 
     EmitCs([
-      cPushConstants = DxvkBuiltInPushData(sampleCount, m_maxTessFactor)
+      cPushData = pushData
     ] (DxvkContext* ctx) {
       ctx->pushData(VK_SHADER_STAGE_ALL_GRAPHICS,
-        0u, sizeof(cPushConstants), &cPushConstants);
+        0u, sizeof(cPushData), &cPushData);
     });
   }
 
@@ -4916,8 +4918,10 @@ namespace dxvk {
       }
 
       // Initialize push constants
-      DxvkBuiltInPushData pc(1u, cMaxTessFactor);
-      ctx->pushData(VK_SHADER_STAGE_ALL_GRAPHICS, 0, sizeof(pc), &pc);
+      D3D11BuiltInPushData pushData = {};
+      pushData.maxTessFactor = cMaxTessFactor;
+
+      ctx->pushData(VK_SHADER_STAGE_ALL_GRAPHICS, 0, sizeof(pushData), &pushData);
     });
   }
 

--- a/src/d3d11/d3d11_shader.cpp
+++ b/src/d3d11/d3d11_shader.cpp
@@ -1,3 +1,6 @@
+#include <optional>
+#include <utility>
+
 #include <dxbc/dxbc_container.h>
 #include <dxbc/dxbc_interface.h>
 #include <dxbc/dxbc_parser.h>
@@ -56,6 +59,8 @@ namespace dxvk {
       } else {
         if (!converter.convertShader(builder))
           throw DxvkError(str::format("Failed to convert shader: ", m_key.toString()));
+
+        lowerBuiltIns(builder);
       }
     }
 
@@ -98,8 +103,114 @@ namespace dxvk {
 
     bool                    m_lowerIcb = false;
 
+    struct BuiltInInfo {
+      dxbc_spv::ir::BuiltIn builtIn;
+      dxbc_spv::ir::BasicType type;
+      const char* name;
+    };
+
+    static const std::array<BuiltInInfo, 2u> s_builtIns;
+
+    static void lowerBuiltIns(dxbc_spv::ir::Builder& builder) {
+      using namespace dxbc_spv;
+
+      // Nothing to do for compute, our speshul built-ins are
+      // only used in graphics pipelines.
+      auto [entryPoint, shaderStage] = findEntryPoint(builder);
+
+      if (shaderStage == ir::ShaderStage::eCompute)
+        return;
+
+      // Set up push data
+      ir::Type pushDataType = ir::Type();
+
+      for (uint32_t i = 0u; i < s_builtIns.size(); i++)
+        pushDataType.addStructMember(s_builtIns[i].type);
+
+      ir::SsaDef pushData = builder.add(ir::Op::DclPushData(
+        pushDataType, entryPoint, 0u, ir::ShaderStageMask()));
+
+      builder.add(ir::Op::DebugName(pushData, "builtIns"));
+
+      for (uint32_t i = 0u; i < s_builtIns.size(); i++)
+        builder.add(ir::Op::DebugMemberName(pushData, i, s_builtIns[i].name));
+
+      // Gather built-in inputs
+      small_vector<ir::SsaDef, 32u> inputs;
+
+      for (auto iter = builder.getDeclarations().first;
+                iter != builder.getDeclarations().second; iter++) {
+        if (iter->getOpCode() == ir::OpCode::eDclInputBuiltIn)
+          inputs.push_back(iter->getDef());
+      }
+
+      // Rewrite input loads as push data loads
+      for (auto inputDef : inputs) {
+        const auto& inputOp = builder.getOp(inputDef);
+
+        auto builtIn = ir::BuiltIn(inputOp.getOperand(inputOp.getFirstLiteralOperandIndex()));
+        auto pushIndex = getBuiltInPushDataIndex(builtIn);
+
+        if (pushIndex)
+          rewriteBuiltIn(builder, inputDef, pushData, *pushIndex);
+      }
+    }
+
+    static void rewriteBuiltIn(dxbc_spv::ir::Builder& builder, dxbc_spv::ir::SsaDef def, dxbc_spv::ir::SsaDef pushData, uint32_t pushIndex) {
+      using namespace dxbc_spv;
+
+      small_vector<ir::SsaDef, 32u> uses;
+      builder.getUses(def, uses);
+
+      for (auto use : uses) {
+        const auto& useOp = builder.getOp(use);
+
+        if (useOp.getOpCode() == ir::OpCode::eInputLoad) {
+          auto pushType = s_builtIns[pushIndex].type;
+
+          auto loadType = useOp.getType().getBaseType(0u);
+          auto loadOp = builder.addBefore(use, ir::Op::PushDataLoad(
+            pushType, pushData, builder.makeConstant(pushIndex)));
+
+          // Convert to expected result type
+          ir::Op convertOp = (loadType.isFloatType())
+            ? ir::Op::ConvertItoF(loadType, loadOp)
+            : ir::Op::ConvertItoI(loadType, loadOp);
+
+          builder.rewriteOp(use, std::move(convertOp));
+        }
+      }
+    }
+
+    static std::optional<uint32_t> getBuiltInPushDataIndex(dxbc_spv::ir::BuiltIn builtIn) {
+      for (uint32_t i = 0u; i < s_builtIns.size(); i++) {
+        if (s_builtIns[i].builtIn == builtIn)
+          return std::make_optional(i);
+      }
+
+      return std::nullopt;
+    }
+
+    static std::pair<dxbc_spv::ir::SsaDef, dxbc_spv::ir::ShaderStage> findEntryPoint(dxbc_spv::ir::Builder& builder) {
+      using namespace dxbc_spv;
+
+      auto [a, b] = builder.getDeclarations();
+
+      for (auto iter = a; iter != b; iter++) {
+        if (iter->getOpCode() == ir::OpCode::eEntryPoint)
+          return std::make_pair(iter->getDef(), ir::ShaderStage(iter->getOperand(iter->getFirstLiteralOperandIndex())));
+      }
+
+      return {};
+    }
+
   };
 
+
+  const std::array<D3D11ShaderConverter::BuiltInInfo, 2u> D3D11ShaderConverter::s_builtIns = {{
+    { dxbc_spv::ir::BuiltIn::eTessFactorLimit,  dxbc_spv::ir::ScalarType::eU16, "maxTessFactor" },
+    { dxbc_spv::ir::BuiltIn::eSampleCount,      dxbc_spv::ir::ScalarType::eU16, "rasterizerSampleCount" },
+  }};
 
 
   

--- a/src/d3d11/d3d11_shader.h
+++ b/src/d3d11/d3d11_shader.h
@@ -29,6 +29,16 @@ namespace dxvk {
   using D3D11ShaderTypeFlags = Flags<dxbc_spv::dxbc::ShaderType>;
 
   /**
+   * \brief D3D11 built-in push data
+   */
+  struct D3D11BuiltInPushData {
+    /// Tess factor limit, set via config. HS only.
+    uint16_t maxTessFactor = 0u;
+    /// Rasterizer sample count. PS only.
+    uint16_t sampleCount = 0u;
+  };
+
+  /**
    * \brief Translates D3D11 shader stage to corresponding Vulkan stage
    *
    * \param [in] ProgramType DXBC program type

--- a/src/dxvk/dxvk_device.cpp
+++ b/src/dxvk/dxvk_device.cpp
@@ -776,13 +776,15 @@ namespace dxvk {
     m_shaderOptions.minStorageBufferAlignment =
       m_properties.core.properties.limits.minStorageBufferOffsetAlignment;
 
-    if (m_features.core.features.shaderInt16 && m_features.vk12.shaderFloat16)
+    if (m_features.vk12.shaderFloat16)
       m_shaderOptions.flags.set(DxvkShaderCompileFlag::Supports16BitArithmetic);
 
-    // RADV currently does not emit great code with 16-bit sampler indices
-    if (m_features.core.features.shaderInt16 && m_features.vk11.storagePushConstant16
+    // RADV currently can't pre-load SGPRs with sub-dword push data and will
+    // load them from memory instead, so promote everything to dwords.
+    if (m_features.vk11.storagePushConstant16
+     && m_features.vk12.storagePushConstant8
      && !m_adapter->matchesDriver(VK_DRIVER_ID_MESA_RADV))
-      m_shaderOptions.flags.set(DxvkShaderCompileFlag::Supports16BitPushData);
+      m_shaderOptions.flags.set(DxvkShaderCompileFlag::SupportsSubDwordPushData);
 
     // Need to tag typed storage image loads with the format on some devices
     auto r32Features = getFormatFeatures(VK_FORMAT_R32_SFLOAT).optimal

--- a/src/dxvk/dxvk_device_info.cpp
+++ b/src/dxvk/dxvk_device_info.cpp
@@ -849,6 +849,7 @@ namespace dxvk {
 
       ENABLE_FEATURE(vk12, bufferDeviceAddress, true),
       ENABLE_FEATURE(vk12, descriptorIndexing, true),
+      ENABLE_FEATURE(vk12, storagePushConstant8, false),
       ENABLE_FEATURE(vk12, shaderUniformTexelBufferArrayDynamicIndexing, false),
       ENABLE_FEATURE(vk12, shaderStorageTexelBufferArrayDynamicIndexing, false),
       ENABLE_FEATURE(vk12, shaderUniformBufferArrayNonUniformIndexing, false),

--- a/src/dxvk/dxvk_shader.h
+++ b/src/dxvk/dxvk_shader.h
@@ -59,9 +59,9 @@ namespace dxvk {
     /// Whether the device supports 16-bit int and float
     /// arithmetic. Effectively enables min16 lowering.
     Supports16BitArithmetic     = 5u,
-    /// Whether 16-bit push data is supported. Used to
-    /// pack sampler indices in the binding model
-    Supports16BitPushData       = 6u,
+    /// Whether 16-bit and 8-bit push data is supported.
+    /// Used to pack sampler indices in the binding model.
+    SupportsSubDwordPushData    = 6u,
     /// Whether to lower unsigned int to float conversions.
     /// Needed to work around an Nvidia driver bug.
     LowerItoF                   = 7u,

--- a/src/dxvk/dxvk_shader.h
+++ b/src/dxvk/dxvk_shader.h
@@ -18,26 +18,6 @@ namespace dxvk {
   struct DxvkPipelineStats;
 
   /**
-   * \brief Push data to handle built-ins
-   */
-  struct DxvkBuiltInPushData {
-    static constexpr uint32_t SampleCountOffset = 0u;
-    static constexpr uint32_t SampleCountBits = 8u;
-
-    static constexpr uint32_t MaxTessFactorOffset = SampleCountOffset + SampleCountBits;
-    static constexpr uint32_t MaxTessFactorBits = 8u;
-
-    DxvkBuiltInPushData() = default;
-
-    explicit DxvkBuiltInPushData(uint32_t sampleCount, uint32_t maxTessFactor)
-    : builtIns((sampleCount   << SampleCountOffset)
-             | (maxTessFactor << MaxTessFactorOffset)) { }
-
-    uint32_t builtIns = 0u;
-  };
-
-
-  /**
    * \brief Shader compile flags
    */
   enum class DxvkShaderCompileFlag : uint32_t {

--- a/src/dxvk/dxvk_shader_ir.cpp
+++ b/src/dxvk/dxvk_shader_ir.cpp
@@ -609,10 +609,6 @@ namespace dxvk {
 
       auto builtIn = dxbc_spv::ir::BuiltIn(op->getOperand(op->getFirstLiteralOperandIndex()));
 
-      if (builtIn == dxbc_spv::ir::BuiltIn::eSampleCount
-       || builtIn == dxbc_spv::ir::BuiltIn::eTessFactorLimit)
-        return rewriteBuiltIn(op, builtIn);
-
       if (builtIn == dxbc_spv::ir::BuiltIn::eIsFullyCovered)
         m_metadata.flags.set(DxvkShaderFlag::UsesFragmentCoverage);
 
@@ -830,74 +826,6 @@ namespace dxvk {
       }
 
       return m_builtInPushData;
-    }
-
-
-    dxbc_spv::ir::Builder::iterator rewriteBuiltIn(dxbc_spv::ir::Builder::iterator op, dxbc_spv::ir::BuiltIn builtIn) {
-      // Map built-in to bit range in the built-in push data dword
-      static const std::array<std::tuple<dxbc_spv::ir::BuiltIn, uint16_t, uint16_t>, 2u> s_builtins = {{
-        { dxbc_spv::ir::BuiltIn::eSampleCount,     DxvkBuiltInPushData::SampleCountOffset,    DxvkBuiltInPushData::SampleCountBits },
-        { dxbc_spv::ir::BuiltIn::eTessFactorLimit, DxvkBuiltInPushData::MaxTessFactorOffset,  DxvkBuiltInPushData::MaxTessFactorBits },
-      }};
-
-      uint32_t bitIndex = 0u;
-      uint32_t bitCount = 32u;
-
-      for (const auto& e : s_builtins) {
-        auto [which, index, count] = e;
-
-        if (which == builtIn) {
-          bitIndex = index;
-          bitCount = count;
-          break;
-        }
-      }
-
-      // Emit helper function to actually load the push data dword
-      auto ref = m_builder.getCode().first->getDef();
-
-      auto helper = m_builder.addBefore(ref, dxbc_spv::ir::Op::Function(op->getType()));
-      auto cursor = m_builder.setCursor(helper);
-
-      m_builder.add(dxbc_spv::ir::Op::Label());
-
-      auto value = m_builder.add(dxbc_spv::ir::Op::PushDataLoad(
-        dxbc_spv::ir::ScalarType::eU32, defineBuiltInPushData(), dxbc_spv::ir::SsaDef()));
-      value = m_builder.add(dxbc_spv::ir::Op::UBitExtract(dxbc_spv::ir::ScalarType::eU32,
-        value, m_builder.makeConstant(bitIndex), m_builder.makeConstant(bitCount)));
-
-      if (op->getType() != dxbc_spv::ir::ScalarType::eU32) {
-        value = m_builder.add(op->getType().getBaseType(0u).isFloatType()
-          ? dxbc_spv::ir::Op::ConvertItoF(op->getType(), value)
-          : dxbc_spv::ir::Op::ConvertItoI(op->getType(), value));
-      }
-
-      m_builder.add(dxbc_spv::ir::Op::Return(op->getType(), value));
-      m_builder.add(dxbc_spv::ir::Op::FunctionEnd());
-      m_builder.setCursor(cursor);
-
-      auto debugName = getDebugName(op->getDef());
-
-      if (!debugName.empty())
-        m_builder.add(dxbc_spv::ir::Op::DebugName(helper, debugName.c_str()));
-
-      // Replace all input loads with a call to the helper function and remove
-      // any debug instructions, as well as the input declaration itself.
-      small_vector<dxbc_spv::ir::SsaDef, 64u> uses;
-      m_builder.getUses(op->getDef(), uses);
-
-      for (auto use : uses) {
-        const auto& useOp = m_builder.getOp(use);
-
-        if (useOp.getOpCode() == dxbc_spv::ir::OpCode::eInputLoad) {
-          m_builder.rewriteOp(useOp.getDef(),
-            dxbc_spv::ir::Op::FunctionCall(op->getType(), helper));
-        } else {
-          m_builder.remove(use);
-        }
-      }
-
-      return m_builder.iter(m_builder.remove(op->getDef()));
     }
 
 

--- a/src/dxvk/dxvk_shader_ir.cpp
+++ b/src/dxvk/dxvk_shader_ir.cpp
@@ -795,18 +795,12 @@ namespace dxvk {
 
       m_localPushDataResourceMask |= ((1ull << dwordCount) - 1ull) << dwordIndex;
 
-      if (m_info.options.flags.test(DxvkShaderCompileFlag::Supports16BitPushData)) {
-        // Add each word separately and pad with a dummy entry if unaligned
-        for (uint32_t i = 0u; i < wordCount; i++)
-          pushDataType.addStructMember(dxbc_spv::ir::ScalarType::eU16);
+      // Add each word separately and pad with a dummy entry if unaligned
+      for (uint32_t i = 0u; i < wordCount; i++)
+        pushDataType.addStructMember(dxbc_spv::ir::ScalarType::eU16);
 
-        if (wordCount & 1u)
-          pushDataType.addStructMember(dxbc_spv::ir::ScalarType::eU16);
-      } else {
-        // Add dword member for each pair fo samplers
-        for (uint32_t i = 0u; i < dwordCount; i++)
-          pushDataType.addStructMember(dxbc_spv::ir::ScalarType::eU32);
-      }
+      if (wordCount & 1u)
+        pushDataType.addStructMember(dxbc_spv::ir::ScalarType::eU16);
 
       // Declare actual push data structure
       auto def = m_builder.add(dxbc_spv::ir::Op::DclPushData(
@@ -815,23 +809,8 @@ namespace dxvk {
       m_localPushDataOffset += pushDataType.byteSize();
 
       // Add debug names for sampler indices
-      for (const auto& e : m_samplers) {
-        if (m_info.options.flags.test(DxvkShaderCompileFlag::Supports16BitPushData)) {
-          addDebugMemberName(def, e.samplerIndex, getDebugName(e.sampler));
-        } else if (!(e.samplerIndex % 2u)) {
-          std::string debugName = getDebugName(e.sampler);
-
-          for (const auto& eHi : m_samplers) {
-            if (eHi.samplerIndex == e.samplerIndex + 1u) {
-              debugName += "_";
-              debugName += getDebugName(eHi.sampler);
-              break;
-            }
-          }
-
-          addDebugMemberName(def, e.samplerIndex / 2u, debugName);
-        }
-      }
+      for (const auto& e : m_samplers)
+        addDebugMemberName(def, e.samplerIndex, getDebugName(e.sampler));
 
       return def;
     }
@@ -1038,30 +1017,16 @@ namespace dxvk {
     dxbc_spv::ir::SsaDef loadConstantSamplerIndex(dxbc_spv::ir::SsaDef ref, dxbc_spv::ir::SsaDef pushDataDef, const SamplerInfo& info, uint32_t index) {
       uint32_t wordIndex = info.samplerIndex + index;
 
-      if (m_info.options.flags.test(DxvkShaderCompileFlag::Supports16BitPushData)) {
-        dxbc_spv::ir::SsaDef memberIndex = { };
+      dxbc_spv::ir::SsaDef memberIndex = { };
 
-        if (m_builder.getOp(pushDataDef).getType().isStructType())
-          memberIndex = m_builder.makeConstant(wordIndex);
+      if (m_builder.getOp(pushDataDef).getType().isStructType())
+        memberIndex = m_builder.makeConstant(wordIndex);
 
-        dxbc_spv::ir::SsaDef samplerIndex = m_builder.addBefore(ref,
-          dxbc_spv::ir::Op::PushDataLoad(dxbc_spv::ir::ScalarType::eU16, pushDataDef, memberIndex));
-        samplerIndex = m_builder.addBefore(ref, dxbc_spv::ir::Op::ConvertItoI(
-          dxbc_spv::ir::ScalarType::eU32, samplerIndex));
-        return samplerIndex;
-      } else {
-        dxbc_spv::ir::SsaDef bitIndex = m_builder.makeConstant(uint32_t(16u * (wordIndex % 2u)));
-        dxbc_spv::ir::SsaDef memberIndex = { };
-
-        if (m_builder.getOp(pushDataDef).getType().isStructType())
-          memberIndex = m_builder.makeConstant(uint32_t(wordIndex / 2u));
-
-        dxbc_spv::ir::SsaDef samplerIndex = m_builder.addBefore(ref,
-          dxbc_spv::ir::Op::PushDataLoad(dxbc_spv::ir::ScalarType::eU32, pushDataDef, memberIndex));
-        samplerIndex = m_builder.addBefore(ref, dxbc_spv::ir::Op::UBitExtract(
-          dxbc_spv::ir::ScalarType::eU32, samplerIndex, bitIndex, m_builder.makeConstant(16u)));
-        return samplerIndex;
-      }
+      dxbc_spv::ir::SsaDef samplerIndex = m_builder.addBefore(ref,
+        dxbc_spv::ir::Op::PushDataLoad(dxbc_spv::ir::ScalarType::eU16, pushDataDef, memberIndex));
+      samplerIndex = m_builder.addBefore(ref, dxbc_spv::ir::Op::ConvertItoI(
+        dxbc_spv::ir::ScalarType::eU32, samplerIndex));
+      return samplerIndex;
     }
 
 

--- a/src/dxvk/dxvk_shader_ir.cpp
+++ b/src/dxvk/dxvk_shader_ir.cpp
@@ -1573,7 +1573,7 @@ namespace dxvk {
 
     void rewritePushData() {
       // Don't need to do anythig if the driver supports small types properly
-      if (m_info.options.flags.test(DxvkShaderCompileFlag::Supports16BitPushData))
+      if (m_info.options.flags.test(DxvkShaderCompileFlag::SupportsSubDwordPushData))
         return;
 
       small_vector<dxbc_spv::ir::SsaDef, 16u> pushData;

--- a/src/dxvk/dxvk_shader_ir.cpp
+++ b/src/dxvk/dxvk_shader_ir.cpp
@@ -267,6 +267,7 @@ namespace dxvk {
       rewriteSamplers();
       rewriteConstantBuffers();
       rewriteUavCounters();
+      rewritePushData();
 
       if (m_sharedPushDataOffset) {
         auto stageMask = (m_metadata.stage & VK_SHADER_STAGE_ALL_GRAPHICS)
@@ -354,6 +355,17 @@ namespace dxvk {
     struct ResourceAlias {
       bool hasAlias = false;
       bool hasBinding = false;
+    };
+
+    struct PushDataDwordEntry {
+      uint16_t member;
+      uint8_t bitIndex;
+      uint8_t bitCount;
+    };
+
+    struct PushDataDwordMap {
+      std::string debugName;
+      std::array<PushDataDwordEntry, 4u> components;
     };
 
     dxbc_spv::ir::Builder&        m_builder;
@@ -1379,6 +1391,236 @@ namespace dxvk {
 
         addBinding(binding);
       }
+    }
+
+
+    bool typeHasSubDwordMember(const dxbc_spv::ir::Type& type) {
+      for (uint32_t i = 0u; i < type.getStructMemberCount(); i++) {
+        if (byteSize(type.getBaseType(i).getBaseType()) < sizeof(uint32_t))
+          return true;
+      }
+
+      return false;
+    }
+
+
+    void lowerSubDwordPushData(dxbc_spv::ir::SsaDef pushDataDef) {
+      auto pushDataOp = m_builder.getOp(pushDataDef);
+      const auto& pushDataType = pushDataOp.getType();
+
+      if (!typeHasSubDwordMember(pushDataType))
+        return;
+
+      // Build new type and a look-up table to re-map members
+      small_vector<PushDataDwordMap, 64u> map;
+
+      dxbc_spv::ir::Type newType = {};
+
+      for (uint32_t i = 0u; i < pushDataType.getStructMemberCount(); i++) {
+        auto member = pushDataType.getBaseType(i);
+        auto scalarSize = byteSize(member.getBaseType());
+
+        if (scalarSize < sizeof(uint32_t)) {
+          // We enforce scalar alignment everywhere, so remapping sub-dword
+          // members is simple: If the offset is divisible by 4, we need to
+          // add a new dword, otherwise map it to bits of an existing one.
+          auto& entry = map.emplace_back();
+
+          for (uint32_t j = 0u; j < member.getVectorSize(); j++) {
+            uint32_t offset = pushDataType.byteOffset(i) + j * scalarSize;
+
+            if (!(offset % sizeof(uint32_t)))
+              newType.addStructMember(dxbc_spv::ir::ScalarType::eU32);
+
+            entry.components[j].member = newType.getStructMemberCount() - 1u;
+            entry.components[j].bitIndex = 8u * (offset % sizeof(uint32_t));
+            entry.components[j].bitCount = 8u * scalarSize;
+          }
+        } else {
+          // Add member as-is, but we still need to re-map the index. Leave
+          // bit count at 0 since this is not a dword entry.
+          uint32_t newIndex = newType.getStructMemberCount();
+          newType.addStructMember(member);
+
+          auto& entry = map.emplace_back();
+
+          for (uint32_t i = 0u; i < member.getVectorSize(); i++)
+            entry.components[i].member = newIndex;
+        }
+      }
+
+      // Rewrite loads and collect debug names since we'll need to re-emit
+      // those with appropriately remapped member indices and packing.
+      small_vector<dxbc_spv::ir::SsaDef, 256u> uses;
+      m_builder.getUses(pushDataDef, uses);
+
+      for (auto use : uses) {
+        auto useOp = m_builder.getOp(use);
+
+        switch (useOp.getOpCode()) {
+          case dxbc_spv::ir::OpCode::ePushDataLoad: {
+            dxbc_spv_assert(useOp.getType().isBasicType());
+            auto type = useOp.getType().getBaseType(0u);
+
+            auto addressOp = m_builder.getOpForOperand(useOp, 1u);
+            dxbc_spv_assert(!addressOp || addressOp.isConstant());
+
+            uint32_t addressComponent = 0u;
+            uint32_t memberIndex = 0u;
+
+            if (pushDataType.isStructType() && addressComponent < addressOp.getOperandCount())
+              memberIndex = uint32_t(addressOp.getOperand(addressComponent++));
+
+            dxbc_spv_assert(memberIndex < map.size());
+
+            if (byteSize(type.getBaseType()) < sizeof(uint32_t)) {
+              // Work out which component(s) to load
+              uint32_t componentIndex = 0u;
+              uint32_t componentCount = type.getVectorSize();
+
+              if (addressComponent < addressOp.getOperandCount())
+                componentIndex = uint32_t(addressOp.getOperand(addressComponent++));
+
+              // Process vectors one component at a time since components
+              // may straddle multiple different dwords.
+              dxbc_spv::ir::Op compositeOp(dxbc_spv::ir::OpCode::eCompositeConstruct, type);
+
+              for (uint32_t i = componentIndex; i < componentIndex + componentCount; i++) {
+                auto& info = map[memberIndex].components[i];
+
+                dxbc_spv::ir::SsaDef memberAddr = {};
+
+                if (newType.isStructType())
+                  memberAddr = m_builder.makeConstant(uint32_t(info.member));
+
+                dxbc_spv_assert(newType.getBaseType(info.member) == dxbc_spv::ir::ScalarType::eU32);
+
+                auto dw = m_builder.addBefore(use, dxbc_spv::ir::Op::PushDataLoad(
+                  dxbc_spv::ir::ScalarType::eU32, pushDataDef, memberAddr));
+
+                dw = m_builder.addBefore(use, dxbc_spv::ir::Op::UBitExtract(
+                  dxbc_spv::ir::ScalarType::eU32, dw,
+                  m_builder.makeConstant(uint32_t(info.bitIndex)),
+                  m_builder.makeConstant(uint32_t(info.bitCount))));
+
+                auto smallType = byteSize(type.getBaseType()) > 1u
+                  ? dxbc_spv::ir::ScalarType::eU16
+                  : dxbc_spv::ir::ScalarType::eU8;
+
+                dw = m_builder.addBefore(use, dxbc_spv::ir::Op::ConvertItoI(smallType, dw));
+
+                if (type.getBaseType() != smallType)
+                  dw = m_builder.addBefore(use, dxbc_spv::ir::Op::Cast(type.getBaseType(), dw));
+
+                compositeOp.addOperand(dw);
+              }
+
+              // Replace the original push data load with the new sequence of instructions.
+              auto result = dxbc_spv::ir::SsaDef(compositeOp.getOperand(0u));
+
+              if (type.isVector())
+                result = m_builder.addBefore(use, std::move(compositeOp));
+
+              m_builder.rewriteDef(use, result);
+            } else  {
+              // We forward any non-subdword member as-is, so the struct-ness of the
+              // push data block cannot have changed if we have at least one of these.
+              dxbc_spv_assert(newType.isStructType() == pushDataType.isStructType());
+
+              // Adjust member index, but otherwise forward load as-is.
+              if (newType.isStructType())
+                addressOp.setOperand(0u, map[memberIndex].components[0].member);
+
+              m_builder.rewriteOp(use, useOp.setOperand(1u, m_builder.add(std::move(addressOp))));
+            }
+          } break;
+
+          case dxbc_spv::ir::OpCode::eDebugName: {
+            if (!pushDataType.isStructType() && !map.empty())
+              map[0].debugName = useOp.getLiteralString(1u);
+
+            if (!newType.isStructType())
+              m_builder.remove(use);
+          } break;
+
+          case dxbc_spv::ir::OpCode::eDebugMemberName: {
+            uint32_t member = uint32_t(useOp.getOperand(1u));
+
+            if (member < map.size())
+              map[member].debugName = useOp.getLiteralString(2u);
+
+            m_builder.remove(use);
+          } break;
+
+          default:
+            dxbc_spv_unreachable();
+        }
+      }
+
+      // Fuse debug names of merged members
+      small_vector<std::string, 64u> debugNames(newType.getStructMemberCount());
+
+      for (uint32_t i = 0u; i < map.size(); i++) {
+        auto type = pushDataType.getBaseType(i);
+
+        if (map[i].debugName.empty())
+          continue;
+
+        static const char* swizzle = "xyzw";
+
+        bool straddles = map[i].components[0].member != map[i].components[type.getVectorSize() - 1u].member;
+
+        uint32_t lastMember = -1u;
+
+        for (uint32_t j = 0u; j < type.getVectorSize(); j++) {
+          uint32_t member = map[i].components[j].member;
+
+          if (lastMember != member) {
+            lastMember = member;
+
+            if (!debugNames[member].empty())
+              debugNames[member] += '_';
+
+            debugNames[member] += map[i].debugName;
+
+            if (straddles)
+              debugNames[member] += '.';
+          }
+
+          if (straddles)
+            debugNames[member] += swizzle[j];
+        }
+      }
+
+      for (uint32_t i = 0u; i < debugNames.size(); i++) {
+        if (!debugNames[i].empty()) {
+          if (newType.isStructType())
+            m_builder.add(dxbc_spv::ir::Op::DebugMemberName(pushDataDef, i, debugNames[i].c_str()));
+          else
+            m_builder.add(dxbc_spv::ir::Op::DebugName(pushDataDef, debugNames[i].c_str()));
+        }
+      }
+
+      // Rewrite declaration with new type
+      m_builder.rewriteOp(pushDataDef, pushDataOp.setType(std::move(newType)));
+    }
+
+
+    void rewritePushData() {
+      // Don't need to do anythig if the driver supports small types properly
+      if (m_info.options.flags.test(DxvkShaderCompileFlag::Supports16BitPushData))
+        return;
+
+      small_vector<dxbc_spv::ir::SsaDef, 16u> pushData;
+
+      for (auto iter = m_builder.getDeclarations().first;
+                iter != m_builder.getDeclarations().second; iter++) {
+        if (iter->getOpCode() == dxbc_spv::ir::OpCode::eDclPushData)
+          pushData.push_back(iter->getDef());
+      }
+
+      for (auto e : pushData)
+        lowerSubDwordPushData(e);
     }
 
 


### PR DESCRIPTION
Moves the D3D11-specific lowering into the D3D11 module where it really belongs. This approach has been working well for D3D9 already.

Additionally, adds a generic lowering pass to promote 8-bit and 16-bit push constants to 32-bit, which is needed on some drivers (*cough* AMD, including RADV), which opens up the door to some push data compaction on the D3D9 side as well without having to worry about driver support.

D3D11 built-ins now looks like this (on NV), instead of being shoved into some random nameless dword:

```glsl
layout(push_constant, std430) uniform push_data_t
{
    uint16_t maxTessFactor;
    uint16_t rasterizerSampleCount;
} push_data;
```