### PR TITLE
Minor fixed-function stuff

### DIFF
--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -8253,27 +8253,80 @@ namespace dxvk {
   }
 
 
+  D3D9TextureStageStateFlags D3D9DeviceEx::GetTextureStageStateFlags(
+          D3DTEXTUREOP          Op,
+          UINT                  Arg0,
+          UINT                  Arg1,
+          UINT                  Arg2,
+          bool                  Premodulate) {
+    uint32_t usedArgMask;
+
+    switch (Op) {
+      // No args
+      case D3DTOP_DISABLE: {
+        usedArgMask = 0b000u;
+      } break;
+
+      // Arg 1 only
+      case D3DTOP_SELECTARG1:
+      case D3DTOP_PREMODULATE: {
+        usedArgMask = 0b010u;
+      } break;
+
+      // Arg 2 only
+      case D3DTOP_SELECTARG2: {
+        usedArgMask = 0b100u;
+      } break;
+
+      // Arg 0, 1, 2
+      case D3DTOP_MULTIPLYADD:
+      case D3DTOP_LERP: {
+        usedArgMask = 0b111u;
+      } break;
+
+      // Arg 1, 2
+      default: {
+        usedArgMask = 0b110u;
+      } break;
+    }
+
+    // Some ops inherently sample the texture or use the current
+    // accumulator even if there is no explicit texture argument
+    D3D9TextureStageStateFlags result = {};
+
+    if (Op == D3DTOP_BLENDTEXTUREALPHA
+     || Op == D3DTOP_BLENDTEXTUREALPHAPM)
+      result.set(D3D9TextureStageStateFlag::UsesTexture);
+
+    if (Op == D3DTOP_BLENDCURRENTALPHA)
+      result.set(D3D9TextureStageStateFlag::UsesCurrent);
+
+    // Check stage arguments actually used by the op
+    std::array<UINT, 3u> args = { Arg0, Arg1, Arg2 };
+
+    for (uint32_t i = 0u; i < args.size(); i++) {
+      if (usedArgMask & (1u << i)) {
+        auto arg = args[i] & D3DTA_SELECTMASK;
+
+        if (arg == D3DTA_TEXTURE)
+          result.set(D3D9TextureStageStateFlag::UsesTexture);
+        else if (arg == D3DTA_CURRENT)
+          result.set(D3D9TextureStageStateFlag::UsesCurrent);
+        else if (arg == D3DTA_TEMP)
+          result.set(D3D9TextureStageStateFlag::UsesTemp);
+      }
+    }
+
+    if (Premodulate && result.test(D3D9TextureStageStateFlag::UsesCurrent))
+      result.set(D3D9TextureStageStateFlag::UsesTexture);
+
+    return result;
+  }
+
+
   void D3D9DeviceEx::UpdateFixedFunctionPS() {
     // The flags are set based on the specialized shaders.
     m_dirty.clr(D3D9DeviceDirtyFlag::FFPixelShader);
-
-    // Used args for a given operation.
-    auto usesArg = [](DWORD op, uint32_t arg) {
-      switch (op) {
-        case D3DTOP_DISABLE:
-          return false; // No Args
-        case D3DTOP_SELECTARG1:
-        case D3DTOP_PREMODULATE:
-          return arg == 1u; // Arg 1
-        case D3DTOP_SELECTARG2:
-          return arg == 2u; // Arg 2
-        case D3DTOP_MULTIPLYADD:
-        case D3DTOP_LERP:
-          return true; // Arg 0, 1, 2
-        default:
-          return arg > 0u; // Arg 1, 2
-      }
-    };
 
     bool dirty = false;
 
@@ -8284,24 +8337,21 @@ namespace dxvk {
       auto& data = m_state.textureStages[i];
 
       // All subsequent stages are disabled too following the first disabled stage.
-      DWORD colorOp = data[DXVK_TSS_COLOROP];
+      auto colorOp = D3DTEXTUREOP(data[DXVK_TSS_COLOROP]);
+      auto alphaOp = D3DTEXTUREOP(data[DXVK_TSS_ALPHAOP]);
 
       if (colorOp == D3DTOP_DISABLE)
         break;
 
       // If the stage is invalid (ie. it's set to sample a texture and none is bound),
-      // this and all subsequent stages get disabled.
+      // this and all subsequent stages get disabled. Ignore D3DTOP_PREMODULATE here
+      // since it's not clear how that is supposed to behave; shader handles it.
       if (!m_state.textures[i]) {
-        // Strip modifiers from arguments.
-        // TODO fix this to take implicit sampling from certain ops as
-        // well as alpha into account, assuming that matches native.
-        uint32_t pureColorArg1 = data[DXVK_TSS_COLORARG1] & D3DTA_SELECTMASK;
-        uint32_t pureColorArg2 = data[DXVK_TSS_COLORARG2] & D3DTA_SELECTMASK;
-        uint32_t pureColorArg0 = data[DXVK_TSS_COLORARG0] & D3DTA_SELECTMASK;
+        D3D9TextureStageStateFlags flags = {};
+        flags.set(GetTextureStageStateFlags(colorOp, data[DXVK_TSS_COLORARG0], data[DXVK_TSS_COLORARG1], data[DXVK_TSS_COLORARG2], false));
+        flags.set(GetTextureStageStateFlags(alphaOp, data[DXVK_TSS_ALPHAARG0], data[DXVK_TSS_ALPHAARG1], data[DXVK_TSS_ALPHAARG2], false));
 
-        if ((pureColorArg0 == D3DTA_TEXTURE && usesArg(data[DXVK_TSS_COLOROP], 0u))
-         || (pureColorArg1 == D3DTA_TEXTURE && usesArg(data[DXVK_TSS_COLOROP], 1u))
-         || (pureColorArg2 == D3DTA_TEXTURE && usesArg(data[DXVK_TSS_COLOROP], 2u)))
+        if (flags.test(D3D9TextureStageStateFlag::UsesTexture))
           break;
       }
 

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -1753,6 +1753,9 @@ namespace dxvk {
         m_dirty.set(D3D9DeviceDirtyFlag::MultiSampleState);
         m_dirty.set(D3D9DeviceDirtyFlag::AlphaTestState);
       }
+
+      // FFPS may optimize out color ops if unused
+      m_dirty.set(D3D9DeviceDirtyFlag::FFPixelShader);
     }
 
     return D3D_OK;
@@ -8332,6 +8335,7 @@ namespace dxvk {
 
     // Work out which stages are actually in use
     uint32_t activeTextureStageCount = 0u;
+    uint32_t firstDiscardableStage = 0u;
 
     for (uint32_t i = 0; i < caps::TextureStageCount; i++) {
       auto& data = m_state.textureStages[i];
@@ -8355,11 +8359,18 @@ namespace dxvk {
           break;
       }
 
+      // Bump texcoords feed back into alpha, so we cannot discard any color stages
+      // that feed into these texture coordinates even when not rendering color.
+      if (colorOp == D3DTOP_BUMPENVMAP || colorOp == D3DTOP_BUMPENVMAPLUMINANCE)
+        firstDiscardableStage = i + 1u;
+
       activeTextureStageCount += 1u;
     }
 
     // Track which textures are used to avoid unnecessary
     // binding and unnecessary hazard checks.
+    bool hasColorRt = m_state.renderTargets[0u] && !m_state.renderTargets[0u]->IsNull();
+
     uint32_t currTextures = 0u;
     uint32_t tempTextures = 0u;
 
@@ -8386,6 +8397,15 @@ namespace dxvk {
       if (i == 0 && resultIsTemp && colorOp != D3DTOP_DISABLE && alphaOp == D3DTOP_DISABLE) {
         alphaOp   = D3DTOP_SELECTARG1;
         alphaArg1 = D3DTA_DIFFUSE;
+      }
+
+      // Discard color if we can. We will generally have to
+      // preserve alpha for alpha test, ATOC, etc.
+      if (!hasColorRt && i >= firstDiscardableStage) {
+        colorOp = D3DTOP_SELECTARG1;
+        colorArg0 = D3DTA_DIFFUSE;
+        colorArg1 = D3DTA_DIFFUSE;
+        colorArg2 = D3DTA_DIFFUSE;
       }
 
       // The last stage *always* writes to current.

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -7466,7 +7466,8 @@ namespace dxvk {
       auto data = GetConstantBuffer(CbvIndex::PSShared).AllocTyped<D3D9SharedPS>(1u);
 
       for (uint32_t i = 0; i < caps::TextureStageCount; i++) {
-        DecodeD3DCOLOR(D3DCOLOR(m_state.textureStages[i][DXVK_TSS_CONSTANT]), data->Stages[i].Constant);
+        data->Stages[i].Constant = m_state.textureStages[i][DXVK_TSS_CONSTANT];
+        data->Stages[i].Padding = 0u;
 
         // Flip major-ness so we can get away with a nice easy
         // dot in the shader without complex access

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -7346,6 +7346,10 @@ namespace dxvk {
 
 
   void D3D9DeviceEx::PrepareDraw(D3DPRIMITIVETYPE PrimitiveType, bool UploadVBOs, bool UploadIBO) {
+    // Need to update texture masks for FFPS early so that we properly track hazards
+    if (unlikely(!UseProgrammablePS()) && m_dirty.test(D3D9DeviceDirtyFlag::FFPixelShader))
+      UpdateFixedFunctionPS();
+
     if (unlikely(m_textureSlotTracking.unresolvableHazardRT != 0 || m_textureSlotTracking.unresolvableHazardDS != 0))
       EmitFeedbackLoopBarriers();
 
@@ -7374,7 +7378,6 @@ namespace dxvk {
     auto* ibo = GetCommonBuffer(m_state.indices);
     if (unlikely(UploadIBO && ibo != nullptr && ibo->NeedsUpload()))
       FlushBuffer(ibo);
-
 
     if (unlikely(m_dirty.test(D3D9DeviceDirtyFlag::Fog)))
       UpdateFog();
@@ -7441,9 +7444,6 @@ namespace dxvk {
 
       if (m_specData.setPsBoolConstants(boolConstants))
         m_dirty.set(D3D9DeviceDirtyFlag::SpecializationEntries);
-    }
-    else if (m_dirty.test(D3D9DeviceDirtyFlag::FFPixelShader)) {
-      UpdateFixedFunctionPS();
     }
 
     uint32_t nullOrUnusedMask = ~usedSamplerMask | ~usedTextureMask;
@@ -8358,18 +8358,26 @@ namespace dxvk {
       activeTextureStageCount += 1u;
     }
 
+    // Track which textures are used to avoid unnecessary
+    // binding and unnecessary hazard checks.
+    uint32_t currTextures = 0u;
+    uint32_t tempTextures = 0u;
+
+    bool premodulateColor = false;
+    bool premodulateAlpha = false;
+
     for (uint32_t i = 0u; i < activeTextureStageCount; i++) {
       auto& data = m_state.textureStages[i];
 
       DWORD resultArg = data[DXVK_TSS_RESULTARG];
       bool resultIsTemp = resultArg == D3DTA_TEMP;
 
-      DWORD colorOp = data[DXVK_TSS_COLOROP];
+      D3DTEXTUREOP colorOp = D3DTEXTUREOP(data[DXVK_TSS_COLOROP]);
       DWORD colorArg1 = data[DXVK_TSS_COLORARG1];
       DWORD colorArg2 = data[DXVK_TSS_COLORARG2];
       DWORD colorArg0 = data[DXVK_TSS_COLORARG0];
 
-      DWORD alphaOp = data[DXVK_TSS_ALPHAOP];
+      D3DTEXTUREOP alphaOp = D3DTEXTUREOP(data[DXVK_TSS_ALPHAOP]);
       DWORD alphaArg1 = data[DXVK_TSS_ALPHAARG1];
       DWORD alphaArg2 = data[DXVK_TSS_ALPHAARG2];
       DWORD alphaArg0 = data[DXVK_TSS_ALPHAARG0];
@@ -8386,6 +8394,29 @@ namespace dxvk {
 
       dirty |= m_specData.setTextureStage(i, colorOp, alphaOp, resultArg,
         colorArg0, colorArg1, colorArg2, alphaArg0, alphaArg1, alphaArg2);
+
+      // Update texture masks
+      uint32_t stageTextures = 0u;
+
+      D3D9TextureStageStateFlags flags = {};
+      flags.set(GetTextureStageStateFlags(colorOp, colorArg0, colorArg1, colorArg2, premodulateColor));
+      flags.set(GetTextureStageStateFlags(alphaOp, alphaArg0, alphaArg1, alphaArg2, premodulateAlpha));
+
+      if (flags.test(D3D9TextureStageStateFlag::UsesTexture))
+        stageTextures |= 1u << i;
+      if (flags.test(D3D9TextureStageStateFlag::UsesCurrent))
+        stageTextures |= currTextures;
+      if (flags.test(D3D9TextureStageStateFlag::UsesTemp))
+        stageTextures |= tempTextures;
+
+      if (resultArg == D3DTA_TEMP)
+        tempTextures = stageTextures;
+      else
+        currTextures = stageTextures;
+
+      // Ensure subsequent stage gets bound for premodulate
+      premodulateColor = colorOp == D3DTOP_PREMODULATE;
+      premodulateAlpha = alphaOp == D3DTOP_PREMODULATE;
     }
 
     for (uint32_t i = activeTextureStageCount; i < caps::TextureStageCount; i++)
@@ -8393,6 +8424,16 @@ namespace dxvk {
 
     if (dirty)
       m_dirty.set(D3D9DeviceDirtyFlag::SpecializationEntries);
+
+    // Update actively used textures
+    auto prevTextures = m_textureSlotTracking.ffpsTextures;
+
+    if (prevTextures != currTextures) {
+      m_textureSlotTracking.ffpsTextures = currTextures;
+
+      UpdateActiveHazardsRT(prevTextures | currTextures);
+      UpdateActiveHazardsDS(prevTextures | currTextures);
+    }
   }
 
 

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -8162,8 +8162,6 @@ namespace dxvk {
 
       data->ViewportInfo = m_viewportInfo;
 
-      DecodeD3DCOLOR(m_state.renderStates[D3DRS_AMBIENT], data->GlobalAmbient.data);
-
       uint32_t lightIdx = 0;
 
       for (auto& light : m_state.lights) {
@@ -8182,6 +8180,7 @@ namespace dxvk {
       }
 
       data->Material = m_state.material;
+      data->GlobalAmbient = m_state.renderStates[D3DRS_AMBIENT];
       data->TweenFactor = bit::cast<float>(m_state.renderStates[D3DRS_TWEENFACTOR]);
 
       bool vertexHasPositionT = m_state.vertexDecl != nullptr && m_state.vertexDecl->TestFlag(D3D9VertexDeclFlag::HasPositionT);

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -1547,6 +1547,13 @@ namespace dxvk {
 
     void InitShaderOptions();
 
+    static D3D9TextureStageStateFlags GetTextureStageStateFlags(
+            D3DTEXTUREOP          Op,
+            UINT                  Arg0,
+            UINT                  Arg1,
+            UINT                  Arg2,
+            bool                  Premodulate);
+
     Com<D3D9InterfaceEx>            m_parent;
     D3D9Options                     m_d3d9Options;
     D3DDEVTYPE                      m_deviceType;

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -175,6 +175,9 @@ namespace dxvk {
 
     /** Whether there's a texture bound to a slot that needs to have its mip maps generated */
     uint32_t needsMipGen = 0;
+
+    /** Texture stages used by fixed-function pixel shader */
+    uint32_t ffpsTextures = 0u;
   };
 
   struct D3D9RTSlotTracking {
@@ -1520,7 +1523,7 @@ namespace dxvk {
     inline D3D9ShaderMasks PSShaderMasks() const {
       return m_state.pixelShader != nullptr
         ? m_state.pixelShader->GetCommonShader()->GetShaderMask()
-        : FixedFunctionMask;
+        : D3D9ShaderMasks { m_textureSlotTracking.ffpsTextures, 0x1u };
     }
 
     inline static uint16_t EncodePointSize(DWORD Value) {

--- a/src/d3d9/d3d9_fixed_function.h
+++ b/src/d3d9/d3d9_fixed_function.h
@@ -25,6 +25,15 @@ namespace dxvk {
     D3D9FF_VertexBlendMode_Tween,
   };
 
+  // Texture stage properties
+  enum class D3D9TextureStageStateFlag {
+    UsesTexture = 0u,
+    UsesCurrent = 1u,
+    UsesTemp    = 2u,
+  };
+
+  using D3D9TextureStageStateFlags = Flags<D3D9TextureStageStateFlag>;
+
   // No idea what this is
   constexpr uint32_t TCIOffset = 16;
   constexpr uint32_t TCIMask   = 0b111 << TCIOffset;

--- a/src/d3d9/d3d9_shader.cpp
+++ b/src/d3d9/d3d9_shader.cpp
@@ -999,12 +999,12 @@ namespace dxvk {
       dxbc_spv_assert(index);
 
       auto textureStageCbvType = ir::Type()
-        .addStructMember(ir::ScalarType::eF32, 4u)  // constant
+        .addStructMember(ir::ScalarType::eU32)      // constant color
+        .addStructMember(ir::ScalarType::eU32)      // padding
         .addStructMember(ir::ScalarType::eF32, 2u)  // matrix row 0
         .addStructMember(ir::ScalarType::eF32, 2u)  // matrix row 1
         .addStructMember(ir::ScalarType::eF32)      // luminance scale
         .addStructMember(ir::ScalarType::eF32)      // luminance offset
-        .addStructMember(ir::ScalarType::eF32, 2u)  // padding
         .addArrayDimension(caps::TextureStageCount);
 
       if (!m_textureStageCbv) {
@@ -1014,11 +1014,11 @@ namespace dxvk {
 
         m_builder.add(ir::Op::DebugName(m_textureStageCbv, "textureStages"));
         m_builder.add(ir::Op::DebugMemberName(m_textureStageCbv, 0u, "constant"));
-        m_builder.add(ir::Op::DebugMemberName(m_textureStageCbv, 1u, "bumpMat0"));
-        m_builder.add(ir::Op::DebugMemberName(m_textureStageCbv, 2u, "bumpMat1"));
-        m_builder.add(ir::Op::DebugMemberName(m_textureStageCbv, 3u, "bumpLScale"));
-        m_builder.add(ir::Op::DebugMemberName(m_textureStageCbv, 4u, "bumpLOffset"));
-        m_builder.add(ir::Op::DebugMemberName(m_textureStageCbv, 5u, "reserved"));
+        m_builder.add(ir::Op::DebugMemberName(m_textureStageCbv, 1u, "reserved"));
+        m_builder.add(ir::Op::DebugMemberName(m_textureStageCbv, 2u, "bumpMat0"));
+        m_builder.add(ir::Op::DebugMemberName(m_textureStageCbv, 3u, "bumpMat1"));
+        m_builder.add(ir::Op::DebugMemberName(m_textureStageCbv, 4u, "bumpLScale"));
+        m_builder.add(ir::Op::DebugMemberName(m_textureStageCbv, 5u, "bumpLOffset"));
       }
 
       ir::Op resultOp = ir::Op(ir::OpCode::eCompositeConstruct,
@@ -1027,10 +1027,10 @@ namespace dxvk {
       for (uint32_t i = 0u; i < resultOp.getType().getStructMemberCount(); i++) {
         auto member = [i] {
           switch (ir::LegacyTextureStageLayout(i)) {
-            case ir::LegacyTextureStageLayout::eBumpMat0: return 1u;
-            case ir::LegacyTextureStageLayout::eBumpMat1: return 2u;
-            case ir::LegacyTextureStageLayout::eBumpScale: return 3u;
-            case ir::LegacyTextureStageLayout::eBumpOffset: return 4u;
+            case ir::LegacyTextureStageLayout::eBumpMat0: return 2u;
+            case ir::LegacyTextureStageLayout::eBumpMat1: return 3u;
+            case ir::LegacyTextureStageLayout::eBumpScale: return 4u;
+            case ir::LegacyTextureStageLayout::eBumpOffset: return 5u;
           }
 
           dxbc_spv_unreachable();

--- a/src/d3d9/d3d9_state.h
+++ b/src/d3d9/d3d9_state.h
@@ -404,9 +404,9 @@ namespace dxvk {
 
     D3D9ViewportInfo ViewportInfo;
 
-    Vector4 GlobalAmbient;
     std::array<D3D9Light, caps::MaxEnabledLights> Lights;
     D3DMATERIAL9 Material;
+    uint32_t GlobalAmbient;
     float TweenFactor;
 
     // Following part uses uint8 and bool so it's gonna be represented as uint32 in the shader and manually unpacked:

--- a/src/d3d9/d3d9_state.h
+++ b/src/d3d9/d3d9_state.h
@@ -458,11 +458,11 @@ namespace dxvk {
 
   struct D3D9SharedPS {
     struct Stage {
-      float Constant[4];
+      uint32_t Constant;
+      uint32_t Padding;
       float BumpEnvMat[2][2];
       float BumpEnvLScale;
       float BumpEnvLOffset;
-      float Padding[2];
     } Stages[8];
   };
   

--- a/src/d3d9/d3d9_state.h
+++ b/src/d3d9/d3d9_state.h
@@ -233,7 +233,7 @@ namespace dxvk {
       return set(psBoolConstants, bits);
     }
 
-    bool setTextureStage(uint32_t stage, DWORD colorOp, DWORD alphaOp, DWORD resultArg,
+    bool setTextureStage(uint32_t stage, D3DTEXTUREOP colorOp, D3DTEXTUREOP alphaOp, DWORD resultArg,
         DWORD colorArg0, DWORD colorArg1, DWORD colorArg2,
         DWORD alphaArg0, DWORD alphaArg1, DWORD alphaArg2) {
       uint16_t ops = 0u;
@@ -295,7 +295,7 @@ namespace dxvk {
       return dirty;
     }
 
-    static uint16_t getTextureOp(DWORD op) {
+    static uint16_t getTextureOp(D3DTEXTUREOP op) {
       return uint16_t(op) & 0x1fu;
     }
 

--- a/src/d3d9/d3d9_util.h
+++ b/src/d3d9/d3d9_util.h
@@ -21,9 +21,6 @@ namespace dxvk {
     uint32_t rtMask;
   };
 
-  static constexpr D3D9ShaderMasks FixedFunctionMask =
-    { 0b11111111, 0b1 };
-
   struct D3D9BlendState {
     D3DBLEND   Src;
     D3DBLEND   Dst;

--- a/src/d3d9/shaders/d3d9_fixed_function_frag.glsl
+++ b/src/d3d9/shaders/d3d9_fixed_function_frag.glsl
@@ -300,9 +300,10 @@ vec4 sampleTexture(uint stage, vec4 texcoord, vec4 previousStageTextureVal) {
             texcoord = calculateBumpmapCoords(stage, texcoord, previousStageTextureVal);
     }
 
-    // We should never get null textures in FFPS since the corresponding
-    // texture stage should get disabled instead.
-    vec4 texVal = vec4(999.0);
+    // The only time we should ever be able to observe a null texture is with
+    // D3DTOP_PREMODULATE. It's not 100% clear what's supposed to happen in
+    // that case, but make it so that the multiplication has no effect for now.
+    vec4 texVal = vec4(1.0f);
 
     switch (state.type) {
         case TEXTURE_TYPE_2D:
@@ -340,14 +341,14 @@ vec4 sampleTexture(uint stage, vec4 texcoord, vec4 previousStageTextureVal) {
 }
 
 
-vec4 readArgValue(uint stage, uint arg, vec4 current, vec4 temp, vec4 textureVal) {
+vec4 readArgValue(uint stage, uint arg, vec4 current, vec4 temp, vec4 textureVal, bool premodulate) {
     vec4 reg = vec4(1.0);
     switch (arg & D3DTA_SELECTMASK) {
         case D3DTA_CONSTANT:
             reg = decodeD3DColor(sharedData.Stages[stage].Constant);
             break;
         case D3DTA_CURRENT:
-            reg = current;
+            reg = mix(current, current * textureVal, premodulate.xxxx);
             break;
         case D3DTA_DIFFUSE:
             reg = in_Color0;
@@ -383,11 +384,11 @@ struct TextureStageArgumentValues {
     vec4 arg2;
 };
 
-TextureStageArgumentValues readArgValues(uint stage, const TextureStageArguments args, vec4 current, vec4 temp, vec4 textureVal) {
+TextureStageArgumentValues readArgValues(uint stage, const TextureStageArguments args, vec4 current, vec4 temp, vec4 textureVal, bool premodulate) {
     TextureStageArgumentValues argVals;
-    argVals.arg0 = readArgValue(stage, args.arg0, current, temp, textureVal);
-    argVals.arg1 = readArgValue(stage, args.arg1, current, temp, textureVal);
-    argVals.arg2 = readArgValue(stage, args.arg2, current, temp, textureVal);
+    argVals.arg0 = readArgValue(stage, args.arg0, current, temp, textureVal, premodulate);
+    argVals.arg1 = readArgValue(stage, args.arg1, current, temp, textureVal, premodulate);
+    argVals.arg2 = readArgValue(stage, args.arg2, current, temp, textureVal, premodulate);
     return argVals;
 }
 
@@ -447,7 +448,7 @@ vec4 calculateTextureStage(uint op, vec4 dst, const TextureStageArgumentValues a
             return mix(arg.arg2, arg.arg1, current.aaaa);
 
         case D3DTOP_PREMODULATE:
-            return dst; // Not implemented
+            return arg.arg1;
 
         case D3DTOP_MODULATEALPHA_ADDCOLOR:
             return saturate(fma(arg.arg1.aaaa, arg.arg2, arg.arg1));
@@ -528,6 +529,8 @@ struct TextureStageState {
     vec4 current;
     vec4 temp;
     vec4 previousStageTextureVal;
+    bool premodulateColor;
+    bool premodulateAlpha;
 };
 
 vec4 getTexCoord(uint stage) {
@@ -567,17 +570,18 @@ TextureStageState runTextureStage(uint stage, TextureStageState state) {
     bool fastPath = info.colorOp == info.alphaOp &&
         info.colorArgs.arg0 == info.alphaArgs.arg0 &&
         info.colorArgs.arg1 == info.alphaArgs.arg1 &&
-        info.colorArgs.arg2 == info.alphaArgs.arg2;
+        info.colorArgs.arg2 == info.alphaArgs.arg2 &&
+        state.premodulateColor == state.premodulateAlpha;
 
     if (fastPath || info.colorOp == D3DTOP_DOTPRODUCT3) {
-        TextureStageArgumentValues colorArgVals = readArgValues(stage, info.colorArgs, state.current, state.temp, textureVal);
+        TextureStageArgumentValues colorArgVals = readArgValues(stage, info.colorArgs, state.current, state.temp, textureVal, state.premodulateColor);
         next = calculateTextureStage(info.colorOp, prev, colorArgVals, state.current, textureVal);
     } else {
-        TextureStageArgumentValues colorArgVals = readArgValues(stage, info.colorArgs, state.current, state.temp, textureVal);
+        TextureStageArgumentValues colorArgVals = readArgValues(stage, info.colorArgs, state.current, state.temp, textureVal, state.premodulateColor);
         next.rgb = calculateTextureStage(info.colorOp, prev, colorArgVals, state.current, textureVal).rgb;
 
         if (info.alphaOp != D3DTOP_DISABLE) {
-            TextureStageArgumentValues alphaArgVals = readArgValues(stage, info.alphaArgs, state.current, state.temp, textureVal);
+            TextureStageArgumentValues alphaArgVals = readArgValues(stage, info.alphaArgs, state.current, state.temp, textureVal, state.premodulateAlpha);
             next.a = calculateTextureStage(info.alphaOp, prev, alphaArgVals, state.current, textureVal).a;
         }
     }
@@ -585,6 +589,8 @@ TextureStageState runTextureStage(uint stage, TextureStageState state) {
     state.temp = info.storeToTemp ? next : state.temp;
     state.current = info.storeToTemp ? state.current : next;
     state.previousStageTextureVal = textureVal;
+    state.premodulateColor = info.colorOp == D3DTOP_PREMODULATE;
+    state.premodulateAlpha = info.alphaOp == D3DTOP_PREMODULATE;
     return state;
 }
 
@@ -598,6 +604,8 @@ void main() {
     // Temp starts off as equal to vec4(0)
     state.temp = vec4(0.0);
     state.previousStageTextureVal = vec4(0.0);
+    state.premodulateColor = false;
+    state.premodulateAlpha = false;
 
     // If we turn this into a loop, performance becomes very poor on the proprietary Nvidia driver
     // because it fails to unroll it.

--- a/src/d3d9/shaders/d3d9_fixed_function_frag.glsl
+++ b/src/d3d9/shaders/d3d9_fixed_function_frag.glsl
@@ -171,11 +171,11 @@ bool isPointSpriteEnabled() {
 }
 
 struct D3D9SharedPSStage {
-    float Constant[4];
+    uint Constant;
+    uint Padding;
     float BumpEnvMat[2][2];
     float BumpEnvLScale;
     float BumpEnvLOffset;
-    float Padding[2];
 };
 
 struct D3D9SharedPS {
@@ -344,12 +344,7 @@ vec4 readArgValue(uint stage, uint arg, vec4 current, vec4 temp, vec4 textureVal
     vec4 reg = vec4(1.0);
     switch (arg & D3DTA_SELECTMASK) {
         case D3DTA_CONSTANT:
-            reg = vec4(
-                sharedData.Stages[stage].Constant[0],
-                sharedData.Stages[stage].Constant[1],
-                sharedData.Stages[stage].Constant[2],
-                sharedData.Stages[stage].Constant[3]
-            );
+            reg = decodeD3DColor(sharedData.Stages[stage].Constant);
             break;
         case D3DTA_CURRENT:
             reg = current;

--- a/src/d3d9/shaders/d3d9_fixed_function_vert.vert
+++ b/src/d3d9/shaders/d3d9_fixed_function_vert.vert
@@ -95,9 +95,9 @@ struct D3D9FixedFunctionVS {
 
     D3D9ViewportInfo ViewportInfo;
 
-    vec4 GlobalAmbient;
     D3D9Light Lights[MaxEnabledLights];
     D3DMATERIAL9 Material;
+    uint GlobalAmbient;
     float TweenFactor;
 
     uint DataPrimitives[12];
@@ -679,7 +679,7 @@ Lighting computeLighting(vec4 vertex, vec3 normal) {
         vec4 matEmissive = pickMaterialSource(emissiveSource(), data.Material.Emissive);
         vec4 matSpecular = pickMaterialSource(specularSource(), data.Material.Specular);
 
-        vec4 finalColor0 = fma(matAmbient, data.GlobalAmbient, matEmissive);
+        vec4 finalColor0 = fma(matAmbient, decodeD3DColor(data.GlobalAmbient), matEmissive);
              finalColor0 = fma(matAmbient, ambientValue, finalColor0);
              finalColor0 = fma(matDiffuse, diffuseValue, finalColor0);
              finalColor0.a = matDiffuse.a;

--- a/src/dxvk/dxvk_memory.cpp
+++ b/src/dxvk/dxvk_memory.cpp
@@ -2190,8 +2190,14 @@ namespace dxvk {
       VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT |
       VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
 
+    // Handle obscure setups where cached memory is unavailable.
     if (!m_memTypesByPropertyFlags[hostCachedIndex])
       m_memTypesByPropertyFlags[hostCachedIndex] = m_memTypesByPropertyFlags[hostCoherentIndex];
+
+    // If we zero mapped memory, we need good CPU memory bandwidth.
+    // Prefer uncached system memory over HVV in that case.
+    if (m_device->config().zeroMappedMemory)
+      m_memTypesByPropertyFlags[hostVisibleVramIndex] = m_memTypesByPropertyFlags[hostCoherentIndex];
 
     // On tilers, we are likely running on an ARM system where uncached
     // stores are expected to be very slow. Always use cached memory


### PR DESCRIPTION
Brings the size of the shared PS constant buffer down to 32 bytes per stage by storing the raw D3DCOLOR and implements `D3DTOP_PREMODULATE`.