### PR TITLE
[util] Update Gothic 3 comment after removal of floatEmulation config

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -532,8 +532,7 @@ namespace dxvk {
       { "d3d9.lenientClear",                "True" },
       { "d3d9.supportDFFormats",           "False" },
     }} },
-    /* Gothic 3 - Rendering such as water broken  *
-     * on non strict float path with dxvk 3.0     */
+    /* Gothic 3                                   */
     { R"(\\Gothic(3|3Final| III Forsaken Gods)\.exe$)", {{
       { "d3d9.supportDFFormats",           "False" },
     }} },


### PR DESCRIPTION
568b8836 dropped the floatEmulation config for Gothic 3 but forgot to also remove the related explanation in the comment above.