### PR TITLE
[dxvk] Enable descriptor buffer on Alchemist or older

### DIFF
--- a/src/dxvk/dxvk_device_info.cpp
+++ b/src/dxvk/dxvk_device_info.cpp
@@ -525,6 +525,11 @@ namespace dxvk {
        || m_properties.vk12.driverID == VK_DRIVER_ID_AMD_PROPRIETARY)
         enableDescriptorBuffer = !m_hasFmask;
 
+      // Workaround for https://gitlab.freedesktop.org/mesa/mesa/-/work_items/15795.
+      // Does not affect Battlemage, and EDB generally costs perf on Intel.
+      if (m_properties.vk12.driverID == VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA)
+        enableDescriptorBuffer = m_properties.vk13.minSubgroupSize < 16u;
+
       applyTristate(enableDescriptorBuffer, instance.options().enableDescriptorBuffer);
 
       if (!enableDescriptorBuffer)


### PR DESCRIPTION
Should fix ANV GPU hangs with D3D9 FFVS.

This is being fixed in Mesa, but we want to avoid breaking user setups before users have the chance to update. Mesa 26.2 enables descriptor heaps on ANV anyway, so the problem should just go away on its own.