### PR TITLE
[d3d9] Slightly clean up FF VS data

### DIFF
--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -8140,63 +8140,6 @@ namespace dxvk {
   }
 
 
-  D3D9PackedFFVSData D3D9DeviceEx::BuildPackedFFVSData(D3D9FF_VertexBlendMode vertexBlendMode, bool indexedVertexBlend, uint32_t lightCount) const {
-    D3D9PackedFFVSData data = {};
-
-    data.VertexHasPositionT = m_state.vertexDecl != nullptr && m_state.vertexDecl->TestFlag(D3D9VertexDeclFlag::HasPositionT);
-    data.VertexHasColor0    = m_state.vertexDecl != nullptr && m_state.vertexDecl->TestFlag(D3D9VertexDeclFlag::HasColor0);
-    data.VertexHasColor1    = m_state.vertexDecl != nullptr && m_state.vertexDecl->TestFlag(D3D9VertexDeclFlag::HasColor1);
-    data.VertexHasPointSize = m_state.vertexDecl != nullptr && m_state.vertexDecl->TestFlag(D3D9VertexDeclFlag::HasPointSize);
-    data.VertexHasFog       = m_state.vertexDecl != nullptr && m_state.vertexDecl->TestFlag(D3D9VertexDeclFlag::HasFog);
-
-    bool lighting    = m_state.renderStates[D3DRS_LIGHTING] != 0 && !data.VertexHasPositionT;
-    bool colorVertex = m_state.renderStates[D3DRS_COLORVERTEX] != 0;
-    uint32_t mask    = (lighting && colorVertex)
-                     ? (data.VertexHasColor0 ? D3DMCS_COLOR1 : D3DMCS_MATERIAL)
-                     | (data.VertexHasColor1 ? D3DMCS_COLOR2 : D3DMCS_MATERIAL)
-                     : 0;
-
-    data.UseLighting      = lighting;
-    data.NormalizeNormals = m_state.renderStates[D3DRS_NORMALIZENORMALS];
-    data.LocalViewer      = m_state.renderStates[D3DRS_LOCALVIEWER] && lighting;
-
-    data.RangeFog         = m_state.renderStates[D3DRS_RANGEFOGENABLE];
-
-    data.DiffuseSource    = m_state.renderStates[D3DRS_DIFFUSEMATERIALSOURCE]  & mask;
-    data.AmbientSource    = m_state.renderStates[D3DRS_AMBIENTMATERIALSOURCE]  & mask;
-    data.SpecularSource   = m_state.renderStates[D3DRS_SPECULARMATERIALSOURCE] & mask;
-    data.EmissiveSource   = m_state.renderStates[D3DRS_EMISSIVEMATERIALSOURCE] & mask;
-
-    data.LightCount       = data.UseLighting ? lightCount : 0;
-
-    for (uint32_t i = 0; i < caps::MaxTextureBlendStages; i++) {
-      uint32_t transformFlags = m_state.textureStages[i][DXVK_TSS_TEXTURETRANSFORMFLAGS] & ~(D3DTTFF_PROJECTED);
-      uint32_t index          = m_state.textureStages[i][DXVK_TSS_TEXCOORDINDEX];
-      uint32_t indexFlags     = (index & TCIMask) >> TCIOffset;
-
-      transformFlags &= 0b111;
-      index          &= 0b111;
-
-      data.TexcoordTransformFlags[i]  = transformFlags;
-      data.TexcoordFlags[i]   = indexFlags;
-      data.TexcoordIndices[i] = index;
-    }
-
-    data.VertexTexcoordDeclMask = m_state.vertexDecl != nullptr ? m_state.vertexDecl->GetTexcoordMask() : 0;
-
-    data.VertexBlendMode = uint8_t(vertexBlendMode);
-
-    if (vertexBlendMode == D3D9FF_VertexBlendMode_Normal) {
-      data.VertexBlendIndexed = indexedVertexBlend;
-      data.VertexBlendCount   = m_state.renderStates[D3DRS_VERTEXBLEND] & 0xff;
-    }
-
-    data.VertexClipping = m_state.renderStates[D3DRS_CLIPPLANEENABLE] != 0;
-
-    return data;
-  }
-
-
   void D3D9DeviceEx::UpdateFixedFunctionVS() {
     bool hasPositionT    = m_state.vertexDecl != nullptr && m_state.vertexDecl->TestFlag(D3D9VertexDeclFlag::HasPositionT);
     bool hasBlendWeight  = m_state.vertexDecl != nullptr && m_state.vertexDecl->TestFlag(D3D9VertexDeclFlag::HasBlendWeight);
@@ -8292,7 +8235,58 @@ namespace dxvk {
 
       data->Material = m_state.material;
       data->TweenFactor = bit::cast<float>(m_state.renderStates[D3DRS_TWEENFACTOR]);
-      data->Packed = BuildPackedFFVSData(vertexBlendMode, indexedVertexBlend, lightIdx);
+
+      bool vertexHasPositionT = m_state.vertexDecl != nullptr && m_state.vertexDecl->TestFlag(D3D9VertexDeclFlag::HasPositionT);
+      data->VertexHasPositionT = vertexHasPositionT;
+      data->VertexHasColor0    = m_state.vertexDecl != nullptr && m_state.vertexDecl->TestFlag(D3D9VertexDeclFlag::HasColor0);
+      data->VertexHasColor1    = m_state.vertexDecl != nullptr && m_state.vertexDecl->TestFlag(D3D9VertexDeclFlag::HasColor1);
+      data->VertexHasPointSize = m_state.vertexDecl != nullptr && m_state.vertexDecl->TestFlag(D3D9VertexDeclFlag::HasPointSize);
+      data->VertexHasFog       = m_state.vertexDecl != nullptr && m_state.vertexDecl->TestFlag(D3D9VertexDeclFlag::HasFog);
+
+      bool lighting    = m_state.renderStates[D3DRS_LIGHTING] != 0 && !vertexHasPositionT;
+      bool colorVertex = m_state.renderStates[D3DRS_COLORVERTEX] != 0;
+      uint32_t mask    = (lighting && colorVertex)
+                       ? (data->VertexHasColor0 ? D3DMCS_COLOR1 : D3DMCS_MATERIAL)
+                       | (data->VertexHasColor1 ? D3DMCS_COLOR2 : D3DMCS_MATERIAL)
+                       : 0;
+
+      data->UseLighting      = lighting;
+      data->NormalizeNormals = m_state.renderStates[D3DRS_NORMALIZENORMALS];
+      data->LocalViewer      = m_state.renderStates[D3DRS_LOCALVIEWER] && lighting;
+
+      data->RangeFog         = m_state.renderStates[D3DRS_RANGEFOGENABLE];
+
+      data->DiffuseSource    = m_state.renderStates[D3DRS_DIFFUSEMATERIALSOURCE]  & mask;
+      data->AmbientSource    = m_state.renderStates[D3DRS_AMBIENTMATERIALSOURCE]  & mask;
+      data->SpecularSource   = m_state.renderStates[D3DRS_SPECULARMATERIALSOURCE] & mask;
+      data->EmissiveSource   = m_state.renderStates[D3DRS_EMISSIVEMATERIALSOURCE] & mask;
+
+      uint32_t lightCount = lightIdx;
+      data->LightCount       = lighting ? lightCount : 0;
+
+      for (uint32_t i = 0; i < caps::MaxTextureBlendStages; i++) {
+        uint32_t transformFlags = m_state.textureStages[i][DXVK_TSS_TEXTURETRANSFORMFLAGS] & ~(D3DTTFF_PROJECTED);
+        uint32_t index          = m_state.textureStages[i][DXVK_TSS_TEXCOORDINDEX];
+        uint32_t indexFlags     = (index & TCIMask) >> TCIOffset;
+
+        transformFlags &= 0b111;
+        index          &= 0b111;
+
+        data->TexcoordTransformFlags[i]  = transformFlags;
+        data->TexcoordFlags[i]   = indexFlags;
+        data->TexcoordIndices[i] = index;
+      }
+
+      data->VertexTexcoordDeclMask = m_state.vertexDecl != nullptr ? m_state.vertexDecl->GetTexcoordMask() : 0;
+
+      data->VertexBlendMode = uint8_t(vertexBlendMode);
+
+      if (vertexBlendMode == D3D9FF_VertexBlendMode_Normal) {
+        data->VertexBlendIndexed = indexedVertexBlend;
+        data->VertexBlendCount   = m_state.renderStates[D3DRS_VERTEXBLEND] & 0xff;
+      }
+
+      data->VertexClipping = m_state.renderStates[D3DRS_CLIPPLANEENABLE] != 0;
     }
 
     if (m_dirty.test(D3D9DeviceDirtyFlag::FFVertexBlend) && vertexBlendMode == D3D9FF_VertexBlendMode_Normal) {

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -8141,34 +8141,33 @@ namespace dxvk {
 
 
   D3D9PackedFFVSData D3D9DeviceEx::BuildPackedFFVSData(D3D9FF_VertexBlendMode vertexBlendMode, bool indexedVertexBlend, uint32_t lightCount) const {
-    D3D9PackedFFVSData data;
-    data.Primitive = {};
+    D3D9PackedFFVSData data = {};
 
-    data.Contents.VertexHasPositionT = m_state.vertexDecl != nullptr && m_state.vertexDecl->TestFlag(D3D9VertexDeclFlag::HasPositionT);
-    data.Contents.VertexHasColor0    = m_state.vertexDecl != nullptr && m_state.vertexDecl->TestFlag(D3D9VertexDeclFlag::HasColor0);
-    data.Contents.VertexHasColor1    = m_state.vertexDecl != nullptr && m_state.vertexDecl->TestFlag(D3D9VertexDeclFlag::HasColor1);
-    data.Contents.VertexHasPointSize = m_state.vertexDecl != nullptr && m_state.vertexDecl->TestFlag(D3D9VertexDeclFlag::HasPointSize);
-    data.Contents.VertexHasFog       = m_state.vertexDecl != nullptr && m_state.vertexDecl->TestFlag(D3D9VertexDeclFlag::HasFog);
+    data.VertexHasPositionT = m_state.vertexDecl != nullptr && m_state.vertexDecl->TestFlag(D3D9VertexDeclFlag::HasPositionT);
+    data.VertexHasColor0    = m_state.vertexDecl != nullptr && m_state.vertexDecl->TestFlag(D3D9VertexDeclFlag::HasColor0);
+    data.VertexHasColor1    = m_state.vertexDecl != nullptr && m_state.vertexDecl->TestFlag(D3D9VertexDeclFlag::HasColor1);
+    data.VertexHasPointSize = m_state.vertexDecl != nullptr && m_state.vertexDecl->TestFlag(D3D9VertexDeclFlag::HasPointSize);
+    data.VertexHasFog       = m_state.vertexDecl != nullptr && m_state.vertexDecl->TestFlag(D3D9VertexDeclFlag::HasFog);
 
-    bool lighting    = m_state.renderStates[D3DRS_LIGHTING] != 0 && !data.Contents.VertexHasPositionT;
+    bool lighting    = m_state.renderStates[D3DRS_LIGHTING] != 0 && !data.VertexHasPositionT;
     bool colorVertex = m_state.renderStates[D3DRS_COLORVERTEX] != 0;
     uint32_t mask    = (lighting && colorVertex)
-                     ? (data.Contents.VertexHasColor0 ? D3DMCS_COLOR1 : D3DMCS_MATERIAL)
-                     | (data.Contents.VertexHasColor1 ? D3DMCS_COLOR2 : D3DMCS_MATERIAL)
+                     ? (data.VertexHasColor0 ? D3DMCS_COLOR1 : D3DMCS_MATERIAL)
+                     | (data.VertexHasColor1 ? D3DMCS_COLOR2 : D3DMCS_MATERIAL)
                      : 0;
 
-    data.Contents.UseLighting      = lighting;
-    data.Contents.NormalizeNormals = m_state.renderStates[D3DRS_NORMALIZENORMALS];
-    data.Contents.LocalViewer      = m_state.renderStates[D3DRS_LOCALVIEWER] && lighting;
+    data.UseLighting      = lighting;
+    data.NormalizeNormals = m_state.renderStates[D3DRS_NORMALIZENORMALS];
+    data.LocalViewer      = m_state.renderStates[D3DRS_LOCALVIEWER] && lighting;
 
-    data.Contents.RangeFog         = m_state.renderStates[D3DRS_RANGEFOGENABLE];
+    data.RangeFog         = m_state.renderStates[D3DRS_RANGEFOGENABLE];
 
-    data.Contents.DiffuseSource    = m_state.renderStates[D3DRS_DIFFUSEMATERIALSOURCE]  & mask;
-    data.Contents.AmbientSource    = m_state.renderStates[D3DRS_AMBIENTMATERIALSOURCE]  & mask;
-    data.Contents.SpecularSource   = m_state.renderStates[D3DRS_SPECULARMATERIALSOURCE] & mask;
-    data.Contents.EmissiveSource   = m_state.renderStates[D3DRS_EMISSIVEMATERIALSOURCE] & mask;
+    data.DiffuseSource    = m_state.renderStates[D3DRS_DIFFUSEMATERIALSOURCE]  & mask;
+    data.AmbientSource    = m_state.renderStates[D3DRS_AMBIENTMATERIALSOURCE]  & mask;
+    data.SpecularSource   = m_state.renderStates[D3DRS_SPECULARMATERIALSOURCE] & mask;
+    data.EmissiveSource   = m_state.renderStates[D3DRS_EMISSIVEMATERIALSOURCE] & mask;
 
-    data.Contents.LightCount       = data.Contents.UseLighting ? lightCount : 0;
+    data.LightCount       = data.UseLighting ? lightCount : 0;
 
     for (uint32_t i = 0; i < caps::MaxTextureBlendStages; i++) {
       uint32_t transformFlags = m_state.textureStages[i][DXVK_TSS_TEXTURETRANSFORMFLAGS] & ~(D3DTTFF_PROJECTED);
@@ -8178,21 +8177,21 @@ namespace dxvk {
       transformFlags &= 0b111;
       index          &= 0b111;
 
-      data.Contents.TransformFlags  |= transformFlags << (i * 3);
-      data.Contents.TexcoordFlags   |= indexFlags     << (i * 3);
-      data.Contents.TexcoordIndices |= index          << (i * 3);
+      data.TexcoordTransformFlags[i]  = transformFlags;
+      data.TexcoordFlags[i]   = indexFlags;
+      data.TexcoordIndices[i] = index;
     }
 
-    data.Contents.VertexTexcoordDeclMask = m_state.vertexDecl != nullptr ? m_state.vertexDecl->GetTexcoordMask() : 0;
+    data.VertexTexcoordDeclMask = m_state.vertexDecl != nullptr ? m_state.vertexDecl->GetTexcoordMask() : 0;
 
-    data.Contents.VertexBlendMode  = uint32_t(vertexBlendMode);
+    data.VertexBlendMode = uint8_t(vertexBlendMode);
 
     if (vertexBlendMode == D3D9FF_VertexBlendMode_Normal) {
-      data.Contents.VertexBlendIndexed = indexedVertexBlend;
-      data.Contents.VertexBlendCount   = m_state.renderStates[D3DRS_VERTEXBLEND] & 0xff;
+      data.VertexBlendIndexed = indexedVertexBlend;
+      data.VertexBlendCount   = m_state.renderStates[D3DRS_VERTEXBLEND] & 0xff;
     }
 
-    data.Contents.VertexClipping = m_state.renderStates[D3DRS_CLIPPLANEENABLE] != 0;
+    data.VertexClipping = m_state.renderStates[D3DRS_CLIPPLANEENABLE] != 0;
 
     return data;
   }

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -8140,33 +8140,35 @@ namespace dxvk {
   }
 
 
-  D3D9FFShaderKeyVS D3D9DeviceEx::BuildFFKeyVS(D3D9FF_VertexBlendMode vertexBlendMode, bool indexedVertexBlend, uint32_t lightCount) const {
-    D3D9FFShaderKeyVS key;
-    key.Data.Contents.VertexHasPositionT = m_state.vertexDecl != nullptr && m_state.vertexDecl->TestFlag(D3D9VertexDeclFlag::HasPositionT);
-    key.Data.Contents.VertexHasColor0    = m_state.vertexDecl != nullptr && m_state.vertexDecl->TestFlag(D3D9VertexDeclFlag::HasColor0);
-    key.Data.Contents.VertexHasColor1    = m_state.vertexDecl != nullptr && m_state.vertexDecl->TestFlag(D3D9VertexDeclFlag::HasColor1);
-    key.Data.Contents.VertexHasPointSize = m_state.vertexDecl != nullptr && m_state.vertexDecl->TestFlag(D3D9VertexDeclFlag::HasPointSize);
-    key.Data.Contents.VertexHasFog       = m_state.vertexDecl != nullptr && m_state.vertexDecl->TestFlag(D3D9VertexDeclFlag::HasFog);
+  D3D9PackedFFVSData D3D9DeviceEx::BuildPackedFFVSData(D3D9FF_VertexBlendMode vertexBlendMode, bool indexedVertexBlend, uint32_t lightCount) const {
+    D3D9PackedFFVSData data;
+    data.Primitive = {};
 
-    bool lighting    = m_state.renderStates[D3DRS_LIGHTING] != 0 && !key.Data.Contents.VertexHasPositionT;
+    data.Contents.VertexHasPositionT = m_state.vertexDecl != nullptr && m_state.vertexDecl->TestFlag(D3D9VertexDeclFlag::HasPositionT);
+    data.Contents.VertexHasColor0    = m_state.vertexDecl != nullptr && m_state.vertexDecl->TestFlag(D3D9VertexDeclFlag::HasColor0);
+    data.Contents.VertexHasColor1    = m_state.vertexDecl != nullptr && m_state.vertexDecl->TestFlag(D3D9VertexDeclFlag::HasColor1);
+    data.Contents.VertexHasPointSize = m_state.vertexDecl != nullptr && m_state.vertexDecl->TestFlag(D3D9VertexDeclFlag::HasPointSize);
+    data.Contents.VertexHasFog       = m_state.vertexDecl != nullptr && m_state.vertexDecl->TestFlag(D3D9VertexDeclFlag::HasFog);
+
+    bool lighting    = m_state.renderStates[D3DRS_LIGHTING] != 0 && !data.Contents.VertexHasPositionT;
     bool colorVertex = m_state.renderStates[D3DRS_COLORVERTEX] != 0;
     uint32_t mask    = (lighting && colorVertex)
-                     ? (key.Data.Contents.VertexHasColor0 ? D3DMCS_COLOR1 : D3DMCS_MATERIAL)
-                     | (key.Data.Contents.VertexHasColor1 ? D3DMCS_COLOR2 : D3DMCS_MATERIAL)
+                     ? (data.Contents.VertexHasColor0 ? D3DMCS_COLOR1 : D3DMCS_MATERIAL)
+                     | (data.Contents.VertexHasColor1 ? D3DMCS_COLOR2 : D3DMCS_MATERIAL)
                      : 0;
 
-    key.Data.Contents.UseLighting      = lighting;
-    key.Data.Contents.NormalizeNormals = m_state.renderStates[D3DRS_NORMALIZENORMALS];
-    key.Data.Contents.LocalViewer      = m_state.renderStates[D3DRS_LOCALVIEWER] && lighting;
+    data.Contents.UseLighting      = lighting;
+    data.Contents.NormalizeNormals = m_state.renderStates[D3DRS_NORMALIZENORMALS];
+    data.Contents.LocalViewer      = m_state.renderStates[D3DRS_LOCALVIEWER] && lighting;
 
-    key.Data.Contents.RangeFog         = m_state.renderStates[D3DRS_RANGEFOGENABLE];
+    data.Contents.RangeFog         = m_state.renderStates[D3DRS_RANGEFOGENABLE];
 
-    key.Data.Contents.DiffuseSource    = m_state.renderStates[D3DRS_DIFFUSEMATERIALSOURCE]  & mask;
-    key.Data.Contents.AmbientSource    = m_state.renderStates[D3DRS_AMBIENTMATERIALSOURCE]  & mask;
-    key.Data.Contents.SpecularSource   = m_state.renderStates[D3DRS_SPECULARMATERIALSOURCE] & mask;
-    key.Data.Contents.EmissiveSource   = m_state.renderStates[D3DRS_EMISSIVEMATERIALSOURCE] & mask;
+    data.Contents.DiffuseSource    = m_state.renderStates[D3DRS_DIFFUSEMATERIALSOURCE]  & mask;
+    data.Contents.AmbientSource    = m_state.renderStates[D3DRS_AMBIENTMATERIALSOURCE]  & mask;
+    data.Contents.SpecularSource   = m_state.renderStates[D3DRS_SPECULARMATERIALSOURCE] & mask;
+    data.Contents.EmissiveSource   = m_state.renderStates[D3DRS_EMISSIVEMATERIALSOURCE] & mask;
 
-    key.Data.Contents.LightCount       = key.Data.Contents.UseLighting ? lightCount : 0;
+    data.Contents.LightCount       = data.Contents.UseLighting ? lightCount : 0;
 
     for (uint32_t i = 0; i < caps::MaxTextureBlendStages; i++) {
       uint32_t transformFlags = m_state.textureStages[i][DXVK_TSS_TEXTURETRANSFORMFLAGS] & ~(D3DTTFF_PROJECTED);
@@ -8176,23 +8178,23 @@ namespace dxvk {
       transformFlags &= 0b111;
       index          &= 0b111;
 
-      key.Data.Contents.TransformFlags  |= transformFlags << (i * 3);
-      key.Data.Contents.TexcoordFlags   |= indexFlags     << (i * 3);
-      key.Data.Contents.TexcoordIndices |= index          << (i * 3);
+      data.Contents.TransformFlags  |= transformFlags << (i * 3);
+      data.Contents.TexcoordFlags   |= indexFlags     << (i * 3);
+      data.Contents.TexcoordIndices |= index          << (i * 3);
     }
 
-    key.Data.Contents.VertexTexcoordDeclMask = m_state.vertexDecl != nullptr ? m_state.vertexDecl->GetTexcoordMask() : 0;
+    data.Contents.VertexTexcoordDeclMask = m_state.vertexDecl != nullptr ? m_state.vertexDecl->GetTexcoordMask() : 0;
 
-    key.Data.Contents.VertexBlendMode  = uint32_t(vertexBlendMode);
+    data.Contents.VertexBlendMode  = uint32_t(vertexBlendMode);
 
     if (vertexBlendMode == D3D9FF_VertexBlendMode_Normal) {
-      key.Data.Contents.VertexBlendIndexed = indexedVertexBlend;
-      key.Data.Contents.VertexBlendCount   = m_state.renderStates[D3DRS_VERTEXBLEND] & 0xff;
+      data.Contents.VertexBlendIndexed = indexedVertexBlend;
+      data.Contents.VertexBlendCount   = m_state.renderStates[D3DRS_VERTEXBLEND] & 0xff;
     }
 
-    key.Data.Contents.VertexClipping = m_state.renderStates[D3DRS_CLIPPLANEENABLE] != 0;
+    data.Contents.VertexClipping = m_state.renderStates[D3DRS_CLIPPLANEENABLE] != 0;
 
-    return key;
+    return data;
   }
 
 
@@ -8291,7 +8293,7 @@ namespace dxvk {
 
       data->Material = m_state.material;
       data->TweenFactor = bit::cast<float>(m_state.renderStates[D3DRS_TWEENFACTOR]);
-      data->Key = BuildFFKeyVS(vertexBlendMode, indexedVertexBlend, lightIdx).Data;
+      data->Packed = BuildPackedFFVSData(vertexBlendMode, indexedVertexBlend, lightIdx);
     }
 
     if (m_dirty.test(D3D9DeviceDirtyFlag::FFVertexBlend) && vertexBlendMode == D3D9FF_VertexBlendMode_Normal) {

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -1453,7 +1453,7 @@ namespace dxvk {
     void UpdatePointModeSpec(uint32_t mode);
     void UpdateFogModeSpec(bool fogEnabled, D3DFOGMODE vertexFogMode, D3DFOGMODE pixelFogMode);
 
-    D3D9FFShaderKeyVS BuildFFKeyVS(D3D9FF_VertexBlendMode vertexBlendMode, bool indexedVertexBlend, uint32_t lightCount) const;
+    D3D9PackedFFVSData BuildPackedFFVSData(D3D9FF_VertexBlendMode vertexBlendMode, bool indexedVertexBlend, uint32_t lightCount) const;
 
     void BindSpecConstants();
 

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -1453,8 +1453,6 @@ namespace dxvk {
     void UpdatePointModeSpec(uint32_t mode);
     void UpdateFogModeSpec(bool fogEnabled, D3DFOGMODE vertexFogMode, D3DFOGMODE pixelFogMode);
 
-    D3D9PackedFFVSData BuildPackedFFVSData(D3D9FF_VertexBlendMode vertexBlendMode, bool indexedVertexBlend, uint32_t lightCount) const;
-
     void BindSpecConstants();
 
     void TrackBufferMappingBufferSequenceNumber(

--- a/src/d3d9/d3d9_state.h
+++ b/src/d3d9/d3d9_state.h
@@ -113,54 +113,38 @@ namespace dxvk {
   };
 
   struct D3D9PackedFFVSData {
-    union {
-      struct {
-        uint32_t TexcoordIndices : 24;
+    std::array<uint8_t, caps::MaxTextureBlendStages> TexcoordIndices;
+    std::array<uint8_t, caps::MaxTextureBlendStages> TexcoordFlags;
+    std::array<uint8_t, caps::MaxTextureBlendStages> TexcoordTransformFlags;
 
-        uint32_t VertexHasPositionT : 1;
+    // How many vector components does each texcoord have
+    uint32_t VertexTexcoordDeclMask;
 
-        uint32_t VertexHasColor0 : 1; // Diffuse
-        uint32_t VertexHasColor1 : 1; // Specular
+    // Vertex Decl
+    bool VertexHasPositionT;
+    bool VertexHasColor0; // Diffuse
+    bool VertexHasColor1; // Specular
+    bool VertexHasPointSize;
+    bool VertexHasFog;
 
-        uint32_t VertexHasPointSize : 1;
+    // Blending
+    uint8_t VertexBlendMode;
+    bool VertexBlendIndexed;
+    uint8_t VertexBlendCount;
 
-        uint32_t UseLighting : 1;
+    // Misc
+    bool VertexClipping;
+    bool NormalizeNormals;
+    bool LocalViewer;
+    bool RangeFog;
 
-        uint32_t NormalizeNormals : 1;
-        uint32_t LocalViewer : 1;
-        uint32_t RangeFog : 1;
-
-        // End of uint32_t
-
-        uint32_t TexcoordFlags : 24;
-
-        uint32_t DiffuseSource : 2;
-        uint32_t AmbientSource : 2;
-        uint32_t SpecularSource : 2;
-        uint32_t EmissiveSource : 2;
-
-        // Next uint32_t
-
-        uint32_t TransformFlags : 24;
-
-        uint32_t LightCount : 4;
-
-        // End of uint32_t
-
-        uint32_t VertexTexcoordDeclMask : 24;
-        uint32_t VertexHasFog : 1;
-
-        uint32_t VertexBlendMode    : 2;
-        uint32_t VertexBlendIndexed : 1;
-        uint32_t VertexBlendCount   : 2;
-
-        uint32_t VertexClipping     : 1;
-
-        // End of uint32_t
-      } Contents;
-
-      std::array<uint32_t, 5u> Primitive;
-    };
+    // Lighting
+    bool UseLighting;
+    uint8_t LightCount;
+    uint8_t DiffuseSource;
+    uint8_t AmbientSource;
+    uint8_t SpecularSource;
+    uint8_t EmissiveSource;
   };
 
   struct D3D9FixedFunctionVS {

--- a/src/d3d9/d3d9_state.h
+++ b/src/d3d9/d3d9_state.h
@@ -112,7 +112,7 @@ namespace dxvk {
     float Phi;
   };
 
-  struct D3D9FFShaderKeyVSData {
+  struct D3D9PackedFFVSData {
     union {
       struct {
         uint32_t TexcoordIndices : 24;
@@ -159,17 +159,8 @@ namespace dxvk {
         // End of uint32_t
       } Contents;
 
-      uint32_t Primitive[5];
+      std::array<uint32_t, 5u> Primitive;
     };
-  };
-
-  struct D3D9FFShaderKeyVS {
-    D3D9FFShaderKeyVS() {
-      // memcmp safety
-      std::memset(&Data, 0, sizeof(Data));
-    }
-
-    D3D9FFShaderKeyVSData Data;
   };
 
   struct D3D9FixedFunctionVS {
@@ -187,7 +178,7 @@ namespace dxvk {
     D3DMATERIAL9 Material;
     float TweenFactor;
 
-    D3D9FFShaderKeyVSData Key;
+    D3D9PackedFFVSData Packed;
   };
 
   static constexpr uint32_t D3D9MaxVertexBlendTransformsHw = 8u;

--- a/src/d3d9/d3d9_state.h
+++ b/src/d3d9/d3d9_state.h
@@ -112,7 +112,22 @@ namespace dxvk {
     float Phi;
   };
 
-  struct D3D9PackedFFVSData {
+  struct D3D9FixedFunctionVS {
+    Matrix4 WorldView;
+    Matrix4 NormalMatrix;
+    Matrix4 InverseView;
+    Matrix4 Projection;
+
+    std::array<Matrix4, 8> TexcoordMatrices;
+
+    D3D9ViewportInfo ViewportInfo;
+
+    Vector4 GlobalAmbient;
+    std::array<D3D9Light, caps::MaxEnabledLights> Lights;
+    D3DMATERIAL9 Material;
+    float TweenFactor;
+
+    // Following part uses uint8 and bool so it's gonna be represented as uint32 in the shader and manually unpacked:
     std::array<uint8_t, caps::MaxTextureBlendStages> TexcoordIndices;
     std::array<uint8_t, caps::MaxTextureBlendStages> TexcoordFlags;
     std::array<uint8_t, caps::MaxTextureBlendStages> TexcoordTransformFlags;
@@ -145,24 +160,6 @@ namespace dxvk {
     uint8_t AmbientSource;
     uint8_t SpecularSource;
     uint8_t EmissiveSource;
-  };
-
-  struct D3D9FixedFunctionVS {
-    Matrix4 WorldView;
-    Matrix4 NormalMatrix;
-    Matrix4 InverseView;
-    Matrix4 Projection;
-
-    std::array<Matrix4, 8> TexcoordMatrices;
-
-    D3D9ViewportInfo ViewportInfo;
-
-    Vector4 GlobalAmbient;
-    std::array<D3D9Light, caps::MaxEnabledLights> Lights;
-    D3DMATERIAL9 Material;
-    float TweenFactor;
-
-    D3D9PackedFFVSData Packed;
   };
 
   static constexpr uint32_t D3D9MaxVertexBlendTransformsHw = 8u;

--- a/src/d3d9/shaders/d3d9_fixed_function_vert.vert
+++ b/src/d3d9/shaders/d3d9_fixed_function_vert.vert
@@ -98,7 +98,7 @@ struct D3D9FixedFunctionVS {
     D3DMATERIAL9 Material;
     float TweenFactor;
 
-    uint KeyPrimitives[4];
+    uint DataPrimitives[12];
 };
 
 #define D3D9FF_VertexBlendMode uint
@@ -150,77 +150,85 @@ uniform RenderStates {
 };
 
 
-// Functions to extract information from the packed VS key
-// See D3D9FFShaderKeyVSData in d3d9_shader_types.h
+// Functions to extract information from the VS data
+// We can't use bools or uint8_t so we have to do this.
+// Storing every single bool as a 32 bit integer would make the buffer a little too huge.
+// See D3D9PackedFFVSData in d3d9_state.h
 // Please, dearest compiler, inline all of this.
-uint texcoordIndices() {
-    return bitfieldExtract(data.KeyPrimitives[0], 0, 24);
+
+uint extractByte(uint offset) {
+    uint dword = data.DataPrimitives[offset / 4u];
+    return bitfieldExtract(dword, (int(offset) % 4) * 8, 8);
+}
+
+uint texcoordIndex(uint index) {
+    return extractByte(index);
 }
 bool vertexHasPositionT() {
-    return bitfieldExtract(data.KeyPrimitives[0], 24, 1) != 0;
+    return extractByte(28) != 0;
 }
 bool vertexHasColor0() {
-    return bitfieldExtract(data.KeyPrimitives[0], 25, 1) != 0;
+    return extractByte(29) != 0;
 }
 bool vertexHasColor1() {
-    return bitfieldExtract(data.KeyPrimitives[0], 26, 1) != 0;
+    return extractByte(30) != 0;
 }
 bool vertexHasPointSize() {
-    return bitfieldExtract(data.KeyPrimitives[0], 27, 1) != 0;
+    return extractByte(31) != 0;
 }
 bool useLighting() {
-    return bitfieldExtract(data.KeyPrimitives[0], 28, 1) != 0;
+    return extractByte(40) != 0;
 }
 bool normalizeNormals() {
-    return bitfieldExtract(data.KeyPrimitives[0], 29, 1) != 0;
+    return extractByte(37) != 0;
 }
 bool localViewer() {
-    return bitfieldExtract(data.KeyPrimitives[0], 30, 1) != 0;
+    return extractByte(38) != 0;
 }
 bool rangeFog() {
-    return bitfieldExtract(data.KeyPrimitives[0], 31, 1) != 0;
+    return extractByte(39) != 0;
 }
 
-uint texcoordFlags() {
-    return bitfieldExtract(data.KeyPrimitives[1], 0, 24);
+uint texcoordFlags(uint index) {
+    return extractByte(TextureStageCount + index);
 }
 uint diffuseSource() {
-    return bitfieldExtract(data.KeyPrimitives[1], 24, 2);
+    return extractByte(42);
 }
 uint ambientSource() {
-    return bitfieldExtract(data.KeyPrimitives[1], 26, 2);
+    return extractByte(43);
 }
 uint specularSource() {
-    return bitfieldExtract(data.KeyPrimitives[1], 28, 2);
+    return extractByte(44);
 }
 uint emissiveSource() {
-    return bitfieldExtract(data.KeyPrimitives[1], 30, 2);
+    return extractByte(45);
 }
 
-uint transformFlags() {
-    return bitfieldExtract(data.KeyPrimitives[2], 0, 24);
+uint texcoordTransformFlags(uint index) {
+    return extractByte(TextureStageCount * 2 + index);
 }
 uint lightCount() {
-    return bitfieldExtract(data.KeyPrimitives[2], 24, 4);
+    return extractByte(41);
 }
 
 uint vertexTexcoordDeclMask() {
-    return bitfieldExtract(data.KeyPrimitives[3], 0, 24);
+    return data.DataPrimitives[24 / 4];
 }
 bool vertexHasFog() {
-    return bitfieldExtract(data.KeyPrimitives[3], 24, 1) != 0;
+    return extractByte(32) != 0;
 }
 D3D9FF_VertexBlendMode blendMode() {
-    return bitfieldExtract(data.KeyPrimitives[3], 25, 2);
+    return extractByte(33);
 }
 bool vertexBlendIndexed() {
-    return bitfieldExtract(data.KeyPrimitives[3], 27, 1) != 0;
+    return extractByte(34) != 0;
 }
 uint vertexBlendCount() {
-    return bitfieldExtract(data.KeyPrimitives[3], 28, 2);
+    return extractByte(35);
 }
 bool vertexClipping() {
-    return bitfieldExtract(data.KeyPrimitives[3], 30, 1) != 0;
+    return extractByte(36) != 0;
 }
 
 
@@ -432,13 +440,13 @@ void main() {
 
     for (uint i = 0; i < TextureStageCount; i++) {
         // 0b111 = 7
-        uint inputIndex = (texcoordIndices() >> (i * 3)) & 7;
-        uint inputFlags = (texcoordFlags() >> (i * 3)) & 7;
+        uint inputIndex = texcoordIndex(i);
+        uint inputFlags = texcoordFlags(i);
         uint texcoordCount = (vertexTexcoordDeclMask() >> (inputIndex * 3)) & 7;
 
         vec4 transformed;
 
-        uint flags = (transformFlags() >> (i * 3)) & 7;
+        uint flags = texcoordTransformFlags(i);
 
         // Passing 0xffffffff results in it getting clamped to the dimensions of the texture coords and getting treated as PROJECTED
         // but D3D9 does not apply the transformation matrix.


### PR DESCRIPTION
~~Much less significant than the PS one.~~ That didn't really last...

Rename it and remove the extra struct as it's no longer used as a lookup key.

Besides that, it removes the super tight packing for what used to be the key of FF vertex shaders as apparently that was UB.
Unfortunately we can't get rid of it on the shader side because single byte types arent supported and replacing all of it with 4 byte unsigned ints would be a bit excessive size-wise.