### PR TITLE
Properly handle W fog

### DIFF
--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -3565,8 +3565,8 @@ namespace dxvk {
       BindFFUbershader<D3D9ShaderType::VertexShader>();
     }
 
-    m_dirty.set(D3D9DeviceDirtyFlag::InputLayout);
-
+    m_dirty.set(D3D9DeviceDirtyFlag::InputLayout,
+                D3D9DeviceDirtyFlag::Fog);
     return D3D_OK;
   }
 
@@ -4639,8 +4639,12 @@ namespace dxvk {
 
     m_dirty.set(D3D9DeviceDirtyFlag::FFVertexData);
 
-    if (idx == GetTransformIndex(D3DTS_VIEW) || idx >= GetTransformIndex(D3DTS_WORLD))
+    if (idx == GetTransformIndex(D3DTS_VIEW)
+     || idx >= GetTransformIndex(D3DTS_WORLD))
       m_dirty.set(D3D9DeviceDirtyFlag::FFVertexBlend);
+
+    if (idx == GetTransformIndex(D3DTS_PROJECTION))
+      m_dirty.set(D3D9DeviceDirtyFlag::Fog);
 
     return D3D_OK;
   }
@@ -6593,10 +6597,22 @@ namespace dxvk {
     m_dirty.clr(D3D9DeviceDirtyFlag::Fog);
 
     auto& rs = m_state.renderStates;
+
     bool fogEnabled = bool(rs[D3DRS_FOGENABLE]);
+    bool fogUseZ = false;
+
+    if (fogEnabled && !UseProgrammableVS()) {
+      // Z fog is only used if the projection matrix is not a perspective matrix,
+      // otherwise we get W fog, including programmable vertex shaders. SM2 pixel
+      // shaders behave just like fixed-function.
+      // The projection matrix logic is described in a truly prehistoric Nvidia paper:
+      // https://developer.download.nvidia.com/assets/gamedev/docs/Fog2.pdf
+      auto [wNear, wFar] = ComputeWNearFar();
+      fogUseZ = wNear == 1.0f && wFar == 1.0f;
+    }
 
     // Only set up vertex frog if pixel fog is not used
-    if (m_specData.setFogMode(fogEnabled,
+    if (m_specData.setFogMode(fogEnabled, fogUseZ,
         D3DFOGMODE(rs[D3DRS_FOGVERTEXMODE]),
         D3DFOGMODE(rs[D3DRS_FOGTABLEMODE])))
       m_dirty.set(D3D9DeviceDirtyFlag::SpecializationEntries);
@@ -6615,6 +6631,19 @@ namespace dxvk {
     m_pushData.shared.fogDistanceScale = (fogEnd != fogStart) ? 1.0f / (fogEnd - fogStart) : 0.0f;
 
     m_dirty.set(D3D9DeviceDirtyFlag::PushDataShared);
+  }
+
+
+  std::pair<float, float> D3D9DeviceEx::ComputeWNearFar() const {
+    const auto& m = m_state.transforms[GetTransformIndex(D3DTS_PROJECTION)];
+
+    if (m[2][2] == 0.0f || m[2][2] == m[2][3])
+      return std::make_pair(1.0f, 1.0f);
+
+    float wNear = m[3][3] - m[3][2] / m[2][2] * m[2][3];
+    float wFar = (m[3][3] - m[3][2]) / (m[2][2] - m[2][3]) * m[2][3] + m[3][3];
+
+    return std::make_pair(wNear, wFar);
   }
 
 

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -958,6 +958,8 @@ namespace dxvk {
 
     void UpdateFog();
 
+    std::pair<float, float> ComputeWNearFar() const;
+
     void BindFramebuffer();
 
     void BindViewportAndScissor();

--- a/src/d3d9/d3d9_shader.cpp
+++ b/src/d3d9/d3d9_shader.cpp
@@ -776,6 +776,11 @@ namespace dxvk {
               0u, 1u, "fogEnable", ref, ir::ScalarType::eBool, ir::SsaDef()));
           } break;
 
+          case ir::LegacyFogLayout::eFogUseZ: {
+            resultOp.addOperand(emitSpecConstantLoad(offsetof(D3D9SpecData, fogUseZ),
+              0u, 1u, "fogUseZ", ref, ir::ScalarType::eBool, ir::SsaDef()));
+          } break;
+
           case ir::LegacyFogLayout::eFogMode: {
             auto offset = m_shaderStage == ir::ShaderStage::eVertex
               ? offsetof(D3D9SpecData, fogModeVertex)

--- a/src/d3d9/d3d9_state.h
+++ b/src/d3d9/d3d9_state.h
@@ -113,10 +113,10 @@ namespace dxvk {
 
     // Spec ID 1: Fog. Used in fixed-function pipelines as
     // well as pixel shaders with Shader Model 2 and below.
-    uint8_t fogEnable = 0u;
+    bool fogEnable = 0u;
     uint8_t fogModeVertex = 0u;
     uint8_t fogModePixel = 0u;
-    uint8_t spec1Pad = 0u;
+    bool fogUseZ = 0u;
 
     // Spec ID 2: Parameters used in fixed-function pipelines. The
     // projection mask is also used in shader model 1 pixel shaders.
@@ -195,11 +195,12 @@ namespace dxvk {
       return set(enableGlobalSpecular, enable);
     }
 
-    bool setFogMode(bool enable, D3DFOGMODE vertexFog, D3DFOGMODE pixelFog) {
+    bool setFogMode(bool enable, bool zFog, D3DFOGMODE vertexFog, D3DFOGMODE pixelFog) {
       bool dirty = false;
       dirty |= set(fogEnable,     enable);
       dirty |= set(fogModeVertex, enable && !pixelFog ? vertexFog : D3DFOG_NONE);
       dirty |= set(fogModePixel,  enable              ? pixelFog  : D3DFOG_NONE);
+      dirty |= set(fogUseZ,       enable && zFog);
       return dirty;
     }
 

--- a/src/d3d9/shaders/d3d9_fixed_function_common.glsl
+++ b/src/d3d9/shaders/d3d9_fixed_function_common.glsl
@@ -86,6 +86,7 @@ struct FogState {
     bool enable;
     uint pixelMode;
     uint vertexMode;
+    bool useZ;
 };
 
 FogState getFogState() {
@@ -93,6 +94,7 @@ FogState getFogState() {
     result.enable = bitfieldExtract(fogArgs, 0, 1) != 0u;
     result.vertexMode = bitfieldExtract(fogArgs, 8, 2);
     result.pixelMode = bitfieldExtract(fogArgs, 16, 2);
+    result.useZ = bitfieldExtract(fogArgs, 24, 1) != 0u;
     return result;
 }
 // Checks whether specular lighting is enabled

--- a/src/d3d9/shaders/d3d9_fixed_function_frag.glsl
+++ b/src/d3d9/shaders/d3d9_fixed_function_frag.glsl
@@ -204,7 +204,7 @@ layout(set = SRV_SET, binding = SRV_PS_BASE) uniform texture3D t3d[TextureStageC
 
 layout(set = SAMPLER_SET, binding = 0) uniform sampler sampler_heap[];
 
-vec4 calculateFog(vec4 vPos, vec4 oColor) {
+vec4 calculateFog(vec4 oColor) {
     FogState fogState = getFogState();
 
     vec3 fogColor = unpackUnorm4x8(global.packedFogColorAndAlphaRef).bgr;
@@ -215,9 +215,7 @@ vec4 calculateFog(vec4 vPos, vec4 oColor) {
     if (!fogState.enable)
         return oColor;
 
-    float w = vPos.w;
-    float z = vPos.z;
-    float depth = z * (1.0 / w);
+    float depth = fogState.useZ ? gl_FragCoord.z : (1.0 / gl_FragCoord.w);
     float fogFactor;
 
     switch (fogState.pixelMode) {
@@ -620,7 +618,7 @@ void main() {
     if (isSpecularEnabled())
         state.current.xyz += in_Color1.xyz;
 
-    state.current = calculateFog(gl_FragCoord, state.current);
+    state.current = calculateFog(state.current);
 
     out_Color0 = state.current;
 


### PR DESCRIPTION
So, as it turns out, we weren't handling fixed-function fog correctly.

This old paper has a fairly good explanation of everything:
https://developer.download.nvidia.com/assets/gamedev/docs/Fog2.pdf

TL;DR there are two modes:
- W fog, which isn't influenced by .z at all, distances are in world space, and is always used by default whenever programmable VS is used, *or* when the projection matrix is a perspective projection.
- Z fog, where distances are in [0..1], only used if W fog is not applicable.

So instead of `z/w` we actually need to pick one of z and 1/w depending on the projection matrix.

Should fix #5165. The issue there is that Z values are all over the place and nonsensical, so distant terrain isn't getting fogged properly.