### PR TITLE
Simplify D3D9 fixed-function lighting

### DIFF
--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -2171,9 +2171,11 @@ namespace dxvk {
     if (Index >= m_state.lights.size())
       m_state.lights.resize(Index + 1);
 
-    m_state.lights[Index] = *pLight;
+    auto& light = m_state.lights[Index];
+    light.isValid = true;
+    light.light = *pLight;
 
-    if (m_state.IsLightEnabled(Index))
+    if (light.isEnabled)
       m_dirty.set(D3D9DeviceDirtyFlag::FFVertexData);
 
     return D3D_OK;
@@ -2186,11 +2188,15 @@ namespace dxvk {
     if (unlikely(pLight == nullptr))
       return D3DERR_INVALIDCALL;
 
-    if (unlikely(Index >= m_state.lights.size() || !m_state.lights[Index]))
+    if (unlikely(Index >= m_state.lights.size()))
       return D3DERR_INVALIDCALL;
 
-    *pLight = m_state.lights[Index].value();
+    auto& light = m_state.lights[Index];
 
+    if (unlikely(!light.isValid))
+      return D3DERR_INVALIDCALL;
+
+    *pLight = m_state.lights[Index].light;
     return D3D_OK;
   }
 
@@ -2206,27 +2212,16 @@ namespace dxvk {
     if (unlikely(Index >= m_state.lights.size()))
       m_state.lights.resize(Index + 1);
 
-    if (unlikely(!m_state.lights[Index]))
-      m_state.lights[Index] = DefaultLight;
+    auto& light = m_state.lights[Index];
 
-    if (m_state.IsLightEnabled(Index) == !!Enable)
+    if (light.isEnabled == bool(Enable))
       return D3D_OK;
 
-    uint32_t searchIndex = std::numeric_limits<uint32_t>::max();
-    uint32_t setIndex    = Index;
+    light.isValid = true;
+    light.isEnabled = bool(Enable);
 
-    if (!Enable)
-      std::swap(searchIndex, setIndex);
-
-    for (auto& idx : m_state.enabledLightIndices) {
-      if (idx == searchIndex) {
-        idx = setIndex;
-        m_dirty.set(D3D9DeviceDirtyFlag::FFVertexData);
-        m_dirty.set(D3D9DeviceDirtyFlag::FFVertexShader);
-        break;
-      }
-    }
-
+    m_dirty.set(D3D9DeviceDirtyFlag::FFVertexData,
+                D3D9DeviceDirtyFlag::FFVertexShader);
     return D3D_OK;
   }
 
@@ -2237,11 +2232,15 @@ namespace dxvk {
     if (unlikely(pEnable == nullptr))
       return D3DERR_INVALIDCALL;
 
-    if (unlikely(Index >= m_state.lights.size() || !m_state.lights[Index]))
+    if (unlikely(Index >= m_state.lights.size()))
       return D3DERR_INVALIDCALL;
 
-    *pEnable = m_state.IsLightEnabled(Index) ? 128 : 0; // Weird quirk but OK.
+    auto& light = m_state.lights[Index];
 
+    if (unlikely(!light.isValid))
+      return D3DERR_INVALIDCALL;
+
+    *pEnable = light.isEnabled ? 128 : 0; // Weird quirk but OK.
     return D3D_OK;
   }
 
@@ -8169,18 +8168,20 @@ namespace dxvk {
       DecodeD3DCOLOR(m_state.renderStates[D3DRS_AMBIENT], data->GlobalAmbient.data);
 
       uint32_t lightIdx = 0;
-      for (uint32_t i = 0; i < caps::MaxEnabledLights; i++) {
-        auto idx = m_state.enabledLightIndices[i];
-        if (idx == std::numeric_limits<uint32_t>::max())
+
+      for (auto& light : m_state.lights) {
+        if (!light.isEnabled)
           continue;
 
         // D3D8/9 will allow lights with invalid types to be set and retrieved,
         // and even enabled, however they won't affect overall lighting
-        const D3DLIGHT9& light = m_state.lights[idx].value();
-        if (unlikely(light.Type == 0 || light.Type > D3DLIGHT_DIRECTIONAL))
+        if (unlikely(!light.light.Type || light.light.Type > D3DLIGHT_DIRECTIONAL))
           continue;
 
-        data->Lights[lightIdx++] = D3D9Light(light, m_state.transforms[GetTransformIndex(D3DTS_VIEW)]);
+        data->Lights[lightIdx++] = D3D9Light(light.light, m_state.transforms[GetTransformIndex(D3DTS_VIEW)]);
+
+        if (lightIdx == caps::MaxEnabledLights)
+          break;
       }
 
       data->Material = m_state.material;

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -138,7 +138,6 @@ namespace dxvk {
                 D3D9DeviceDirtyFlag::Fog,
                 D3D9DeviceDirtyFlag::FFVertexData,
                 D3D9DeviceDirtyFlag::FFVertexBlend,
-                D3D9DeviceDirtyFlag::FFVertexShader,
                 D3D9DeviceDirtyFlag::FFPixelShader,
                 D3D9DeviceDirtyFlag::FFViewport,
                 D3D9DeviceDirtyFlag::SharedPixelShaderData,
@@ -2220,8 +2219,7 @@ namespace dxvk {
     light.isValid = true;
     light.isEnabled = bool(Enable);
 
-    m_dirty.set(D3D9DeviceDirtyFlag::FFVertexData,
-                D3D9DeviceDirtyFlag::FFVertexShader);
+    m_dirty.set(D3D9DeviceDirtyFlag::FFVertexData);
     return D3D_OK;
   }
 
@@ -2433,7 +2431,7 @@ namespace dxvk {
 
         case D3DRS_CLIPPLANEENABLE:
           if (!Value != !oldValue)
-            m_dirty.set(D3D9DeviceDirtyFlag::FFVertexShader);
+            m_dirty.set(D3D9DeviceDirtyFlag::FFVertexData);
 
           m_dirty.set(D3D9DeviceDirtyFlag::ClipPlanes);
           break;
@@ -2456,7 +2454,7 @@ namespace dxvk {
         case D3DRS_LIGHTING:
         case D3DRS_NORMALIZENORMALS:
         case D3DRS_LOCALVIEWER:
-          m_dirty.set(D3D9DeviceDirtyFlag::FFVertexShader);
+          m_dirty.set(D3D9DeviceDirtyFlag::FFVertexData);
           break;
 
         case D3DRS_AMBIENT:
@@ -2479,7 +2477,7 @@ namespace dxvk {
           break;
 
         case D3DRS_RANGEFOGENABLE:
-          m_dirty.set(D3D9DeviceDirtyFlag::FFVertexShader);
+          m_dirty.set(D3D9DeviceDirtyFlag::FFVertexData);
           break;
 
         case D3DRS_POINTSIZE: {
@@ -2563,14 +2561,14 @@ namespace dxvk {
           break;
 
         case D3DRS_VERTEXBLEND:
-          m_dirty.set(D3D9DeviceDirtyFlag::FFVertexShader);
+          m_dirty.set(D3D9DeviceDirtyFlag::FFVertexData);
           break;
 
         case D3DRS_INDEXEDVERTEXBLENDENABLE:
           if (CanSWVP() && Value)
             m_dirty.set(D3D9DeviceDirtyFlag::FFVertexBlend);
 
-          m_dirty.set(D3D9DeviceDirtyFlag::FFVertexShader);
+          m_dirty.set(D3D9DeviceDirtyFlag::FFVertexData);
           break;
 
         case D3DRS_ADAPTIVETESS_Y: {
@@ -3427,7 +3425,7 @@ namespace dxvk {
                     || decl->GetTexcoordMask() != m_state.vertexDecl->GetTexcoordMask();
 
     if (dirtyFFShader)
-      m_dirty.set(D3D9DeviceDirtyFlag::FFVertexShader);
+      m_dirty.set(D3D9DeviceDirtyFlag::FFVertexData);
 
     const bool wasUsingProgrammableVS = UseProgrammableVS();
 
@@ -3439,7 +3437,7 @@ namespace dxvk {
       if (usesProgrammableVS) {
         BindShader<D3D9ShaderType::VertexShader>(GetCommonShader(m_state.vertexShader));
       } else {
-        m_dirty.set(D3D9DeviceDirtyFlag::FFVertexShader);
+        m_dirty.set(D3D9DeviceDirtyFlag::FFVertexData);
         BindFFUbershader<D3D9ShaderType::VertexShader>();
       }
     }
@@ -3560,7 +3558,7 @@ namespace dxvk {
     if (usesProgrammableVS) {
       BindShader<D3D9ShaderType::VertexShader>(GetCommonShader(shader));
     } else if (wasUsingProgrammableVS) {
-      m_dirty.set(D3D9DeviceDirtyFlag::FFVertexShader);
+      m_dirty.set(D3D9DeviceDirtyFlag::FFVertexData);
       BindFFUbershader<D3D9ShaderType::VertexShader>();
     }
 
@@ -4681,7 +4679,7 @@ namespace dxvk {
           break;
 
         case DXVK_TSS_TEXCOORDINDEX:
-          m_dirty.set(D3D9DeviceDirtyFlag::FFVertexShader);
+          m_dirty.set(D3D9DeviceDirtyFlag::FFVertexData);
           break;
 
         case DXVK_TSS_TEXTURETRANSFORMFLAGS:
@@ -4689,7 +4687,7 @@ namespace dxvk {
           if (Value & D3DTTFF_PROJECTED)
             m_textureSlotTracking.projected |= 1 << Stage;
 
-          m_dirty.set(D3D9DeviceDirtyFlag::FFVertexShader);
+          m_dirty.set(D3D9DeviceDirtyFlag::FFVertexData);
           m_dirty.set(D3D9DeviceDirtyFlag::FFPixelShader);
           break;
 
@@ -8108,12 +8106,6 @@ namespace dxvk {
         vertexBlendMode = D3D9FF_VertexBlendMode_Disabled;
     }
 
-    // Shader...
-    if (m_dirty.test(D3D9DeviceDirtyFlag::FFVertexShader)) {
-      m_dirty.clr(D3D9DeviceDirtyFlag::FFVertexShader);
-      m_dirty.set(D3D9DeviceDirtyFlag::FFVertexData);
-    }
-
     // Viewport...
     if (hasPositionT && (m_dirty.test(D3D9DeviceDirtyFlag::FFViewport) || m_ffZTest != IsZTestEnabled())) {
       m_dirty.clr(D3D9DeviceDirtyFlag::FFViewport);
@@ -8570,7 +8562,7 @@ namespace dxvk {
     rs[D3DRS_LOCALVIEWER]            = TRUE;
     rs[D3DRS_RANGEFOGENABLE]         = FALSE;
     rs[D3DRS_NORMALIZENORMALS]       = FALSE;
-    m_dirty.set(D3D9DeviceDirtyFlag::FFVertexShader);
+    m_dirty.set(D3D9DeviceDirtyFlag::FFVertexData);
 
     // PS
     rs[D3DRS_SPECULARENABLE] = FALSE;

--- a/src/d3d9/d3d9_state.cpp
+++ b/src/d3d9/d3d9_state.cpp
@@ -8,9 +8,6 @@ namespace dxvk {
     D3D9State<ItemType>::D3D9State() {
       for (uint32_t i = 0; i < streamFreq.size(); i++)
         streamFreq[i] = 1;
-
-      for (uint32_t i = 0; i < enabledLightIndices.size(); i++)
-        enabledLightIndices[i] = std::numeric_limits<uint32_t>::max();
     }
 
 

--- a/src/d3d9/d3d9_state.h
+++ b/src/d3d9/d3d9_state.h
@@ -373,6 +373,26 @@ namespace dxvk {
     float Phi;
   };
 
+  constexpr D3DLIGHT9 DefaultLight = {
+    D3DLIGHT_DIRECTIONAL,     // Type
+    {1.0f, 1.0f, 1.0f, 0.0f}, // Diffuse
+    {0.0f, 0.0f, 0.0f, 0.0f}, // Specular
+    {0.0f, 0.0f, 0.0f, 0.0f}, // Ambient
+    {0.0f, 0.0f, 0.0f},       // Position
+    {0.0f, 0.0f, 1.0f},       // Direction
+    0.0f,                     // Range
+    0.0f,                     // Falloff
+    0.0f, 0.0f, 0.0f,         // Attenuations [constant, linear, quadratic]
+    0.0f,                     // Theta
+    0.0f                      // Phi
+  };
+
+  struct D3D9LightState {
+    bool isValid = false;
+    bool isEnabled = false;
+    D3DLIGHT9 light = DefaultLight;
+  };
+
   struct D3D9FixedFunctionVS {
     Matrix4 WorldView;
     Matrix4 NormalMatrix;
@@ -452,20 +472,6 @@ namespace dxvk {
     UINT              offset = 0;
     UINT              length = 0;
     UINT              stride = 0;
-  };
-
-  constexpr D3DLIGHT9 DefaultLight = {
-    D3DLIGHT_DIRECTIONAL,     // Type
-    {1.0f, 1.0f, 1.0f, 0.0f}, // Diffuse
-    {0.0f, 0.0f, 0.0f, 0.0f}, // Specular
-    {0.0f, 0.0f, 0.0f, 0.0f}, // Ambient
-    {0.0f, 0.0f, 0.0f},       // Position
-    {0.0f, 0.0f, 1.0f},       // Direction
-    0.0f,                     // Range
-    0.0f,                     // Falloff
-    0.0f, 0.0f, 0.0f,         // Attenuations [constant, linear, quadratic]
-    0.0f,                     // Theta
-    0.0f                      // Phi
   };
 
   template <typename T>
@@ -589,15 +595,9 @@ namespace dxvk {
 
     ItemType<D3DMATERIAL9>                              material = {};
 
-    std::vector<std::optional<D3DLIGHT9>>               lights;
-    std::array<DWORD, caps::MaxEnabledLights>           enabledLightIndices;
+    std::vector<D3D9LightState>                         lights;
 
     float                                               nPatchSegments = 0.0f;
-
-    bool IsLightEnabled(DWORD Index) const {
-      const auto& enabledIndices = enabledLightIndices;
-      return std::find(enabledIndices.begin(), enabledIndices.end(), Index) != enabledIndices.end();
-    }
   };
 
   using D3D9CapturableState = D3D9State<dynamic_item>;

--- a/src/d3d9/d3d9_stateblock.cpp
+++ b/src/d3d9/d3d9_stateblock.cpp
@@ -191,7 +191,9 @@ namespace dxvk {
     if (Index >= m_state.lights.size())
       m_state.lights.resize(Index + 1);
 
-    m_state.lights[Index] = *pLight;
+    auto& light = m_state.lights[Index];
+    light.isValid = true;
+    light.light = *pLight;
 
     m_captures.flags.set(D3D9CapturedStateFlag::Lights);
     return D3D_OK;
@@ -202,24 +204,13 @@ namespace dxvk {
     if (unlikely(Index >= m_state.lights.size()))
       m_state.lights.resize(Index + 1);
 
-    if (unlikely(!m_state.lights[Index]))
-      m_state.lights[Index] = DefaultLight;
+    // Apply default light on enable, but not disable.
+    // No idea if this is correct, but matches the old logic.
+    auto& light = m_state.lights[Index];
+    light.isEnabled = bool(Enable);
 
-    if (m_state.IsLightEnabled(Index) == !!Enable)
-      return D3D_OK;
-
-    uint32_t searchIndex = std::numeric_limits<uint32_t>::max();
-    uint32_t setIndex    = Index;
-
-    if (!Enable)
-      std::swap(searchIndex, setIndex);
-
-    for (auto& idx : m_state.enabledLightIndices) {
-      if (idx == searchIndex) {
-        idx = setIndex;
-        break;
-      }
-    }
+    if (Enable)
+      light.isValid = true;
 
     m_captures.lightEnabledChanges.set(Index, true);
     m_captures.flags.set(D3D9CapturedStateFlag::Lights);

--- a/src/d3d9/d3d9_stateblock.h
+++ b/src/d3d9/d3d9_stateblock.h
@@ -321,16 +321,18 @@ namespace dxvk {
 
       if (m_captures.flags.test(D3D9CapturedStateFlag::Lights)) {
         for (uint32_t i = 0; i < src->lights.size(); i++) {
-          if (!src->lights[i].has_value())
+          if (!src->lights[i].isValid)
             continue;
 
-          dst->SetLight(i, &src->lights[i].value());
+          dst->SetLight(i, &src->lights[i].light);
         }
+
         for (uint32_t i = 0; i < m_captures.lightEnabledChanges.dwordCount(); i++) {
           for (uint32_t consts : bit::BitMask(m_captures.lightEnabledChanges.dword(i))) {
             uint32_t idx = i * 32 + consts;
 
-            dst->LightEnable(idx, src->IsLightEnabled(idx));
+            if (idx < src->lights.size())
+              dst->LightEnable(idx, src->lights[idx].isEnabled);
           }
         }
       }

--- a/src/d3d9/shaders/d3d9_fixed_function_vert.vert
+++ b/src/d3d9/shaders/d3d9_fixed_function_vert.vert
@@ -610,89 +610,65 @@ void main() {
         for (uint i = 0; i < lightCount(); i++) {
             D3D9Light light = data.Lights[i];
 
-            vec4 diffuse = light.Diffuse;
-            vec4 specular = light.Specular;
-            vec4 ambient = light.Ambient;
-            vec3 position = light.Position.xyz;
-            vec3 direction = light.Direction.xyz;
-            uint type = light.Type;
-            float range = light.Range;
-            float falloff = light.Falloff;
-            float atten0 = light.Attenuation0;
-            float atten1 = light.Attenuation1;
-            float atten2 = light.Attenuation2;
-            float theta = light.Theta;
-            float phi = light.Phi;
+            vec3 delta = light.Position.xyz - vtx.xyz;
+            float dist = length(delta);
 
-            bool isSpot = type == D3DLIGHT_SPOT;
-            bool isDirectional = type == D3DLIGHT_DIRECTIONAL;
+            // Directional light properties
+            vec3 hitDir = -light.Direction.xyz;
+            float atten = 1.0f;
 
-            bvec3 isDirectional3 = bvec3(isDirectional);
+            if (light.Type != D3DLIGHT_DIRECTIONAL) {
+                // Range-based attenuation
+                atten = fma(dist, light.Attenuation2, light.Attenuation1);
+                atten = fma(dist, atten, light.Attenuation0);
+                atten = 1.0 / atten;
+                atten = spvNMin(atten, FloatMaxValue);
+                atten = dist > light.Range ? 0.0 : atten;
 
-            vec3 vtx3 = vtx.xyz;
+                hitDir = normalize(delta);
+            }
 
-            vec3 delta = position - vtx3;
-            float d = length(delta);
-            vec3 hitDir = -direction;
-                 hitDir = mix(delta, hitDir, isDirectional3);
-                 hitDir = normalize(hitDir);
+            if (light.Type == D3DLIGHT_SPOT) {
+                // Angle-based attenuation
+                float rho = dot(-hitDir, light.Direction.xyz);
+                float spotAtten = rho - light.Phi;
+                      spotAtten = spotAtten / (light.Theta - light.Phi);
+                      spotAtten = pow(spotAtten, light.Falloff);
 
-            float atten = fma(d, atten2, atten1);
-                  atten = fma(d, atten, atten0);
-                  atten = 1.0 / atten;
-                  atten = spvNMin(atten, FloatMaxValue);
-
-                  atten = d > range ? 0.0 : atten;
-                  atten = isDirectional ? 1.0 : atten;
-
-            // Spot Lighting
-            {
-                float rho = dot(-hitDir, direction);
-                float spotAtten = rho - phi;
-                      spotAtten = spotAtten / (theta - phi);
-                      spotAtten = pow(spotAtten, falloff);
-
-                bool insideThetaAndPhi = rho <= theta;
-                bool insidePhi = rho > phi;
+                bool insideThetaAndPhi = rho <= light.Theta;
+                bool insidePhi = rho > light.Phi;
                      spotAtten = insidePhi ? spotAtten : 0.0;
                      spotAtten = insideThetaAndPhi ? spotAtten : 1.0;
                      spotAtten = clamp(spotAtten, 0.0, 1.0);
 
-                     spotAtten = atten * spotAtten;
-                     atten     = isSpot ? spotAtten : atten;
+                atten *= spotAtten;
             }
 
+            // Ambient + Diffuse
             float hitDot = dot(normal, hitDir);
                   hitDot = clamp(hitDot, 0.0, 1.0);
 
             float diffuseness = hitDot * atten;
+            ambientValue += light.Ambient * atten;
+            diffuseValue += light.Diffuse * diffuseness;
 
+            // Specular
             vec3 mid;
+
             if (localViewer()) {
-                mid = normalize(vtx3);
+                mid = normalize(vtx.xyz);
                 mid = hitDir - mid;
             } else {
                 mid = hitDir - vec3(0.0, 0.0, 1.0);
             }
 
-            mid = normalize(mid);
-
-            float midDot = dot(normal, mid);
+            float midDot = dot(normal, normalize(mid));
                   midDot = clamp(midDot, 0.0, 1.0);
-            bool doSpec = midDot > 0.0;
-                 doSpec = doSpec && hitDot > 0.0;
 
-            float specularness = pow(midDot, data.Material.Power);
-                  specularness *= atten;
-                  specularness = doSpec ? specularness : 0.0;
-
-            vec4 lightAmbient  = ambient * atten;
-            vec4 lightDiffuse  = diffuse * diffuseness;
-            vec4 lightSpecular = specular * specularness;
-
-            ambientValue  += lightAmbient;
-            diffuseValue  += lightDiffuse;
-            specularValue += lightSpecular;
+            if (midDot > 0.0 && hitDot > 0.0) {
+                float specularness = pow(midDot, data.Material.Power) * atten;
+                specularValue += light.Specular * specularness;
+            }
         }
 
         vec4 matDiffuse  = pickMaterialSource(diffuseSource(), data.Material.Diffuse);


### PR DESCRIPTION
There were multiple bugs here, one with tracking enabled lights which wasn't really working properly if the app set >8 lights, and one where state blocks wouldn't disable lights.

This fixes lighting issues in Sang-Froid: Tales of Werewolves.

Also cleans up the lighting-related shader code for good measure, because dear god that was hard to disect in renderdoc.