### PR TITLE
[d3d8] Handle odd cases of texture UAF

### DIFF
--- a/src/d3d8/d3d8_device.cpp
+++ b/src/d3d8/d3d8_device.cpp
@@ -311,7 +311,14 @@ namespace dxvk {
     if (unlikely(FAILED(res)))
       return res;
 
-    *ppTexture = ref(new D3D8Texture2D(this, Pool, std::move(pTex9)));
+    IDirect3DTexture8* tex = new D3D8Texture2D(this, Pool, std::move(pTex9));
+
+    if (unlikely(m_d3d8Options.textureUAFGuard)) {
+      D3D8DeviceLock lock = LockDevice();
+      m_validTextures.insert(tex);
+    }
+
+    *ppTexture = ref(tex);
 
     return D3D_OK;
   }
@@ -349,7 +356,14 @@ namespace dxvk {
     if (unlikely(FAILED(res)))
       return res;
 
-    *ppVolumeTexture = ref(new D3D8Texture3D(this, Pool, std::move(pVolume9)));
+    IDirect3DVolumeTexture8* tex = new D3D8Texture3D(this, Pool, std::move(pVolume9));
+
+    if (unlikely(m_d3d8Options.textureUAFGuard)) {
+      D3D8DeviceLock lock = LockDevice();
+      m_validTextures.insert(tex);
+    }
+
+    *ppVolumeTexture = ref(tex);
 
     return D3D_OK;
   }
@@ -386,7 +400,14 @@ namespace dxvk {
     if (unlikely(FAILED(res)))
       return res;
 
-    *ppCubeTexture = ref(new D3D8TextureCube(this, Pool, std::move(pCube9)));
+    IDirect3DCubeTexture8* tex = new D3D8TextureCube(this, Pool, std::move(pCube9));
+
+    if (unlikely(m_d3d8Options.textureUAFGuard)) {
+      D3D8DeviceLock lock = LockDevice();
+      m_validTextures.insert(tex);
+    }
+
+    *ppCubeTexture = ref(tex);
 
     return D3D_OK;
   }
@@ -1364,7 +1385,9 @@ namespace dxvk {
     if (unlikely(ShouldRecord()))
       return m_recorder->SetTexture(Stage, pTexture);
 
-    D3D8Texture2D* tex = static_cast<D3D8Texture2D*>(pTexture);
+    const bool isValidTexture = !m_d3d8Options.textureUAFGuard
+                              || m_validTextures.find(pTexture) != m_validTextures.end();
+    D3D8Texture2D* tex = isValidTexture ? static_cast<D3D8Texture2D*>(pTexture) : nullptr;
 
     // Splinter Cell: Force perspective divide when a shadow map is bound to slot 0
     if (unlikely(m_d3d8Options.shadowPerspectiveDivide && Stage == 0)) {

--- a/src/d3d8/d3d8_device.cpp
+++ b/src/d3d8/d3d8_device.cpp
@@ -116,7 +116,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D8Device::TestCooperativeLevel() {
-    // Equivalent of D3D11/DXGI present tests.
     return GetD3D9()->TestCooperativeLevel();
   }
 
@@ -139,16 +138,17 @@ namespace dxvk {
 
   HRESULT STDMETHODCALLTYPE D3D8Device::GetDeviceCaps(D3DCAPS8* pCaps) {
     d3d9::D3DCAPS9 caps9;
+
     HRESULT res = GetD3D9()->GetDeviceCaps(&caps9);
+    if (unlikely(FAILED(res)))
+      return res;
 
-    if (likely(SUCCEEDED(res)))
-      ConvertCaps8(caps9, pCaps);
+    ConvertCaps8(caps9, pCaps);
 
-    return res;
+    return D3D_OK;
   }
 
   HRESULT STDMETHODCALLTYPE D3D8Device::GetDisplayMode(D3DDISPLAYMODE* pMode) {
-    // swap chain 0
     return GetD3D9()->GetDisplayMode(0, reinterpret_cast<d3d9::D3DDISPLAYMODE*>(pMode));
   }
 
@@ -191,18 +191,18 @@ namespace dxvk {
       &params,
       &pSwapChain9
     );
+    if (unlikely(FAILED(res)))
+      return res;
 
-    if (likely(SUCCEEDED(res)))
-      *ppSwapChain = ref(new D3D8SwapChain(this, pPresentationParameters, std::move(pSwapChain9)));
+    *ppSwapChain = ref(new D3D8SwapChain(this, pPresentationParameters, std::move(pSwapChain9)));
 
-    return res;
+    return D3D_OK;
   }
 
   HRESULT STDMETHODCALLTYPE D3D8Device::Reset(D3DPRESENT_PARAMETERS* pPresentationParameters) {
     D3D8DeviceLock lock = LockDevice();
 
     HRESULT res = m_parent->ValidatePresentationParameters(pPresentationParameters);
-
     if (unlikely(FAILED(res)))
       return res;
 
@@ -213,11 +213,12 @@ namespace dxvk {
 
     d3d9::D3DPRESENT_PARAMETERS params = ConvertPresentParameters9(pPresentationParameters);
     res = GetD3D9()->Reset(&params);
+    if (unlikely(FAILED(res)))
+      return res;
 
-    if (likely(SUCCEEDED(res)))
-      RecreateBackBuffersAndAutoDepthStencil();
+    RecreateBackBuffersAndAutoDepthStencil();
 
-    return res;
+    return D3D_OK;
   }
 
   HRESULT STDMETHODCALLTYPE D3D8Device::Present(
@@ -248,13 +249,10 @@ namespace dxvk {
     if (iBackBuffer >= m_backBuffers.size() || m_backBuffers[iBackBuffer] == nullptr) {
       Com<d3d9::IDirect3DSurface9> pSurface9;
       HRESULT res = GetD3D9()->GetBackBuffer(0, iBackBuffer, (d3d9::D3DBACKBUFFER_TYPE)Type, &pSurface9);
+      if (unlikely(FAILED(res)))
+        return res;
 
-      if (likely(SUCCEEDED(res))) {
-        m_backBuffers[iBackBuffer] = new D3D8Surface(this, D3DPOOL_DEFAULT, std::move(pSurface9));
-        *ppBackBuffer = m_backBuffers[iBackBuffer].ref();
-      }
-
-      return res;
+      m_backBuffers[iBackBuffer] = new D3D8Surface(this, D3DPOOL_DEFAULT, std::move(pSurface9));
     }
 
     *ppBackBuffer = m_backBuffers[iBackBuffer].ref();
@@ -268,12 +266,10 @@ namespace dxvk {
 
   void STDMETHODCALLTYPE D3D8Device::SetGammaRamp(DWORD Flags, const D3DGAMMARAMP* pRamp) {
     StateChange();
-    // For swap chain 0
     GetD3D9()->SetGammaRamp(0, Flags, reinterpret_cast<const d3d9::D3DGAMMARAMP*>(pRamp));
   }
 
   void STDMETHODCALLTYPE D3D8Device::GetGammaRamp(D3DGAMMARAMP* pRamp) {
-    // For swap chain 0
     GetD3D9()->GetGammaRamp(0, reinterpret_cast<d3d9::D3DGAMMARAMP*>(pRamp));
   }
 
@@ -312,11 +308,12 @@ namespace dxvk {
       d3d9::D3DPOOL(Pool),
       &pTex9,
       NULL);
+    if (unlikely(FAILED(res)))
+      return res;
 
-    if (likely(SUCCEEDED(res)))
-      *ppTexture = ref(new D3D8Texture2D(this, Pool, std::move(pTex9)));
+    *ppTexture = ref(new D3D8Texture2D(this, Pool, std::move(pTex9)));
 
-    return res;
+    return D3D_OK;
   }
 
   HRESULT STDMETHODCALLTYPE D3D8Device::CreateVolumeTexture(
@@ -349,11 +346,12 @@ namespace dxvk {
       d3d9::D3DPOOL(Pool),
       &pVolume9,
       NULL);
+    if (unlikely(FAILED(res)))
+      return res;
 
-    if (likely(SUCCEEDED(res)))
-      *ppVolumeTexture = ref(new D3D8Texture3D(this, Pool, std::move(pVolume9)));
+    *ppVolumeTexture = ref(new D3D8Texture3D(this, Pool, std::move(pVolume9)));
 
-    return res;
+    return D3D_OK;
   }
 
   HRESULT STDMETHODCALLTYPE D3D8Device::CreateCubeTexture(
@@ -385,11 +383,12 @@ namespace dxvk {
       d3d9::D3DPOOL(Pool),
       &pCube9,
       NULL);
+    if (unlikely(FAILED(res)))
+      return res;
 
-    if (likely(SUCCEEDED(res)))
-      *ppCubeTexture = ref(new D3D8TextureCube(this, Pool, std::move(pCube9)));
+    *ppCubeTexture = ref(new D3D8TextureCube(this, Pool, std::move(pCube9)));
 
-    return res;
+    return D3D_OK;
   }
 
   HRESULT STDMETHODCALLTYPE D3D8Device::CreateVertexBuffer(
@@ -410,11 +409,12 @@ namespace dxvk {
 
     Com<d3d9::IDirect3DVertexBuffer9> pVertexBuffer9;
     HRESULT res = GetD3D9()->CreateVertexBuffer(Length, Usage, FVF, d3d9::D3DPOOL(Pool), &pVertexBuffer9, NULL);
+    if (unlikely(FAILED(res)))
+      return res;
 
-    if (likely(SUCCEEDED(res)))
-      *ppVertexBuffer = ref(new D3D8VertexBuffer(this, std::move(pVertexBuffer9), Pool, Usage));
+    *ppVertexBuffer = ref(new D3D8VertexBuffer(this, std::move(pVertexBuffer9), Pool, Usage));
 
-    return res;
+    return D3D_OK;
   }
 
   HRESULT STDMETHODCALLTYPE D3D8Device::CreateIndexBuffer(
@@ -430,11 +430,12 @@ namespace dxvk {
 
     Com<d3d9::IDirect3DIndexBuffer9> pIndexBuffer9;
     HRESULT res = GetD3D9()->CreateIndexBuffer(Length, Usage, d3d9::D3DFORMAT(Format), d3d9::D3DPOOL(Pool), &pIndexBuffer9, NULL);
+    if (unlikely(FAILED(res)))
+      return res;
 
-    if (likely(SUCCEEDED(res)))
-      *ppIndexBuffer = ref(new D3D8IndexBuffer(this, std::move(pIndexBuffer9), Pool, Usage));
+    *ppIndexBuffer = ref(new D3D8IndexBuffer(this, std::move(pIndexBuffer9), Pool, Usage));
 
-    return res;
+    return D3D_OK;
   }
 
   HRESULT STDMETHODCALLTYPE D3D8Device::CreateRenderTarget(
@@ -470,11 +471,12 @@ namespace dxvk {
       Lockable,
       &pSurf9,
       NULL);
+    if (unlikely(FAILED(res)))
+      return res;
 
-    if (likely(SUCCEEDED(res)))
-      *ppSurface = ref(new D3D8Surface(this, D3DPOOL_DEFAULT, std::move(pSurf9)));
+    *ppSurface = ref(new D3D8Surface(this, D3DPOOL_DEFAULT, std::move(pSurf9)));
 
-    return res;
+    return D3D_OK;
   }
 
   HRESULT STDMETHODCALLTYPE D3D8Device::CreateDepthStencilSurface(
@@ -506,11 +508,12 @@ namespace dxvk {
       FALSE, // z-buffer discarding is not used in D3D8
       &pSurf9,
       NULL);
+    if (unlikely(FAILED(res)))
+      return res;
 
-    if (likely(SUCCEEDED(res)))
-      *ppSurface = ref(new D3D8Surface(this, D3DPOOL_DEFAULT, std::move(pSurf9)));
+    *ppSurface = ref(new D3D8Surface(this, D3DPOOL_DEFAULT, std::move(pSurf9)));
 
-    return res;
+    return D3D_OK;
   }
 
   HRESULT STDMETHODCALLTYPE D3D8Device::CreateImageSurface(
@@ -544,11 +547,12 @@ namespace dxvk {
       d3d9::D3DPOOL(pool),
       &pSurf,
       NULL);
+    if (unlikely(FAILED(res)))
+      return res;
 
-    if (likely(SUCCEEDED(res)))
-      *ppSurface = ref(new D3D8Surface(this, pool, std::move(pSurf)));
+    *ppSurface = ref(new D3D8Surface(this, pool, std::move(pSurf)));
 
-    return res;
+    return D3D_OK;
   }
 
   // Copies texture rect in system mem using memcpy.
@@ -643,14 +647,14 @@ namespace dxvk {
    * The following table shows the possible combinations of source
    * and destination surface pools, and how we handle each of them.
    *
-   *     ┌────────────┬───────────────────────────┬───────────────────────┬───────────────────────┬──────────────────────┐
-   *     │ Src/Dst    │ DEFAULT                   │ MANAGED               │ SYSTEMMEM             │ SCRATCH              │
-   *     ├────────────┼───────────────────────────┼───────────────────────┼───────────────────────┼──────────────────────┤
-   *     │ DEFAULT    │  StretchRect              │  GetRenderTargetData  │  GetRenderTargetData  │ GetRenderTargetData  │
-   *     │ MANAGED    │  UpdateTextureFromBuffer  │  memcpy               │  memcpy               │ memcpy               │
-   *     │ SYSTEMMEM  │  UpdateSurface            │  memcpy               │  memcpy               │ memcpy               │
-   *     │ SCRATCH    │  memcpy + UpdateSurface   │  memcpy               │  memcpy               │ memcpy               │
-   *     └────────────┴───────────────────────────┴───────────────────────┴───────────────────────┴──────────────────────┘
+   *    ┌────────────┬───────────────────────────┬───────────────────────┬───────────────────────┬──────────────────────┐
+   *    │ Src/Dst    │ DEFAULT                   │ MANAGED               │ SYSTEMMEM             │ SCRATCH              │
+   *    ├────────────┼───────────────────────────┼───────────────────────┼───────────────────────┼──────────────────────┤
+   *    │ DEFAULT    │  StretchRect              │  GetRenderTargetData  │  GetRenderTargetData  │ GetRenderTargetData  │
+   *    │ MANAGED    │  UpdateTextureFromBuffer  │  memcpy               │  memcpy               │ memcpy               │
+   *    │ SYSTEMMEM  │  UpdateSurface            │  memcpy               │  memcpy               │ memcpy               │
+   *    │ SCRATCH    │  memcpy + UpdateSurface   │  memcpy               │  memcpy               │ memcpy               │
+   *    └────────────┴───────────────────────────┴───────────────────────┴───────────────────────┴──────────────────────┘
    */
   HRESULT STDMETHODCALLTYPE D3D8Device::CopyRects(
           IDirect3DSurface8*  pSourceSurface,
@@ -1003,8 +1007,8 @@ namespace dxvk {
       // needs to be readjusted and reset.
       StateChange();
       res = GetD3D9()->SetRenderTarget(0, D3D8Surface::GetD3D9Nullable(surf));
-
-      if (unlikely(FAILED(res))) return res;
+      if (unlikely(FAILED(res)))
+        return res;
 
       m_renderTarget = surf;
     }
@@ -1017,13 +1021,13 @@ namespace dxvk {
     if (m_renderTarget != nullptr && zStencil != nullptr) {
       D3DSURFACE_DESC rtDesc;
       res = m_renderTarget->GetDesc(&rtDesc);
-
-      if (unlikely(FAILED(res))) return res;
+      if (unlikely(FAILED(res)))
+        return res;
 
       D3DSURFACE_DESC dsDesc;
       res = zStencil->GetDesc(&dsDesc);
-
-      if (unlikely(FAILED(res))) return res;
+      if (unlikely(FAILED(res)))
+        return res;
 
       if (unlikely(dsDesc.Width  < rtDesc.Width
                 || dsDesc.Height < rtDesc.Height))
@@ -1050,17 +1054,15 @@ namespace dxvk {
 
     if (unlikely(m_renderTarget == nullptr)) {
       Com<d3d9::IDirect3DSurface9> pRT9;
-      HRESULT res = GetD3D9()->GetRenderTarget(0, &pRT9); // use RT index 0
+      HRESULT res = GetD3D9()->GetRenderTarget(0, &pRT9);
+      if (unlikely(FAILED(res)))
+        return res;
 
-      if (likely(SUCCEEDED(res))) {
-        m_renderTarget = new D3D8Surface(this, D3DPOOL_DEFAULT, std::move(pRT9));
-        *ppRenderTarget = m_renderTarget.ref();
-      }
-
-      return res;
+      m_renderTarget = new D3D8Surface(this, D3DPOOL_DEFAULT, std::move(pRT9));
     }
 
     *ppRenderTarget = m_renderTarget.ref();
+
     return D3D_OK;
   }
 
@@ -1075,22 +1077,25 @@ namespace dxvk {
     if (unlikely(m_depthStencil == nullptr)) {
       Com<d3d9::IDirect3DSurface9> pStencil9;
       HRESULT res = GetD3D9()->GetDepthStencilSurface(&pStencil9);
+      if (unlikely(FAILED(res)))
+        return res;
 
-      if (likely(SUCCEEDED(res))) {
-        m_depthStencil = new D3D8Surface(this, D3DPOOL_DEFAULT, std::move(pStencil9));
-        *ppZStencilSurface = m_depthStencil.ref();
-      }
-
-      return res;
+      m_depthStencil = new D3D8Surface(this, D3DPOOL_DEFAULT, std::move(pStencil9));
     }
 
     *ppZStencilSurface = m_depthStencil.ref();
+
     return D3D_OK;
   }
 
-  HRESULT STDMETHODCALLTYPE D3D8Device::BeginScene() { return GetD3D9()->BeginScene(); }
+  HRESULT STDMETHODCALLTYPE D3D8Device::BeginScene() {
+    return GetD3D9()->BeginScene();
+  }
 
-  HRESULT STDMETHODCALLTYPE D3D8Device::EndScene() { StateChange(); return GetD3D9()->EndScene(); }
+  HRESULT STDMETHODCALLTYPE D3D8Device::EndScene() {
+    StateChange();
+    return GetD3D9()->EndScene();
+  }
 
   HRESULT STDMETHODCALLTYPE D3D8Device::Clear(
           DWORD    Count,
@@ -1217,16 +1222,16 @@ namespace dxvk {
 
     Com<d3d9::IDirect3DStateBlock9> pStateBlock9;
     HRESULT res = GetD3D9()->CreateStateBlock(d3d9::D3DSTATEBLOCKTYPE(Type), &pStateBlock9);
+    if (unlikely(FAILED(res)))
+      return res;
 
-    if (likely(SUCCEEDED(res))) {
-      m_token++;
-      m_stateBlocks.emplace(std::piecewise_construct,
-                            std::forward_as_tuple(m_token),
-                            std::forward_as_tuple(this, stateBlockType, pStateBlock9.ptr()));
-      *pToken = m_token;
-    }
+    m_token++;
+    m_stateBlocks.emplace(std::piecewise_construct,
+                          std::forward_as_tuple(m_token),
+                          std::forward_as_tuple(this, stateBlockType, pStateBlock9.ptr()));
+    *pToken = m_token;
 
-    return res;
+    return D3D_OK;
   }
 
   HRESULT STDMETHODCALLTYPE D3D8Device::CaptureStateBlock(DWORD Token) {
@@ -1237,7 +1242,6 @@ namespace dxvk {
       return D3DERR_INVALIDCALL;
 
     auto stateBlockIter = m_stateBlocks.find(Token);
-
     if (unlikely(stateBlockIter == m_stateBlocks.end())) {
       Logger::warn(str::format("D3D8Device::CaptureStateBlock: Invalid token: ", std::hex, Token));
       return D3D_OK;
@@ -1256,7 +1260,6 @@ namespace dxvk {
     StateChange();
 
     auto stateBlockIter = m_stateBlocks.find(Token);
-
     if (unlikely(stateBlockIter == m_stateBlocks.end())) {
       Logger::warn(str::format("D3D8Device::ApplyStateBlock: Invalid token: ", std::hex, Token));
       return D3D_OK;
@@ -1273,7 +1276,6 @@ namespace dxvk {
       return D3DERR_INVALIDCALL;
 
     auto stateBlockIter = m_stateBlocks.find(Token);
-
     if (unlikely(stateBlockIter == m_stateBlocks.end())) {
       Logger::warn(str::format("D3D8Device::DeleteStateBlock: Invalid token: ", std::hex, Token));
       return D3D_OK;
@@ -1297,17 +1299,17 @@ namespace dxvk {
       return D3DERR_INVALIDCALL;
 
     HRESULT res = GetD3D9()->BeginStateBlock();
+    if (unlikely(FAILED(res)))
+      return res;
 
-    if (likely(SUCCEEDED(res))) {
-      m_token++;
-      auto stateBlockIterPair = m_stateBlocks.emplace(std::piecewise_construct,
-                                                      std::forward_as_tuple(m_token),
-                                                      std::forward_as_tuple(this));
-      m_recorder = &stateBlockIterPair.first->second;
-      m_recorderToken = m_token;
-    }
+    m_token++;
+    auto stateBlockIterPair = m_stateBlocks.emplace(std::piecewise_construct,
+                                                    std::forward_as_tuple(m_token),
+                                                    std::forward_as_tuple(this));
+    m_recorder = &stateBlockIterPair.first->second;
+    m_recorderToken = m_token;
 
-    return res;
+    return D3D_OK;
   }
 
   HRESULT STDMETHODCALLTYPE D3D8Device::EndStateBlock(DWORD* pToken) {
@@ -1318,17 +1320,17 @@ namespace dxvk {
 
     Com<d3d9::IDirect3DStateBlock9> pStateBlock;
     HRESULT res = GetD3D9()->EndStateBlock(&pStateBlock);
+    if (unlikely(FAILED(res)))
+      return res;
 
-    if (likely(SUCCEEDED(res))) {
-      m_recorder->SetD3D9(std::move(pStateBlock));
+    m_recorder->SetD3D9(std::move(pStateBlock));
 
-      *pToken = m_recorderToken;
+    *pToken = m_recorderToken;
 
-      m_recorder = nullptr;
-      m_recorderToken = 0;
-    }
+    m_recorder = nullptr;
+    m_recorderToken = 0;
 
-    return res;
+    return D3D_OK;
   }
 
   HRESULT STDMETHODCALLTYPE D3D8Device::SetClipStatus(const D3DCLIPSTATUS8* pClipStatus) {
@@ -1390,11 +1392,12 @@ namespace dxvk {
 
     StateChange();
     HRESULT res = GetD3D9()->SetTexture(Stage, D3D8Texture2D::GetD3D9Nullable(tex));
+    if (unlikely(FAILED(res)))
+      return res;
 
-    if (likely(SUCCEEDED(res)))
-      m_textures[Stage] = tex;
+    m_textures[Stage] = tex;
 
-    return res;
+    return D3D_OK;
   }
 
   HRESULT STDMETHODCALLTYPE D3D8Device::GetTextureStageState(
@@ -1476,7 +1479,8 @@ namespace dxvk {
 
     return GetD3D9()->DrawIndexedPrimitive(
       d3d9::D3DPRIMITIVETYPE(PrimitiveType),
-      static_cast<INT>(std::min(m_baseVertexIndex, static_cast<UINT>(std::numeric_limits<int32_t>::max()))), // set by SetIndices
+      static_cast<INT>(std::min(m_baseVertexIndex, // set by SetIndices()
+                                static_cast<UINT>(std::numeric_limits<int32_t>::max()))),
       MinVertexIndex,
       NumVertices,
       StartIndex,
@@ -1495,7 +1499,11 @@ namespace dxvk {
     // Stream 0 is set to null by this call
     m_streams[0] = D3D8VBO {nullptr, 0};
 
-    return GetD3D9()->DrawPrimitiveUP(d3d9::D3DPRIMITIVETYPE(PrimitiveType), PrimitiveCount, pVertexStreamZeroData, VertexStreamZeroStride);
+    return GetD3D9()->DrawPrimitiveUP(
+      d3d9::D3DPRIMITIVETYPE(PrimitiveType),
+      PrimitiveCount,
+      pVertexStreamZeroData,
+      VertexStreamZeroStride);
   }
 
   HRESULT STDMETHODCALLTYPE D3D8Device::DrawIndexedPrimitiveUP(
@@ -1534,6 +1542,7 @@ namespace dxvk {
       IDirect3DVertexBuffer8*      pDestBuffer,
       DWORD                        Flags) {
     D3D8VertexBuffer* buffer = static_cast<D3D8VertexBuffer*>(pDestBuffer);
+
     return GetD3D9()->ProcessVertices(
       SrcStartIndex,
       DestIndex,
@@ -1571,18 +1580,18 @@ namespace dxvk {
 
     D3D8VertexBuffer* buffer = static_cast<D3D8VertexBuffer*>(pStreamData);
     HRESULT res = GetD3D9()->SetStreamSource(StreamNumber, D3D8VertexBuffer::GetD3D9Nullable(buffer), 0, Stride);
+    if (unlikely(FAILED(res)))
+      return res;
 
-    if (likely(SUCCEEDED(res))) {
-      if (unlikely(ShouldBatch()))
-        m_batcher->SetStream(StreamNumber, buffer, Stride);
+    if (unlikely(ShouldBatch()))
+      m_batcher->SetStream(StreamNumber, buffer, Stride);
 
-      m_streams[StreamNumber].buffer = buffer;
-      // The previous stride is preserved if pStreamData is NULL
-      if (likely(buffer != nullptr))
-        m_streams[StreamNumber].stride = Stride;
-    }
+    m_streams[StreamNumber].buffer = buffer;
+    // The previous stride is preserved if pStreamData is NULL
+    if (likely(buffer != nullptr))
+      m_streams[StreamNumber].stride = Stride;
 
-    return res;
+    return D3D_OK;
   }
 
   HRESULT STDMETHODCALLTYPE D3D8Device::GetStreamSource(
@@ -1621,17 +1630,17 @@ namespace dxvk {
 
     D3D8IndexBuffer* buffer = static_cast<D3D8IndexBuffer*>(pIndexData);
     HRESULT res = GetD3D9()->SetIndices(D3D8IndexBuffer::GetD3D9Nullable(buffer));
+    if (unlikely(FAILED(res)))
+      return res;
 
-    if (likely(SUCCEEDED(res))) {
-      if (unlikely(ShouldBatch()))
-        m_batcher->SetIndices(buffer, BaseVertexIndex);
+    if (unlikely(ShouldBatch()))
+      m_batcher->SetIndices(buffer, BaseVertexIndex);
 
-      m_indices = buffer;
-      // used by DrawIndexedPrimitive
-      m_baseVertexIndex = BaseVertexIndex;
-    }
+    m_indices = buffer;
+    // used by DrawIndexedPrimitive
+    m_baseVertexIndex = BaseVertexIndex;
 
-    return res;
+    return D3D_OK;
   }
 
   HRESULT STDMETHODCALLTYPE D3D8Device::GetIndices(
@@ -1824,46 +1833,43 @@ namespace dxvk {
     Com<d3d9::IDirect3DVertexShader9> pVertexShader;
     if (pFunction != nullptr) {
       res = GetD3D9()->CreateVertexShader(translatedVS.function.data(), &pVertexShader);
+      if (unlikely(FAILED(res)))
+        return res;
     } else {
       // pFunction is NULL: fixed function pipeline
       pVertexShader = nullptr;
     }
 
-    if (likely(SUCCEEDED(res))) {
-      D3D8VertexShaderInfo& info = m_vertexShaders.emplace_back();
+    D3D8VertexShaderInfo& info = m_vertexShaders.emplace_back();
 
-      info.pVertexDecl = std::move(pVertexDecl);
-      info.pVertexShader = std::move(pVertexShader);
+    info.pVertexDecl = std::move(pVertexDecl);
+    info.pVertexShader = std::move(pVertexShader);
 
-      // Store D3D8 bytecodes in the shader info
-      for (uint32_t i = 0; pDeclaration[i] != D3DVSD_END(); i++)
-        info.declaration.push_back(pDeclaration[i]);
-      info.declaration.push_back(D3DVSD_END());
+    // Store D3D8 bytecodes in the shader info
+    for (uint32_t i = 0; pDeclaration[i] != D3DVSD_END(); i++)
+      info.declaration.push_back(pDeclaration[i]);
+    info.declaration.push_back(D3DVSD_END());
 
-      if (pFunction != nullptr) {
-        for (uint32_t i = 0; pFunction[i] != D3DVS_END(); i++)
-          info.function.push_back(pFunction[i]);
-        info.function.push_back(D3DVS_END());
-      }
-
-      // Set bit to indicate this is not an FVF
-      *pHandle = getShaderHandle(m_vertexShaders.size());
+    if (pFunction != nullptr) {
+      for (uint32_t i = 0; pFunction[i] != D3DVS_END(); i++)
+        info.function.push_back(pFunction[i]);
+      info.function.push_back(D3DVS_END());
     }
 
-    return res;
+    // Set bit to indicate this is not an FVF
+    *pHandle = getShaderHandle(m_vertexShaders.size());
+
+    return D3D_OK;
   }
 
   inline D3D8VertexShaderInfo* getVertexShaderInfo(D3D8Device* device, DWORD Handle) {
-
     Handle = getShaderIndex(Handle);
-
     if (unlikely(Handle >= device->m_vertexShaders.size())) {
       Logger::debug(str::format("D3D8: Invalid vertex shader index ", std::hex, Handle));
       return nullptr;
     }
 
     D3D8VertexShaderInfo& info = device->m_vertexShaders[Handle];
-
     if (unlikely(info.pVertexDecl == nullptr && info.pVertexShader == nullptr)) {
       Logger::debug(str::format("D3D8: Application provided deleted vertex shader ", std::hex, Handle));
       return nullptr;
@@ -1883,7 +1889,6 @@ namespace dxvk {
 
     // Check for extra bit that indicates this is not an FVF
     if (!isFVF(Handle)) {
-
       D3D8VertexShaderInfo* info = getVertexShaderInfo(this, Handle);
 
       if (!info)
@@ -1893,27 +1898,21 @@ namespace dxvk {
 
       GetD3D9()->SetVertexDeclaration(info->pVertexDecl.ptr());
       res = GetD3D9()->SetVertexShader(info->pVertexShader.ptr());
+      if (unlikely(FAILED(res)))
+        return res;
 
-      if (likely(SUCCEEDED(res))) {
-        // Cache current shader
-        m_currentVertexShader = Handle;
-      }
-
-      return res;
-
+      m_currentVertexShader = Handle;
     } else if (m_currentVertexShader != Handle) {
       StateChange();
 
       //GetD3D9()->SetVertexDeclaration(nullptr);
       GetD3D9()->SetVertexShader(nullptr);
       res = GetD3D9()->SetFVF(Handle);
+      if (unlikely(FAILED(res)))
+        return res;
 
-      if (likely(SUCCEEDED(res))) {
-        // Cache current FVF
-        m_currentVertexShader = Handle;
-      }
-
-      return res;
+      // Cache current FVF
+      m_currentVertexShader = Handle;
     }
 
     return D3D_OK;
@@ -1935,7 +1934,6 @@ namespace dxvk {
 
     d3d9::IDirect3DVertexShader9* pVertexShader;
     HRESULT res = GetD3D9()->GetVertexShader(&pVertexShader);
-
     if (FAILED(res) || pVertexShader == nullptr) {
       return GetD3D9()->GetFVF(pHandle);
     }
@@ -1945,11 +1943,11 @@ namespace dxvk {
 
       if (info.pVertexShader == pVertexShader) {
         *pHandle = getShaderHandle(i);
-        return res;
+        return D3D_OK;
       }
     }
 
-    return res;
+    return D3D_OK;
     */
   }
 
@@ -2047,18 +2045,17 @@ namespace dxvk {
 
     Com<d3d9::IDirect3DPixelShader9> pPixelShader;
     HRESULT res = GetD3D9()->CreatePixelShader(pFunction, &pPixelShader);
+    if (unlikely(FAILED(res)))
+      return res;
 
-    if (likely(SUCCEEDED(res))) {
-      m_pixelShaders.push_back(std::move(pPixelShader));
-      // Still set the shader bit, to prevent conflicts with NULL.
-      *pHandle = getShaderHandle(m_pixelShaders.size());
-    }
+    m_pixelShaders.push_back(std::move(pPixelShader));
+    // Still set the shader bit, to prevent conflicts with NULL.
+    *pHandle = getShaderHandle(m_pixelShaders.size());
 
-    return res;
+    return D3D_OK;
   }
 
   inline d3d9::IDirect3DPixelShader9* getPixelShaderPtr(D3D8Device* device, DWORD Handle) {
-
     Handle = getShaderIndex(Handle);
 
     if (unlikely(Handle >= device->m_pixelShaders.size())) {
@@ -2097,13 +2094,13 @@ namespace dxvk {
 
     StateChange();
     HRESULT res = GetD3D9()->SetPixelShader(pPixelShader);
+    if (unlikely(FAILED(res)))
+      return res;
 
-    if (likely(SUCCEEDED(res))) {
-      // Cache current pixel shader
-      m_currentPixelShader = Handle;
-    }
+    // Cache current pixel shader
+    m_currentPixelShader = Handle;
 
-    return res;
+    return D3D_OK;
   }
 
   HRESULT STDMETHODCALLTYPE D3D8Device::GetPixelShader(DWORD* pHandle) {

--- a/src/d3d8/d3d8_device.h
+++ b/src/d3d8/d3d8_device.h
@@ -15,6 +15,7 @@
 #include <array>
 #include <vector>
 #include <type_traits>
+#include <unordered_set>
 #include <unordered_map>
 
 namespace dxvk {
@@ -418,6 +419,14 @@ namespace dxvk {
       m_depthStencil = m_autoDepthStencil;
     }
 
+    void RemoveValidTexture(IDirect3DBaseTexture8* tex) {
+      D3D8DeviceLock lock = LockDevice();
+
+      auto textureIter = m_validTextures.find(tex);
+      if (likely(textureIter != m_validTextures.end()))
+        m_validTextures.erase(textureIter);
+    }
+
     friend d3d9::IDirect3DPixelShader9* getPixelShaderPtr(D3D8Device* device, DWORD Handle);
     friend D3D8VertexShaderInfo*        getVertexShaderInfo(D3D8Device* device, DWORD Handle);
 
@@ -450,6 +459,8 @@ namespace dxvk {
 
     std::array<Com<D3D8Texture2D, false>, d8caps::MAX_TEXTURE_STAGES> m_textures;
     std::array<D3D8VBO, d8caps::MAX_STREAMS>                          m_streams;
+
+    std::unordered_set<IDirect3DBaseTexture8*> m_validTextures;
 
     Com<D3D8IndexBuffer, false>          m_indices;
     UINT                                 m_baseVertexIndex = 0;

--- a/src/d3d8/d3d8_device.h
+++ b/src/d3d8/d3d8_device.h
@@ -383,7 +383,7 @@ namespace dxvk {
       m_presentParams.BackBufferCount = std::max(m_presentParams.BackBufferCount, 1u);
 
       // Reset D3D8 exclusive render states
-      m_linePattern = {};
+      m_linePattern = { };
       m_zVisible    = 0;
 
       // Purge cached objects
@@ -431,39 +431,39 @@ namespace dxvk {
     D3DPRESENT_PARAMETERS m_presentParams;
     
     // Value of D3DRS_LINEPATTERN
-    D3DLINEPATTERN        m_linePattern   = {};
+    D3DLINEPATTERN        m_linePattern = { };
     // Value of D3DRS_ZVISIBLE (although the RS is not supported, its value is stored)
-    DWORD                 m_zVisible      = 0;
+    DWORD                 m_zVisible    = 0;
 
     bool                  m_shadowPerspectiveDivide = false;
 
-    D3D8StateBlock*                            m_recorder = nullptr;
-    DWORD                                      m_recorderToken = 0;
-    DWORD                                      m_token    = 0;
-    std::unordered_map<DWORD, D3D8StateBlock>  m_stateBlocks;
-    D3D8Batcher*                               m_batcher  = nullptr;
+    D3D8StateBlock*                           m_recorder = nullptr;
+    DWORD                                     m_recorderToken = 0;
+    DWORD                                     m_token    = 0;
+    std::unordered_map<DWORD, D3D8StateBlock> m_stateBlocks;
+    D3D8Batcher*                              m_batcher  = nullptr;
 
     struct D3D8VBO {
       Com<D3D8VertexBuffer, false>   buffer = nullptr;
       UINT                           stride = 0;
     };
 
-    std::array<Com<D3D8Texture2D, false>, d8caps::MAX_TEXTURE_STAGES>  m_textures;
-    std::array<D3D8VBO, d8caps::MAX_STREAMS>                           m_streams;
+    std::array<Com<D3D8Texture2D, false>, d8caps::MAX_TEXTURE_STAGES> m_textures;
+    std::array<D3D8VBO, d8caps::MAX_STREAMS>                          m_streams;
 
-    Com<D3D8IndexBuffer, false>        m_indices;
-    UINT                               m_baseVertexIndex = 0;
+    Com<D3D8IndexBuffer, false>          m_indices;
+    UINT                                 m_baseVertexIndex = 0;
 
     std::vector<Com<D3D8Surface, false>> m_backBuffers;
     Com<D3D8Surface, false>              m_autoDepthStencil;
 
-    Com<D3D8Surface, false>     m_renderTarget;
-    Com<D3D8Surface, false>     m_depthStencil;
+    Com<D3D8Surface, false>              m_renderTarget;
+    Com<D3D8Surface, false>              m_depthStencil;
 
-    std::vector<D3D8VertexShaderInfo>               m_vertexShaders;
-    std::vector<Com<d3d9::IDirect3DPixelShader9>>   m_pixelShaders;
-    DWORD                                           m_currentVertexShader  = 0; // can be FVF or vs index (marked by D3DFVF_RESERVED0)
-    DWORD                                           m_currentPixelShader   = 0;
+    std::vector<D3D8VertexShaderInfo>             m_vertexShaders;
+    std::vector<Com<d3d9::IDirect3DPixelShader9>> m_pixelShaders;
+    DWORD                                         m_currentVertexShader  = 0; // can be FVF or vs index (marked by D3DFVF_RESERVED0)
+    DWORD                                         m_currentPixelShader   = 0;
 
     D3DDEVTYPE            m_deviceType;
     HWND                  m_window;

--- a/src/d3d8/d3d8_device_child.h
+++ b/src/d3d8/d3d8_device_child.h
@@ -63,6 +63,7 @@ namespace dxvk {
         return D3DERR_INVALIDCALL;
 
       *ppDevice = ref(GetDevice());
+
       return D3D_OK;
     }
 

--- a/src/d3d8/d3d8_interface.cpp
+++ b/src/d3d8/d3d8_interface.cpp
@@ -27,7 +27,6 @@ namespace dxvk {
 
       // cache adapter modes and mode counts for each d3d9 format
       for (d3d9::D3DFORMAT fmt : ADAPTER_FORMATS) {
-
         const UINT modeCount = m_d3d9->GetAdapterModeCount(adapter, fmt);
         for (UINT mode = 0; mode < modeCount; mode++) {
 
@@ -74,7 +73,6 @@ namespace dxvk {
 
     d3d9::D3DADAPTER_IDENTIFIER9 identifier9;
     HRESULT res = m_d3d9->GetAdapterIdentifier(Adapter, Flags, &identifier9);
-
     if (unlikely(FAILED(res)))
       return res;
 
@@ -93,7 +91,7 @@ namespace dxvk {
     return D3D_OK;
   }
 
-  HRESULT __stdcall D3D8Interface::EnumAdapterModes(
+  HRESULT STDMETHODCALLTYPE D3D8Interface::EnumAdapterModes(
           UINT Adapter,
           UINT Mode,
           D3DDISPLAYMODE* pMode) {
@@ -109,7 +107,7 @@ namespace dxvk {
     return D3D_OK;
   }
 
-  HRESULT __stdcall D3D8Interface::CreateDevice(
+  HRESULT STDMETHODCALLTYPE D3D8Interface::CreateDevice(
         UINT Adapter,
         D3DDEVTYPE DeviceType,
         HWND hFocusWindow,
@@ -122,7 +120,6 @@ namespace dxvk {
       return D3DERR_INVALIDCALL;
 
     HRESULT res = ValidatePresentationParameters(pPresentationParameters);
-
     if (unlikely(FAILED(res)))
       return res;
 
@@ -136,7 +133,6 @@ namespace dxvk {
       &params,
       &pDevice9
     );
-
     if (unlikely(FAILED(res)))
       return res;
 

--- a/src/d3d8/d3d8_interface.h
+++ b/src/d3d8/d3d8_interface.h
@@ -151,11 +151,12 @@ namespace dxvk {
 
       d3d9::D3DCAPS9 caps9;
       HRESULT res = m_d3d9->GetDeviceCaps(Adapter, d3d9::D3DDEVTYPE(DeviceType), &caps9);
+      if (unlikely(FAILED(res)))
+        return res;
 
-      if (likely(SUCCEEDED(res)))
-        ConvertCaps8(caps9, pCaps);
+      ConvertCaps8(caps9, pCaps);
 
-      return res;
+      return D3D_OK;
     }
 
     HMONITOR STDMETHODCALLTYPE GetAdapterMonitor(UINT Adapter) {

--- a/src/d3d8/d3d8_options.cpp
+++ b/src/d3d8/d3d8_options.cpp
@@ -54,4 +54,15 @@ namespace dxvk {
     }
   }
 
+  D3D8Options::D3D8Options(const Config& config) {
+    auto forceVsDeclStr           = config.getOption<std::string>("d3d8.forceVsDecl",             "");
+
+    this->batching                = config.getOption<bool>       ("d3d8.batching",                false);
+    this->placeP8InScratch        = config.getOption<bool>       ("d3d8.placeP8InScratch",        false);
+    this->forceLegacyDiscard      = config.getOption<bool>       ("d3d8.forceLegacyDiscard",      false);
+    this->shadowPerspectiveDivide = config.getOption<bool>       ("d3d8.shadowPerspectiveDivide", false);
+
+    parseVsDecl(forceVsDeclStr);
+  }
+
 }

--- a/src/d3d8/d3d8_options.cpp
+++ b/src/d3d8/d3d8_options.cpp
@@ -61,6 +61,7 @@ namespace dxvk {
     this->placeP8InScratch        = config.getOption<bool>       ("d3d8.placeP8InScratch",        false);
     this->forceLegacyDiscard      = config.getOption<bool>       ("d3d8.forceLegacyDiscard",      false);
     this->shadowPerspectiveDivide = config.getOption<bool>       ("d3d8.shadowPerspectiveDivide", false);
+    this->textureUAFGuard         = config.getOption<bool>       ("d3d8.textureUAFGuard",         false);
 
     parseVsDecl(forceVsDeclStr);
   }

--- a/src/d3d8/d3d8_options.h
+++ b/src/d3d8/d3d8_options.h
@@ -4,9 +4,18 @@
 #include "../d3d9/d3d9_bridge.h"
 #include "../util/config/config.h"
 
+#include <vector>
+#include <utility>
+
 namespace dxvk {
 
   struct D3D8Options {
+
+    void parseVsDecl(const std::string& decl);
+
+    D3D8Options() {};
+
+    D3D8Options(const Config& config);
 
     /// Override application vertex shader declarations.
     std::vector<std::pair<D3DVSDE_REGISTER, D3DVSDT_TYPE>> forceVsDecl;
@@ -23,19 +32,6 @@ namespace dxvk {
     /// Force D3DTTFF_PROJECTED for the necessary stages when a depth texture is bound to slot 0.
     bool shadowPerspectiveDivide;
 
-    D3D8Options() {}
-
-    D3D8Options(const Config& config) {
-      auto forceVsDeclStr     = config.getOption<std::string>("d3d8.forceVsDecl",             "");
-      batching                = config.getOption<bool>       ("d3d8.batching",                false);
-      placeP8InScratch        = config.getOption<bool>       ("d3d8.placeP8InScratch",        false);
-      forceLegacyDiscard      = config.getOption<bool>       ("d3d8.forceLegacyDiscard",      false);
-      shadowPerspectiveDivide = config.getOption<bool>       ("d3d8.shadowPerspectiveDivide", false);
-
-      parseVsDecl(forceVsDeclStr);
-    }
-
-    void parseVsDecl(const std::string& decl);
   };
 
 }

--- a/src/d3d8/d3d8_options.h
+++ b/src/d3d8/d3d8_options.h
@@ -32,6 +32,9 @@ namespace dxvk {
     /// Force D3DTTFF_PROJECTED for the necessary stages when a depth texture is bound to slot 0.
     bool shadowPerspectiveDivide;
 
+    /// Keep track of live texture objects and validate them during SetTexture calls.
+    bool textureUAFGuard;
+
   };
 
 }

--- a/src/d3d8/d3d8_resource.h
+++ b/src/d3d8/d3d8_resource.h
@@ -29,18 +29,16 @@ namespace dxvk {
             DWORD       SizeOfData,
             DWORD       Flags) final {
       HRESULT hr;
+
       if (Flags & D3DSPD_IUNKNOWN) {
         if(unlikely(SizeOfData != sizeof(IUnknown*)))
           return D3DERR_INVALIDCALL;
-        IUnknown* unknown =
-          const_cast<IUnknown*>(
-            reinterpret_cast<const IUnknown*>(pData));
-        hr = m_privateData.setInterface(
-          refguid, unknown);
+
+        IUnknown* unknown = const_cast<IUnknown*>(reinterpret_cast<const IUnknown*>(pData));
+        hr = m_privateData.setInterface(refguid, unknown);
+      } else {
+        hr = m_privateData.setData(refguid, SizeOfData, pData);
       }
-      else
-        hr = m_privateData.setData(
-          refguid, SizeOfData, pData);
 
       if (unlikely(FAILED(hr)))
         return D3DERR_INVALIDCALL;

--- a/src/d3d8/d3d8_surface.cpp
+++ b/src/d3d8/d3d8_surface.cpp
@@ -27,11 +27,12 @@ namespace dxvk {
 
     d3d9::D3DSURFACE_DESC desc;
     HRESULT res = GetD3D9()->GetDesc(&desc);
+    if (unlikely(FAILED(res)))
+      return res;
 
-    if (likely(SUCCEEDED(res)))
-      ConvertSurfaceDesc8(&desc, pDesc);
+    ConvertSurfaceDesc8(&desc, pDesc);
 
-    return res;
+    return D3D_OK;
   }
 
   HRESULT STDMETHODCALLTYPE D3D8Surface::LockRect(
@@ -68,7 +69,6 @@ namespace dxvk {
       FALSE,
       &image,
       NULL);
-
     if (FAILED(res))
       throw DxvkError("D3D8: Failed to create blit image");
 

--- a/src/d3d8/d3d8_swapchain.cpp
+++ b/src/d3d8/d3d8_swapchain.cpp
@@ -25,16 +25,14 @@ namespace dxvk {
     if (BackBuffer >= m_backBuffers.size() || m_backBuffers[BackBuffer] == nullptr) {
       Com<d3d9::IDirect3DSurface9> pSurface9;
       HRESULT res = GetD3D9()->GetBackBuffer(BackBuffer, (d3d9::D3DBACKBUFFER_TYPE)Type, &pSurface9);
+      if (unlikely(FAILED(res)))
+        return res;
 
-      if (likely(SUCCEEDED(res))) {
-        m_backBuffers[BackBuffer] = new D3D8Surface(GetParent(), D3DPOOL_DEFAULT, std::move(pSurface9));
-        *ppBackBuffer = m_backBuffers[BackBuffer].ref();
-      }
-
-      return res;
+      m_backBuffers[BackBuffer] = new D3D8Surface(GetParent(), D3DPOOL_DEFAULT, std::move(pSurface9));
     }
 
     *ppBackBuffer = m_backBuffers[BackBuffer].ref();
+
     return D3D_OK;
   }
 

--- a/src/d3d8/d3d8_texture.cpp
+++ b/src/d3d8/d3d8_texture.cpp
@@ -21,11 +21,12 @@ namespace dxvk {
 
     d3d9::D3DSURFACE_DESC surf;
     HRESULT res = GetD3D9()->GetLevelDesc(Level, &surf);
+    if (unlikely(FAILED(res)))
+      return res;
 
-    if (likely(SUCCEEDED(res)))
-      ConvertSurfaceDesc8(&surf, pDesc);
+    ConvertSurfaceDesc8(&surf, pDesc);
 
-    return res;
+    return D3D_OK;
   }
 
   HRESULT STDMETHODCALLTYPE D3D8Texture2D::GetSurfaceLevel(UINT Level, IDirect3DSurface8** ppSurfaceLevel) {
@@ -64,11 +65,12 @@ namespace dxvk {
 
     d3d9::D3DVOLUME_DESC vol;
     HRESULT res = GetD3D9()->GetLevelDesc(Level, &vol);
+    if (unlikely(FAILED(res)))
+      return res;
 
-    if (likely(SUCCEEDED(res)))
-      ConvertVolumeDesc8(&vol, pDesc);
+    ConvertVolumeDesc8(&vol, pDesc);
 
-    return res;
+    return D3D_OK;
   }
 
   HRESULT STDMETHODCALLTYPE D3D8Texture3D::GetVolumeLevel(UINT Level, IDirect3DVolume8** ppVolumeLevel) {
@@ -113,11 +115,12 @@ namespace dxvk {
 
     d3d9::D3DSURFACE_DESC surf;
     HRESULT res = GetD3D9()->GetLevelDesc(Level, &surf);
+    if (unlikely(FAILED(res)))
+      return res;
 
-    if (likely(SUCCEEDED(res)))
-      ConvertSurfaceDesc8(&surf, pDesc);
+    ConvertSurfaceDesc8(&surf, pDesc);
 
-    return res;
+    return D3D_OK;
   }
 
   HRESULT STDMETHODCALLTYPE D3D8TextureCube::GetCubeMapSurface(

--- a/src/d3d8/d3d8_texture.cpp
+++ b/src/d3d8/d3d8_texture.cpp
@@ -1,5 +1,6 @@
 #include "d3d8_texture.h"
 
+#include "d3d8_device.h"
 #include "d3d8_util.h"
 
 namespace dxvk {
@@ -11,6 +12,11 @@ namespace dxvk {
     const D3DPOOL                        Pool,
           Com<d3d9::IDirect3DTexture9>&& pTexture)
     : D3D8Texture2DBase(pDevice, Pool, std::move(pTexture), pTexture->GetLevelCount()) {
+  }
+
+  D3D8Texture2D::~D3D8Texture2D() {
+    if (unlikely(m_parent->GetOptions()->textureUAFGuard))
+      m_parent->RemoveValidTexture(this);
   }
 
   D3DRESOURCETYPE STDMETHODCALLTYPE D3D8Texture2D::GetType() { return D3DRTYPE_TEXTURE; }
@@ -56,6 +62,11 @@ namespace dxvk {
     const D3DPOOL                               Pool,
           Com<d3d9::IDirect3DVolumeTexture9>&&  pVolumeTexture)
     : D3D8Texture3DBase(pDevice, Pool, std::move(pVolumeTexture), pVolumeTexture->GetLevelCount()) {}
+
+  D3D8Texture3D::~D3D8Texture3D() {
+    if (unlikely(m_parent->GetOptions()->textureUAFGuard))
+      m_parent->RemoveValidTexture(this);
+  }
 
   D3DRESOURCETYPE STDMETHODCALLTYPE D3D8Texture3D::GetType() { return D3DRTYPE_VOLUMETEXTURE; }
 
@@ -105,6 +116,11 @@ namespace dxvk {
     const D3DPOOL                             Pool,
           Com<d3d9::IDirect3DCubeTexture9>&&  pTexture)
     : D3D8TextureCubeBase(pDevice, Pool, std::move(pTexture), pTexture->GetLevelCount() * CUBE_FACES) {
+  }
+
+  D3D8TextureCube::~D3D8TextureCube() {
+    if (unlikely(m_parent->GetOptions()->textureUAFGuard))
+      m_parent->RemoveValidTexture(this);
   }
 
   D3DRESOURCETYPE STDMETHODCALLTYPE D3D8TextureCube::GetType() { return D3DRTYPE_CUBETEXTURE; }

--- a/src/d3d8/d3d8_texture.h
+++ b/src/d3d8/d3d8_texture.h
@@ -118,6 +118,8 @@ namespace dxvk {
       const D3DPOOL                        Pool,
             Com<d3d9::IDirect3DTexture9>&& pTexture);
 
+    ~D3D8Texture2D();
+
     D3DRESOURCETYPE STDMETHODCALLTYPE GetType() final;
 
     HRESULT STDMETHODCALLTYPE GetLevelDesc(UINT Level, D3DSURFACE_DESC* pDesc);
@@ -146,6 +148,8 @@ namespace dxvk {
       const D3DPOOL                               Pool,
             Com<d3d9::IDirect3DVolumeTexture9>&&  pVolumeTexture);
 
+    ~D3D8Texture3D();
+
     D3DRESOURCETYPE STDMETHODCALLTYPE GetType() final;
 
     HRESULT STDMETHODCALLTYPE GetLevelDesc(UINT Level, D3DVOLUME_DESC *pDesc);
@@ -173,6 +177,8 @@ namespace dxvk {
             D3D8Device*                         pDevice,
       const D3DPOOL                             Pool,
             Com<d3d9::IDirect3DCubeTexture9>&&  pTexture);
+
+    ~D3D8TextureCube();
 
     D3DRESOURCETYPE STDMETHODCALLTYPE GetType() final;
 

--- a/src/d3d8/d3d8_volume.cpp
+++ b/src/d3d8/d3d8_volume.cpp
@@ -18,11 +18,12 @@ namespace dxvk {
 
     d3d9::D3DVOLUME_DESC desc;
     HRESULT res = GetD3D9()->GetDesc(&desc);
+    if (unlikely(FAILED(res)))
+      return res;
 
-    if (likely(SUCCEEDED(res)))
-      ConvertVolumeDesc8(&desc, pDesc);
+    ConvertVolumeDesc8(&desc, pDesc);
 
-    return res;
+    return D3D_OK;
   }
 
   HRESULT STDMETHODCALLTYPE D3D8Volume::LockBox(D3DLOCKED_BOX* pLockedBox, CONST D3DBOX* pBox, DWORD Flags) {

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -1374,6 +1374,16 @@ namespace dxvk {
     { R"(\\Smash up Derby\\cars\.exe$)", {{
       { "d3d9.allowDirectBufferMapping",   "False" },
     }} },
+    /* Age of Pirates: Caribbean Tales            *
+     * Crashes due to a texture UAF otherwise     */
+    { R"(\\(Age of Pirates|Sea Dogs).*Caribbean Tales\\ENGINE\.exe$)", {{
+      { "d3d8.textureUAFGuard",             "True" },
+    }} },
+    /* Age of Pirates 2: City of Abandoned Ships  *
+     * Crashes due to a texture UAF otherwise     */
+    { R"(\\(Age of Pirates|Sea Dogs).*City of Abandoned Ships\\START\.exe$)", {{
+      { "d3d8.textureUAFGuard",             "True" },
+    }} },
   };
 
 


### PR DESCRIPTION
The first two games in the Age of Pirates series will crash on startup in most cases because they call SetTexture() with an already released object, and our code blows up when we try to add a private ref to it.

In a moment of absolute irony, Pirates of the Caribbean, a game made by the same studio and using the same bloody engine, but under the obvious license, *doesn't* exhibit such problems, nor does it have any fogging issues for that matter...

In any case, keeping track of valid textures and checking during SetTexture() calls seems to do the trick with no ill effect in the two games. The logic is gated behind a config option due to the obvious overhead, though it's nothing tragic by any means. If anyone has any better ideas, which don't cause a lot of pain and suffering for well behaving games, I'm all ears.

I've taken the liberty to do some code style cleanup while I was at it, split in a preceding commit (with no functional impact).

Related to #5165, but has no impact on it (other than making the affected games playable).