### PR TITLE
[dxvk] Fix self-assignment of resource cookie for imported resources

### DIFF
--- a/src/dxvk/dxvk_memory.cpp
+++ b/src/dxvk/dxvk_memory.cpp
@@ -1304,7 +1304,7 @@ namespace dxvk {
     const DxvkBufferImportInfo&       importInfo) {
     Rc<DxvkResourceAllocation> allocation = m_allocationPool.create(this, nullptr);
     allocation->m_flags.set(DxvkAllocationFlag::Imported);
-    allocation->m_resourceCookie = allocation->m_resourceCookie;
+    allocation->m_resourceCookie = allocationInfo.resourceCookie;
     allocation->m_size = createInfo.size;
     allocation->m_mapPtr = importInfo.mapPtr;
     allocation->m_buffer = importInfo.buffer;
@@ -1323,7 +1323,7 @@ namespace dxvk {
           VkImage                     imageHandle) {
     Rc<DxvkResourceAllocation> allocation = m_allocationPool.create(this, nullptr);
     allocation->m_flags.set(DxvkAllocationFlag::Imported);
-    allocation->m_resourceCookie = allocation->m_resourceCookie;
+    allocation->m_resourceCookie = allocationInfo.resourceCookie;
     allocation->m_image = imageHandle;
 
     return allocation;


### PR DESCRIPTION
`DxvkMemoryAllocator::importBufferResource()` and `importImageResource()` assign `m_resourceCookie` to itself instead of `allocationInfo.resourceCookie`:

```cpp
allocation->m_resourceCookie = allocation->m_resourceCookie;
```

so every imported buffer/image resource ends up with a cookie of `0`. Every other allocation path (`createBufferResource()` etc.) correctly uses `allocationInfo.resourceCookie`. The zeroed cookie breaks the cookie-keyed lookup in `m_resourceMap` that defragmentation and eviction rely on for imported resources.
