### PR TITLE
[util] Add FPS limit for Manhunt

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -1395,6 +1395,11 @@ namespace dxvk {
     { R"(\\Mafia\\Game\.exe$)", {{
       { "d3d9.samplerAnisotropy",             "16" },
     }} },
+    /* Manhunt                                    *
+     * Broken AI behavior above 60 FPS (game bug) */
+    { R"(\\manhunt\.exe$)", {{
+      { "d3d9.maxFrameRate",                 "-60" },
+    }} },
 
   };
 


### PR DESCRIPTION
Above 60 FPS there are erroneous AI behaviors such as AI standing completely still and doing nothing.

(A game bug, not a DXVK bug.)

Manhunt is a D3D8 game.

See:
- https://steamcommunity.com/app/12130/discussions/0/864980278113314892/
- https://steamcommunity.com/app/12130/discussions/0/360671727322545063/
- https://steamcommunity.com/app/12130/discussions/0/348292957935657900/
- https://steamcommunity.com/sharedfiles/filedetails/?id=2166039806 (Manhunt Fixer - from the GUI screenshot: "Game is now locked at 60FPS, preventing many script and AI errors.")