### PR TITLE
Only hide Intel vendor ID for XeSS 1.x

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -107,6 +107,7 @@ if platform == 'windows'
   lib_d3d11   = cpp.find_library('d3d11')
   lib_dxgi    = cpp.find_library('dxgi')
   lib_gdi32   = cpp.find_library('gdi32')
+  lib_version = cpp.find_library('version')
 
   if dxvk_is_msvc
     res_ext = '.res'

--- a/src/dxgi/dxgi_options.cpp
+++ b/src/dxgi/dxgi_options.cpp
@@ -28,18 +28,69 @@ namespace dxvk {
 
   /* First generation XeSS causes crash on proton for Intel due to missing
    * Intel interface. Avoid crash by pretending to be non-Intel if the
-   * libxess.dll module is loaded by an application.
-   */
-  static bool isXessUsed() {
-#ifdef _WIN32
-      if (GetModuleHandleA("libxess") != nullptr ||
-          GetModuleHandleA("libxess_dx11") != nullptr)
-        return true;
-      else
-        return false;
-#else
+   * libxess.dll module is loaded by an application. */
+  static bool isXess1xUsed() {
+    #ifdef _WIN32
+    HMODULE libxess = nullptr;
+
+    // Use Ex variant here to keep the library loaded while we use the handle
+    if (!GetModuleHandleExA(0u, "libxess", &libxess)
+     && !GetModuleHandleExA(0u, "libxess_dx11", &libxess))
       return false;
-#endif
+
+    if (!libxess)
+      return false;
+
+    // For some reason it seems to be impossible to just query
+    // the length, need to pre-allocate for the worst case
+    std::array<char, MAX_PATH + 1u> fileName = {};
+    auto nameLen = GetModuleFileNameA(libxess, fileName.data(), fileName.size());
+
+    // Should be safe to release the module now, we only operate
+    // on the actual file from now on
+    FreeLibrary(libxess);
+
+    if (!nameLen) {
+      Logger::warn("DXGI: Failed to get file name for XeSS module");
+      return true;
+    }
+
+    // Query version info blob size...
+    auto fiSize = GetFileVersionInfoSizeA(fileName.data(), nullptr);
+
+    if (!fiSize) {
+      Logger::warn("DXGI: Failed to get XeSS version info size");
+      return true;
+    }
+
+    // Retrieve actual version info blob
+    std::vector<char> fiData(fiSize);
+
+    if (!GetFileVersionInfoA(fileName.data(), 0u, fiSize, fiData.data())) {
+      Logger::warn("DXGI: Failed to get XeSS version info");
+      return true;
+    }
+
+    void* fiBlock = nullptr;
+    UINT fiBlockSize = 0u;
+
+    if (!VerQueryValueA(fiData.data(), "\\", &fiBlock, &fiBlockSize)) {
+      Logger::warn("DXGI: Failed to get XeSS version info block");
+      return true;
+    }
+
+    auto fiBlockTyped = reinterpret_cast<const VS_FIXEDFILEINFO*>(fiBlock);
+
+    if (!fiBlockTyped || fiBlockSize < sizeof(*fiBlockTyped)) {
+      Logger::warn("DXGI: Invalid XeSS version info block");
+      return true;
+    }
+
+    // XeSS 2.0 onwards should be fine
+    return fiBlockTyped->dwProductVersionMS < 0x20000u;
+    #else
+    return false;
+    #endif
   }
 
   static bool isNvapiEnabled() {
@@ -113,9 +164,9 @@ namespace dxvk {
     this->hideAmdGpu = config.getOption<Tristate>("dxgi.hideAmdGpu", Tristate::Auto) == Tristate::True;
     this->hideIntelGpu = config.getOption<Tristate>("dxgi.hideIntelGpu", Tristate::Auto) == Tristate::True;
 
-    /* Force vendor ID to non-Intel ID when XeSS is in use */
-    if (isXessUsed()) {
-      Logger::info(str::format("Detected XeSS usage, hiding Intel GPU Vendor"));
+    // Old XeSS libraries will crash if an Intel GPU is detected
+    if (isXess1xUsed()) {
+      Logger::info(str::format("Detected XeSS 1.x usage, hiding Intel GPU Vendor"));
       this->hideIntelGpu = true;
     }
 

--- a/src/dxgi/meson.build
+++ b/src/dxgi/meson.build
@@ -15,14 +15,17 @@ dxgi_src = [
 
 dxgi_ld_args      = []
 dxgi_link_depends = []
+dxgi_extra_dep    = []
 
-if platform != 'windows'
+if platform == 'windows'
+  dxgi_extra_dep    += [ cpp.find_library('version') ]
+else
   dxgi_ld_args      += [ '-Wl,--version-script', join_paths(meson.current_source_dir(), 'dxgi.sym') ]
   dxgi_link_depends += files('dxgi.sym')
 endif
 
 dxgi_dll = shared_library(dxvk_name_prefix+'dxgi', dxgi_src, dxgi_res,
-  dependencies        : [ dxvk_dep ],
+  dependencies        : [ dxvk_dep, dxgi_extra_dep ],
   include_directories : dxvk_include_path,
   install             : true,
   vs_module_defs      : 'dxgi'+def_spec_ext,

--- a/src/dxvk/dxvk_device_info.cpp
+++ b/src/dxvk/dxvk_device_info.cpp
@@ -484,13 +484,15 @@ namespace dxvk {
     const DxvkInstance&               instance,
           bool                        safeMode) {
     if (m_featuresSupported.extDescriptorHeap.descriptorHeap) {
-      // Only enable descriptor heaps on drivers that are known to work
-      // and don't have known performance regressions currently.
-      // TODO revisit w.r.t. Intel, Turnip.
+      // Only enable descriptor heaps on drivers that are known to work and don't
+      // have known performance regressions currently.
+      // Keep this disabled on Turnip for now to give the driver as much information
+      // about resources used as possible; CPU overhead should not matter there.
       bool enableDescriptorHeap = m_properties.vk12.driverID == VK_DRIVER_ID_MESA_RADV
+                               || m_properties.vk12.driverID == VK_DRIVER_ID_MESA_NVK
                                || m_properties.vk12.driverID == VK_DRIVER_ID_MESA_LLVMPIPE
-                               || m_properties.vk12.driverID == VK_DRIVER_ID_AMD_PROPRIETARY
-                               || m_properties.vk12.driverID == VK_DRIVER_ID_MESA_NVK;
+                               || m_properties.vk12.driverID == VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA
+                               || m_properties.vk12.driverID == VK_DRIVER_ID_AMD_PROPRIETARY;
 
       // Heap regresses performance on the initial NV driver releases.
       // The maintenance11 check enables it on 595 Vulkan beta drivers.


### PR DESCRIPTION
What a mess.

Not sure if I'm looking at the *correct* version info here, but Trails beyond the Horizion is detected as XeSS 2.0 whereas Shadow of the Tomb Raider reports 1.1.