### PR TITLE
Only enable CUDA interop extensions on winevulkan

### DIFF
--- a/src/dxvk/dxvk_device_info.cpp
+++ b/src/dxvk/dxvk_device_info.cpp
@@ -535,7 +535,7 @@ namespace dxvk {
     if (!instance.options().enableUnifiedImageLayout)
       m_featuresSupported.khrUnifiedImageLayouts.unifiedImageLayouts = VK_FALSE;
 
-    if (env::is32BitHostPlatform() || safeMode) {
+    if (env::is32BitHostPlatform() || !env::isWineVulkan() || safeMode) {
       // CUDA interop is unnecessary on 32-bit, no games use it. These extensions
       // can also cause device creation errors for unknown reasons.
       m_featuresSupported.nvxBinaryImport = VK_FALSE;

--- a/src/util/util_env.cpp
+++ b/src/util/util_env.cpp
@@ -36,6 +36,15 @@ namespace dxvk::env {
   }
 
 
+  bool isWineVulkan() {
+#ifdef _WIN32
+    return bool(::GetModuleHandleA("winevulkan.dll"));
+#else
+    return false;
+#endif
+  }
+
+
   size_t matchFileExtension(const std::string& name, const char* ext) {
     auto pos = name.find_last_of('.');
 

--- a/src/util/util_env.h
+++ b/src/util/util_env.h
@@ -18,6 +18,11 @@ namespace dxvk::env {
   }
 
   /**
+   * \brief Checks whether winevulkan is loaded
+   */
+  bool isWineVulkan();
+
+  /**
    * \brief Gets environment variable
    * 
    * If the variable is not defined, this will return


### PR DESCRIPTION
We don't really have any use case for these outside of Proton, and enabling these forces us to create legacy sampler and view descriptors even on the Heap path.

Fixes #5744.