### PR TITLE
Revert "[d3d9] Ignore buffer lock range for static D3DPOOL_DEFAULT buffers

### DIFF
--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -5482,8 +5482,7 @@ namespace dxvk {
     // (TODO: Apparently this is meant to happen for DYNAMIC too but I am not sure
     //  how that works given it is meant to be a DIRECT access..?)
     const bool respectUserBounds = !(Flags & D3DLOCK_DISCARD) &&
-                                    SizeToLock != 0 &&
-                                    (desc.Pool == D3DPOOL_MANAGED || (desc.Usage & D3DUSAGE_DYNAMIC));
+                                    SizeToLock != 0;
 
     // If we don't respect the bounds, encompass it all in our tests/checks
     // These values may be out of range and don't get clamped.


### PR DESCRIPTION
The change to ignore the locking range arguments for `D3DPOOL_DEFAULT` buffers was done to fix #5067 because IIRC that wrote outside of the provided range. It severely impacted performance in Kane and Lynch.

A random broken demo is much less important as an actual game so let's just revert it for now.

Fixes #5638