### PR TITLE
[util] Enable ignoring default lock ranges for Halo Trial and Halo CE

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -592,6 +592,10 @@ namespace dxvk {
      * spec-constantly chose the sampler type     *
      * automagically.                             */
       { "d3d9.forceSamplerTypeSpecConstants", "True" },
+    /* The game passes incorrect values when      *
+     * locking a vertex buffer causing it to      *
+     * render "behind" the initial loading screen */
+      { "d3d9.ignoreDefaultBufferLockRange", "True" },
     }} },
     /* Counter Strike: Global Offensive
        Needs NVAPI to avoid a forced AO + Smoke


### PR DESCRIPTION
Commit cc13f9deb35d710ed9f20881afe6e104a19bb3cb broke Halo Custom Edition and Halo Trial. It worked in 3.0.0 and older releases.
This adds the new locking workaround for these games.


BTW, we fixed this directly in out mod here https://github.com/SnowyMouse/chimera/commit/c12909a1425b0f7fdb26e616260b3633ab493f40 and having the workaround *mildly* hurts FPS, what is the best way to get DXVK to not apply these workarounds automatically? should we include a `dxvk.conf` that turns them off like this?
```
#
# dxvk.conf for disabling the built-in workarounds for bugs fixed by Chimera
#
# See https://github.com/doitsujin/dxvk/blob/master/dxvk.conf for more information and options
#

# Incorrect sampler types have been fixed in Chimera's internal shaders
d3d9.forceSamplerTypeSpecConstants = False

# Chimera patches an incorrect SizeToLock parameter to use the correct size
d3d9.ignoreDefaultBufferLockRange = False
```



does DXVK promise that `dxvk.conf` always takes priority over built-in settings?