### PR TITLE
[dxgi] Create a windowed swapchain instead when the fullscreen mode scanline order or scaling is invalid.

### DIFF
--- a/src/dxgi/dxgi_swapchain.cpp
+++ b/src/dxgi/dxgi_swapchain.cpp
@@ -40,7 +40,10 @@ namespace dxvk {
     
     // Apply initial window mode and fullscreen state
     if (!m_descFs.Windowed && FAILED(EnterFullscreenMode(nullptr)))
-      throw DxvkError("DXGI: Failed to set initial fullscreen state");
+    {
+      Logger::warn("DXGI: EnterFullscreenMode failed. Creating a windowed swapchain instead.");
+      m_descFs.Windowed = TRUE;
+    }
 
     // Ensure that RGBA16 swap chains are scRGB if supported
     UpdateColorSpace(m_desc.Format, m_colorSpace);
@@ -717,6 +720,20 @@ namespace dxvk {
 
     if (!wsi::isWindow(m_window))
       return DXGI_ERROR_NOT_CURRENTLY_AVAILABLE;
+
+    if (!(m_descFs.ScanlineOrdering >= DXGI_MODE_SCANLINE_ORDER_UNSPECIFIED
+     && m_descFs.ScanlineOrdering <= DXGI_MODE_SCANLINE_ORDER_LOWER_FIELD_FIRST))
+    {
+      Logger::err(str::format("DXGI: EnterFullscreenMode: Invalid scanline order ", m_descFs.ScanlineOrdering));
+      return DXGI_ERROR_INVALID_CALL;
+    }
+
+    if (!(m_descFs.Scaling >= DXGI_MODE_SCALING_UNSPECIFIED
+     && m_descFs.Scaling <= DXGI_MODE_SCALING_STRETCHED))
+    {
+      Logger::err(str::format("DXGI: EnterFullscreenMode: Invalid scaling ", m_descFs.Scaling));
+      return DXGI_ERROR_INVALID_CALL;
+    }
     
     if (output == nullptr) {
       if (FAILED(GetOutputFromMonitor(wsi::getWindowMonitor(m_window), &output))) {


### PR DESCRIPTION
Titan Quest Anniversary Edition (SteamID: 475150) tries to create a fullscreen swapchain with an invalid scanline order and scaling and gets a windowed swapchain instead on Windows. Wine creates a fullscreen swapchain in this case and thus causes some unexpected window management bugs, such as the taskbar showing up on top of the game window. On Windows 11, DXGI_STATUS_OCCLUDED is returned when creating a fullscreen swapchain in such cases and S_OK is returned on Windows 10 <= 22H2. Choose S_OK here because I worry that some applications might not handle DXGI_STATUS_OCCLUDED gracefully.

Please see the corresponding Wine tests at https://gitlab.winehq.org/wine/wine/-/merge_requests/11231.