### PR TITLE
Clean up and compact D3D9 push data

### DIFF
--- a/src/d3d9/d3d9_constant_copy.cpp
+++ b/src/d3d9/d3d9_constant_copy.cpp
@@ -50,17 +50,33 @@ namespace dxvk {
 
   D3D9ConstantBufferLayout::D3D9ConstantBufferLayout(
           uint32_t            maxCount,
-          uint32_t            defLength,
-    const uint32_t*           defMask,
+          uint32_t            useLength,
+    const uint32_t*           useMask,
           size_t              defCount,
     const D3D9ImmediateFloatConstant* defData)
   : m_minCount(0u), m_maxCount(maxCount), m_dynamicIndexing(true) {
     uint32_t defIndex = 0u;
     uint32_t dstIndex = 0u;
 
+    // Build mask of shader-defined constants
+    small_vector<uint32_t, 64u> defMask(align(maxCount, 32u) / 32u);
+
+    for (uint32_t i = 0u; i < defCount; i++) {
+      if (defData[i].index < maxCount)
+        defMask[defData[i].index / 32u] |= 1u << (defData[i].index % 32u);
+    }
+
+    // Find index of highest statically indexed constant
+    for (uint32_t i = useLength; i; i--) {
+      if (useMask[i - 1u]) {
+        m_minCount = std::min(32u * i + bit::tzcnt(useMask[i - 1u]) - 31u, maxCount);
+        break;
+      }
+    }
+
     // More or less the inverse of the above logic. Keep all constants intact,
     // but insert ranges for any constants that are shader-defined.
-    for (uint32_t i = 0u; i < defLength; i++) {
+    for (uint32_t i = 0u; i < defMask.size(); i++) {
       uint32_t mask = defMask[i];
 
       while (mask) {

--- a/src/d3d9/d3d9_constant_copy.h
+++ b/src/d3d9/d3d9_constant_copy.h
@@ -92,14 +92,14 @@ namespace dxvk {
      * \brief Builds constant layout for dynamic indexing
      *
      * \param [in] maxCount Maximum available constant count
-     * \param [in] defLength Number of dwords in shader-defined constant mask
-     * \param [in] defMask Bit mask of shader-defined constants
+     * \param [in] useLength Number of dwords in constant mask
+     * \param [in] useMask Bit mask of statically indexed constants
      * \param [in] defData Actual shader-defined constant data
      */
     D3D9ConstantBufferLayout(
             uint32_t            maxCount,
-            uint32_t            defLength,
-      const uint32_t*           defMask,
+            uint32_t            useLength,
+      const uint32_t*           useMask,
             size_t              defCount,
       const D3D9ImmediateFloatConstant* defData);
 

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -6057,6 +6057,10 @@ namespace dxvk {
       copyArgs.floatConstantCount = dynamicFloatCount;
       copyArgs.flushNan = m_d3d9Options.d3d9FloatEmulation == D3D9FloatEmulation::Enabled;
 
+      // Over-allocate buffer by one constant so that we always have
+      // at least one entry that reads zeroes.
+      dynamicSize += sizeof(Vector4);
+
       // Allocate storage for dynamically indexed floats. Pad this
       // to the full allocation size as well so we write everything.
       auto& buffer = GetConstantBuffer(CbvIndex::VSDynamicConstants);
@@ -6067,6 +6071,12 @@ namespace dxvk {
       copyArgs.constFloatApi = m_state.vsConsts->fConsts;
 
       layout->copyConstantData(copyArgs);
+
+      // Pass float count to vertex shader
+      if (m_pushData.vs.floatCount != dynamicFloatCount) {
+        m_pushData.vs.floatCount = dynamicFloatCount;
+        m_dirty.set(D3D9DeviceDirtyFlag::PushDataVs);
+      }
     }
 
     constants.dirty = false;

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -2113,7 +2113,6 @@ namespace dxvk {
     m_dirty.set(D3D9DeviceDirtyFlag::ViewportScissor);
     m_dirty.set(D3D9DeviceDirtyFlag::FFViewport);
     m_dirty.set(D3D9DeviceDirtyFlag::PointScale);
-
     return D3D_OK;
   }
 
@@ -2441,11 +2440,13 @@ namespace dxvk {
           break;
 
         case D3DRS_ALPHAREF:
-          UpdatePushConstant<D3D9RenderStateItem::AlphaRef>();
+          m_pushData.shared.alphaRef = Value;
+          m_dirty.set(D3D9DeviceDirtyFlag::PushDataShared);
           break;
 
         case D3DRS_TEXTUREFACTOR:
-          UpdatePushConstant<D3D9RenderStateItem::TextureFactor>();
+          m_pushData.ffps.textureFactor = Value;
+          m_dirty.set(D3D9DeviceDirtyFlag::PushDataFfps);
           break;
 
         case D3DRS_DIFFUSEMATERIALSOURCE:
@@ -2526,16 +2527,19 @@ namespace dxvk {
             }
           }
 
-          UpdatePushConstant<D3D9RenderStateItem::PointSize>();
+          m_pushData.vs.pointSize = EncodePointSize(Value);
+          m_dirty.set(D3D9DeviceDirtyFlag::PushDataVs);
           break;
         }
 
         case D3DRS_POINTSIZE_MIN:
-          UpdatePushConstant<D3D9RenderStateItem::PointSizeMin>();
+          m_pushData.vs.pointSizeMin = EncodePointSize(Value);
+          m_dirty.set(D3D9DeviceDirtyFlag::PushDataVs);
           break;
 
         case D3DRS_POINTSIZE_MAX:
-          UpdatePushConstant<D3D9RenderStateItem::PointSizeMax>();
+          m_pushData.vs.pointSizeMax = EncodePointSize(Value);
+          m_dirty.set(D3D9DeviceDirtyFlag::PushDataVs);
           break;
 
         case D3DRS_POINTSCALE_A:
@@ -6093,85 +6097,6 @@ namespace dxvk {
   }
 
 
-  template <uint32_t Offset, uint32_t Length>
-  void D3D9DeviceEx::UpdatePushConstant(const void* pData) {
-    struct ConstantData { uint8_t Data[Length]; };
-
-    const ConstantData* constData = reinterpret_cast<const ConstantData*>(pData);
-
-    EmitCs([
-      cData = *constData
-    ](DxvkContext* ctx) {
-      // Render state uses the shared push constant block
-      ctx->pushData(VK_SHADER_STAGE_ALL_GRAPHICS, Offset, Length, &cData);
-    });
-  }
-
-
-  template <D3D9RenderStateItem Item>
-  void D3D9DeviceEx::UpdatePushConstant() {
-    auto& rs = m_state.renderStates;
-
-    if constexpr (Item == D3D9RenderStateItem::AlphaRef) {
-      uint32_t alpha = rs[D3DRS_ALPHAREF] & 0xFF;
-      UpdatePushConstant<offsetof(D3D9RenderStateInfo, alphaRef), sizeof(uint32_t)>(&alpha);
-    }
-    else if constexpr (Item == D3D9RenderStateItem::FogColor) {
-      Vector4 color;
-      DecodeD3DCOLOR(D3DCOLOR(rs[D3DRS_FOGCOLOR]), color.data);
-      UpdatePushConstant<offsetof(D3D9RenderStateInfo, fogColor), sizeof(D3D9RenderStateInfo::fogColor)>(&color);
-    }
-    else if constexpr (Item == D3D9RenderStateItem::FogDensity) {
-      float density = bit::cast<float>(rs[D3DRS_FOGDENSITY]);
-      UpdatePushConstant<offsetof(D3D9RenderStateInfo, fogDensity), sizeof(float)>(&density);
-    }
-    else if constexpr (Item == D3D9RenderStateItem::FogEnd) {
-      float end = bit::cast<float>(rs[D3DRS_FOGEND]);
-      UpdatePushConstant<offsetof(D3D9RenderStateInfo, fogEnd), sizeof(float)>(&end);
-    }
-    else if constexpr (Item == D3D9RenderStateItem::FogScale) {
-      float end = bit::cast<float>(rs[D3DRS_FOGEND]);
-      float start = bit::cast<float>(rs[D3DRS_FOGSTART]);
-
-      float scale = (end != start) ? 1.0f / (end - start) : 0.0f;
-      UpdatePushConstant<offsetof(D3D9RenderStateInfo, fogScale), sizeof(float)>(&scale);
-    }
-    else if constexpr (Item == D3D9RenderStateItem::PointSize) {
-      UpdatePushConstant<offsetof(D3D9RenderStateInfo, pointSize), sizeof(float)>(&rs[D3DRS_POINTSIZE]);
-    }
-    else if constexpr (Item == D3D9RenderStateItem::PointSizeMin) {
-      UpdatePushConstant<offsetof(D3D9RenderStateInfo, pointSizeMin), sizeof(float)>(&rs[D3DRS_POINTSIZE_MIN]);
-    }
-    else if constexpr (Item == D3D9RenderStateItem::PointSizeMax) {
-      UpdatePushConstant<offsetof(D3D9RenderStateInfo, pointSizeMax), sizeof(float)>(&rs[D3DRS_POINTSIZE_MAX]);
-    }
-    else if constexpr (Item == D3D9RenderStateItem::PointScaleA) {
-      float scale = bit::cast<float>(rs[D3DRS_POINTSCALE_A]);
-      scale /= float(m_state.viewport.Height * m_state.viewport.Height);
-
-      UpdatePushConstant<offsetof(D3D9RenderStateInfo, pointScaleA), sizeof(float)>(&scale);
-    }
-    else if constexpr (Item == D3D9RenderStateItem::PointScaleB) {
-      float scale = bit::cast<float>(rs[D3DRS_POINTSCALE_B]);
-      scale /= float(m_state.viewport.Height * m_state.viewport.Height);
-
-      UpdatePushConstant<offsetof(D3D9RenderStateInfo, pointScaleB), sizeof(float)>(&scale);
-    }
-    else if constexpr (Item == D3D9RenderStateItem::PointScaleC) {
-      float scale = bit::cast<float>(rs[D3DRS_POINTSCALE_C]);
-      scale /= float(m_state.viewport.Height * m_state.viewport.Height);
-
-      UpdatePushConstant<offsetof(D3D9RenderStateInfo, pointScaleC), sizeof(float)>(&scale);
-    }
-    else if constexpr (Item == D3D9RenderStateItem::TextureFactor) {
-      uint32_t textureFactor = bit::cast<uint32_t>(rs[D3DRS_TEXTUREFACTOR]);
-      UpdatePushConstant<offsetof(D3D9RenderStateInfo, textureFactor), sizeof(uint32_t)>(&textureFactor);
-    }
-    else
-      Logger::warn("D3D9: Invalid push constant set to update.");
-  }
-
-
   void D3D9DeviceEx::ExecuteFlush(bool Synchronize9On12) {
     D3D9DeviceLock lock = LockDevice();
 
@@ -6634,9 +6559,12 @@ namespace dxvk {
     if (rs[D3DRS_POINTSCALEENABLE] && m_dirty.test(D3D9DeviceDirtyFlag::PointScale)) {
       m_dirty.clr(D3D9DeviceDirtyFlag::PointScale);
 
-      UpdatePushConstant<D3D9RenderStateItem::PointScaleA>();
-      UpdatePushConstant<D3D9RenderStateItem::PointScaleB>();
-      UpdatePushConstant<D3D9RenderStateItem::PointScaleC>();
+      float scale = 1.0f / float(m_state.viewport.Height * m_state.viewport.Height);
+      m_pushData.ffvs.pointScaleA = scale * bit::cast<float>(rs[D3DRS_POINTSCALE_A]);
+      m_pushData.ffvs.pointScaleB = scale * bit::cast<float>(rs[D3DRS_POINTSCALE_B]);
+      m_pushData.ffvs.pointScaleC = scale * bit::cast<float>(rs[D3DRS_POINTSCALE_C]);
+
+      m_dirty.set(D3D9DeviceDirtyFlag::PushDataFfvs);
     }
 
     UpdatePointModeSpec(mode);
@@ -6662,10 +6590,20 @@ namespace dxvk {
 
     UpdateFogModeSpec(fogEnabled, vsFog, psFog);
 
-    UpdatePushConstant<D3D9RenderStateItem::FogColor>();
-    UpdatePushConstant<D3D9RenderStateItem::FogScale>();
-    UpdatePushConstant<D3D9RenderStateItem::FogEnd>();
-    UpdatePushConstant<D3D9RenderStateItem::FogDensity>();
+    // Update fog parameters
+    uint32_t fogColor = rs[D3DRS_FOGCOLOR];
+    float fogDensity = bit::cast<float>(rs[D3DRS_FOGDENSITY]);
+    float fogEnd   = bit::cast<float>(rs[D3DRS_FOGEND]);
+    float fogStart = bit::cast<float>(rs[D3DRS_FOGSTART]);
+
+    m_pushData.shared.fogColor[0] = uint8_t(fogColor >>  0u);
+    m_pushData.shared.fogColor[1] = uint8_t(fogColor >>  8u);
+    m_pushData.shared.fogColor[2] = uint8_t(fogColor >> 16u);
+    m_pushData.shared.fogDensity = fogDensity;
+    m_pushData.shared.fogDistanceEnd = fogEnd;
+    m_pushData.shared.fogDistanceScale = (fogEnd != fogStart) ? 1.0f / (fogEnd - fogStart) : 0.0f;
+
+    m_dirty.set(D3D9DeviceDirtyFlag::PushDataShared);
   }
 
 
@@ -6676,6 +6614,31 @@ namespace dxvk {
 
     if (m_specInfo.set<D3D9SpecConstantId::SpecFFGlobalSpecularEnabled>(specularEnabled))
       m_dirty.set(D3D9DeviceDirtyFlag::SpecializationEntries);
+  }
+
+
+  template<typename T>
+  void D3D9DeviceEx::UpdatePushDataBlock(const T& Block) {
+    EmitCs([cBlock = Block] (DxvkContext* ctx) {
+      ctx->pushData(T::Stages, T::Offset, sizeof(T), &cBlock);
+    });
+  }
+
+
+  void D3D9DeviceEx::UpdatePushData() {
+    if (m_dirty.test(D3D9DeviceDirtyFlag::PushDataShared))
+      UpdatePushDataBlock(m_pushData.shared);
+    if (m_dirty.test(D3D9DeviceDirtyFlag::PushDataVs))
+      UpdatePushDataBlock(m_pushData.vs);
+    if (m_dirty.test(D3D9DeviceDirtyFlag::PushDataFfvs))
+      UpdatePushDataBlock(m_pushData.ffvs);
+    if (m_dirty.test(D3D9DeviceDirtyFlag::PushDataFfps))
+      UpdatePushDataBlock(m_pushData.ffps);
+
+    m_dirty.clr(D3D9DeviceDirtyFlag::PushDataShared,
+                D3D9DeviceDirtyFlag::PushDataVs,
+                D3D9DeviceDirtyFlag::PushDataFfvs,
+                D3D9DeviceDirtyFlag::PushDataFfps);
   }
 
 
@@ -7551,6 +7514,12 @@ namespace dxvk {
       BindIndices();
       m_dirty.clr(D3D9DeviceDirtyFlag::IndexBuffer);
     }
+
+    if (m_dirty.any(D3D9DeviceDirtyFlag::PushDataShared,
+                    D3D9DeviceDirtyFlag::PushDataVs,
+                    D3D9DeviceDirtyFlag::PushDataFfvs,
+                    D3D9DeviceDirtyFlag::PushDataFfps))
+      UpdatePushData();
   }
 
 
@@ -8565,13 +8534,13 @@ namespace dxvk {
     rs[D3DRS_ALPHAFUNC]           = D3DCMP_ALWAYS;
     BindAlphaTestState();
     rs[D3DRS_ALPHAREF]            = 0;
-    UpdatePushConstant<D3D9RenderStateItem::AlphaRef>();
+    m_pushData.shared.alphaRef    = rs[D3DRS_ALPHAREF];
 
     rs[D3DRS_MULTISAMPLEMASK]     = 0xffffffff;
     BindMultiSampleState();
 
     rs[D3DRS_TEXTUREFACTOR]       = 0xffffffff;
-    UpdatePushConstant<D3D9RenderStateItem::TextureFactor>();
+    m_pushData.ffps.textureFactor = rs[D3DRS_TEXTUREFACTOR];
 
     rs[D3DRS_DIFFUSEMATERIALSOURCE]  = D3DMCS_COLOR1;
     rs[D3DRS_SPECULARMATERIALSOURCE] = D3DMCS_COLOR2;
@@ -8612,9 +8581,9 @@ namespace dxvk {
     rs[D3DRS_POINTSIZE]                  = bit::cast<DWORD>(1.0f);
     rs[D3DRS_POINTSIZE_MIN]              = m_isD3D8Compatible ? bit::cast<DWORD>(0.0f) : bit::cast<DWORD>(1.0f);
     rs[D3DRS_POINTSIZE_MAX]              = bit::cast<DWORD>(limits.pointSizeRange[1]);
-    UpdatePushConstant<D3D9RenderStateItem::PointSize>();
-    UpdatePushConstant<D3D9RenderStateItem::PointSizeMin>();
-    UpdatePushConstant<D3D9RenderStateItem::PointSizeMax>();
+    m_pushData.vs.pointSize = EncodePointSize(rs[D3DRS_POINTSIZE]);
+    m_pushData.vs.pointSizeMin = EncodePointSize(rs[D3DRS_POINTSIZE_MIN]);
+    m_pushData.vs.pointSizeMax = EncodePointSize(rs[D3DRS_POINTSIZE_MAX]);
     m_dirty.set(D3D9DeviceDirtyFlag::PointScale);
     UpdatePointMode(false);
 
@@ -8763,6 +8732,12 @@ namespace dxvk {
     m_alphaTestEnabled = false;
     m_atocEnabled      = false;
     m_nvdbEnabled      = false;
+
+    // Update all push data
+    m_dirty.set(D3D9DeviceDirtyFlag::PushDataShared,
+                D3D9DeviceDirtyFlag::PushDataVs,
+                D3D9DeviceDirtyFlag::PushDataFfvs,
+                D3D9DeviceDirtyFlag::PushDataFfps);
   }
 
 

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -126,32 +126,26 @@ namespace dxvk {
 
     // Initially set all the dirty flags so we
     // always end up giving the backend *something* to work with.
-    m_dirty.set(D3D9DeviceDirtyFlag::Framebuffer);
-    m_dirty.set(D3D9DeviceDirtyFlag::ClipPlanes);
-    m_dirty.set(D3D9DeviceDirtyFlag::DepthStencilState);
-    m_dirty.set(D3D9DeviceDirtyFlag::BlendState);
-    m_dirty.set(D3D9DeviceDirtyFlag::RasterizerState);
-    m_dirty.set(D3D9DeviceDirtyFlag::DepthBias);
-    m_dirty.set(D3D9DeviceDirtyFlag::AlphaTestState);
-    m_dirty.set(D3D9DeviceDirtyFlag::InputLayout);
-    m_dirty.set(D3D9DeviceDirtyFlag::ViewportScissor);
-    m_dirty.set(D3D9DeviceDirtyFlag::MultiSampleState);
-
-    m_dirty.set(D3D9DeviceDirtyFlag::FogState);
-    m_dirty.set(D3D9DeviceDirtyFlag::FogColor);
-    m_dirty.set(D3D9DeviceDirtyFlag::FogDensity);
-    m_dirty.set(D3D9DeviceDirtyFlag::FogScale);
-    m_dirty.set(D3D9DeviceDirtyFlag::FogEnd);
-
-    m_dirty.set(D3D9DeviceDirtyFlag::FFVertexData);
-    m_dirty.set(D3D9DeviceDirtyFlag::FFVertexBlend);
-    m_dirty.set(D3D9DeviceDirtyFlag::FFVertexShader);
-    m_dirty.set(D3D9DeviceDirtyFlag::FFPixelShader);
-    m_dirty.set(D3D9DeviceDirtyFlag::FFViewport);
-    m_dirty.set(D3D9DeviceDirtyFlag::FFGlobalSpecular);
-    m_dirty.set(D3D9DeviceDirtyFlag::SharedPixelShaderData);
-    m_dirty.set(D3D9DeviceDirtyFlag::DepthBounds);
-    m_dirty.set(D3D9DeviceDirtyFlag::PointScale);
+    m_dirty.set(D3D9DeviceDirtyFlag::Framebuffer,
+                D3D9DeviceDirtyFlag::ClipPlanes,
+                D3D9DeviceDirtyFlag::DepthStencilState,
+                D3D9DeviceDirtyFlag::BlendState,
+                D3D9DeviceDirtyFlag::RasterizerState,
+                D3D9DeviceDirtyFlag::DepthBias,
+                D3D9DeviceDirtyFlag::AlphaTestState,
+                D3D9DeviceDirtyFlag::InputLayout,
+                D3D9DeviceDirtyFlag::ViewportScissor,
+                D3D9DeviceDirtyFlag::MultiSampleState,
+                D3D9DeviceDirtyFlag::Fog,
+                D3D9DeviceDirtyFlag::FFVertexData,
+                D3D9DeviceDirtyFlag::FFVertexBlend,
+                D3D9DeviceDirtyFlag::FFVertexShader,
+                D3D9DeviceDirtyFlag::FFPixelShader,
+                D3D9DeviceDirtyFlag::FFViewport,
+                D3D9DeviceDirtyFlag::FFGlobalSpecular,
+                D3D9DeviceDirtyFlag::SharedPixelShaderData,
+                D3D9DeviceDirtyFlag::DepthBounds,
+                D3D9DeviceDirtyFlag::PointScale);
 
     m_dirty.set(D3D9DeviceDirtyFlag::SpecializationEntries);
 
@@ -2476,28 +2470,15 @@ namespace dxvk {
         case D3DRS_FOGENABLE:
         case D3DRS_FOGVERTEXMODE:
         case D3DRS_FOGTABLEMODE:
-          m_dirty.set(D3D9DeviceDirtyFlag::FogState);
+        case D3DRS_FOGCOLOR:
+        case D3DRS_FOGSTART:
+        case D3DRS_FOGEND:
+        case D3DRS_FOGDENSITY:
+          m_dirty.set(D3D9DeviceDirtyFlag::Fog);
           break;
 
         case D3DRS_RANGEFOGENABLE:
           m_dirty.set(D3D9DeviceDirtyFlag::FFVertexShader);
-          break;
-
-        case D3DRS_FOGCOLOR:
-          m_dirty.set(D3D9DeviceDirtyFlag::FogColor);
-          break;
-
-        case D3DRS_FOGSTART:
-          m_dirty.set(D3D9DeviceDirtyFlag::FogScale);
-          break;
-
-        case D3DRS_FOGEND:
-          m_dirty.set(D3D9DeviceDirtyFlag::FogScale);
-          m_dirty.set(D3D9DeviceDirtyFlag::FogEnd);
-          break;
-
-        case D3DRS_FOGDENSITY:
-          m_dirty.set(D3D9DeviceDirtyFlag::FogDensity);
           break;
 
         case D3DRS_POINTSIZE: {
@@ -6152,7 +6133,7 @@ namespace dxvk {
       float end = bit::cast<float>(rs[D3DRS_FOGEND]);
       float start = bit::cast<float>(rs[D3DRS_FOGSTART]);
 
-      float scale = 1.0f / (end - start);
+      float scale = (end != start) ? 1.0f / (end - start) : 0.0f;
       UpdatePushConstant<offsetof(D3D9RenderStateInfo, fogScale), sizeof(float)>(&scale);
     }
     else if constexpr (Item == D3D9RenderStateItem::PointSize) {
@@ -6663,70 +6644,28 @@ namespace dxvk {
 
 
   void D3D9DeviceEx::UpdateFog() {
+    m_dirty.clr(D3D9DeviceDirtyFlag::Fog);
+
     auto& rs = m_state.renderStates;
+    bool fogEnabled = bool(rs[D3DRS_FOGENABLE]);
 
-    bool fogEnabled = rs[D3DRS_FOGENABLE];
+    // Only set up vertex frog if pixel fog is not used
+    D3DFOGMODE vsFog = D3DFOG_NONE;
+    D3DFOGMODE psFog = D3DFOG_NONE;
 
-    bool pixelFog   = rs[D3DRS_FOGTABLEMODE]  != D3DFOG_NONE && fogEnabled;
-    bool vertexFog  = rs[D3DRS_FOGVERTEXMODE] != D3DFOG_NONE && fogEnabled && !pixelFog;
+    if (fogEnabled) {
+      psFog = D3DFOGMODE(rs[D3DRS_FOGTABLEMODE]);
 
-    auto UpdateFogConstants = [&](D3DFOGMODE FogMode) {
-      if (m_dirty.test(D3D9DeviceDirtyFlag::FogColor)) {
-        m_dirty.clr(D3D9DeviceDirtyFlag::FogColor);
-        UpdatePushConstant<D3D9RenderStateItem::FogColor>();
-      }
-
-      if (FogMode == D3DFOG_LINEAR) {
-        if (m_dirty.test(D3D9DeviceDirtyFlag::FogScale)) {
-          m_dirty.clr(D3D9DeviceDirtyFlag::FogScale);
-          UpdatePushConstant<D3D9RenderStateItem::FogScale>();
-        }
-
-        if (m_dirty.test(D3D9DeviceDirtyFlag::FogEnd)) {
-          m_dirty.clr(D3D9DeviceDirtyFlag::FogEnd);
-          UpdatePushConstant<D3D9RenderStateItem::FogEnd>();
-        }
-      }
-      else if (FogMode == D3DFOG_EXP || FogMode == D3DFOG_EXP2) {
-        if (m_dirty.test(D3D9DeviceDirtyFlag::FogDensity)) {
-          m_dirty.clr(D3D9DeviceDirtyFlag::FogDensity);
-          UpdatePushConstant<D3D9RenderStateItem::FogDensity>();
-        }
-      }
-    };
-
-    if (vertexFog) {
-      D3DFOGMODE mode = D3DFOGMODE(rs[D3DRS_FOGVERTEXMODE]);
-
-      UpdateFogConstants(mode);
-
-      if (m_dirty.test(D3D9DeviceDirtyFlag::FogState)) {
-        m_dirty.clr(D3D9DeviceDirtyFlag::FogState);
-
-        UpdateFogModeSpec(true, mode, D3DFOG_NONE);
-      }
+      if (psFog == D3DFOG_NONE)
+        vsFog = D3DFOGMODE(rs[D3DRS_FOGVERTEXMODE]);
     }
-    else if (pixelFog) {
-      D3DFOGMODE mode = D3DFOGMODE(rs[D3DRS_FOGTABLEMODE]);
 
-      UpdateFogConstants(mode);
+    UpdateFogModeSpec(fogEnabled, vsFog, psFog);
 
-      if (m_dirty.test(D3D9DeviceDirtyFlag::FogState)) {
-        m_dirty.clr(D3D9DeviceDirtyFlag::FogState);
-
-        UpdateFogModeSpec(true, D3DFOG_NONE, mode);
-      }
-    }
-    else {
-      if (fogEnabled)
-        UpdateFogConstants(D3DFOG_NONE);
-
-      if (m_dirty.test(D3D9DeviceDirtyFlag::FogState)) {
-        m_dirty.clr(D3D9DeviceDirtyFlag::FogState);
-
-        UpdateFogModeSpec(fogEnabled, D3DFOG_NONE, D3DFOG_NONE);
-      }
-    }
+    UpdatePushConstant<D3D9RenderStateItem::FogColor>();
+    UpdatePushConstant<D3D9RenderStateItem::FogScale>();
+    UpdatePushConstant<D3D9RenderStateItem::FogEnd>();
+    UpdatePushConstant<D3D9RenderStateItem::FogDensity>();
   }
 
 
@@ -7443,7 +7382,9 @@ namespace dxvk {
     if (unlikely(UploadIBO && ibo != nullptr && ibo->NeedsUpload()))
       FlushBuffer(ibo);
 
-    UpdateFog();
+
+    if (unlikely(m_dirty.test(D3D9DeviceDirtyFlag::Fog)))
+      UpdateFog();
 
     if (unlikely(m_dirty.test(D3D9DeviceDirtyFlag::Framebuffer)))
       BindFramebuffer();
@@ -8656,11 +8597,7 @@ namespace dxvk {
     rs[D3DRS_FOGEND]                     = bit::cast<DWORD>(1.0f);
     rs[D3DRS_FOGDENSITY]                 = bit::cast<DWORD>(1.0f);
     rs[D3DRS_FOGVERTEXMODE]              = D3DFOG_NONE;
-    m_dirty.set(D3D9DeviceDirtyFlag::FogColor);
-    m_dirty.set(D3D9DeviceDirtyFlag::FogDensity);
-    m_dirty.set(D3D9DeviceDirtyFlag::FogEnd);
-    m_dirty.set(D3D9DeviceDirtyFlag::FogScale);
-    m_dirty.set(D3D9DeviceDirtyFlag::FogState);
+    m_dirty.set(D3D9DeviceDirtyFlag::Fog);
 
     rs[D3DRS_CLIPPLANEENABLE] = 0;
     m_dirty.set(D3D9DeviceDirtyFlag::ClipPlanes);

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -64,13 +64,7 @@ namespace dxvk {
     MultiSampleState,
     VertexBuffers,
     IndexBuffer,
-
-    FogState,
-    FogColor,
-    FogDensity,
-    FogScale,
-    FogEnd,
-
+    Fog,
     FFVertexData,
     FFVertexBlend,
     FFVertexShader,

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -76,6 +76,11 @@ namespace dxvk {
     DepthBounds,
     PointScale,
 
+    PushDataShared,
+    PushDataVs,
+    PushDataFfvs,
+    PushDataFfps,
+
     SpecializationEntries,
   };
 
@@ -988,23 +993,10 @@ namespace dxvk {
 
     void UpdateGlobalSpecular();
 
-    /**
-     * \brief Updates the push constant data at the given offset with data from the specified pointer.
-     *
-     * \param Offset Offset at which the push constant data gets written.
-     * \param Length Length of the push constant data to write.
-     * \param pData Push constant data
-     */
-    template <uint32_t Offset, uint32_t Length>
-    void UpdatePushConstant(const void* pData);
+    template<typename T>
+    void UpdatePushDataBlock(const T& Block);
 
-    /**
-     * \brief Updates the specified push constant based on the device state.
-     *
-     * \param Item Render state push constant to update
-     */
-    template <D3D9RenderStateItem Item>
-    void UpdatePushConstant();
+    void UpdatePushData();
 
     void BindSampler(DWORD Sampler);
 
@@ -1526,6 +1518,11 @@ namespace dxvk {
         : FixedFunctionMask;
     }
 
+    inline static uint16_t EncodePointSize(DWORD Value) {
+      // Basically 13.3 fixed point, highest value is 8191.875
+      return uint16_t(std::clamp(bit::cast<float>(Value) * 8.0f, 0.0f, 65535.0f));
+    }
+
     D3D9ConstantBuffer& GetConstantBuffer(CbvIndex Index) {
       return m_constantBuffers[uint32_t(Index)];
     }
@@ -1675,6 +1672,7 @@ namespace dxvk {
     // m_state should be declared last (i.e. freed first), because it
     // references objects that can call back into the device when freed.
     Direct3DState9                  m_state;
+    D3D9PushData                    m_pushData = {};
 
     D3D9VkInteropDevice             m_d3d9Interop;
     D3D9ON12_ARGS                   m_d3d9On12Args = { };

--- a/src/d3d9/d3d9_fixed_function.cpp
+++ b/src/d3d9/d3d9_fixed_function.cpp
@@ -63,8 +63,10 @@ namespace dxvk {
     info.bindingCount = bindings.size();
     info.bindings = bindings.data();
     info.flatShadingInputs = 0;
-    info.sharedPushData = DxvkPushDataBlock(0u, sizeof(D3D9RenderStateInfo), 4u, 0u);
-    info.localPushData = DxvkPushDataBlock();
+    info.sharedPushData = DxvkPushDataBlock(0u,
+      D3D9VsPushData::Offset + sizeof(D3D9VsPushData), 4u, 0u);
+    info.localPushData = DxvkPushDataBlock(VK_SHADER_STAGE_VERTEX_BIT,
+      MaxSharedPushDataSize, sizeof(D3D9FfvsPushData), 4u, 0u);
     info.samplerHeap = DxvkShaderBinding();
     info.debugName = "FF VS";
 
@@ -119,13 +121,18 @@ namespace dxvk {
     uint32_t samplerCount = caps::TextureStageCount;
     uint32_t samplerDwordCount = (samplerCount + 1u) / 2u;
 
+    uint32_t pushDataSamplerOffset = GetPushSamplerOffset(0u) - MaxSharedPushDataSize;
+    uint32_t pushDataSamplerShift = pushDataSamplerOffset / 4u;
+    uint32_t pushDataSize = GetPushSamplerOffset(caps::TextureStageCount) - MaxSharedPushDataSize;
+
     DxvkSpirvShaderCreateInfo info;
     info.bindingCount = bindings.size();
     info.bindings = bindings.data();
     info.flatShadingInputs = flatShadingMask;
-    info.sharedPushData = DxvkPushDataBlock(0u, sizeof(D3D9RenderStateInfo), 4u, 0u);
-    info.localPushData = DxvkPushDataBlock(VK_SHADER_STAGE_FRAGMENT_BIT, GetPushSamplerOffset(0u),
-      samplerDwordCount * sizeof(uint32_t), sizeof(uint32_t), (1u << samplerDwordCount) - 1u);
+    info.sharedPushData = DxvkPushDataBlock(0u,
+      D3D9SharedPushData::Offset + sizeof(D3D9SharedPushData), 4u, 0u);
+    info.localPushData = DxvkPushDataBlock(VK_SHADER_STAGE_FRAGMENT_BIT, MaxSharedPushDataSize,
+      pushDataSize, 4u, ((1u << samplerDwordCount) - 1u) << pushDataSamplerShift);
     info.samplerHeap = DxvkShaderBinding(VK_SHADER_STAGE_FRAGMENT_BIT, SamplerSet, 0u);
     info.debugName = "FF FS";
 

--- a/src/d3d9/d3d9_fixed_function.h
+++ b/src/d3d9/d3d9_fixed_function.h
@@ -53,8 +53,10 @@ namespace dxvk {
     static Rc<DxvkShader> buildFs(D3D9DeviceEx* pDevice);
 
     constexpr static uint32_t GetPushSamplerOffset(uint32_t samplerIndex) {
-      // Must not conflict with render state block
-      return MaxSharedPushDataSize + sizeof(uint16_t) * samplerIndex;
+      // Located directly after the PS push data block.
+      return MaxSharedPushDataSize +
+        sizeof(D3D9FfpsPushData) +
+        sizeof(uint16_t) * samplerIndex;
     }
 
   };

--- a/src/d3d9/d3d9_shader.cpp
+++ b/src/d3d9/d3d9_shader.cpp
@@ -233,7 +233,7 @@ namespace dxvk {
       using namespace dxbc_spv;
 
       auto type = ir::Type()
-        .addStructMember(ir::ScalarType::eU16)      // Reserved
+        .addStructMember(ir::ScalarType::eU16)      // Dynamic float count
         .addStructMember(ir::ScalarType::eU16)      // Point size
         .addStructMember(ir::ScalarType::eU16)      // Minimum point size
         .addStructMember(ir::ScalarType::eU16);     // Maximum point size
@@ -242,7 +242,7 @@ namespace dxvk {
         D3D9VsPushData::Offset, getPushDataStage(D3D9VsPushData::Stages)));
 
       m_builder.add(ir::Op::DebugName(m_vsPushData, "vs"));
-      m_builder.add(ir::Op::DebugMemberName(m_vsPushData, 0u, "reserved"));
+      m_builder.add(ir::Op::DebugMemberName(m_vsPushData, 0u, "cFSize"));
       m_builder.add(ir::Op::DebugMemberName(m_vsPushData, 1u, "pointSize"));
       m_builder.add(ir::Op::DebugMemberName(m_vsPushData, 2u, "pointSizeMin"));
       m_builder.add(ir::Op::DebugMemberName(m_vsPushData, 3u, "pointSizeMax"));
@@ -318,12 +318,13 @@ namespace dxvk {
       if (!layout.isDynamicallyIndexed())
         return;
 
-      // Trivial, just emit a float vector array with the maximum required size.
-      auto cbvSize = layout.computeConstantCount(-1u);
+      // Over-declare by one element so that we can index past the
+      // last actual constant in order to read zero.
+      auto cbvSize = layout.computeConstantCount(-1u) + 1u;
       auto cbvType = ir::Type(ir::ScalarType::eF32, 4u).addArrayDimension(cbvSize);
 
-      m_dynamicCbv = m_builder.add(ir::Op::DclCbv(cbvType, m_entryPoint,
-        0u, D3D9ShaderResourceMapping::CbvIndex::VSDynamicConstants, 1u));
+      m_dynamicCbv = m_builder.add(ir::Op::DclCbv(cbvType, m_entryPoint, 0u,
+        D3D9ShaderResourceMapping::CbvIndex::VSDynamicConstants, 1u).setFlags(ir::OpFlag::eInBounds));
       m_builder.add(ir::Op::DebugName(m_dynamicCbv, "cF"));
     }
 
@@ -355,8 +356,26 @@ namespace dxvk {
             auto cbvDescriptor = m_builder.addBefore(use, ir::Op::DescriptorLoad(
               ir::ScalarType::eCbv, m_dynamicCbv, m_builder.makeConstant(0u)));
 
-            m_builder.rewriteOp(use, ir::Op::BufferLoad(useOp.getType(),
-              cbvDescriptor, addressOp.getDef(), useOp.getType().byteSize()));
+            // The front-end promises to bind *at least* all statically
+            // indexed constants. Only clamp dynamic indices.
+            auto addressDef = addressOp.getDef();
+
+            if (!addressOp.isConstant()) {
+              auto cursor = m_builder.setCursor(m_builder.getPrev(use));
+
+              auto count = m_builder.add(ir::Op::PushDataLoad(ir::ScalarType::eU16,
+                m_vsPushData, m_builder.makeConstant(0u)));
+              count = m_builder.add(ir::Op::ConvertItoI(ir::ScalarType::eU32, count));
+
+              auto index = ir::extractFromVector(m_builder, addressDef, 0u);
+              index = m_builder.add(ir::Op::UMin(ir::ScalarType::eU32, index, count));
+              addressDef = ir::insertIntoVector(m_builder, addressDef, 0u, index);
+
+              m_builder.setCursor(cursor);
+            }
+
+            m_builder.rewriteOp(use, ir::Op::BufferLoad(useOp.getType(), cbvDescriptor,
+              addressDef, useOp.getType().byteSize()).setFlags(ir::OpFlag::eInBounds));
           } else {
             // For compacted constants, we need to map the source constant
             // to a member index in the static constant buffer struct.

--- a/src/d3d9/d3d9_shader.cpp
+++ b/src/d3d9/d3d9_shader.cpp
@@ -26,6 +26,11 @@ namespace dxvk {
       std::tie(m_entryPoint, m_shaderStage) = findEntryPoint();
       dxbc_spv_assert(m_entryPoint);
 
+      setupSharedPushData();
+
+      if (m_shaderStage == ir::ShaderStage::eVertex)
+        setupVsPushData();
+
       setupStaticCbv();
       setupDynamicCbv();
 
@@ -88,9 +93,8 @@ namespace dxvk {
     uint32_t                  m_firstConstInt  = 0u;
     uint32_t                  m_firstConstBool = 0u;
 
-    dxbc_spv::ir::SsaDef      m_fogPushData = {};
-    dxbc_spv::ir::SsaDef      m_alphaTestPushData = {};
-    dxbc_spv::ir::SsaDef      m_pointSizePushData = {};
+    dxbc_spv::ir::SsaDef      m_sharedPushData = {};
+    dxbc_spv::ir::SsaDef      m_vsPushData = {};
 
     std::array<dxbc_spv::ir::SsaDef, DxvkLimits::MaxNumSpecConstants> m_specConstants = { };
     std::array<dxbc_spv::ir::SsaDef, D3D9SpecConstantId::SpecConstantCount> m_specFunctions = { };
@@ -202,6 +206,46 @@ namespace dxvk {
         auto name = debugName.getLiteralString(2u);
         m_builder.add(ir::Op::DebugName(m_staticCbv, name.c_str()));
       }
+    }
+
+    void setupSharedPushData() {
+      using namespace dxbc_spv;
+
+      auto type = ir::Type()
+        .addStructMember(ir::ScalarType::eU8, 3u)   // Fog color
+        .addStructMember(ir::ScalarType::eU8)       // Alpha ref
+        .addStructMember(ir::ScalarType::eF32)      // Fog scale
+        .addStructMember(ir::ScalarType::eF32)      // Fog end
+        .addStructMember(ir::ScalarType::eF32);     // Fog density
+
+      m_sharedPushData = m_builder.add(ir::Op::DclPushData(type, m_entryPoint,
+        D3D9SharedPushData::Offset, getPushDataStage(D3D9SharedPushData::Stages)));
+
+      m_builder.add(ir::Op::DebugName(m_sharedPushData, "global"));
+      m_builder.add(ir::Op::DebugMemberName(m_sharedPushData, 0u, "fogColor"));
+      m_builder.add(ir::Op::DebugMemberName(m_sharedPushData, 1u, "alphaRef"));
+      m_builder.add(ir::Op::DebugMemberName(m_sharedPushData, 2u, "fogDistanceScale"));
+      m_builder.add(ir::Op::DebugMemberName(m_sharedPushData, 3u, "fogDistanceEnd"));
+      m_builder.add(ir::Op::DebugMemberName(m_sharedPushData, 4u, "fogDensity"));
+    }
+
+    void setupVsPushData() {
+      using namespace dxbc_spv;
+
+      auto type = ir::Type()
+        .addStructMember(ir::ScalarType::eU16)      // Reserved
+        .addStructMember(ir::ScalarType::eU16)      // Point size
+        .addStructMember(ir::ScalarType::eU16)      // Minimum point size
+        .addStructMember(ir::ScalarType::eU16);     // Maximum point size
+
+      m_vsPushData = m_builder.add(ir::Op::DclPushData(type, m_entryPoint,
+        D3D9VsPushData::Offset, getPushDataStage(D3D9VsPushData::Stages)));
+
+      m_builder.add(ir::Op::DebugName(m_vsPushData, "vs"));
+      m_builder.add(ir::Op::DebugMemberName(m_vsPushData, 0u, "reserved"));
+      m_builder.add(ir::Op::DebugMemberName(m_vsPushData, 1u, "pointSize"));
+      m_builder.add(ir::Op::DebugMemberName(m_vsPushData, 2u, "pointSizeMin"));
+      m_builder.add(ir::Op::DebugMemberName(m_vsPushData, 3u, "pointSizeMax"));
     }
 
     void setupStaticCbv() {
@@ -670,13 +714,6 @@ namespace dxvk {
     dxbc_spv::ir::SsaDef loadAlphaTestArgs(dxbc_spv::ir::SsaDef ref) {
       using namespace dxbc_spv;
 
-      if (!m_alphaTestPushData) {
-        m_alphaTestPushData = m_builder.add(ir::Op::DclPushData(ir::ScalarType::eU32,
-          m_entryPoint, offsetof(D3D9RenderStateInfo, alphaRef),
-          ir::ShaderStage::eVertex | ir::ShaderStage::ePixel));
-        m_builder.add(ir::Op::DebugName(m_alphaTestPushData, "alphaRef"));
-      }
-
       ir::Op resultOp = ir::Op(ir::OpCode::eCompositeConstruct, ir::makeLegacyAlphaTestType());
 
       for (uint32_t i = 0u; i < resultOp.getType().getStructMemberCount(); i++) {
@@ -694,8 +731,10 @@ namespace dxvk {
           } break;
 
           case ir::LegacyAlphaTestLayout::eAlphaRef: {
-            resultOp.addOperand(m_builder.addBefore(ref, ir::Op::PushDataLoad(
-              ir::ScalarType::eU32, m_alphaTestPushData, ir::SsaDef())));
+            auto alphaRef = m_builder.addBefore(ref, ir::Op::PushDataLoad(
+              ir::ScalarType::eU8, m_sharedPushData, m_builder.makeConstant(1u)));
+            alphaRef = m_builder.addBefore(ref, ir::Op::ConvertItoI(ir::ScalarType::eU32, alphaRef));
+            resultOp.addOperand(alphaRef);
           } break;
         }
       }
@@ -705,23 +744,6 @@ namespace dxvk {
 
     dxbc_spv::ir::SsaDef loadFogArgs(dxbc_spv::ir::SsaDef ref) {
       using namespace dxbc_spv;
-
-      if (!m_fogPushData) {
-        auto fogDataType = ir::Type()
-          .addStructMember(ir::ScalarType::eF32, 3u)  // color
-          .addStructMember(ir::ScalarType::eF32)      // scale
-          .addStructMember(ir::ScalarType::eF32)      // end
-          .addStructMember(ir::ScalarType::eF32);     // density
-
-        m_fogPushData = m_builder.add(ir::Op::DclPushData(fogDataType,
-          m_entryPoint, offsetof(D3D9RenderStateInfo, fogColor),
-          ir::ShaderStage::eVertex | ir::ShaderStage::ePixel));
-
-        m_builder.add(ir::Op::DebugMemberName(m_fogPushData, 0u, "fogColor"));
-        m_builder.add(ir::Op::DebugMemberName(m_fogPushData, 1u, "fogDistScale"));
-        m_builder.add(ir::Op::DebugMemberName(m_fogPushData, 2u, "fogDistEnd"));
-        m_builder.add(ir::Op::DebugMemberName(m_fogPushData, 3u, "fogDensity"));
-      }
 
       ir::Op resultOp = ir::Op(ir::OpCode::eCompositeConstruct, ir::makeLegacyFogType());
 
@@ -742,23 +764,35 @@ namespace dxvk {
           } break;
 
           case ir::LegacyFogLayout::eFogColor: {
-            resultOp.addOperand(m_builder.addBefore(ref, ir::Op::PushDataLoad(
-              resultOp.getType().getSubType(i), m_fogPushData, m_builder.makeConstant(0u))));
+            // We store the raw D3DCOLOR in .bgr order. Convert to float and swizzle.
+            auto fogColor = m_builder.addBefore(ref, ir::Op::PushDataLoad(
+              ir::BasicType(ir::ScalarType::eU8, 3u), m_sharedPushData, m_builder.makeConstant(0u)));
+
+            ir::Op op(ir::OpCode::eCompositeConstruct, resultOp.getType().getSubType(i));
+
+            for (uint32_t i = 0u; i < 3u; i++) {
+              auto scalar = m_builder.addBefore(ref, ir::Op::CompositeExtract(ir::ScalarType::eU8, fogColor, m_builder.makeConstant(2u - i)));
+              scalar = m_builder.addBefore(ref, ir::Op::ConvertItoF(ir::ScalarType::eF32, scalar));
+              scalar = m_builder.addBefore(ref, ir::Op::FDiv(ir::ScalarType::eF32, scalar, m_builder.makeConstant(255.0f)));
+              op.addOperand(scalar);
+            }
+
+            resultOp.addOperand(m_builder.addBefore(ref, std::move(op)));
           } break;
 
           case ir::LegacyFogLayout::eFogScale: {
             resultOp.addOperand(m_builder.addBefore(ref, ir::Op::PushDataLoad(
-              resultOp.getType().getSubType(i), m_fogPushData, m_builder.makeConstant(1u))));
+              resultOp.getType().getSubType(i), m_sharedPushData, m_builder.makeConstant(2u))));
           } break;
 
           case ir::LegacyFogLayout::eFogEnd: {
             resultOp.addOperand(m_builder.addBefore(ref, ir::Op::PushDataLoad(
-              resultOp.getType().getSubType(i), m_fogPushData, m_builder.makeConstant(2u))));
+              resultOp.getType().getSubType(i), m_sharedPushData, m_builder.makeConstant(3u))));
           } break;
 
           case ir::LegacyFogLayout::eFogDensity: {
             resultOp.addOperand(m_builder.addBefore(ref, ir::Op::PushDataLoad(
-              resultOp.getType().getSubType(i), m_fogPushData, m_builder.makeConstant(3u))));
+              resultOp.getType().getSubType(i), m_sharedPushData, m_builder.makeConstant(4u))));
           } break;
         }
       }
@@ -811,21 +845,6 @@ namespace dxvk {
     dxbc_spv::ir::SsaDef loadPointArgs(dxbc_spv::ir::SsaDef ref) {
       using namespace dxbc_spv;
 
-      if (!m_pointSizePushData) {
-        auto pointSizeType = ir::Type()
-          .addStructMember(ir::ScalarType::eF32)  // size
-          .addStructMember(ir::ScalarType::eF32)  // min
-          .addStructMember(ir::ScalarType::eF32); // max
-
-        m_pointSizePushData = m_builder.add(ir::Op::DclPushData(pointSizeType,
-          m_entryPoint, offsetof(D3D9RenderStateInfo, pointSize),
-          ir::ShaderStage::eVertex | ir::ShaderStage::ePixel));
-
-        m_builder.add(ir::Op::DebugMemberName(m_pointSizePushData, 0u, "pointSize"));
-        m_builder.add(ir::Op::DebugMemberName(m_pointSizePushData, 1u, "pointSizeMin"));
-        m_builder.add(ir::Op::DebugMemberName(m_pointSizePushData, 2u, "pointSizeMax"));
-      }
-
       ir::Op resultOp = ir::Op(ir::OpCode::eCompositeConstruct, ir::makeLegacyPointArgsType());
 
       for (uint32_t i = 0u; i < resultOp.getType().getStructMemberCount(); i++) {
@@ -838,18 +857,21 @@ namespace dxvk {
           } break;
 
           case ir::LegacyPointArgsLayout::ePointSize: {
-            resultOp.addOperand(m_builder.addBefore(ref, ir::Op::PushDataLoad(
-              ir::ScalarType::eF32, m_pointSizePushData, m_builder.makeConstant(0u))));
+            auto size = m_builder.addBefore(ref, ir::Op::PushDataLoad(
+              ir::ScalarType::eU16, m_vsPushData, m_builder.makeConstant(1u)));
+            resultOp.addOperand(emitDecodePointSize(ref, size));
           } break;
 
           case ir::LegacyPointArgsLayout::ePointSizeMin: {
-            resultOp.addOperand(m_builder.addBefore(ref, ir::Op::PushDataLoad(
-              ir::ScalarType::eF32, m_pointSizePushData, m_builder.makeConstant(1u))));
+            auto size = m_builder.addBefore(ref, ir::Op::PushDataLoad(
+              ir::ScalarType::eU16, m_vsPushData, m_builder.makeConstant(2u)));
+            resultOp.addOperand(emitDecodePointSize(ref, size));
           } break;
 
           case ir::LegacyPointArgsLayout::ePointSizeMax: {
-            resultOp.addOperand(m_builder.addBefore(ref, ir::Op::PushDataLoad(
-              ir::ScalarType::eF32, m_pointSizePushData, m_builder.makeConstant(2u))));
+            auto size = m_builder.addBefore(ref, ir::Op::PushDataLoad(
+              ir::ScalarType::eU16, m_vsPushData, m_builder.makeConstant(3u)));
+            resultOp.addOperand(emitDecodePointSize(ref, size));
           } break;
         }
       }
@@ -1003,6 +1025,13 @@ namespace dxvk {
       return m_builder.addBefore(ref, std::move(resultOp));
     }
 
+    dxbc_spv::ir::SsaDef emitDecodePointSize(dxbc_spv::ir::SsaDef ref, dxbc_spv::ir::SsaDef size) {
+      using namespace dxbc_spv;
+
+      auto value = m_builder.addBefore(ref, ir::Op::ConvertItoF(ir::ScalarType::eF32, size));
+      return m_builder.addBefore(ref, ir::Op::FDiv(ir::ScalarType::eF32, value, m_builder.makeConstant(8.0f)));
+    }
+
     dxbc_spv::ir::SsaDef getDebugName(const dxbc_spv::ir::Op& decl, uint32_t index) {
       using namespace dxbc_spv;
 
@@ -1016,6 +1045,19 @@ namespace dxvk {
 
       return ir::SsaDef();
     }
+
+    static dxbc_spv::ir::ShaderStageMask getPushDataStage(VkShaderStageFlags flags) {
+      using namespace dxbc_spv;
+
+      if (flags == VK_SHADER_STAGE_VERTEX_BIT)
+        return ir::ShaderStage::eVertex;
+
+      if (flags == VK_SHADER_STAGE_FRAGMENT_BIT)
+        return ir::ShaderStage::ePixel;
+
+      return ir::ShaderStageMask();
+    }
+
   };
 
   class D3D9ShaderConverter : public DxvkIrShaderConverter {

--- a/src/d3d9/d3d9_shader_analysis.cpp
+++ b/src/d3d9/d3d9_shader_analysis.cpp
@@ -54,21 +54,11 @@ namespace dxvk {
 
     m_length = parser.getByteOffset();
 
-    if (m_constants.floatsAccessedDynamically) {
-      // Repurpose float mask as shader-defined constant mask
-      // as a mask of defined constants as necessary
-      constMaskF.clear();
+    // The compiler will always constant-fold inline constants that
+    // are statically indexed, so there is no need to keep them around
+    for (size_t i = 0u; i < shaderDefs.floats.size(); i++)
+      clrBit(constMaskF, shaderDefs.floats[i].index);
 
-      for (size_t i = 0u; i < shaderDefs.floats.size(); i++)
-        setBit(constMaskF, shaderDefs.floats[i].index);
-    } else {
-      // The compiler will always constant-fold inline constants that
-      // are statically indexed, so there is no need to keep them around
-      for (size_t i = 0u; i < shaderDefs.floats.size(); i++)
-        clrBit(constMaskF, shaderDefs.floats[i].index);
-    }
-
-    // Same for shader-defied floats, they will never be read from the buffer.
     for (size_t i = 0u; i < shaderDefs.ints.size(); i++)
       clrBit(constMaskI, shaderDefs.ints[i]);
 
@@ -149,10 +139,8 @@ namespace dxvk {
               m_isSWVP ? MaxFloatConstantsSoftware : hwvpFloatConstantsCount);
 
             m_constants.floatsAccessedDynamically = true;
-          }
-
-          // Access mask is useless if we have dynamic indexing
-          if (!m_constants.floatsAccessedDynamically) {
+          } else {
+            // Gather indices of statically accessed constants
             for (uint32_t j = 0u; j < count; j++)
               setBit(constMaskF, index + j);
           }

--- a/src/d3d9/d3d9_state.h
+++ b/src/d3d9/d3d9_state.h
@@ -33,43 +33,6 @@ namespace dxvk {
     }
   };
 
-  struct D3D9RenderStateInfo {
-    std::array<float, 3> fogColor = { };
-    float fogScale   = 0.0f;
-    float fogEnd     = 1.0f;
-    float fogDensity = 1.0f;
-
-    uint32_t alphaRef = 0u;
-
-    float pointSize    = 1.0f;
-    float pointSizeMin = 1.0f;
-    float pointSizeMax = 64.0f;
-    float pointScaleA  = 1.0f;
-    float pointScaleB  = 0.0f;
-    float pointScaleC  = 0.0f;
-
-    uint32_t textureFactor = 0u;
-  };
-
-  enum class D3D9RenderStateItem {
-    FogColor   = 0,
-    FogScale   = 1,
-    FogEnd,
-    FogDensity,
-    AlphaRef,
-
-    PointSize,
-    PointSizeMin,
-    PointSizeMax,
-    PointScaleA,
-    PointScaleB,
-    PointScaleC,
-
-    TextureFactor,
-
-    Count
-  };
-
   /// Shared push data
   struct D3D9SharedPushData {
     static constexpr VkShaderStageFlags Stages = VK_SHADER_STAGE_ALL_GRAPHICS;

--- a/src/d3d9/d3d9_state.h
+++ b/src/d3d9/d3d9_state.h
@@ -70,6 +70,61 @@ namespace dxvk {
     Count
   };
 
+  /// Shared push data
+  struct D3D9SharedPushData {
+    static constexpr VkShaderStageFlags Stages = VK_SHADER_STAGE_ALL_GRAPHICS;
+    static constexpr uint32_t           Offset = 0u;
+
+    uint8_t fogColor[3] = {};
+    uint8_t alphaRef = 0u;
+
+    float fogDistanceScale = 0.0f;
+    float fogDistanceEnd = 0.0f;
+    float fogDensity = 0.0f;
+  };
+
+  /// Vertex shader push data
+  struct D3D9VsPushData {
+    // We don't have enough VS-only push data space available to fit all
+    // possible samplers, constant buffers and data in there, so put VS
+    // data into the shared block.
+    static constexpr VkShaderStageFlags Stages = VK_SHADER_STAGE_ALL_GRAPHICS;
+    static constexpr uint32_t           Offset = sizeof(D3D9SharedPushData);
+
+    uint16_t reserved = 0u;
+    // Point size, as 13.3 fixed-point
+    uint16_t pointSize = 0u;
+    uint16_t pointSizeMin = 0u;
+    uint16_t pointSizeMax = 0u;
+  };
+
+  /// Fixed-function vertex shader push data.
+  /// Can theoretically use up to 32 bytes.
+  struct D3D9FfvsPushData {
+    static constexpr VkShaderStageFlags Stages = VK_SHADER_STAGE_VERTEX_BIT;
+    static constexpr uint32_t           Offset = 0u;
+
+    float pointScaleA = 0.0f;
+    float pointScaleB = 0.0f;
+    float pointScaleC = 0.0f;
+  };
+
+  /// Fixed-function pixel shader push data.
+  struct D3D9FfpsPushData {
+    static constexpr VkShaderStageFlags Stages = VK_SHADER_STAGE_FRAGMENT_BIT;
+    static constexpr uint32_t           Offset = 0u;
+
+    uint32_t textureFactor = 0u;
+  };
+
+  /// Complete push data state. Note that the data layout inside
+  /// this struct is different from what it is in shaders.
+  struct D3D9PushData {
+    D3D9SharedPushData shared;
+    D3D9VsPushData vs;
+    D3D9FfvsPushData ffvs;
+    D3D9FfpsPushData ffps;
+  };
 
   // This is needed in fixed function for POSITION_T support.
   // These are constants we need to * and add to move

--- a/src/d3d9/d3d9_state.h
+++ b/src/d3d9/d3d9_state.h
@@ -54,7 +54,8 @@ namespace dxvk {
     static constexpr VkShaderStageFlags Stages = VK_SHADER_STAGE_ALL_GRAPHICS;
     static constexpr uint32_t           Offset = sizeof(D3D9SharedPushData);
 
-    uint16_t reserved = 0u;
+    // Dynamically indexed float count
+    uint16_t floatCount = 0u;
     // Point size, as 13.3 fixed-point
     uint16_t pointSize = 0u;
     uint16_t pointSizeMin = 0u;

--- a/src/d3d9/shaders/d3d9_fixed_function_common.glsl
+++ b/src/d3d9/shaders/d3d9_fixed_function_common.glsl
@@ -8,7 +8,7 @@ const uint D3DFOG_EXP    = 1;
 const uint D3DFOG_EXP2   = 2;
 const uint D3DFOG_LINEAR = 3;
 
-const uint MaxSharedPushDataSize = 64;
+const uint MaxSharedPushDataSize = 32;
 
 struct D3D9VsPushData {
     uint packedReservedAndPointSize;

--- a/src/d3d9/shaders/d3d9_fixed_function_common.glsl
+++ b/src/d3d9/shaders/d3d9_fixed_function_common.glsl
@@ -8,24 +8,29 @@ const uint D3DFOG_EXP    = 1;
 const uint D3DFOG_EXP2   = 2;
 const uint D3DFOG_LINEAR = 3;
 
-struct D3D9RenderStateInfo {
-    float fogColor[3];
-    float fogScale;
-    float fogEnd;
-    float fogDensity;
+const uint MaxSharedPushDataSize = 64;
 
-    uint alphaRef;
+struct D3D9VsPushData {
+    uint packedReservedAndPointSize;
+    uint packedPointSizeMinMax;
+};
 
-    float pointSize;
-    float pointSizeMin;
-    float pointSizeMax;
+struct D3D9FfvsPushData {
     float pointScaleA;
     float pointScaleB;
     float pointScaleC;
+};
 
+struct D3D9FfpsPushData {
     uint textureFactor;
 };
 
+struct D3D9SharedPushData {
+    uint packedFogColorAndAlphaRef;
+    float fogDistanceScale;
+    float fogDistanceEnd;
+    float fogDensity;
+};
 
 // Thanks SPIRV-Cross
 spirv_instruction(set = "GLSL.std.450", id = 79) float spvNMin(float, float);

--- a/src/d3d9/shaders/d3d9_fixed_function_frag.glsl
+++ b/src/d3d9/shaders/d3d9_fixed_function_frag.glsl
@@ -29,7 +29,6 @@ layout(location = 0) out vec4 out_Color0;
 
 
 const uint TextureArgCount = 3;
-const uint MaxSharedPushDataSize = 64;
 
 #include "d3d9_fixed_function_common.glsl"
 
@@ -109,9 +108,13 @@ uniform SharedData {
 
 layout(push_constant, scalar, row_major)
 uniform RenderStates {
-    D3D9RenderStateInfo rs;
+    D3D9SharedPushData global;
+    D3D9VsPushData vs;
 
-    layout(offset = MaxSharedPushDataSize) uint packedSamplerIndices[TextureStageCount / 2];
+    layout(offset = MaxSharedPushDataSize)
+    D3D9FfpsPushData ffps;
+
+    uint packedSamplerIndices[TextureStageCount / 2u];
 };
 
 layout(set = SRV_SET, binding = SRV_PS_BASE) uniform texture2D t2d[TextureStageCount];
@@ -121,10 +124,11 @@ layout(set = SRV_SET, binding = SRV_PS_BASE) uniform texture3D t3d[TextureStageC
 layout(set = SAMPLER_SET, binding = 0) uniform sampler sampler_heap[];
 
 vec4 calculateFog(vec4 vPos, vec4 oColor) {
-    vec3 fogColor = vec3(rs.fogColor[0], rs.fogColor[1], rs.fogColor[2]);
-    float fogScale = rs.fogScale;
-    float fogEnd = rs.fogEnd;
-    float fogDensity = rs.fogDensity;
+    vec3 fogColor = unpackUnorm4x8(global.packedFogColorAndAlphaRef).bgr;
+    float fogScale = global.fogDistanceScale;
+    float fogEnd = global.fogDistanceEnd;
+    float fogDensity = global.fogDensity;
+
     D3DFOGMODE fogMode = specUint(SpecPixelFogMode);
     bool fogEnabled = specBool(SpecFogEnabled);
     if (!fogEnabled) {
@@ -293,7 +297,7 @@ vec4 readArgValue(uint stage, uint arg, vec4 current, vec4 temp, vec4 textureVal
             reg = textureVal;
             break;
         case D3DTA_TFACTOR:
-            reg = decodeD3DColor(rs.textureFactor);
+            reg = decodeD3DColor(ffps.textureFactor);
             break;
     }
 
@@ -380,7 +384,7 @@ vec4 calculateTextureStage(uint op, vec4 dst, const TextureStageArgumentValues a
             return mix(arg.arg2, arg.arg1, textureVal.aaaa);
 
         case D3DTOP_BLENDFACTORALPHA:
-            return mix(arg.arg2, arg.arg1, decodeD3DColor(rs.textureFactor).aaaa);
+            return mix(arg.arg2, arg.arg1, decodeD3DColor(ffps.textureFactor).aaaa);
 
         case D3DTOP_BLENDTEXTUREALPHAPM:
             return saturate(fma(arg.arg2, complement(textureVal.aaaa), arg.arg1));
@@ -430,7 +434,7 @@ vec4 calculateTextureStage(uint op, vec4 dst, const TextureStageArgumentValues a
 void alphaTest() {
     uint alphaFunc = specUint(SpecAlphaCompareOp);
     uint alphaPrecision = specUint(SpecAlphaPrecisionBits);
-    uint alphaRefInitial = rs.alphaRef;
+    uint alphaRefInitial = bitfieldExtract(global.packedFogColorAndAlphaRef, 24, 8);
     float alphaRef;
     float alpha = out_Color0.a;
 

--- a/src/d3d9/shaders/d3d9_fixed_function_vert.vert
+++ b/src/d3d9/shaders/d3d9_fixed_function_vert.vert
@@ -228,7 +228,6 @@ float calculateFog(vec4 vPos) {
     vec4 specular = in_Color1;
     bool hasSpecular = vertexHasColor1();
 
-    vec3 fogColor = vec3(rs.fogColor[0], rs.fogColor[1], rs.fogColor[2]);
     float fogScale = rs.fogScale;
     float fogEnd = rs.fogEnd;
     float fogDensity = rs.fogDensity;

--- a/src/d3d9/shaders/d3d9_fixed_function_vert.vert
+++ b/src/d3d9/shaders/d3d9_fixed_function_vert.vert
@@ -146,9 +146,21 @@ uniform ClipPlanes {
 
 layout(push_constant, scalar, row_major)
 uniform RenderStates {
-    D3D9RenderStateInfo rs;
+    D3D9SharedPushData global;
+    D3D9VsPushData vs;
+
+    layout(offset = MaxSharedPushDataSize)
+    D3D9FfvsPushData ffvs;
 };
 
+// Return point size, min, max as raw float
+vec3 decodePointSize() {
+    uvec3 pointData = uvec3(
+        bitfieldExtract(vs.packedReservedAndPointSize, 16, 16),
+        bitfieldExtract(vs.packedPointSizeMinMax,  0, 16),
+        bitfieldExtract(vs.packedPointSizeMinMax, 16, 16));
+    return vec3(pointData) / 8.0f;
+}
 
 // Functions to extract information from the packed VS key
 // See D3D9FFShaderKeyVSData in d3d9_shader_types.h
@@ -228,14 +240,14 @@ float calculateFog(vec4 vPos) {
     vec4 specular = in_Color1;
     bool hasSpecular = vertexHasColor1();
 
-    float fogScale = rs.fogScale;
-    float fogEnd = rs.fogEnd;
-    float fogDensity = rs.fogDensity;
+    float fogScale = global.fogDistanceScale;
+    float fogEnd = global.fogDistanceEnd;
+    float fogDensity = global.fogDensity;
+
     D3DFOGMODE fogMode = specUint(SpecVertexFogMode);
-    bool fogEnabled = specBool(SpecFogEnabled);
-    if (!fogEnabled) {
+
+    if (!specBool(SpecFogEnabled))
         return 0.0;
-    }
 
     float w = vPos.w;
     float z = vPos.z;
@@ -251,6 +263,7 @@ float calculateFog(vec4 vPos) {
         fogFactor = hasSpecular ? specular.w : 1.0;
     } else {
         switch (fogMode) {
+            default:
             case D3DFOG_NONE:
                 fogFactor = hasSpecular ? specular.w : 1.0;
                 break;
@@ -283,12 +296,14 @@ float calculateFog(vec4 vPos) {
 
 
 float calculatePointSize(vec4 vtx) {
-    float value = vertexHasPointSize() ? in_PointSize : rs.pointSize;
+    vec3 pointSizeArgs = decodePointSize();
+
+    float value = vertexHasPointSize() ? in_PointSize : pointSizeArgs.x;
     uint pointMode = specUint(SpecPointMode);
     bool isScale = bitfieldExtract(pointMode, 0, 1) != 0;
-    float scaleC = rs.pointScaleC;
-    float scaleB = rs.pointScaleB;
-    float scaleA = rs.pointScaleA;
+    float scaleC = ffvs.pointScaleC;
+    float scaleB = ffvs.pointScaleB;
+    float scaleA = ffvs.pointScaleA;
 
     vec3 vtx3 = vtx.xyz;
 
@@ -302,8 +317,8 @@ float calculatePointSize(vec4 vtx) {
 
     value = isScale ? scaleValue : value;
 
-    float pointSizeMin = rs.pointSizeMin;
-    float pointSizeMax = rs.pointSizeMax;
+    float pointSizeMin = pointSizeArgs.y;
+    float pointSizeMax = pointSizeArgs.z;
 
     return clamp(value, pointSizeMin, pointSizeMax);
 }

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -7984,7 +7984,7 @@ namespace dxvk {
         auto block = layout->getPushDataBlock(i);
         auto blockSize = block.getSize();
 
-        auto srcOffset = computePushDataBlockOffset(i);
+        auto srcOffset = DxvkPushDataBlock::computeBlockOffsetForIndex(i);
         auto dstOffset = block.getOffset();
 
         auto constantData = &m_state.pc.constantData[srcOffset];

--- a/src/dxvk/dxvk_context.h
+++ b/src/dxvk/dxvk_context.h
@@ -960,9 +960,7 @@ namespace dxvk {
             uint32_t                  offset,
             uint32_t                  size,
       const void*                     data) {
-      uint32_t index = DxvkPushDataBlock::computeIndex(stages);
-
-      uint32_t baseOffset = computePushDataBlockOffset(index);
+      uint32_t baseOffset = DxvkPushDataBlock::computeBlockOffsetForStage(stages);
       std::memcpy(&m_state.pc.constantData[baseOffset + offset], data, size);
 
       m_flags.set(DxvkContextFlag::DirtyPushData);
@@ -2271,10 +2269,6 @@ namespace dxvk {
     bool formatsAreImageCopyCompatible(
             VkFormat                  dstFormat,
             VkFormat                  srcFormat);
-
-    static uint32_t computePushDataBlockOffset(uint32_t index) {
-      return index ? MaxSharedPushDataSize + MaxPerStagePushDataSize * (index - 1u) : 0u;
-    }
 
     static VkStencilOpState convertStencilOp(
       const DxvkStencilOp&            op,

--- a/src/dxvk/dxvk_device.cpp
+++ b/src/dxvk/dxvk_device.cpp
@@ -779,11 +779,7 @@ namespace dxvk {
     if (m_features.vk12.shaderFloat16)
       m_shaderOptions.flags.set(DxvkShaderCompileFlag::Supports16BitArithmetic);
 
-    // RADV currently can't pre-load SGPRs with sub-dword push data and will
-    // load them from memory instead, so promote everything to dwords.
-    if (m_features.vk11.storagePushConstant16
-     && m_features.vk12.storagePushConstant8
-     && !m_adapter->matchesDriver(VK_DRIVER_ID_MESA_RADV))
+    if (m_features.vk11.storagePushConstant16 && m_features.vk12.storagePushConstant8)
       m_shaderOptions.flags.set(DxvkShaderCompileFlag::SupportsSubDwordPushData);
 
     // Need to tag typed storage image loads with the format on some devices

--- a/src/dxvk/dxvk_limits.h
+++ b/src/dxvk/dxvk_limits.h
@@ -20,9 +20,9 @@ namespace dxvk {
     MaxUniformBufferSize        = 65536,
     MaxVertexBindingStride      =  2048,
     MaxTotalPushDataSize        =   256,
-    MaxSharedPushDataSize       =    64,
+    MaxSharedPushDataSize       =    32,
     MaxPerStagePushDataSize     =    32,
-    MaxReservedPushDataSize     =    32,
+    MaxReservedPushDataSize     =    16,
   };
   
 }

--- a/src/dxvk/dxvk_pipelayout.cpp
+++ b/src/dxvk/dxvk_pipelayout.cpp
@@ -522,12 +522,13 @@ namespace dxvk {
 
       for (auto i : bit::BitMask(stageMask)) {
         auto stage = VkShaderStageFlagBits(1u << i);
+        auto size = DxvkPushDataBlock::computeBlockSizeForStage(stage);
         index = DxvkPushDataBlock::computeIndex(stage);
 
         pushDataBlocks[index] = DxvkPushDataBlock(stage,
-          pushDataSize, MaxPerStagePushDataSize, 8u, 0u);
+          pushDataSize, size, 8u, 0u);
 
-        pushDataSize += MaxPerStagePushDataSize;
+        pushDataSize += size;
         pushDataMask |= 1u << index;
       }
 

--- a/src/dxvk/dxvk_pipelayout.h
+++ b/src/dxvk/dxvk_pipelayout.h
@@ -708,6 +708,50 @@ namespace dxvk {
       return remainder ? 0u : (bit::tzcnt(uint32_t(stageMask)) + 1u);
     }
 
+    /**
+     * \brief Computes push data block offset for a given block index
+     *
+     * \param [in] index Block index, see \c computeIndex
+     * \returns Absolute offset of push data block in global push data
+     */
+    static uint32_t computeBlockOffsetForIndex(uint32_t index) {
+      return index ? MaxSharedPushDataSize + MaxPerStagePushDataSize * (index - 1u) : 0u;
+    }
+
+    /**
+     * \brief Computes push data block offset for a given stage
+     *
+     * \param [in] stageMask Shader stage mask
+     * \returns Push data offset for given stage
+     */
+    static uint32_t computeBlockOffsetForStage(VkShaderStageFlags stageMask) {
+      return computeBlockOffsetForIndex(computeIndex(stageMask));
+    }
+
+    /**
+     * \brief Computes maximum push data size for given shader stage
+     *
+     * For graphics pipelines, fragment shaders will be able to use all
+     * data from the block offset to the reserved block. This is useful
+     * because fragment shaders will often have a lot of sampler indices.
+     * \param [in] stageMask Shader stage mask
+     * \returns Push data size that the given stage can use
+     */
+    static uint32_t computeBlockSizeForStage(VkShaderStageFlags stageMask) {
+      if (stageMask & VK_SHADER_STAGE_COMPUTE_BIT)
+        return MaxTotalPushDataSize - MaxReservedPushDataSize;
+
+      if (stageMask & (stageMask - 1u))
+        return MaxSharedPushDataSize;
+
+      if (stageMask == VK_SHADER_STAGE_FRAGMENT_BIT) {
+        uint32_t size = MaxTotalPushDataSize - MaxReservedPushDataSize;
+        return size - computeBlockOffsetForStage(VK_SHADER_STAGE_FRAGMENT_BIT);
+      }
+
+      return MaxPerStagePushDataSize;
+    }
+
   private:
 
     uint16_t  m_stageMask     = 0u;

--- a/src/dxvk/dxvk_shader_ir.cpp
+++ b/src/dxvk/dxvk_shader_ir.cpp
@@ -919,11 +919,13 @@ namespace dxvk {
 
         // If we can use BDA or push address mapping with at least the same
         // level of performance as a constant buffer, rewrite the binding.
+        uint32_t maxPushDataSize = DxvkPushDataBlock::computeBlockSizeForStage(convertShaderStage(m_stage));
+
         bool useHeap = m_info.options.spirv.test(DxvkShaderSpirvFlag::SupportsDescriptorHeap);
         bool useBda = m_info.options.flags.test(DxvkShaderCompileFlag::LowerInBoundsCbvToBda);
 
         if ((useHeap || useBda) && (op.getFlags() & dxbc_spv::ir::OpFlag::eInBounds)
-         && (m_localPushDataOffset + sizeof(uint64_t) <= MaxPerStagePushDataSize)) {
+         && (m_localPushDataOffset + sizeof(uint64_t) <= maxPushDataSize)) {
           m_localPushDataAlign = std::max<uint32_t>(m_localPushDataAlign, sizeof(uint64_t));
           m_localPushDataOffset = align(m_localPushDataOffset, m_localPushDataAlign);
 
@@ -1215,11 +1217,8 @@ namespace dxvk {
       // In compute shaders, we can freely use push data space
       auto ssboAlignment = m_info.options.minStorageBufferAlignment;
 
-      size_t maxPushDataSize = m_stage == dxbc_spv::ir::ShaderStage::eCompute
-        ? MaxTotalPushDataSize - MaxReservedPushDataSize
-        : MaxPerStagePushDataSize;
-
-      size_t uavCounterIndex = 0u;
+      uint32_t maxPushDataSize = DxvkPushDataBlock::computeBlockSizeForStage(convertShaderStage(m_stage));
+      uint32_t uavCounterIndex = 0u;
 
       if (m_localPushDataOffset + sizeof(uint64_t) <= maxPushDataSize && ssboAlignment <= 4u && !hasUavCounterArray()) {
         // Align push data to a multiple of 8 bytes before emitting counters
@@ -1229,7 +1228,7 @@ namespace dxvk {
         // Declare push data variable and type
         dxbc_spv::ir::Type pushDataType = { };
 
-        size_t maxUavCounters = std::min<size_t>(m_uavCounters.size(),
+        uint32_t maxUavCounters = std::min<uint32_t>(m_uavCounters.size(),
           (maxPushDataSize - m_localPushDataOffset) / sizeof(uint64_t));
 
         for (uint32_t i = 0u; i < maxUavCounters; i++)


### PR DESCRIPTION
Definitely needs a fair bit of testing mostly with older games that use fixed-function stuff, fog, alpha testing, point rendering, and especially Sims 2.

The main goal here is to rearrange push constant space in such a way that we can:
a) fit pointers to all constant buffers into push data for programmable shaders, even if PS uses more than 12 samplers
b) get rid of the spec constant fallback UBO and fit everything into push data as well, including all fixed-function texture parameters.