### PR TITLE
[dxvk] Use acq_rel ordering for allocation reference count decrement

### DIFF
--- a/src/dxvk/dxvk_memory.h
+++ b/src/dxvk/dxvk_memory.h
@@ -535,7 +535,10 @@ namespace dxvk {
      * Frees allocation if necessary
      */
     force_inline void decRef() {
-      if (unlikely(m_useCount.fetch_sub(1u, std::memory_order_acquire) == 1u))
+      // Release publishes prior uses of the allocation before the reference is
+      // dropped; acquire ensures the thread that drops the last reference
+      // observes them before freeing.
+      if (unlikely(m_useCount.fetch_sub(1u, std::memory_order_acq_rel) == 1u))
         free();
     }
 


### PR DESCRIPTION
`DxvkResourceAllocation::decRef()` decrements the reference count with `std::memory_order_acquire`:

```cpp
if (unlikely(m_useCount.fetch_sub(1u, std::memory_order_acquire) == 1u))
  free();
```

A reference-count decrement that may run the destructor (here `free()`, which can call `vkDestroyBuffer`/`vkFreeMemory`) needs **release** ordering so that prior uses of the allocation are published before the reference is dropped, and **acquire** ordering so that the thread which observes the last reference sees those uses before freeing. `acquire` alone provides neither for the decrement.

The sibling reference count `DxvkPagedResource::release()` already uses `release` ordering for the same purpose. On x86 the locked RMW is a full barrier so this is benign, but on weakly-ordered architectures the missing ordering is a genuine data race on the freed allocation.
