### PR TITLE
Do not use inline uniform block with legacy binding model.

### DIFF
--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -7183,16 +7183,21 @@ namespace dxvk {
 
     if (BindPoint == VK_PIPELINE_BIND_POINT_GRAPHICS
      && unlikely(m_flags.all(DxvkContextFlag::GpIndependentSets, DxvkContextFlag::GpDirtySpecDataBlock))) {
+      DxvkResourceBufferInfo specData = allocateSpecDataBuffer(pipelineLayout);
+      pipelineLayout->writeSpecData(specData.mapPtr, m_state.gp.state.sc.specConstants);
+
       VkDescriptorSet set = m_descriptorPool->alloc(m_trackingId, m_device->getSpecDataSetLayout());
 
-      VkWriteDescriptorSetInlineUniformBlock blockInfo = { VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET_INLINE_UNIFORM_BLOCK };
-      blockInfo.dataSize = sizeof(DxvkScInfo);
-      blockInfo.pData = m_state.gp.state.sc.specConstants;
+      VkDescriptorBufferInfo bufferInfo = {};
+      bufferInfo.buffer = specData.buffer;
+      bufferInfo.offset = specData.offset;
+      bufferInfo.range = specData.size;
 
-      VkWriteDescriptorSet writeInfo = { VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, &blockInfo };
+      VkWriteDescriptorSet writeInfo = { VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET };
       writeInfo.dstSet = set;
-      writeInfo.descriptorCount = blockInfo.dataSize;
-      writeInfo.descriptorType = VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK;
+      writeInfo.descriptorCount = 1u;
+      writeInfo.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+      writeInfo.pBufferInfo = &bufferInfo;
 
       m_cmd->updateDescriptorSets(1u, &writeInfo);
 

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -9128,6 +9128,28 @@ namespace dxvk {
   }
 
 
+  DxvkResourceBufferInfo DxvkContext::allocateSpecDataBuffer(const DxvkPipelineLayout* layout) {
+    if (unlikely(!m_specBuffer)) {
+      DxvkBufferCreateInfo bufInfo;
+      bufInfo.size    = layout->getSpecDataMemorySize();
+      bufInfo.usage   = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
+      bufInfo.stages  = m_device->getShaderPipelineStages();
+      bufInfo.access  = VK_ACCESS_2_UNIFORM_READ_BIT;
+      bufInfo.debugName = "Spec data buffer";
+
+      m_specBuffer = m_device->createBuffer(bufInfo,
+        VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT |
+        VK_MEMORY_PROPERTY_HOST_COHERENT_BIT |
+        VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+    } else {
+      m_cmd->track(m_specBuffer->assignStorage(m_specBuffer->allocateStorage()));
+    }
+
+    m_cmd->track(m_specBuffer, DxvkAccess::Write);
+    return m_specBuffer->getSliceInfo();
+  }
+
+
   void DxvkContext::freeZeroBuffer() {
     constexpr uint64_t ZeroBufferLifetime = 4096u;
 

--- a/src/dxvk/dxvk_context.h
+++ b/src/dxvk/dxvk_context.h
@@ -1346,6 +1346,7 @@ namespace dxvk {
 
     Rc<DxvkCommandList>     m_cmd;
     Rc<DxvkBuffer>          m_zeroBuffer;
+    Rc<DxvkBuffer>          m_specBuffer;
 
     Rc<DxvkBuffer>          m_scratchBuffer;
     VkDeviceSize            m_scratchOffset = 0u;
@@ -1882,6 +1883,9 @@ namespace dxvk {
     
     Rc<DxvkBuffer> createZeroBuffer(
             VkDeviceSize              size);
+
+    DxvkResourceBufferInfo allocateSpecDataBuffer(
+      const DxvkPipelineLayout*       layout);
 
     void freeZeroBuffer();
 

--- a/src/dxvk/dxvk_descriptor_pool.cpp
+++ b/src/dxvk/dxvk_descriptor_pool.cpp
@@ -141,7 +141,7 @@ namespace dxvk {
     // assume that all other descriptor types share pool memory.
     constexpr static uint32_t MaxSets = 1024u;
 
-    static const std::array<VkDescriptorPoolSize, 8> pools = {{
+    static const std::array<VkDescriptorPoolSize, 7u> pools = {{
       { VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE,          MaxSets / 2   },
       { VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,          MaxSets / 4   },
       { VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER,   MaxSets / 2   },
@@ -149,13 +149,9 @@ namespace dxvk {
       { VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,         MaxSets * 2   },
       { VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,         MaxSets / 2   },
       { VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT,       MaxSets / 64  },
-      { VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK,   MaxSets * 128 },
     }};
 
-    VkDescriptorPoolInlineUniformBlockCreateInfo inlineUboInfo = { VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_INLINE_UNIFORM_BLOCK_CREATE_INFO };
-    inlineUboInfo.maxInlineUniformBlockBindings = MaxSets / 2u;
-
-    VkDescriptorPoolCreateInfo info = { VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO, &inlineUboInfo };
+    VkDescriptorPoolCreateInfo info = { VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO };
     info.maxSets       = MaxSets;
     info.poolSizeCount = pools.size();
     info.pPoolSizes    = pools.data();

--- a/src/dxvk/dxvk_device_info.cpp
+++ b/src/dxvk/dxvk_device_info.cpp
@@ -550,13 +550,6 @@ namespace dxvk {
     if (m_properties.vk12.driverID == VK_DRIVER_ID_QUALCOMM_PROPRIETARY)
       m_featuresSupported.extMultiDraw.multiDraw = VK_FALSE;
 
-    // Intel drivers on Windows throw OUT_OF_POOL_MEMORY errors with inline uniform
-    // blocks for some reason. Disable GPL as a workaround if legacy binding is used.
-    if (m_properties.vk12.driverID == VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS
-     && !m_featuresSupported.extDescriptorHeap.descriptorHeap
-     && !m_featuresSupported.extDescriptorBuffer.descriptorBuffer)
-      m_featuresSupported.extGraphicsPipelineLibrary.graphicsPipelineLibrary = VK_FALSE;
-
     // If we're running off a device without a sparse binding queue,
     // disable all the sparse binding features as well
     uint32_t sparseQueue = findQueueFamily(VK_QUEUE_SPARSE_BINDING_BIT, VK_QUEUE_SPARSE_BINDING_BIT);

--- a/src/dxvk/dxvk_pipelayout.cpp
+++ b/src/dxvk/dxvk_pipelayout.cpp
@@ -322,7 +322,9 @@ namespace dxvk {
       return std::make_pair(align(size, alignment), offset);
     }
 
-    return std::make_pair(0u, 0u);
+    // On the legacy path, we use a plain uniform buffer.
+    alignment = std::max<VkDeviceSize>(CACHE_LINE_SIZE, m_device->properties().core.properties.limits.minUniformBufferOffsetAlignment);
+    return std::make_pair(align<VkDeviceSize>(sizeof(DxvkScInfo), alignment), 0u);
   }
 
 

--- a/src/dxvk/dxvk_pipemanager.cpp
+++ b/src/dxvk/dxvk_pipemanager.cpp
@@ -419,9 +419,15 @@ namespace dxvk {
     auto vk = m_device->vkd();
 
     VkDescriptorSetLayoutBinding binding = {};
-    binding.descriptorType = VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK;
-    binding.descriptorCount = sizeof(DxvkScInfo);
     binding.stageFlags = VK_SHADER_STAGE_ALL_GRAPHICS;
+
+    if (m_device->canUseDescriptorBuffer()) {
+      binding.descriptorType = VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK;
+      binding.descriptorCount = sizeof(DxvkScInfo);
+    } else {
+      binding.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+      binding.descriptorCount = 1u;
+    }
 
     VkDescriptorSetLayoutCreateInfo info = { VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO };
     info.bindingCount = 1u;


### PR DESCRIPTION
Inline UBO is broken on Intel's Windows driver, and this should be a more tolerable workaround than disabling GPL.

Fixes #5756.