### PR TITLE
[d3d9] Do not transform normals if WorldView is not invertible

### DIFF
--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -8150,7 +8150,7 @@ namespace dxvk {
       m_dirty.clr(D3D9DeviceDirtyFlag::FFVertexData);
 
       auto WorldView    = m_state.transforms[GetTransformIndex(D3DTS_VIEW)] * m_state.transforms[GetTransformIndex(D3DTS_WORLD)];
-      auto NormalMatrix = inverse(WorldView);
+      auto NormalMatrix = tryInverse(WorldView).value_or(Matrix4(1.0f));
       auto Projection   = m_state.transforms[GetTransformIndex(D3DTS_PROJECTION)];
 
       auto data = GetConstantBuffer(CbvIndex::VSFixedFunction).AllocTyped<D3D9FixedFunctionVS>(1u);

--- a/src/util/util_matrix.cpp
+++ b/src/util/util_matrix.cpp
@@ -158,8 +158,7 @@ namespace dxvk {
     return (dot0.x + dot0.y) + (dot0.z + dot0.w);
   }
 
-  Matrix4 inverse(const Matrix4& m)
-  {
+  std::optional<Matrix4> tryInverse(const Matrix4& m) {
     float coef00    = m[2][2] * m[3][3] - m[3][2] * m[2][3];
     float coef02    = m[1][2] * m[3][3] - m[3][2] * m[1][3];
     float coef03    = m[1][2] * m[2][3] - m[2][2] * m[1][3];
@@ -178,24 +177,24 @@ namespace dxvk {
     float coef20    = m[2][0] * m[3][1] - m[3][0] * m[2][1];
     float coef22    = m[1][0] * m[3][1] - m[3][0] * m[1][1];
     float coef23    = m[1][0] * m[2][1] - m[2][0] * m[1][1];
-  
+
     Vector4 fac0    = { coef00, coef00, coef02, coef03 };
     Vector4 fac1    = { coef04, coef04, coef06, coef07 };
     Vector4 fac2    = { coef08, coef08, coef10, coef11 };
     Vector4 fac3    = { coef12, coef12, coef14, coef15 };
     Vector4 fac4    = { coef16, coef16, coef18, coef19 };
     Vector4 fac5    = { coef20, coef20, coef22, coef23 };
-  
+
     Vector4 vec0    = { m[1][0], m[0][0], m[0][0], m[0][0] };
     Vector4 vec1    = { m[1][1], m[0][1], m[0][1], m[0][1] };
     Vector4 vec2    = { m[1][2], m[0][2], m[0][2], m[0][2] };
     Vector4 vec3    = { m[1][3], m[0][3], m[0][3], m[0][3] };
-  
+
     Vector4 inv0    = { vec1 * fac0 - vec2 * fac1 + vec3 * fac2 };
     Vector4 inv1    = { vec0 * fac0 - vec2 * fac3 + vec3 * fac4 };
     Vector4 inv2    = { vec0 * fac1 - vec1 * fac3 + vec3 * fac5 };
     Vector4 inv3    = { vec0 * fac2 - vec1 * fac4 + vec2 * fac5 };
-  
+
     Vector4 signA   = { +1, -1, +1, -1 };
     Vector4 signB   = { -1, +1, -1, +1 };
     Matrix4 inverse = { inv0 * signA, inv1 * signB, inv2 * signA, inv3 * signB };
@@ -205,11 +204,14 @@ namespace dxvk {
     Vector4 dot0    = { m[0] * row0 };
     float dot1      = (dot0.x + dot0.y) + (dot0.z + dot0.w);
 
-    if (unlikely(std::abs(dot1) <= std::numeric_limits<float>::min() * 10)) {
-      return m;
-    }
+    if (unlikely(std::abs(dot1) <= std::numeric_limits<float>::min() * 10))
+      return std::nullopt;
 
-    return inverse * (1.0f / dot1);
+    return std::make_optional(inverse * (1.0f / dot1));
+  }
+
+  Matrix4 inverse(const Matrix4& m) {
+    return tryInverse(m).value_or(m);
   }
 
   Matrix4 hadamardProduct(const Matrix4& a, const Matrix4& b) {

--- a/src/util/util_matrix.h
+++ b/src/util/util_matrix.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <optional>
+
 #include "util_vector.h"
 
 namespace dxvk {
@@ -76,6 +78,8 @@ namespace dxvk {
   Matrix4 transpose(const Matrix4& m);
 
   float determinant(const Matrix4& m);
+
+  std::optional<Matrix4> tryInverse(const Matrix4& m);
 
   Matrix4 inverse(const Matrix4& m);
 


### PR DESCRIPTION
Finally fixes #2480.

Game uses orthographic projection to render the background and uses a world transform with a Z row of 0, and what happens on native in that case is that normals are seemingly not transformed at all.

Of course this isn't documented at all, and does need a bit of regression testing in fixed-function-heavy games to make sure I'm not misinterpreting native behaviour. @WinterSnowfall 