### PR TITLE
[dxgi] Use singleton for DXGI options

### DIFF
--- a/src/dxgi/dxgi_factory.cpp
+++ b/src/dxgi/dxgi_factory.cpp
@@ -10,6 +10,7 @@
 namespace dxvk {
 
   static Singleton<DxvkInstance>   g_dxvkInstance;
+  static Singleton<DxgiOptions>    g_dxgiOptions;
 
   static dxvk::mutex               s_globalHDRStateMutex;
   static DXVK_VK_GLOBAL_HDR_STATE  s_globalHDRState{};
@@ -81,8 +82,8 @@ namespace dxvk {
   DxgiFactory::DxgiFactory(UINT Flags)
   : m_instance        (g_dxvkInstance.acquire(0)),
     m_interop         (this),
-    m_options         (m_instance->config()),
-    m_monitorInfo     (this, m_options),
+    m_options         (g_dxgiOptions.acquire(m_instance->config())),
+    m_monitorInfo     (this, *m_options),
     m_flags           (Flags),
     m_monitorFallback (false),
     m_destructionNotifier(this) {
@@ -134,6 +135,7 @@ namespace dxvk {
   
   
   DxgiFactory::~DxgiFactory() {
+    g_dxgiOptions.release();
     g_dxvkInstance.release();
   }
   
@@ -284,7 +286,7 @@ namespace dxvk {
           IDXGISwapChain1**     ppSwapChain) {
     InitReturnPtr(ppSwapChain);
 
-    if (!m_options.enableDummyCompositionSwapchain) {
+    if (!m_options->enableDummyCompositionSwapchain) {
       Logger::err("DxgiFactory::CreateSwapChainForComposition: Not implemented");
       return E_NOTIMPL;
     }

--- a/src/dxgi/dxgi_factory.h
+++ b/src/dxgi/dxgi_factory.h
@@ -182,7 +182,7 @@ namespace dxvk {
     }
 
     const DxgiOptions* GetOptions() const {
-      return &m_options;
+      return m_options.ptr();
     }
 
     DxgiMonitorInfo* GetMonitorInfo() {
@@ -195,7 +195,7 @@ namespace dxvk {
     
     Rc<DxvkInstance> m_instance;
     DxgiVkFactory    m_interop;
-    DxgiOptions      m_options;
+    Rc<DxgiOptions>  m_options;
     DxgiMonitorInfo  m_monitorInfo;
     UINT             m_flags;
     BOOL             m_monitorFallback;

--- a/src/dxgi/dxgi_options.h
+++ b/src/dxgi/dxgi_options.h
@@ -17,6 +17,15 @@ namespace dxvk {
   struct DxgiOptions {
     DxgiOptions(const Config& config);
 
+    void incRef() {
+      m_useCount.fetch_add(1u);
+    }
+
+    void decRef() {
+      if (m_useCount.fetch_sub(1u) == 1u)
+        delete this;
+    }
+
     /// Override PCI vendor and device IDs reported to the
     /// application. This may make apps think they are running
     /// on a different GPU than they do and behave differently.
@@ -58,6 +67,11 @@ namespace dxvk {
 
     /// Forced refresh rate, disable other modes
     uint32_t forceRefreshRate;
+
+  private:
+
+    std::atomic<uint32_t> m_useCount = { 0u };
+
   };
   
 }


### PR DESCRIPTION
Dying Light: The Beast is insane and creates a new DXGI factory every single fucking frame, and evaluating options with XeSS checks etc is not exactly cheap.