### PR TITLE
Add option to ignore D3DDPOOL_DEFAULT buffer lock range

### DIFF
--- a/dxvk.conf
+++ b/dxvk.conf
@@ -877,6 +877,18 @@
 # d3d9.useFP16 = False
 
 
+# Ignore the locking range for D3DPOOL_DEFAULT buffers
+#
+# Some games pass incorrect values when locking D3DPOOL_DEFAULT buffers and expect it to work.
+# This option makes DXVK just ignore these and mark the whole buffer as dirty.
+# Might come with a performance hit because more data needs to get copied.
+#
+# Supported values:
+# - True: Ignore the locking range for D3DPOOL_DEFAULT buffers.
+# - False: Respect the locking range.
+
+# d3d9.ignoreDefaultBufferLockRange = False
+
 # Dref scaling for DXS0/FVF
 #
 # Some early D3D8 games expect Dref (depth texcoord Z) to be on the range of

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -5482,7 +5482,8 @@ namespace dxvk {
     // (TODO: Apparently this is meant to happen for DYNAMIC too but I am not sure
     //  how that works given it is meant to be a DIRECT access..?)
     const bool respectUserBounds = !(Flags & D3DLOCK_DISCARD) &&
-                                    SizeToLock != 0;
+                                    SizeToLock != 0 &&
+                                    !m_d3d9Options.ignoreDefaultBufferLockRange;
 
     // If we don't respect the bounds, encompass it all in our tests/checks
     // These values may be out of range and don't get clamped.

--- a/src/d3d9/d3d9_options.cpp
+++ b/src/d3d9/d3d9_options.cpp
@@ -68,6 +68,7 @@ namespace dxvk {
     this->deviceLocalConstantBuffers    = config.getOption<Tristate>    ("d3d9.deviceLocalConstantBuffers",    Tristate::Auto);
     this->allowDirectBufferMapping      = config.getOption<bool>        ("d3d9.allowDirectBufferMapping",      true);
     this->forceDrawTimeBufferUpload     = config.getOption<bool>        ("d3d9.forceDrawTimeBufferUpload",     false);
+    this->ignoreDefaultBufferLockRange  = config.getOption<bool>        ("d3d9.ignoreDefaultBufferLockRange",  false);
     this->seamlessCubes                 = config.getOption<bool>        ("d3d9.seamlessCubes",                 false);
     this->textureMemory                 = config.getOption<int32_t>     ("d3d9.textureMemory",                 100) << 20;
     this->deviceLossOnFocusLoss         = config.getOption<bool>        ("d3d9.deviceLossOnFocusLoss",         false);

--- a/src/d3d9/d3d9_options.h
+++ b/src/d3d9/d3d9_options.h
@@ -134,6 +134,11 @@ namespace dxvk {
     /// objects because they never get their proper UVs.
     bool forceDrawTimeBufferUpload;
 
+    /// Ignore the lock range passed to Buffer::Lock for buffers in the D3DPOOL_DEFAULT and mark the whole buffer
+    /// dirty instead.
+    /// Used for games that pass incorrect values.
+    bool ignoreDefaultBufferLockRange;
+
     /// Don't use non seamless cube maps
     bool seamlessCubes;
 

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -1174,6 +1174,11 @@ namespace dxvk {
     { R"(\\(SplinterCell4|SCDA_online)\.exe$)", {{
       { "d3d9.hideAmdGpu",                  "True" },
     }} },
+    /* Splinter Cell: Chaos Theory                *
+     * Passes incorrect values when locking a vertex buffer  */
+    { R"(\\splintercell3\.exe$)", {{
+      { "d3d9.ignoreDefaultBufferLockRange", "True" },
+    }} },
 
     /**********************************************/
     /* D3D8 GAMES                                 */


### PR DESCRIPTION
Fixes #5780

<img width="2933" height="2160" alt="Screenshot_20260706_201942" src="https://github.com/user-attachments/assets/aed16fd6-2516-428e-bb95-bb5e1008f4fd" />
