### PR TITLE
[util] Remove floatEmulation config for Gothic 3

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -536,7 +536,6 @@ namespace dxvk {
      * on non strict float path with dxvk 3.0     */
     { R"(\\Gothic(3|3Final| III Forsaken Gods)\.exe$)", {{
       { "d3d9.supportDFFormats",           "False" },
-      { "d3d9.floatEmulation",            "Strict" },
     }} },
     /* Sonic Adventure 2                          */
     { R"(\\Sonic Adventure 2\\(launcher|sonic2app)\.exe$)", {{


### PR DESCRIPTION
Works again without. Likely since https://github.com/doitsujin/dxvk/commit/73345afd7813136673951975fb3c78867838a73a