### PR TITLE
Small FFVS clean-up

### DIFF
--- a/src/d3d9/shaders/d3d9_fixed_function_vert.vert
+++ b/src/d3d9/shaders/d3d9_fixed_function_vert.vert
@@ -385,6 +385,133 @@ vec4 pickMaterialSource(uint source, vec4 material) {
 }
 
 
+vec4 loadTexcoord(uint idx) {
+    vec4 result = vec4(0.0f);
+    result = mix(result, in_Texcoord0, bvec4(idx == 0u));
+    result = mix(result, in_Texcoord1, bvec4(idx == 1u));
+    result = mix(result, in_Texcoord2, bvec4(idx == 2u));
+    result = mix(result, in_Texcoord3, bvec4(idx == 3u));
+    result = mix(result, in_Texcoord4, bvec4(idx == 4u));
+    result = mix(result, in_Texcoord5, bvec4(idx == 5u));
+    result = mix(result, in_Texcoord6, bvec4(idx == 6u));
+    result = mix(result, in_Texcoord7, bvec4(idx == 7u));
+    return result;
+}
+
+
+float vectorExtract(vec4 vector, uint idx) {
+    float result = vector.x;
+    result = mix(result, vector.y, idx == 1u);
+    result = mix(result, vector.z, idx == 2u);
+    result = mix(result, vector.w, idx == 3u);
+    return result;
+}
+
+
+vec4 transformTexCoord(uint idx, vec4 vertex, vec3 normal) {
+    // 0b111 = 7
+    uint inputIndex = texcoordIndex(idx);
+    uint inputFlags = texcoordFlags(idx) << TCIOffset;
+    uint texcoordCount = bitfieldExtract(vertexTexcoordDeclMask(), int(inputIndex) * 3, 3);
+
+    vec4 transformed = vec4(0.0f);
+
+    uint flags = texcoordTransformFlags(idx);
+
+    // Passing 0xffffffff results in it getting clamped to the dimensions of the texture coords and getting treated as PROJECTED
+    // but D3D9 does not apply the transformation matrix.
+    bool applyTransform = flags > D3DTTFF_COUNT1 && flags <= D3DTTFF_COUNT4;
+
+    uint count = min(flags, 4u);
+
+    // A projection component index of 4 means we won't do projection
+    uint projIndex = count != 0u ? count - 1u : 4u;
+
+    switch (inputFlags) {
+        default:
+        case DXVK_TSS_TCI_PASSTHRU:
+            transformed = loadTexcoord(inputIndex & 0xffu);
+
+            if (texcoordCount < 4) {
+                // Vulkan sets the w component to 1.0 if that's not provided by the vertex buffer, D3D9 expects 0 here
+                transformed.w = 0.0;
+            }
+
+            if (applyTransform && !vertexHasPositionT()) {
+                /*This doesn't happen every time and I cannot figure out the difference between when it does and doesn't.
+                Keep it disabled for now, it's more likely that games rely on the zero texcoord than the weird 1 here.
+                if (texcoordCount <= 1) {
+                    // y gets padded to 1 for some reason
+                    transformed.y = 1.0;
+                }*/
+
+                // The first component after the last one thats backed by a vertex buffer gets padded to 1 for some reason.
+                if (texcoordCount >= 1u)
+                    transformed = mix(transformed, vec4(1.0f), equal(uvec4(0u, 1u, 2u, 3u), texcoordCount.xxxx));
+            } else if (texcoordCount != 0 && !applyTransform) {
+                // COUNT0, COUNT1, COUNT > 4 => take count from vertex decl if that's not zero
+                count = texcoordCount;
+            }
+
+            projIndex = count != 0u ? count - 1u : 4u;
+            break;
+
+        case DXVK_TSS_TCI_CAMERASPACENORMAL:
+            transformed = vec4(normal, 1.0f);
+
+            if (!applyTransform) {
+                count = 3u;
+                projIndex = 4u;
+            }
+            break;
+
+        case DXVK_TSS_TCI_CAMERASPACEPOSITION:
+            transformed = vertex;
+            if (!applyTransform) {
+                count = 3u;
+                projIndex = 4u;
+            }
+            break;
+
+        case DXVK_TSS_TCI_CAMERASPACEREFLECTIONVECTOR: {
+            vec3 reflection = reflect(normalize(vertex.xyz), normal);
+            transformed = vec4(reflection, 1.0f);
+
+            if (!applyTransform) {
+                count = 3u;
+                projIndex = 4u;
+            }
+
+            break;
+        }
+
+        case DXVK_TSS_TCI_SPHEREMAP: {
+            vec3 reflection = reflect(normalize(vertex.xyz), normal);
+
+            float m = length(reflection + vec3(0.0f, 0.0f, 1.0f)) * 2.0f;
+            transformed = vec4(reflection.xy / m + 0.5f, 0.0f, 1.0f);
+            break;
+        }
+    }
+
+    if (applyTransform && !vertexHasPositionT())
+        transformed = transformed * data.TexcoordMatrices[idx];
+
+    // Discard the components that exceed the specified D3DTTFF_COUNT
+    vec4 result = mix(transformed, vec4(0.0f), lessThan(count.xxxx, uvec4(1u, 2u, 3u, 4u)));
+
+    if (isSamplerProjected(idx) && projIndex < 4) {
+        // The projection idx is always based on the flags, even when the input
+        // mode is not DXVK_TSS_TCI_PASSTHRU. The w component is only used for
+        // projection or unused, so always insert the divisor there. The pixel
+        // shader will then decide whether to project or not.
+        result.w = vectorExtract(transformed, projIndex);
+    }
+
+    return result;
+}
+
+
 void main() {
     vec4 vtx = in_Position0;
     gl_Position = in_Position0;
@@ -455,147 +582,16 @@ void main() {
         gl_Position.w = rhw;
     }
 
-    vec4 outNrm = vec4(normal, 1.0);
-    out_Normal = outNrm;
+    out_Normal = vec4(normal, 1.0);
 
-    vec4 texCoords[TextureStageCount];
-    texCoords[0] = in_Texcoord0;
-    texCoords[1] = in_Texcoord1;
-    texCoords[2] = in_Texcoord2;
-    texCoords[3] = in_Texcoord3;
-    texCoords[4] = in_Texcoord4;
-    texCoords[5] = in_Texcoord5;
-    texCoords[6] = in_Texcoord6;
-    texCoords[7] = in_Texcoord7;
-
-    vec4 transformedTexCoords[TextureStageCount];
-
-    for (uint i = 0; i < TextureStageCount; i++) {
-        // 0b111 = 7
-        uint inputIndex = texcoordIndex(i);
-        uint inputFlags = texcoordFlags(i);
-        uint texcoordCount = (vertexTexcoordDeclMask() >> (inputIndex * 3)) & 7;
-
-        vec4 transformed;
-
-        uint flags = texcoordTransformFlags(i);
-
-        // Passing 0xffffffff results in it getting clamped to the dimensions of the texture coords and getting treated as PROJECTED
-        // but D3D9 does not apply the transformation matrix.
-        bool applyTransform = flags > D3DTTFF_COUNT1 && flags <= D3DTTFF_COUNT4;
-
-        uint count = min(flags, 4u);
-
-        // A projection component index of 4 means we won't do projection
-        uint projIndex = count != 0 ? count - 1 : 4;
-
-        switch (inputFlags) {
-            default:
-            case (DXVK_TSS_TCI_PASSTHRU >> TCIOffset):
-                transformed = texCoords[inputIndex & 0xFF];
-
-                if (texcoordCount < 4) {
-                    // Vulkan sets the w component to 1.0 if that's not provided by the vertex buffer, D3D9 expects 0 here
-                    transformed.w = 0.0;
-                }
-
-                if (applyTransform && !vertexHasPositionT()) {
-                    /*This doesn't happen every time and I cannot figure out the difference between when it does and doesn't.
-                    Keep it disabled for now, it's more likely that games rely on the zero texcoord than the weird 1 here.
-                    if (texcoordCount <= 1) {
-                      // y gets padded to 1 for some reason
-                      transformed.y = 1.0;
-                    }*/
-
-                    if (texcoordCount >= 1 && texcoordCount < 4) {
-                        // The first component after the last one thats backed by a vertex buffer gets padded to 1 for some reason.
-                        uint idx = texcoordCount;
-                        transformed[idx] = 1.0;
-                    }
-                } else if (texcoordCount != 0 && !applyTransform) {
-                    // COUNT0, COUNT1, COUNT > 4 => take count from vertex decl if that's not zero
-                    count = texcoordCount;
-                }
-
-                projIndex = count != 0 ? count - 1 : 4;
-                break;
-
-            case (DXVK_TSS_TCI_CAMERASPACENORMAL >> TCIOffset):
-                transformed = outNrm;
-                if (!applyTransform) {
-                    count = 3;
-                    projIndex = 4;
-                }
-                break;
-
-            case (DXVK_TSS_TCI_CAMERASPACEPOSITION >> TCIOffset):
-                transformed = vtx;
-                if (!applyTransform) {
-                    count = 3;
-                    projIndex = 4;
-                }
-                break;
-
-            case (DXVK_TSS_TCI_CAMERASPACEREFLECTIONVECTOR >> TCIOffset): {
-                vec3 vtx3 = vtx.xyz;
-                vtx3 = normalize(vtx3);
-
-                vec3 reflection = reflect(vtx3, normal);
-                transformed = vec4(reflection, 1.0);
-                if (!applyTransform) {
-                    count = 3;
-                    projIndex = 4;
-                }
-                break;
-            }
-
-            case (DXVK_TSS_TCI_SPHEREMAP >> TCIOffset): {
-                vec3 vtx3 = vtx.xyz;
-                vtx3 = normalize(vtx3);
-
-                vec3 reflection = reflect(vtx3, normal);
-                float m = length(reflection + vec3(0.0, 0.0, 1.0)) * 2.0;
-
-                transformed = vec4(
-                    reflection.x / m + 0.5,
-                    reflection.y / m + 0.5,
-                    0.0,
-                    1.0
-                );
-                break;
-            }
-        }
-
-        if (applyTransform && !vertexHasPositionT()) {
-            transformed = transformed * data.TexcoordMatrices[i];
-        }
-
-        if (isSamplerProjected(i) && projIndex < 4) {
-            // The projection idx is always based on the flags, even when the input mode is not DXVK_TSS_TCI_PASSTHRU.
-            float projValue = transformed[projIndex];
-
-            // The w component is only used for projection or unused, so always insert the component that's supposed to be divided by there.
-            // The fragment shader will then decide whether to project or not.
-            transformed.w = projValue;
-        }
-
-        uint totalComponents = (isSamplerProjected(i) && projIndex < 4) ? 3 : 4;
-
-        // Discard the components that exceed the specified D3DTTFF_COUNT
-        for (uint j = count; j < totalComponents; j++)
-            transformed[j] = 0.0;
-
-        transformedTexCoords[i] = transformed;
-    }
-
-    out_Texcoord0 = transformedTexCoords[0];
-    out_Texcoord1 = transformedTexCoords[1];
-    out_Texcoord2 = transformedTexCoords[2];
-    out_Texcoord3 = transformedTexCoords[3];
-    out_Texcoord4 = transformedTexCoords[4];
-    out_Texcoord5 = transformedTexCoords[5];
-    out_Texcoord6 = transformedTexCoords[6];
-    out_Texcoord7 = transformedTexCoords[7];
+    out_Texcoord0 = transformTexCoord(0u, vtx, normal);
+    out_Texcoord1 = transformTexCoord(1u, vtx, normal);
+    out_Texcoord2 = transformTexCoord(2u, vtx, normal);
+    out_Texcoord3 = transformTexCoord(3u, vtx, normal);
+    out_Texcoord4 = transformTexCoord(4u, vtx, normal);
+    out_Texcoord5 = transformTexCoord(5u, vtx, normal);
+    out_Texcoord6 = transformTexCoord(6u, vtx, normal);
+    out_Texcoord7 = transformTexCoord(7u, vtx, normal);
 
     if (useLighting()) {
         vec4 diffuseValue = vec4(0.0);

--- a/src/d3d9/shaders/d3d9_fixed_function_vert.vert
+++ b/src/d3d9/shaders/d3d9_fixed_function_vert.vert
@@ -512,6 +512,112 @@ vec4 transformTexCoord(uint idx, vec4 vertex, vec3 normal) {
 }
 
 
+struct Lighting {
+    vec4 diffuse;
+    vec4 specular;
+};
+
+
+Lighting computeLighting(vec4 vertex, vec3 normal) {
+    Lighting result;
+    result.diffuse = vertexHasColor0() ? in_Color0 : vec4(1.0, 1.0, 1.0, 1.0);
+    result.specular = vertexHasColor1() ? in_Color1 : vec4(0.0, 0.0, 0.0, boundPsIsShaderModel3() ? 0.0 : 1.0);
+
+    if (useLighting()) {
+        vec4 diffuseValue = vec4(0.0);
+        vec4 specularValue = vec4(0.0);
+        vec4 ambientValue = vec4(0.0);
+
+        for (uint i = 0; i < lightCount(); i++) {
+            D3D9Light light = data.Lights[i];
+
+            vec3 delta = light.Position.xyz - vertex.xyz;
+            float dist = length(delta);
+
+            // Directional light properties
+            vec3 hitDir = -light.Direction.xyz;
+            float atten = 1.0f;
+
+            if (light.Type != D3DLIGHT_DIRECTIONAL) {
+                // Range-based attenuation
+                atten = fma(dist, light.Attenuation2, light.Attenuation1);
+                atten = fma(dist, atten, light.Attenuation0);
+                atten = 1.0 / atten;
+                atten = spvNMin(atten, FloatMaxValue);
+                atten = dist > light.Range ? 0.0 : atten;
+
+                hitDir = normalize(delta);
+            }
+
+            if (light.Type == D3DLIGHT_SPOT) {
+                // Angle-based attenuation
+                float rho = dot(-hitDir, light.Direction.xyz);
+                float spotAtten = rho - light.Phi;
+                      spotAtten = spotAtten / (light.Theta - light.Phi);
+                      spotAtten = pow(spotAtten, light.Falloff);
+
+                bool insideThetaAndPhi = rho <= light.Theta;
+                bool insidePhi = rho > light.Phi;
+                     spotAtten = insidePhi ? spotAtten : 0.0;
+                     spotAtten = insideThetaAndPhi ? spotAtten : 1.0;
+                     spotAtten = clamp(spotAtten, 0.0, 1.0);
+
+                atten *= spotAtten;
+            }
+
+            // Ambient + Diffuse
+            float hitDot = dot(normal, hitDir);
+                  hitDot = clamp(hitDot, 0.0, 1.0);
+
+            float diffuseness = hitDot * atten;
+            ambientValue += light.Ambient * atten;
+            diffuseValue += light.Diffuse * diffuseness;
+
+            // Specular
+            vec3 mid;
+
+            if (localViewer()) {
+                mid = normalize(vertex.xyz);
+                mid = hitDir - mid;
+            } else {
+                mid = hitDir - vec3(0.0, 0.0, 1.0);
+            }
+
+            float midDot = dot(normal, normalize(mid));
+                  midDot = clamp(midDot, 0.0, 1.0);
+
+            if (midDot > 0.0 && hitDot > 0.0) {
+                float specularness = pow(midDot, data.Material.Power) * atten;
+                specularValue += light.Specular * specularness;
+            }
+        }
+
+        vec4 matDiffuse  = pickMaterialSource(diffuseSource(), data.Material.Diffuse);
+        vec4 matAmbient  = pickMaterialSource(ambientSource(), data.Material.Ambient);
+        vec4 matEmissive = pickMaterialSource(emissiveSource(), data.Material.Emissive);
+        vec4 matSpecular = pickMaterialSource(specularSource(), data.Material.Specular);
+
+        vec4 finalColor0 = fma(matAmbient, data.GlobalAmbient, matEmissive);
+             finalColor0 = fma(matAmbient, ambientValue, finalColor0);
+             finalColor0 = fma(matDiffuse, diffuseValue, finalColor0);
+             finalColor0.a = matDiffuse.a;
+
+        vec4 finalColor1 = matSpecular * specularValue;
+
+        // Saturate
+        finalColor0 = clamp(finalColor0, vec4(0.0), vec4(1.0));
+        finalColor1 = clamp(finalColor1, vec4(0.0), vec4(1.0));
+
+        result.diffuse = finalColor0;
+
+        if (isSpecularEnabled())
+            result.specular = finalColor1;
+    }
+
+    return result;
+}
+
+
 void main() {
     vec4 vtx = in_Position0;
     gl_Position = in_Position0;
@@ -593,101 +699,9 @@ void main() {
     out_Texcoord6 = transformTexCoord(6u, vtx, normal);
     out_Texcoord7 = transformTexCoord(7u, vtx, normal);
 
-    if (useLighting()) {
-        vec4 diffuseValue = vec4(0.0);
-        vec4 specularValue = vec4(0.0);
-        vec4 ambientValue = vec4(0.0);
-
-        for (uint i = 0; i < lightCount(); i++) {
-            D3D9Light light = data.Lights[i];
-
-            vec3 delta = light.Position.xyz - vtx.xyz;
-            float dist = length(delta);
-
-            // Directional light properties
-            vec3 hitDir = -light.Direction.xyz;
-            float atten = 1.0f;
-
-            if (light.Type != D3DLIGHT_DIRECTIONAL) {
-                // Range-based attenuation
-                atten = fma(dist, light.Attenuation2, light.Attenuation1);
-                atten = fma(dist, atten, light.Attenuation0);
-                atten = 1.0 / atten;
-                atten = spvNMin(atten, FloatMaxValue);
-                atten = dist > light.Range ? 0.0 : atten;
-
-                hitDir = normalize(delta);
-            }
-
-            if (light.Type == D3DLIGHT_SPOT) {
-                // Angle-based attenuation
-                float rho = dot(-hitDir, light.Direction.xyz);
-                float spotAtten = rho - light.Phi;
-                      spotAtten = spotAtten / (light.Theta - light.Phi);
-                      spotAtten = pow(spotAtten, light.Falloff);
-
-                bool insideThetaAndPhi = rho <= light.Theta;
-                bool insidePhi = rho > light.Phi;
-                     spotAtten = insidePhi ? spotAtten : 0.0;
-                     spotAtten = insideThetaAndPhi ? spotAtten : 1.0;
-                     spotAtten = clamp(spotAtten, 0.0, 1.0);
-
-                atten *= spotAtten;
-            }
-
-            // Ambient + Diffuse
-            float hitDot = dot(normal, hitDir);
-                  hitDot = clamp(hitDot, 0.0, 1.0);
-
-            float diffuseness = hitDot * atten;
-            ambientValue += light.Ambient * atten;
-            diffuseValue += light.Diffuse * diffuseness;
-
-            // Specular
-            vec3 mid;
-
-            if (localViewer()) {
-                mid = normalize(vtx.xyz);
-                mid = hitDir - mid;
-            } else {
-                mid = hitDir - vec3(0.0, 0.0, 1.0);
-            }
-
-            float midDot = dot(normal, normalize(mid));
-                  midDot = clamp(midDot, 0.0, 1.0);
-
-            if (midDot > 0.0 && hitDot > 0.0) {
-                float specularness = pow(midDot, data.Material.Power) * atten;
-                specularValue += light.Specular * specularness;
-            }
-        }
-
-        vec4 matDiffuse  = pickMaterialSource(diffuseSource(), data.Material.Diffuse);
-        vec4 matAmbient  = pickMaterialSource(ambientSource(), data.Material.Ambient);
-        vec4 matEmissive = pickMaterialSource(emissiveSource(), data.Material.Emissive);
-        vec4 matSpecular = pickMaterialSource(specularSource(), data.Material.Specular);
-
-        vec4 finalColor0 = fma(matAmbient, data.GlobalAmbient, matEmissive);
-             finalColor0 = fma(matAmbient, ambientValue, finalColor0);
-             finalColor0 = fma(matDiffuse, diffuseValue, finalColor0);
-             finalColor0.a = matDiffuse.a;
-
-        vec4 finalColor1 = matSpecular * specularValue;
-
-        // Saturate
-        finalColor0 = clamp(finalColor0, vec4(0.0), vec4(1.0));
-        finalColor1 = clamp(finalColor1, vec4(0.0), vec4(1.0));
-
-        out_Color0 = finalColor0;
-
-        if (isSpecularEnabled())
-            out_Color1 = finalColor1;
-        else
-            out_Color1 = vertexHasColor1() ? in_Color1 : vec4(0.0, 0.0, 0.0, boundPsIsShaderModel3() ? 0.0 : 1.0);
-    } else {
-        out_Color0 = vertexHasColor0() ? in_Color0 : vec4(1.0, 1.0, 1.0, 1.0);
-        out_Color1 = vertexHasColor1() ? in_Color1 : vec4(0.0, 0.0, 0.0, boundPsIsShaderModel3() ? 0.0 : 1.0);
-    }
+    Lighting lighting = computeLighting(vtx, normal);
+    out_Color0 = lighting.diffuse;
+    out_Color1 = lighting.specular;
 
     out_Fog = calculateFog(vtx);
 

--- a/src/d3d9/shaders/d3d9_fixed_function_vert.vert
+++ b/src/d3d9/shaders/d3d9_fixed_function_vert.vert
@@ -370,13 +370,8 @@ void emitVsClipping(vec4 vtx) {
     uint clipPlaneCount = getClipPlaneCount();
 
     // Compute clip distances
-    for (uint i = 0; i < MaxClipPlaneCount; i++) {
-        vec4 clipPlane = clipPlanes[i];
-        float dist = dp4(worldPos, clipPlane);
-        bool clipPlaneEnabled = i < clipPlaneCount;
-        float value = clipPlaneEnabled ? dist : 0.0;
-        gl_ClipDistance[i] = value;
-    }
+    for (uint i = 0u; i < MaxClipPlaneCount; i++)
+        gl_ClipDistance[i] = i < clipPlaneCount ? dp4(worldPos, clipPlanes[i]) : 0.0;
 }
 
 

--- a/src/d3d9/shaders/d3d9_fixed_function_vert.vert
+++ b/src/d3d9/shaders/d3d9_fixed_function_vert.vert
@@ -363,6 +363,10 @@ precise vec4 vecTimesMat4(vec4 a, mat4 b) {
                 dp4(a, b[2]), dp4(a, b[3]));
 }
 
+float mul_legacy(float a, float b) {
+    return (b == 0.0f ? 0.0f : a) * (a == 0.0f ? 0.0f : b);
+}
+
 void emitVsClipping(vec4 vtx) {
     vec4 worldPos = data.InverseView * vtx;
 
@@ -382,6 +386,84 @@ vec4 pickMaterialSource(uint source, vec4 material) {
         return in_Color1;
     else
         return material;
+}
+
+
+struct Vertex {
+    vec4 coord;
+    vec4 transformed;
+    vec3 normal;
+};
+
+
+Vertex transformVertex() {
+    Vertex result;
+    result.coord = in_Position0;
+    result.normal = in_Normal0.xyz;
+
+    if (blendMode() == D3D9FF_VertexBlendMode_Tween) {
+        result.coord = mix(result.coord, in_Position1, data.TweenFactor);
+        result.normal = mix(result.normal, in_Normal1.xyz, data.TweenFactor);
+    }
+
+    if (!vertexHasPositionT()) {
+        if (blendMode() == D3D9FF_VertexBlendMode_Normal) {
+            float blendWeightRemaining = 1.0;
+
+            vec4 vtxSum = vec4(0.0);
+            vec3 nrmSum = vec3(0.0);
+
+            for (uint i = 0; i <= vertexBlendCount(); i++) {
+                uint arrayIndex = i;
+
+                if (vertexBlendIndexed())
+                    arrayIndex = uint(roundEven(in_BlendIndices[i]));
+
+                mat4 worldView = WorldViewArray[arrayIndex];
+                mat3 nrmMtx = mat3(worldView);
+
+                vec4 vtxResult = vecTimesMat4(result.coord, worldView);
+                vec3 nrmResult = result.normal * nrmMtx;
+
+                float weight = blendWeightRemaining;
+
+                if (i < vertexBlendCount()) {
+                    weight = in_BlendWeight[i];
+                    blendWeightRemaining -= weight;
+                }
+
+                vtxSum = fma(vtxResult, weight.xxxx, vtxSum);
+                nrmSum = fma(nrmResult, weight.xxx, nrmSum);
+            }
+
+            result.coord = vtxSum;
+            result.normal = nrmSum;
+            result.transformed = vecTimesMat4(result.coord, data.Projection);
+        } else {
+            // Apply pre-multiplied world-view-projection matrix, Railroad Tycoon 3
+            // relies on this and will break if we apply matrices one by one.
+            result.transformed = vecTimesMat4(result.coord, data.WorldViewProj);
+            result.coord = vecTimesMat4(result.coord, data.WorldView);
+            result.normal = mat3(data.NormalMatrix) * result.normal;
+        }
+
+        if (normalizeNormals()) {
+            float normalScale = inversesqrt(dot(result.normal, result.normal));
+            result.normal.x = mul_legacy(result.normal.x, normalScale);
+            result.normal.y = mul_legacy(result.normal.y, normalScale);
+            result.normal.z = mul_legacy(result.normal.z, normalScale);
+        }
+
+        return result;
+    } else {
+        // We still need to account for perspective correction here...
+        result.transformed = fma(result.coord, data.ViewportInfo.inverseExtent, data.ViewportInfo.inverseOffset);
+
+        float rhw = result.transformed.w == 0.0 ? 1.0 : 1.0 / result.transformed.w;
+        result.transformed.xyz *= rhw;
+        result.transformed.w = rhw;
+        return result;
+    }
 }
 
 
@@ -432,7 +514,7 @@ vec4 transformTexCoord(uint idx, vec4 vertex, vec3 normal) {
         case DXVK_TSS_TCI_PASSTHRU:
             transformed = loadTexcoord(inputIndex & 0xffu);
 
-            if (texcoordCount < 4) {
+            if (texcoordCount < 4u) {
                 // Vulkan sets the w component to 1.0 if that's not provided by the vertex buffer, D3D9 expects 0 here
                 transformed.w = 0.0;
             }
@@ -500,7 +582,7 @@ vec4 transformTexCoord(uint idx, vec4 vertex, vec3 normal) {
     // Discard the components that exceed the specified D3DTTFF_COUNT
     vec4 result = mix(transformed, vec4(0.0f), lessThan(count.xxxx, uvec4(1u, 2u, 3u, 4u)));
 
-    if (isSamplerProjected(idx) && projIndex < 4) {
+    if (isSamplerProjected(idx) && projIndex < 4u) {
         // The projection idx is always based on the flags, even when the input
         // mode is not DXVK_TSS_TCI_PASSTHRU. The w component is only used for
         // projection or unused, so always insert the divisor there. The pixel
@@ -619,94 +701,27 @@ Lighting computeLighting(vec4 vertex, vec3 normal) {
 
 
 void main() {
-    vec4 vtx = in_Position0;
-    gl_Position = in_Position0;
-    vec3 normal = in_Normal0.xyz;
+    Vertex vtx = transformVertex();
 
-    if (blendMode() == D3D9FF_VertexBlendMode_Tween) {
-        vec4 vtx1 = in_Position1;
-        vec3 normal1 = in_Normal1.xyz;
-        vtx = mix(vtx, vtx1, data.TweenFactor);
-        normal = mix(normal, normal1, data.TweenFactor);
-    }
+    gl_Position = vtx.transformed;
+    gl_PointSize = calculatePointSize(vtx.coord);
 
-    if (!vertexHasPositionT()) {
-        if (blendMode() == D3D9FF_VertexBlendMode_Normal) {
-            float blendWeightRemaining = 1.0;
-            vec4 vtxSum = vec4(0.0);
-            vec3 nrmSum = vec3(0.0);
+    emitVsClipping(vtx.coord);
 
-            for (uint i = 0; i <= vertexBlendCount(); i++) {
-                uint arrayIndex = i;
+    out_Normal = vec4(vtx.normal, 1.0);
 
-                if (vertexBlendIndexed())
-                    arrayIndex = uint(roundEven(in_BlendIndices[i]));
+    out_Texcoord0 = transformTexCoord(0u, vtx.coord, vtx.normal);
+    out_Texcoord1 = transformTexCoord(1u, vtx.coord, vtx.normal);
+    out_Texcoord2 = transformTexCoord(2u, vtx.coord, vtx.normal);
+    out_Texcoord3 = transformTexCoord(3u, vtx.coord, vtx.normal);
+    out_Texcoord4 = transformTexCoord(4u, vtx.coord, vtx.normal);
+    out_Texcoord5 = transformTexCoord(5u, vtx.coord, vtx.normal);
+    out_Texcoord6 = transformTexCoord(6u, vtx.coord, vtx.normal);
+    out_Texcoord7 = transformTexCoord(7u, vtx.coord, vtx.normal);
 
-                mat4 worldView = WorldViewArray[arrayIndex];
-                mat3 nrmMtx = mat3(worldView);
-
-                vec4 vtxResult = vecTimesMat4(vtx, worldView);
-                vec3 nrmResult = normal * nrmMtx;
-
-                float weight = blendWeightRemaining;
-
-                if (i < vertexBlendCount()) {
-                    weight = in_BlendWeight[i];
-                    blendWeightRemaining -= weight;
-                }
-
-                vec4 weightVec4 = vec4(weight, weight, weight, weight);
-                vtxSum = fma(vtxResult, weightVec4, vtxSum);
-                nrmSum = fma(nrmResult, weightVec4.xyz, nrmSum);
-            }
-
-            vtx = vtxSum;
-            normal = nrmSum;
-            gl_Position = vecTimesMat4(vtx, data.Projection);
-        } else {
-            gl_Position = vecTimesMat4(vtx, data.WorldViewProj);
-            vtx = vecTimesMat4(vtx, data.WorldView);
-
-            mat3 nrmMtx = mat3(data.NormalMatrix);
-            normal = nrmMtx * normal;
-        }
-
-        // Some games rely on normals not being normal.
-        if (normalizeNormals()) {
-            bool isZeroNormal = all(equal(normal, vec3(0.0, 0.0, 0.0)));
-            normal = isZeroNormal ? normal : normalize(normal);
-        }
-    } else {
-        gl_Position *= data.ViewportInfo.inverseExtent;
-        gl_Position += data.ViewportInfo.inverseOffset;
-
-        // We still need to account for perspective correction here...
-
-        float w = gl_Position.w;
-        float rhw = w == 0.0 ? 1.0 : 1.0 / w;
-        gl_Position.xyz *= rhw;
-        gl_Position.w = rhw;
-    }
-
-    out_Normal = vec4(normal, 1.0);
-
-    out_Texcoord0 = transformTexCoord(0u, vtx, normal);
-    out_Texcoord1 = transformTexCoord(1u, vtx, normal);
-    out_Texcoord2 = transformTexCoord(2u, vtx, normal);
-    out_Texcoord3 = transformTexCoord(3u, vtx, normal);
-    out_Texcoord4 = transformTexCoord(4u, vtx, normal);
-    out_Texcoord5 = transformTexCoord(5u, vtx, normal);
-    out_Texcoord6 = transformTexCoord(6u, vtx, normal);
-    out_Texcoord7 = transformTexCoord(7u, vtx, normal);
-
-    Lighting lighting = computeLighting(vtx, normal);
+    Lighting lighting = computeLighting(vtx.coord, vtx.normal);
     out_Color0 = lighting.diffuse;
     out_Color1 = lighting.specular;
 
-    out_Fog = calculateFog(vtx);
-
-    gl_PointSize = calculatePointSize(vtx);
-
-    // We statically declare 6 clip planes, so we always need to write values.
-    emitVsClipping(vtx);
+    out_Fog = calculateFog(vtx.coord);
 }


### PR DESCRIPTION
Trying to un-spaghetti this whole thing so that it's more obvious what contributes to which output. This is still sort-of a result of debugging Sang-Froid.

Shouldn't functionally change anything, however there were some spots where we were basically asking for questionable code gen (the whole texcoord array, indexing into the texcoord vectors for writing in ways that compilers couldn't optimize, etc), that should be fixed now too.