### PR TITLE
Add rudimentary GPU hang debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,11 @@ The following environment variables can be used for **debugging** purposes.
 - `VK_INSTANCE_LAYERS=VK_LAYER_KHRONOS_validation` Enables Vulkan debug layers. Highly recommended for troubleshooting rendering issues and driver crashes. Requires the Vulkan SDK to be installed on the host system.
 - `DXVK_LOG_LEVEL=none|error|warn|info|debug` Controls message logging.
 - `DXVK_LOG_PATH=/some/directory` Changes path where log files are stored. Set to `none` to disable log file creation entirely, without disabling logging.
-- `DXVK_DEBUG=markers|validation` Enables use of the `VK_EXT_debug_utils` extension for translating performance event markers, or to enable Vulkan validation, respecticely.
+- `DXVK_DEBUG=...` Enables one of various debugging modes:
+  - `capture`: Default when used with certain tools. Enables dxvk-internal debug names and debug markers for render passes, shaders, etc.
+  - `hang`: Detects GPU hangs or driver crashes resulting in `VK_ERROR_DEVICE_LOST` and logs failing command(s).
+  - `markers`: Uses `VK_EXT_debug_utils` to forward applocation-provided resource names and debug markers to Vulkan.
+  - `validation`: Enables validation debug callback. Must also set `VK_INSTANCE_LAYERS=VK_LAYER_KHRONOS_validation` on Linux.
 - `DXVK_CONFIG_FILE=/xxx/dxvk.conf` Sets path to the configuration file.
 - `DXVK_CONFIG="dxgi.hideAmdGpu = True; dxgi.syncInterval = 0"` Can be used to set config variables through the environment instead of a configuration file using the same syntax. `;` is used as a seperator.
 - `DXVK_SHADER_CACHE=0`: Disables the internal shader cache.

--- a/src/dxvk/dxvk_cmdlist.cpp
+++ b/src/dxvk/dxvk_cmdlist.cpp
@@ -1,8 +1,16 @@
+#include <algorithm>
 
 #include "dxvk_cmdlist.h"
 #include "dxvk_device.h"
 
 namespace dxvk {
+
+  DxvkDeviceQueue getQueueForCommandBuffer(DxvkDevice* device, DxvkCmdBuffer cmdBuffer) {
+    return cmdBuffer < DxvkCmdBuffer::SdmaBuffer
+      ? device->queues().graphics
+      : device->queues().transfer;
+  }
+
 
   DxvkCommandSubmission::DxvkCommandSubmission() {
 
@@ -234,6 +242,8 @@ namespace dxvk {
       m_transferPool = new DxvkCommandPool(device, transferQueue.queueFamily);
     else
       m_transferPool = m_graphicsPool;
+
+    resetCheckpoints();
   }
   
   
@@ -406,8 +416,15 @@ namespace dxvk {
     // For consistency, end all command buffers here,
     // regardless of whether they have been used.
     for (uint32_t i = 0; i < m_cmd.cmdBuffers.size(); i++) {
-      if (m_cmd.cmdBuffers[i])
+      if (m_cmd.cmdBuffers[i]) {
+        if (m_checkpoints) {
+          m_checkpoints->endCommandBuffer(
+            getQueueForCommandBuffer(m_device, DxvkCmdBuffer(i)),
+            m_cmd.cmdBuffers[i], m_checkpointIds[i]);
+        }
+
         endCommandBuffer(m_cmd.cmdBuffers[i]);
+      }
     }
 
     // Reset all command buffer handles
@@ -451,6 +468,8 @@ namespace dxvk {
 
   
   void DxvkCommandList::reset() {
+    resetCheckpoints();
+
     // We will re-apply heap bindings first thing in a
     // new command list, so reset this flag here
     m_descriptorHeapInvalidated = false;
@@ -1044,6 +1063,85 @@ namespace dxvk {
       VkDeviceSize dataSize = range->getAllocationOffset() - baseOffset;
       addStatCtr(DxvkStatCounter::DescriptorHeapUsed, dataSize);
     }
+  }
+
+
+  void DxvkCommandList::resetCheckpoints() {
+    std::fill(m_checkpointIds.begin(), m_checkpointIds.end(), -1);
+  }
+
+
+  void DxvkCommandList::debugMarker(
+          DxvkCmdBuffer                 cmdBuffer,
+    const char*                         text) {
+    if (m_checkpoints) {
+      auto cmdIndex = uint32_t(cmdBuffer);
+
+      m_checkpointIds.at(cmdIndex) = m_checkpoints->addCheckpoint(
+        getQueueForCommandBuffer(m_device, cmdBuffer), getCmdBuffer(cmdBuffer),
+        m_checkpointIds.at(cmdIndex), text);
+    }
+  }
+
+
+  void DxvkCommandList::debugDispatch(
+          DxvkCmdBuffer                 cmdBuffer,
+    const char*                         text,
+          uint32_t                      x,
+          uint32_t                      y,
+          uint32_t                      z) {
+    debugMarker(cmdBuffer, str::format(text, " (", x, ", ", y, ", ", z, ")").c_str());
+  }
+
+
+  void DxvkCommandList::debugDraw(
+          DxvkCmdBuffer                 cmdBuffer,
+    const char*                         text,
+          uint32_t                      count,
+          uint32_t                      instances) {
+    debugMarker(cmdBuffer, str::format(text, " (", count, ", ", instances, ")").c_str());
+  }
+
+
+  void DxvkCommandList::debugDrawMulti(
+          DxvkCmdBuffer                 cmdBuffer,
+    const char*                         text,
+          uint32_t                      count) {
+    debugMarker(cmdBuffer, str::format(text, " (", count, ")").c_str());
+  }
+
+
+  void DxvkCommandList::debugDrawIndirect(
+          DxvkCmdBuffer                 cmdBuffer,
+    const char*                         text,
+          uint32_t                      count,
+          uint32_t                      stride) {
+    debugMarker(cmdBuffer, str::format(text, " (", count, ", ", stride, ")").c_str());
+  }
+
+
+  void DxvkCommandList::debugBarrier(
+          DxvkCmdBuffer                 cmdBuffer,
+    const VkDependencyInfo*             depInfo) {
+    VkMemoryBarrier2 barrier = {};
+
+    for (uint32_t i = 0u; i < depInfo->memoryBarrierCount; i++) {
+      barrier.srcStageMask |= depInfo->pMemoryBarriers[i].srcStageMask;
+      barrier.srcAccessMask |= depInfo->pMemoryBarriers[i].srcAccessMask;
+      barrier.dstStageMask |= depInfo->pMemoryBarriers[i].dstStageMask;
+      barrier.dstAccessMask |= depInfo->pMemoryBarriers[i].dstAccessMask;
+    }
+
+    for (uint32_t i = 0u; i < depInfo->imageMemoryBarrierCount; i++) {
+      barrier.srcStageMask |= depInfo->pImageMemoryBarriers[i].srcStageMask;
+      barrier.srcAccessMask |= depInfo->pImageMemoryBarriers[i].srcAccessMask;
+      barrier.dstStageMask |= depInfo->pImageMemoryBarriers[i].dstStageMask;
+      barrier.dstAccessMask |= depInfo->pImageMemoryBarriers[i].dstAccessMask;
+    }
+
+    debugMarker(cmdBuffer, str::format("Barrier (", depInfo->memoryBarrierCount, ", ", depInfo->imageMemoryBarrierCount, "): ",
+      "0x", std::hex, barrier.srcStageMask, ":0x", std::hex, barrier.srcAccessMask, " -> ",
+      "0x", std::hex, barrier.dstStageMask, ":0x", std::hex, barrier.dstAccessMask).c_str());
   }
 
 }

--- a/src/dxvk/dxvk_cmdlist.cpp
+++ b/src/dxvk/dxvk_cmdlist.cpp
@@ -223,7 +223,8 @@ namespace dxvk {
   DxvkCommandList::DxvkCommandList(DxvkDevice* device)
   : m_device        (device),
     m_vkd           (device->vkd()),
-    m_vki           (device->vki()) {
+    m_vki           (device->vki()),
+    m_checkpoints   (device->getCheckpointBuffer()) {
     const auto& graphicsQueue = m_device->queues().graphics;
     const auto& transferQueue = m_device->queues().transfer;
 

--- a/src/dxvk/dxvk_cmdlist.h
+++ b/src/dxvk/dxvk_cmdlist.h
@@ -597,6 +597,9 @@ namespace dxvk {
     void cmdBeginRendering(
             DxvkCmdBuffer             cmdBuffer,
       const VkRenderingInfo*          pRenderingInfo) {
+      if (unlikely(m_checkpoints))
+        debugMarker(cmdBuffer, "BeginRendering");
+
       m_cmd.execCommands |= cmdBuffer == DxvkCmdBuffer::ExecBuffer;
 
       m_vkd->vkCmdBeginRendering(getCmdBuffer(cmdBuffer), pRenderingInfo);
@@ -608,6 +611,9 @@ namespace dxvk {
             uint32_t                  bufferCount,
       const VkBuffer*                 counterBuffers,
       const VkDeviceSize*             counterOffsets) {
+      if (unlikely(m_checkpoints))
+        debugMarker(DxvkCmdBuffer::ExecBuffer, "BeginTransformFeedback");
+
       m_vkd->vkCmdBeginTransformFeedbackEXT(getCmdBuffer(),
         firstBuffer, bufferCount, counterBuffers, counterOffsets);
     }
@@ -678,6 +684,9 @@ namespace dxvk {
 
     void cmdBlitImage(
         const VkBlitImageInfo2*     pBlitInfo) {
+      if (unlikely(m_checkpoints))
+        debugMarker(DxvkCmdBuffer::ExecBuffer, "BlitImage");
+
       m_cmd.execCommands = true;
 
       m_vkd->vkCmdBlitImage2(getCmdBuffer(), pBlitInfo);
@@ -690,6 +699,9 @@ namespace dxvk {
       const VkClearAttachment*      pAttachments,
             uint32_t                rectCount,
       const VkClearRect*            pRects) {
+      if (unlikely(m_checkpoints))
+        debugMarker(cmdBuffer, "ClearAttachments");
+
       m_vkd->vkCmdClearAttachments(getCmdBuffer(cmdBuffer),
         attachmentCount, pAttachments, rectCount, pRects);
     }
@@ -702,6 +714,9 @@ namespace dxvk {
       const VkClearColorValue*      pColor,
             uint32_t                rangeCount,
       const VkImageSubresourceRange* pRanges) {
+      if (unlikely(m_checkpoints))
+        debugMarker(cmdBuffer, "ClearColorImage");
+
       m_cmd.execCommands |= cmdBuffer == DxvkCmdBuffer::ExecBuffer;
 
       m_vkd->vkCmdClearColorImage(getCmdBuffer(cmdBuffer),
@@ -717,6 +732,9 @@ namespace dxvk {
       const VkClearDepthStencilValue* pDepthStencil,
             uint32_t                rangeCount,
       const VkImageSubresourceRange* pRanges) {
+      if (unlikely(m_checkpoints))
+        debugMarker(cmdBuffer, "ClearDepthStencilImage");
+
       m_cmd.execCommands |= cmdBuffer == DxvkCmdBuffer::ExecBuffer;
 
       m_vkd->vkCmdClearDepthStencilImage(getCmdBuffer(cmdBuffer),
@@ -728,8 +746,10 @@ namespace dxvk {
     void cmdCopyBuffer(
             DxvkCmdBuffer           cmdBuffer,
       const VkCopyBufferInfo2*      copyInfo) {
-      m_cmd.execCommands |= cmdBuffer == DxvkCmdBuffer::ExecBuffer;
+      if (unlikely(m_checkpoints))
+        debugMarker(cmdBuffer, "CopyBuffer");
 
+      m_cmd.execCommands |= cmdBuffer == DxvkCmdBuffer::ExecBuffer;
       m_vkd->vkCmdCopyBuffer2(getCmdBuffer(cmdBuffer), copyInfo);
     }
     
@@ -737,8 +757,10 @@ namespace dxvk {
     void cmdCopyBufferToImage(
             DxvkCmdBuffer           cmdBuffer,
       const VkCopyBufferToImageInfo2* copyInfo) {
-      m_cmd.execCommands |= cmdBuffer == DxvkCmdBuffer::ExecBuffer;
+      if (unlikely(m_checkpoints))
+        debugMarker(cmdBuffer, "CopyBufferToImage");
 
+      m_cmd.execCommands |= cmdBuffer == DxvkCmdBuffer::ExecBuffer;
       m_vkd->vkCmdCopyBufferToImage2(getCmdBuffer(cmdBuffer), copyInfo);
     }
     
@@ -746,8 +768,10 @@ namespace dxvk {
     void cmdCopyImage(
             DxvkCmdBuffer           cmdBuffer,
       const VkCopyImageInfo2*       copyInfo) {
-      m_cmd.execCommands |= cmdBuffer == DxvkCmdBuffer::ExecBuffer;
+      if (unlikely(m_checkpoints))
+        debugMarker(cmdBuffer, "CopyImage");
 
+      m_cmd.execCommands |= cmdBuffer == DxvkCmdBuffer::ExecBuffer;
       m_vkd->vkCmdCopyImage2(getCmdBuffer(cmdBuffer), copyInfo);
     }
     
@@ -755,8 +779,10 @@ namespace dxvk {
     void cmdCopyImageToBuffer(
             DxvkCmdBuffer           cmdBuffer,
       const VkCopyImageToBufferInfo2* copyInfo) {
-      m_cmd.execCommands |= cmdBuffer == DxvkCmdBuffer::ExecBuffer;
+      if (unlikely(m_checkpoints))
+        debugMarker(cmdBuffer, "CopyImageToBuffer");
 
+      m_cmd.execCommands |= cmdBuffer == DxvkCmdBuffer::ExecBuffer;
       m_vkd->vkCmdCopyImageToBuffer2(getCmdBuffer(cmdBuffer), copyInfo);
     }
 
@@ -783,8 +809,10 @@ namespace dxvk {
             uint32_t                x,
             uint32_t                y,
             uint32_t                z) {
-      m_cmd.execCommands |= cmdBuffer == DxvkCmdBuffer::ExecBuffer;
+     if (unlikely(m_checkpoints))
+        debugDispatch(cmdBuffer, "Dispatch", x, y, z);
 
+      m_cmd.execCommands |= cmdBuffer == DxvkCmdBuffer::ExecBuffer;
       m_vkd->vkCmdDispatch(getCmdBuffer(cmdBuffer), x, y, z);
     }
     
@@ -793,8 +821,10 @@ namespace dxvk {
             DxvkCmdBuffer           cmdBuffer,
             VkBuffer                buffer,
             VkDeviceSize            offset) {
-      m_cmd.execCommands |= cmdBuffer == DxvkCmdBuffer::ExecBuffer;
+     if (unlikely(m_checkpoints))
+        debugMarker(cmdBuffer, "DispatchIndirect");
 
+      m_cmd.execCommands |= cmdBuffer == DxvkCmdBuffer::ExecBuffer;
       m_vkd->vkCmdDispatchIndirect(getCmdBuffer(cmdBuffer), buffer, offset);
     }
     
@@ -804,6 +834,9 @@ namespace dxvk {
             uint32_t                instanceCount,
             uint32_t                firstVertex,
             uint32_t                firstInstance) {
+      if (unlikely(m_checkpoints))
+        debugDraw(DxvkCmdBuffer::ExecBuffer, "Draw", vertexCount, instanceCount);
+
       m_vkd->vkCmdDraw(getCmdBuffer(),
         vertexCount, instanceCount,
         firstVertex, firstInstance);
@@ -815,6 +848,9 @@ namespace dxvk {
       const VkMultiDrawInfoEXT*     drawInfos,
             uint32_t                instanceCount,
             uint32_t                firstInstance) {
+      if (unlikely(m_checkpoints))
+        debugDrawMulti(DxvkCmdBuffer::ExecBuffer, "DrawMulti", drawCount);
+
       m_vkd->vkCmdDrawMultiEXT(getCmdBuffer(),
         drawCount, drawInfos, instanceCount, firstInstance, sizeof(*drawInfos));
     }
@@ -825,6 +861,9 @@ namespace dxvk {
             VkDeviceSize            offset,
             uint32_t                drawCount,
             uint32_t                stride) {
+      if (unlikely(m_checkpoints))
+        debugDrawIndirect(DxvkCmdBuffer::ExecBuffer, "DrawIndirect", drawCount, stride);
+
       m_vkd->vkCmdDrawIndirect(getCmdBuffer(),
         buffer, offset, drawCount, stride);
     }
@@ -837,6 +876,9 @@ namespace dxvk {
             VkDeviceSize            countOffset,
             uint32_t                maxDrawCount,
             uint32_t                stride) {
+      if (unlikely(m_checkpoints))
+        debugDrawIndirect(DxvkCmdBuffer::ExecBuffer, "DrawIndirectCount", maxDrawCount, stride);
+
       m_vkd->vkCmdDrawIndirectCount(getCmdBuffer(), buffer,
         offset, countBuffer, countOffset, maxDrawCount, stride);
     }
@@ -848,6 +890,9 @@ namespace dxvk {
             uint32_t                firstIndex,
             int32_t                 vertexOffset,
             uint32_t                firstInstance) {
+      if (unlikely(m_checkpoints))
+        debugDraw(DxvkCmdBuffer::ExecBuffer, "DrawIndexed", indexCount, instanceCount);
+
       m_vkd->vkCmdDrawIndexed(getCmdBuffer(),
         indexCount, instanceCount,
         firstIndex, vertexOffset,
@@ -860,6 +905,9 @@ namespace dxvk {
       const VkMultiDrawIndexedInfoEXT* drawInfos,
             uint32_t                instanceCount,
             uint32_t                firstInstance) {
+      if (unlikely(m_checkpoints))
+        debugDrawMulti(DxvkCmdBuffer::ExecBuffer, "DrawMultiIndexed", drawCount);
+
       m_vkd->vkCmdDrawMultiIndexedEXT(getCmdBuffer(), drawCount,
         drawInfos, instanceCount, firstInstance, sizeof(*drawInfos), nullptr);
     }
@@ -870,6 +918,9 @@ namespace dxvk {
             VkDeviceSize            offset,
             uint32_t                drawCount,
             uint32_t                stride) {
+      if (unlikely(m_checkpoints))
+        debugDrawIndirect(DxvkCmdBuffer::ExecBuffer, "DrawIndexedIndirect", drawCount, stride);
+
       m_vkd->vkCmdDrawIndexedIndirect(getCmdBuffer(),
         buffer, offset, drawCount, stride);
     }
@@ -882,6 +933,9 @@ namespace dxvk {
             VkDeviceSize            countOffset,
             uint32_t                maxDrawCount,
             uint32_t                stride) {
+      if (unlikely(m_checkpoints))
+        debugDrawIndirect(DxvkCmdBuffer::ExecBuffer, "DrawIndexedIndirectCount", maxDrawCount, stride);
+
       m_vkd->vkCmdDrawIndexedIndirectCount(getCmdBuffer(),
         buffer, offset, countBuffer, countOffset, maxDrawCount, stride);
     }
@@ -894,6 +948,9 @@ namespace dxvk {
             VkDeviceSize            counterBufferOffset,
             uint32_t                counterOffset,
             uint32_t                vertexStride) {
+      if (unlikely(m_checkpoints))
+        debugDrawIndirect(DxvkCmdBuffer::ExecBuffer, "DrawIndirectVertexCount", 1, 0);
+
       m_vkd->vkCmdDrawIndirectByteCountEXT(getCmdBuffer(),
         instanceCount, firstInstance, counterBuffer,
         counterBufferOffset, counterOffset, vertexStride);
@@ -918,6 +975,9 @@ namespace dxvk {
     
     void cmdEndRendering(
             DxvkCmdBuffer             cmdBuffer) {
+      if (unlikely(m_checkpoints))
+        debugMarker(cmdBuffer, "EndRendering");
+
       m_vkd->vkCmdEndRendering(getCmdBuffer(cmdBuffer));
     }
 
@@ -927,6 +987,9 @@ namespace dxvk {
             uint32_t                  bufferCount,
       const VkBuffer*                 counterBuffers,
       const VkDeviceSize*             counterOffsets) {
+      if (unlikely(m_checkpoints))
+        debugMarker(DxvkCmdBuffer::ExecBuffer, "EndTransformFeedback");
+
       m_vkd->vkCmdEndTransformFeedbackEXT(getCmdBuffer(),
         firstBuffer, bufferCount, counterBuffers, counterOffsets);
     }
@@ -938,6 +1001,9 @@ namespace dxvk {
             VkDeviceSize            dstOffset,
             VkDeviceSize            size,
             uint32_t                data) {
+      if (unlikely(m_checkpoints))
+        debugMarker(cmdBuffer, "FillBuffer");
+
       m_cmd.execCommands |= cmdBuffer == DxvkCmdBuffer::ExecBuffer;
 
       m_vkd->vkCmdFillBuffer(getCmdBuffer(cmdBuffer),
@@ -948,6 +1014,9 @@ namespace dxvk {
     void cmdPipelineBarrier(
             DxvkCmdBuffer           cmdBuffer,
       const VkDependencyInfo*       dependencyInfo) {
+      if (unlikely(m_checkpoints))
+        debugBarrier(cmdBuffer, dependencyInfo);
+
       m_cmd.execCommands |= cmdBuffer == DxvkCmdBuffer::ExecBuffer;
       m_statCounters.addCtr(DxvkStatCounter::CmdBarrierCount, 1);
 
@@ -983,6 +1052,9 @@ namespace dxvk {
 
     void cmdResolveImage(
       const VkResolveImageInfo2*    resolveInfo) {
+      if (unlikely(m_checkpoints))
+        debugMarker(DxvkCmdBuffer::ExecBuffer, "ResolveImage");
+
       m_cmd.execCommands = true;
 
       m_vkd->vkCmdResolveImage2(getCmdBuffer(), resolveInfo);
@@ -995,6 +1067,9 @@ namespace dxvk {
             VkDeviceSize            dstOffset,
             VkDeviceSize            dataSize,
       const void*                   pData) {
+      if (unlikely(m_checkpoints))
+        debugMarker(cmdBuffer, "UpdateBuffer");
+
       m_cmd.execCommands |= cmdBuffer == DxvkCmdBuffer::ExecBuffer;
 
       m_vkd->vkCmdUpdateBuffer(getCmdBuffer(cmdBuffer),
@@ -1184,16 +1259,17 @@ namespace dxvk {
     void cmdBeginDebugUtilsLabel(
             DxvkCmdBuffer           cmdBuffer,
       const VkDebugUtilsLabelEXT&   labelInfo) {
-      m_cmd.execCommands = true;
+      if (unlikely(m_checkpoints))
+        debugMarker(cmdBuffer, labelInfo.pLabelName);
 
+      m_cmd.execCommands |= cmdBuffer == DxvkCmdBuffer::ExecBuffer;
       m_vki->vkCmdBeginDebugUtilsLabelEXT(getCmdBuffer(cmdBuffer), &labelInfo);
     }
 
 
     void cmdEndDebugUtilsLabel(
             DxvkCmdBuffer           cmdBuffer) {
-      m_cmd.execCommands = true;
-
+      m_cmd.execCommands |= cmdBuffer == DxvkCmdBuffer::ExecBuffer;
       m_vki->vkCmdEndDebugUtilsLabelEXT(getCmdBuffer(cmdBuffer));
     }
 
@@ -1201,8 +1277,10 @@ namespace dxvk {
     void cmdInsertDebugUtilsLabel(
             DxvkCmdBuffer           cmdBuffer,
       const VkDebugUtilsLabelEXT&   labelInfo) {
-      m_cmd.execCommands = true;
+      if (unlikely(m_checkpoints))
+        debugMarker(cmdBuffer, labelInfo.pLabelName);
 
+      m_cmd.execCommands |= cmdBuffer == DxvkCmdBuffer::ExecBuffer;
       m_vki->vkCmdInsertDebugUtilsLabelEXT(getCmdBuffer(cmdBuffer), &labelInfo);
     }
 
@@ -1316,6 +1394,8 @@ namespace dxvk {
 
     bool m_descriptorHeapInvalidated = false;
 
+    std::array<int32_t, uint32_t(DxvkCmdBuffer::Count)> m_checkpointIds = {};
+
     force_inline VkCommandBuffer getCmdBuffer() const {
       // Allocation logic will always provide an execution buffer
       return m_cmd.cmdBuffers[uint32_t(DxvkCmdBuffer::ExecBuffer)];
@@ -1386,6 +1466,40 @@ namespace dxvk {
     void countDescriptorStats(
       const Rc<DxvkResourceDescriptorRange>& range,
             VkDeviceSize                  baseOffset);
+
+    void resetCheckpoints();
+
+    void debugMarker(
+            DxvkCmdBuffer                 cmdBuffer,
+      const char*                         text);
+
+    void debugDispatch(
+            DxvkCmdBuffer                 cmdBuffer,
+      const char*                         text,
+            uint32_t                      x,
+            uint32_t                      y,
+            uint32_t                      z);
+
+    void debugDraw(
+            DxvkCmdBuffer                 cmdBuffer,
+      const char*                         text,
+            uint32_t                      count,
+            uint32_t                      instances);
+
+    void debugDrawMulti(
+            DxvkCmdBuffer                 cmdBuffer,
+      const char*                         text,
+            uint32_t                      count);
+
+    void debugDrawIndirect(
+            DxvkCmdBuffer                 cmdBuffer,
+      const char*                         text,
+            uint32_t                      count,
+            uint32_t                      stride);
+
+    void debugBarrier(
+            DxvkCmdBuffer                 cmdBuffer,
+      const VkDependencyInfo*             depInfo);
 
     static VkBindHeapInfoEXT getHeapBindInfo(const DxvkDescriptorHeapBindingInfo& heapInfo) {
       VkBindHeapInfoEXT bindInfo = { VK_STRUCTURE_TYPE_BIND_HEAP_INFO_EXT };

--- a/src/dxvk/dxvk_cmdlist.h
+++ b/src/dxvk/dxvk_cmdlist.h
@@ -21,6 +21,8 @@
 
 namespace dxvk {
 
+  class DxvkCheckpointBuffer;
+
   /**
    * \brief Immediate descriptor write
    *
@@ -1277,6 +1279,8 @@ namespace dxvk {
     DxvkDevice*               m_device;
     Rc<vk::DeviceFn>          m_vkd;
     Rc<vk::InstanceFn>        m_vki;
+
+    DxvkCheckpointBuffer*     m_checkpoints = nullptr;
     
     Rc<DxvkCommandPool>       m_graphicsPool;
     Rc<DxvkCommandPool>       m_transferPool;

--- a/src/dxvk/dxvk_device.cpp
+++ b/src/dxvk/dxvk_device.cpp
@@ -24,6 +24,7 @@ namespace dxvk {
     m_properties        (caps.getProperties()),
     m_perfHints         (getPerfHints()),
     m_objects           (this),
+    m_checkpoints       (this),
     m_submissionQueue   (this, queueCallback) {
 
     if (adapter->kmtLocal()) {

--- a/src/dxvk/dxvk_device.h
+++ b/src/dxvk/dxvk_device.h
@@ -7,6 +7,7 @@
 #include "dxvk_context.h"
 #include "dxvk_fence.h"
 #include "dxvk_framebuffer.h"
+#include "dxvk_hang.h"
 #include "dxvk_image.h"
 #include "dxvk_instance.h"
 #include "dxvk_latency.h"
@@ -133,6 +134,14 @@ namespace dxvk {
      */
     DxvkDebugFlags debugFlags() const {
       return m_debugFlags;
+    }
+
+    /**
+     * \brief Retrieves checkpoint buffer for debug purposes
+     * \returns Checkpoint buffer, or \c nullptr.
+     */
+    DxvkCheckpointBuffer* getCheckpointBuffer() {
+      return m_debugFlags.test(DxvkDebugFlag::Hang) ? &m_checkpoints : nullptr;
     }
 
     /**
@@ -754,6 +763,7 @@ namespace dxvk {
 
     DxvkDevicePerfHints         m_perfHints;
     DxvkObjects                 m_objects;
+    DxvkCheckpointBuffer        m_checkpoints;
 
     sync::Spinlock              m_statLock;
     DxvkStatCounters            m_statCounters;

--- a/src/dxvk/dxvk_device_info.cpp
+++ b/src/dxvk/dxvk_device_info.cpp
@@ -68,6 +68,7 @@ namespace dxvk {
     HANDLE_EXT(khrSwapchainMutableFormat);         \
     HANDLE_EXT(khrUnifiedImageLayouts);            \
     HANDLE_EXT(khrWin32KeyedMutex);                \
+    HANDLE_EXT(amdBufferMarker);                   \
     HANDLE_EXT(nvDeviceDiagnosticCheckpoints);     \
     HANDLE_EXT(nvLowLatency2);                     \
     HANDLE_EXT(nvRawAccessChains);                 \
@@ -612,8 +613,10 @@ namespace dxvk {
       m_featuresSupported.nvLowLatency2 = VK_FALSE;
 
     // Disable debug extensions if hang debugging is disabled
-    if (!instance.debugFlags().test(DxvkDebugFlag::Hang))
+    if (!instance.debugFlags().test(DxvkDebugFlag::Hang)) {
+      m_featuresSupported.amdBufferMarker = VK_FALSE;
       m_featuresSupported.nvDeviceDiagnosticCheckpoints = VK_FALSE;
+    }
   }
 
 
@@ -1053,6 +1056,9 @@ namespace dxvk {
 
       /* Keyed mutex support in wine */
       ENABLE_EXT(khrWin32KeyedMutex, false),
+
+      /* Hang debugging on AMD */
+      ENABLE_EXT(amdBufferMarker, false),
 
       /* Hang debugging on Nvidia */
       ENABLE_EXT(nvDeviceDiagnosticCheckpoints, false),

--- a/src/dxvk/dxvk_device_info.cpp
+++ b/src/dxvk/dxvk_device_info.cpp
@@ -44,6 +44,7 @@ namespace dxvk {
     HANDLE_EXT(extSwapchainMaintenance1);          \
     HANDLE_EXT(extTransformFeedback);              \
     HANDLE_EXT(extVertexAttributeDivisor);         \
+    HANDLE_EXT(khrDeviceFault);                    \
     HANDLE_EXT(khrDynamicRenderingLocalRead);      \
     HANDLE_EXT(khrExternalMemoryWin32);            \
     HANDLE_EXT(khrExternalSemaphoreWin32);         \
@@ -88,6 +89,7 @@ namespace dxvk {
     HANDLE_EXT(extSampleLocations);                \
     HANDLE_EXT(extTransformFeedback);              \
     HANDLE_EXT(extVertexAttributeDivisor);         \
+    HANDLE_EXT(khrDeviceFault);                    \
     HANDLE_EXT(khrMaintenance5);                   \
     HANDLE_EXT(khrMaintenance6);                   \
     HANDLE_EXT(khrMaintenance7);                   \
@@ -614,6 +616,9 @@ namespace dxvk {
 
     // Disable debug extensions if hang debugging is disabled
     if (!instance.debugFlags().test(DxvkDebugFlag::Hang)) {
+      m_featuresSupported.khrDeviceFault.deviceFault = VK_FALSE;
+      m_featuresSupported.khrDeviceFault.deviceFaultVendorBinary = VK_FALSE;
+
       m_featuresSupported.amdBufferMarker = VK_FALSE;
       m_featuresSupported.nvDeviceDiagnosticCheckpoints = VK_FALSE;
     }
@@ -1002,6 +1007,10 @@ namespace dxvk {
       /* Vertex attribute divisor, used by client APIs */
       ENABLE_EXT_FEATURE(extVertexAttributeDivisor, vertexAttributeInstanceRateDivisor, false),
       ENABLE_EXT_FEATURE(extVertexAttributeDivisor, vertexAttributeInstanceRateZeroDivisor, false),
+
+      /* Hang debugging */
+      ENABLE_EXT_FEATURE(khrDeviceFault, deviceFault, false),
+      ENABLE_EXT_FEATURE(khrDeviceFault, deviceFaultVendorBinary, false),
 
       /* Tiler stuff */
       ENABLE_EXT_FEATURE(khrDynamicRenderingLocalRead, dynamicRenderingLocalRead, false),

--- a/src/dxvk/dxvk_device_info.cpp
+++ b/src/dxvk/dxvk_device_info.cpp
@@ -68,6 +68,7 @@ namespace dxvk {
     HANDLE_EXT(khrSwapchainMutableFormat);         \
     HANDLE_EXT(khrUnifiedImageLayouts);            \
     HANDLE_EXT(khrWin32KeyedMutex);                \
+    HANDLE_EXT(nvDeviceDiagnosticCheckpoints);     \
     HANDLE_EXT(nvLowLatency2);                     \
     HANDLE_EXT(nvRawAccessChains);                 \
     HANDLE_EXT(nvxBinaryImport);                   \
@@ -609,6 +610,10 @@ namespace dxvk {
     if (!m_featuresSupported.khrPresentId.presentId
      && !m_featuresSupported.khrPresentId2.presentId2)
       m_featuresSupported.nvLowLatency2 = VK_FALSE;
+
+    // Disable debug extensions if hang debugging is disabled
+    if (!instance.debugFlags().test(DxvkDebugFlag::Hang))
+      m_featuresSupported.nvDeviceDiagnosticCheckpoints = VK_FALSE;
   }
 
 
@@ -1048,6 +1053,9 @@ namespace dxvk {
 
       /* Keyed mutex support in wine */
       ENABLE_EXT(khrWin32KeyedMutex, false),
+
+      /* Hang debugging on Nvidia */
+      ENABLE_EXT(nvDeviceDiagnosticCheckpoints, false),
 
       /* Reflex support */
       ENABLE_EXT(nvLowLatency2, false),

--- a/src/dxvk/dxvk_device_info.h
+++ b/src/dxvk/dxvk_device_info.h
@@ -38,6 +38,7 @@ namespace dxvk {
     VkPhysicalDeviceSampleLocationsPropertiesEXT              extSampleLocations              = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SAMPLE_LOCATIONS_PROPERTIES_EXT };
     VkPhysicalDeviceTransformFeedbackPropertiesEXT            extTransformFeedback            = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TRANSFORM_FEEDBACK_PROPERTIES_EXT };
     VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT       extVertexAttributeDivisor       = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_ATTRIBUTE_DIVISOR_PROPERTIES_EXT };
+    VkPhysicalDeviceFaultPropertiesKHR                        khrDeviceFault                  = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FAULT_PROPERTIES_KHR };
     VkPhysicalDeviceMaintenance5PropertiesKHR                 khrMaintenance5                 = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_5_PROPERTIES_KHR };
     VkPhysicalDeviceMaintenance6PropertiesKHR                 khrMaintenance6                 = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_6_PROPERTIES_KHR };
     VkPhysicalDeviceMaintenance7PropertiesKHR                 khrMaintenance7                 = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_7_PROPERTIES_KHR };
@@ -86,6 +87,7 @@ namespace dxvk {
     VkPhysicalDeviceSwapchainMaintenance1FeaturesEXT          extSwapchainMaintenance1        = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SWAPCHAIN_MAINTENANCE_1_FEATURES_EXT };
     VkPhysicalDeviceTransformFeedbackFeaturesEXT              extTransformFeedback            = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TRANSFORM_FEEDBACK_FEATURES_EXT };
     VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT         extVertexAttributeDivisor       = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_ATTRIBUTE_DIVISOR_FEATURES };
+    VkPhysicalDeviceFaultFeaturesKHR                          khrDeviceFault                  = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FAULT_FEATURES_KHR };
     VkPhysicalDeviceDynamicRenderingLocalReadFeatures         khrDynamicRenderingLocalRead    = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DYNAMIC_RENDERING_LOCAL_READ_FEATURES_KHR };
     VkBool32                                                  khrExternalMemoryWin32          = VK_FALSE;
     VkBool32                                                  khrExternalSemaphoreWin32       = VK_FALSE;
@@ -160,6 +162,7 @@ namespace dxvk {
     VkExtensionProperties extSwapchainMaintenance1          = vk::makeExtension(VK_EXT_SWAPCHAIN_MAINTENANCE_1_EXTENSION_NAME);
     VkExtensionProperties extTransformFeedback              = vk::makeExtension(VK_EXT_TRANSFORM_FEEDBACK_EXTENSION_NAME);
     VkExtensionProperties extVertexAttributeDivisor         = vk::makeExtension(VK_EXT_VERTEX_ATTRIBUTE_DIVISOR_EXTENSION_NAME);
+    VkExtensionProperties khrDeviceFault                    = vk::makeExtension(VK_KHR_DEVICE_FAULT_EXTENSION_NAME);
     VkExtensionProperties khrDynamicRenderingLocalRead      = vk::makeExtension(VK_KHR_DYNAMIC_RENDERING_LOCAL_READ_EXTENSION_NAME);
     VkExtensionProperties khrExternalMemoryWin32            = vk::makeExtension(VK_KHR_EXTERNAL_MEMORY_WIN32_EXTENSION_NAME);
     VkExtensionProperties khrExternalSemaphoreWin32         = vk::makeExtension(VK_KHR_EXTERNAL_SEMAPHORE_WIN32_EXTENSION_NAME);

--- a/src/dxvk/dxvk_device_info.h
+++ b/src/dxvk/dxvk_device_info.h
@@ -110,6 +110,7 @@ namespace dxvk {
     VkPhysicalDeviceUnifiedImageLayoutsFeaturesKHR            khrUnifiedImageLayouts          = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_UNIFIED_IMAGE_LAYOUTS_FEATURES_KHR };
     VkBool32                                                  khrSwapchainMutableFormat       = VK_FALSE;
     VkBool32                                                  khrWin32KeyedMutex              = VK_FALSE;
+    VkBool32                                                  nvDeviceDiagnosticCheckpoints   = VK_FALSE;
     VkBool32                                                  nvLowLatency2                   = VK_FALSE;
     VkPhysicalDeviceRawAccessChainsFeaturesNV                 nvRawAccessChains               = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAW_ACCESS_CHAINS_FEATURES_NV };
     VkBool32                                                  nvxBinaryImport                 = VK_FALSE;
@@ -182,6 +183,7 @@ namespace dxvk {
     VkExtensionProperties khrSwapchainMutableFormat         = vk::makeExtension(VK_KHR_SWAPCHAIN_MUTABLE_FORMAT_EXTENSION_NAME);
     VkExtensionProperties khrUnifiedImageLayouts            = vk::makeExtension(VK_KHR_UNIFIED_IMAGE_LAYOUTS_EXTENSION_NAME);
     VkExtensionProperties khrWin32KeyedMutex                = vk::makeExtension(VK_KHR_WIN32_KEYED_MUTEX_EXTENSION_NAME);
+    VkExtensionProperties nvDeviceDiagnosticCheckpoints     = vk::makeExtension(VK_NV_DEVICE_DIAGNOSTIC_CHECKPOINTS_EXTENSION_NAME);
     VkExtensionProperties nvLowLatency2                     = vk::makeExtension(VK_NV_LOW_LATENCY_2_EXTENSION_NAME);
     VkExtensionProperties nvRawAccessChains                 = vk::makeExtension(VK_NV_RAW_ACCESS_CHAINS_EXTENSION_NAME);
     VkExtensionProperties nvxBinaryImport                   = vk::makeExtension(VK_NVX_BINARY_IMPORT_EXTENSION_NAME);

--- a/src/dxvk/dxvk_device_info.h
+++ b/src/dxvk/dxvk_device_info.h
@@ -110,6 +110,7 @@ namespace dxvk {
     VkPhysicalDeviceUnifiedImageLayoutsFeaturesKHR            khrUnifiedImageLayouts          = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_UNIFIED_IMAGE_LAYOUTS_FEATURES_KHR };
     VkBool32                                                  khrSwapchainMutableFormat       = VK_FALSE;
     VkBool32                                                  khrWin32KeyedMutex              = VK_FALSE;
+    VkBool32                                                  amdBufferMarker                 = VK_FALSE;
     VkBool32                                                  nvDeviceDiagnosticCheckpoints   = VK_FALSE;
     VkBool32                                                  nvLowLatency2                   = VK_FALSE;
     VkPhysicalDeviceRawAccessChainsFeaturesNV                 nvRawAccessChains               = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAW_ACCESS_CHAINS_FEATURES_NV };
@@ -183,6 +184,7 @@ namespace dxvk {
     VkExtensionProperties khrSwapchainMutableFormat         = vk::makeExtension(VK_KHR_SWAPCHAIN_MUTABLE_FORMAT_EXTENSION_NAME);
     VkExtensionProperties khrUnifiedImageLayouts            = vk::makeExtension(VK_KHR_UNIFIED_IMAGE_LAYOUTS_EXTENSION_NAME);
     VkExtensionProperties khrWin32KeyedMutex                = vk::makeExtension(VK_KHR_WIN32_KEYED_MUTEX_EXTENSION_NAME);
+    VkExtensionProperties amdBufferMarker                   = vk::makeExtension(VK_AMD_BUFFER_MARKER_EXTENSION_NAME);
     VkExtensionProperties nvDeviceDiagnosticCheckpoints     = vk::makeExtension(VK_NV_DEVICE_DIAGNOSTIC_CHECKPOINTS_EXTENSION_NAME);
     VkExtensionProperties nvLowLatency2                     = vk::makeExtension(VK_NV_LOW_LATENCY_2_EXTENSION_NAME);
     VkExtensionProperties nvRawAccessChains                 = vk::makeExtension(VK_NV_RAW_ACCESS_CHAINS_EXTENSION_NAME);

--- a/src/dxvk/dxvk_hang.cpp
+++ b/src/dxvk/dxvk_hang.cpp
@@ -1,7 +1,10 @@
+#include <optional>
 #include <iomanip>
 
 #include "dxvk_hang.h"
 #include "dxvk_device.h"
+
+#include "../util/util_file.h"
 
 namespace dxvk {
 
@@ -104,6 +107,9 @@ namespace dxvk {
 
     Logger::err("DXVK: Hang detected:");
 
+    if (m_device->features().khrDeviceFault.deviceFault)
+      logDeviceFaults();
+
     if (m_device->features().nvDeviceDiagnosticCheckpoints) {
       auto vk = m_device->vkd();
 
@@ -139,6 +145,9 @@ namespace dxvk {
     } else {
       Logger::err("Cannot determine hang location.");
     }
+
+    if (m_device->features().khrDeviceFault.deviceFaultVendorBinary)
+      dumpDeviceFaultInfo();
   }
 
 
@@ -262,6 +271,101 @@ namespace dxvk {
   }
 
 
+  void DxvkCheckpointBuffer::logDeviceFaults() {
+    auto vk = m_device->vkd();
+
+    uint32_t faultCount = 0u;
+    VkResult vr = vk->vkGetDeviceFaultReportsKHR(vk->device(), 0u, &faultCount, nullptr);
+
+    if (vr < 0) {
+      Logger::err(str::format("Failed to get device faults: ", vr));
+      return;
+    }
+
+    if (!faultCount)
+      return;
+
+    std::vector<VkDeviceFaultInfoKHR> faults(faultCount,
+      VkDeviceFaultInfoKHR { VK_STRUCTURE_TYPE_DEVICE_FAULT_INFO_KHR });
+    vr = vk->vkGetDeviceFaultReportsKHR(vk->device(), 0u, &faultCount, faults.data());
+
+    if (vr < 0) {
+      Logger::err(str::format("Failed to get device faults: ", vr));
+      return;
+    }
+
+    std::optional<uint64_t> groupId;
+
+    for (const auto& fault : faults) {
+      if (fault.groupId != groupId) {
+        groupId = std::make_optional(fault.groupId);
+
+        Logger::err(str::format("Device fault ", fault.groupId, ":"));
+      }
+
+      Logger::err(str::format(fault.description));
+
+      if (fault.flags & VK_DEVICE_FAULT_FLAG_MEMORY_ADDRESS_KHR)
+        Logger::err(str::format("- Memory address: ", faultAddressToString(fault.faultAddressInfo)));
+
+      if (fault.flags & VK_DEVICE_FAULT_FLAG_INSTRUCTION_ADDRESS_KHR)
+        Logger::err(str::format("- Instruction address: ", faultAddressToString(fault.instructionAddressInfo)));
+
+      if (fault.flags & VK_DEVICE_FAULT_FLAG_VENDOR_KHR) {
+        Logger::err(str::format("- Error code: 0x",
+          std::hex, fault.vendorInfo.vendorFaultCode,
+          " (0x", std::hex, fault.vendorInfo.vendorFaultData, ")"));
+        Logger::err(str::format("- Error info: ", fault.vendorInfo.description));
+      }
+    }
+  }
+
+
+  void DxvkCheckpointBuffer::dumpDeviceFaultInfo() {
+    auto vk = m_device->vkd();
+
+    VkDeviceFaultDebugInfoKHR debugInfo = { VK_STRUCTURE_TYPE_DEVICE_FAULT_DEBUG_INFO_KHR };
+    VkResult vr = vk->vkGetDeviceFaultDebugInfoKHR(vk->device(), &debugInfo);
+
+    if (vr != VK_SUCCESS) {
+      Logger::err(str::format("Failed to get device fault debug info: ", vr));
+      return;
+    }
+
+    if (!debugInfo.vendorBinarySize) {
+      Logger::err("No vendor binary present.");
+      return;
+    }
+
+    std::vector<char> debugData(debugInfo.vendorBinarySize);
+    debugInfo.pVendorBinaryData = debugData.data();
+    vr = vk->vkGetDeviceFaultDebugInfoKHR(vk->device(), &debugInfo);
+
+    if (vr != VK_SUCCESS) {
+      Logger::err(str::format("Failed to get device fault debug info: ", vr));
+      return;
+    }
+
+    std::string path = env::getEnvVar("DXVK_LOG_PATH");
+
+    if (!path.empty() && *path.rbegin() != '/')
+      path += '/';
+
+    path += env::getExeBaseName();
+    path += "_device_fault.bin";
+
+    util::File file(path, util::FileFlag::Truncate);
+
+    if (!file) {
+      Logger::err(str::format("Failed to open ", path));
+      return;
+    }
+
+    file.append(debugData.size(), debugData.data());
+    Logger::err(str::format("Dumped device fault debug info to ", path));
+  }
+
+
   std::pair<int32_t, int32_t> DxvkCheckpointBuffer::getCommandList(int32_t command) const {
     if (command == -1)
       return std::make_pair(-1, -1);
@@ -276,6 +380,22 @@ namespace dxvk {
       tail = m_checkpoints.at(tail).next;
 
     return std::make_pair(head, tail);
+  }
+
+
+  std::string DxvkCheckpointBuffer::faultAddressToString(const VkDeviceFaultAddressInfoKHR& address) {
+    VkDeviceAddress mask = VkDeviceAddress(1u) << address.addressPrecision;
+
+    VkDeviceAddress lo = address.reportedAddress & -mask;
+    VkDeviceAddress hi = address.reportedAddress | (mask - 1u);
+
+    std::string result = str::format("0x", std::hex, lo);
+
+    if (lo != hi)
+      result += str::format(" - 0x", std::hex, hi);
+
+    result += str::format(" (type ", std::dec, address.addressType, ")");
+    return result;
   }
 
 }

--- a/src/dxvk/dxvk_hang.cpp
+++ b/src/dxvk/dxvk_hang.cpp
@@ -1,0 +1,278 @@
+#include <iomanip>
+
+#include "dxvk_hang.h"
+#include "dxvk_device.h"
+
+namespace dxvk {
+
+  DxvkCheckpointBuffer::DxvkCheckpointBuffer(DxvkDevice* device)
+  : m_device(device) {
+    if (m_device->debugFlags().test(DxvkDebugFlag::Hang))
+      m_checkpoints.resize(NumCheckpoints);
+  }
+
+
+  DxvkCheckpointBuffer::~DxvkCheckpointBuffer() {
+
+  }
+
+
+  int32_t DxvkCheckpointBuffer::addCheckpoint(
+    const DxvkDeviceQueue&      queue,
+          VkCommandBuffer       cmd,
+          int32_t               prev,
+    const char*                 text) {
+    std::lock_guard lock(m_mutex);
+
+    int32_t index = getNextCheckpoint();
+
+    // Assume that entry is default-initialized
+    auto& entry = m_checkpoints.at(index);
+
+    if (prev >= 0) {
+      m_checkpoints.at(prev).next = index;
+      entry.prev = prev;
+    }
+
+    size_t len = std::min(std::strlen(text), entry.info.size() - 1u);
+    std::memcpy(entry.info.data(), text, len);
+
+    auto vk = m_device->vkd();
+
+    if (m_device->features().nvDeviceDiagnosticCheckpoints) {
+      // Need to record the 'end' marker for the previous command.
+      uintptr_t marker = uintptr_t(prev);
+      vk->vkCmdSetCheckpointNV(cmd, reinterpret_cast<void*>(marker));
+    } else if (m_device->features().amdBufferMarker) {
+      // Record both the 'end' marker for the previous command as
+      // well as the 'start' marker for the new one on the AMD path.
+      auto prevMarkers = getMarkerBuffer(queue, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT);
+      auto nextMarkers = getMarkerBuffer(queue, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT);
+
+      if (prev >= 0) {
+        vk->vkCmdWriteBufferMarkerAMD(cmd,
+          VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
+          prevMarkers.buffer, prevMarkers.offset,
+          uint32_t(prev));
+      }
+
+      vk->vkCmdWriteBufferMarkerAMD(cmd,
+        VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
+        nextMarkers.buffer, nextMarkers.offset,
+        uint32_t(index));
+    }
+
+    return index;
+  }
+
+
+  void DxvkCheckpointBuffer::endCommandBuffer(
+    const DxvkDeviceQueue&      queue,
+          VkCommandBuffer       cmd,
+          int32_t               prev) {
+    std::lock_guard lock(m_mutex);
+
+    auto vk = m_device->vkd();
+
+    if (m_device->features().nvDeviceDiagnosticCheckpoints) {
+      // Need to add unique queues, even if we don't have a
+      // reason to use the result here.
+      getQueueIndex(queue);
+
+      uintptr_t marker = uintptr_t(prev);
+      vk->vkCmdSetCheckpointNV(cmd, reinterpret_cast<void*>(marker));
+    } else if (m_device->features().amdBufferMarker) {
+      // Record last end marker into command buffer
+      auto prevMarkers = getMarkerBuffer(queue, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT);
+
+      vk->vkCmdWriteBufferMarkerAMD(cmd,
+        VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
+        prevMarkers.buffer, prevMarkers.offset,
+        uint32_t(prev));
+    }
+  }
+
+
+  void DxvkCheckpointBuffer::printHangInfo() {
+    std::lock_guard lock(m_mutex);
+
+    if (std::exchange(m_hung, true))
+      return;
+
+    Logger::err("DXVK: Hang detected:");
+
+    if (m_device->features().nvDeviceDiagnosticCheckpoints) {
+      auto vk = m_device->vkd();
+
+      for (const auto& q : m_markerQueues) {
+        uint32_t checkpointCount = 0u;
+        vk->vkGetQueueCheckpointDataNV(q.queueHandle, &checkpointCount, nullptr);
+
+        std::vector<VkCheckpointDataNV> checkpointData(checkpointCount,
+          VkCheckpointDataNV { VK_STRUCTURE_TYPE_CHECKPOINT_DATA_NV });
+        vk->vkGetQueueCheckpointDataNV(q.queueHandle, &checkpointCount, checkpointData.data());
+
+        int32_t hangTop = -1;
+        int32_t hangBottom = -1;
+
+        for (const auto& cp : checkpointData) {
+          if (cp.stage == VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT)
+            hangTop = int32_t(reinterpret_cast<uintptr_t>(cp.pCheckpointMarker));
+          if (cp.stage == VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT)
+            hangBottom = int32_t(reinterpret_cast<uintptr_t>(cp.pCheckpointMarker));
+        }
+
+        if (hangTop != hangBottom)
+          logHangCommands(q, hangTop, hangBottom);
+      }
+    } else if (m_device->features().amdBufferMarker) {
+      for (const auto& q : m_markerQueues) {
+        auto* hangTop = reinterpret_cast<int32_t*>(getMarkerBuffer(q, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT).mapPtr);
+        auto* hangBottom = reinterpret_cast<int32_t*>(getMarkerBuffer(q, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT).mapPtr);
+
+        if (*hangTop != *hangBottom)
+          logHangCommands(q, *hangTop, *hangBottom);
+      }
+    } else {
+      Logger::err("Cannot determine hang location.");
+    }
+  }
+
+
+  int32_t DxvkCheckpointBuffer::getNextCheckpoint() {
+    uint32_t index = m_next;
+
+    // Wrap checkpoint indices around. This is a linked list,
+    // a higher index does not necessarily imply later execution.
+    if (++m_next == int32_t(NumCheckpoints))
+      m_next = 0u;
+
+    // Remove any existing links to other commands
+    auto& entry = m_checkpoints.at(index);
+
+    if (entry.prev >= 0)
+      m_checkpoints.at(entry.prev).next = -1;
+    if (entry.next >= 0)
+      m_checkpoints.at(entry.next).prev = -1;
+
+    entry = DxvkCheckpoint();
+    return index;
+  }
+
+
+  size_t DxvkCheckpointBuffer::getQueueIndex(
+    const DxvkDeviceQueue&        queue) {
+    size_t index = m_markerQueues.size();
+
+    for (size_t i = 0u; i < m_markerQueues.size(); i++) {
+      if (m_markerQueues[i].queueHandle == queue.queueHandle)
+        index = i;
+    }
+
+    if (index == m_markerQueues.size())
+      m_markerQueues.push_back(queue);
+
+    return index;
+  }
+
+
+  DxvkResourceBufferInfo DxvkCheckpointBuffer::getMarkerBuffer(
+    const DxvkDeviceQueue&        queue,
+          VkPipelineStageFlagBits stage) {
+    if (!m_markerBuffer) {
+      if (!(m_markerBuffer = createMarkerBuffer()))
+        return DxvkResourceBufferInfo();
+    }
+
+    VkDeviceSize offset = sizeof(Marker) * getQueueIndex(queue) +
+      (stage == VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT
+        ? offsetof(Marker, bottom)
+        : offsetof(Marker, top));
+
+    return m_markerBuffer->getSliceInfo(offset, sizeof(uint32_t));
+  }
+
+
+  Rc<DxvkBuffer> DxvkCheckpointBuffer::createMarkerBuffer() {
+    DxvkBufferCreateInfo info = {};
+    info.debugName = "Hang markers";
+    info.size = 256u;
+    info.usage = VK_BUFFER_USAGE_TRANSFER_DST_BIT;
+    info.stages = VK_PIPELINE_STAGE_TRANSFER_BIT;
+    info.access = VK_ACCESS_TRANSFER_WRITE_BIT;
+
+    Rc<DxvkBuffer> buffer = m_device->createBuffer(info,
+      VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT |
+      VK_MEMORY_PROPERTY_HOST_COHERENT_BIT |
+      VK_MEMORY_PROPERTY_HOST_CACHED_BIT |
+      VK_MEMORY_PROPERTY_DEVICE_COHERENT_BIT_AMD |
+      VK_MEMORY_PROPERTY_DEVICE_UNCACHED_BIT_AMD);
+
+    std::memset(buffer->mapPtr(0), -1, info.size);
+    return buffer;
+  }
+
+
+  void DxvkCheckpointBuffer::logHangCommands(
+    const DxvkDeviceQueue&        queue,
+          int32_t                 lastBegun,
+          int32_t                 lastComplete) {
+    Logger::err(str::format("Queue family ", queue.queueFamily, ", index ", queue.queueIndex));
+
+    auto listComplete = getCommandList(lastComplete);
+    auto listBegun = getCommandList(lastBegun);
+
+    Logger::err(str::format("Last command completed: ", lastComplete));
+    Logger::err(str::format("Last command started:   ", lastBegun));
+
+    if (listComplete.first == listBegun.first) {
+      logHangCommandSequence(listComplete, lastBegun, lastComplete);
+    } else {
+      logHangCommandSequence(listComplete, -1, lastComplete);
+      Logger::err("...");
+      logHangCommandSequence(listBegun, lastBegun, -1);
+    }
+  }
+
+
+  void DxvkCheckpointBuffer::logHangCommandSequence(
+    const std::pair<int32_t, int32_t>& list,
+          int32_t                 lastBegun,
+          int32_t                 lastComplete) {
+    int32_t index = list.first;
+
+    while (index >= 0) {
+      const auto& entry = m_checkpoints.at(index);
+      Logger::err(str::format(std::setw(6), index, ": ", entry.info.data()));
+
+      if (index == lastComplete)
+        Logger::err("!!! Potential hang region BEGIN !!!");
+
+      if (index == lastBegun)
+        Logger::err("!!! Potential hang region END !!!");
+
+      if (index == list.second)
+        break;
+
+      index = entry.next;
+    }
+  }
+
+
+  std::pair<int32_t, int32_t> DxvkCheckpointBuffer::getCommandList(int32_t command) const {
+    if (command == -1)
+      return std::make_pair(-1, -1);
+
+    int32_t head = command;
+    int32_t tail = command;
+
+    while (m_checkpoints.at(head).prev >= 0)
+      head = m_checkpoints.at(head).prev;
+
+    while (m_checkpoints.at(tail).next >= 0)
+      tail = m_checkpoints.at(tail).next;
+
+    return std::make_pair(head, tail);
+  }
+
+}

--- a/src/dxvk/dxvk_hang.cpp
+++ b/src/dxvk/dxvk_hang.cpp
@@ -72,6 +72,9 @@ namespace dxvk {
           int32_t               prev) {
     std::lock_guard lock(m_mutex);
 
+    if (prev < 0)
+      return;
+
     auto vk = m_device->vkd();
 
     if (m_device->features().nvDeviceDiagnosticCheckpoints) {

--- a/src/dxvk/dxvk_hang.h
+++ b/src/dxvk/dxvk_hang.h
@@ -1,0 +1,119 @@
+#pragma once
+
+#include <array>
+#include <vector>
+
+#include "dxvk_buffer.h"
+#include "dxvk_include.h"
+
+#include "../util/thread.h"
+
+namespace dxvk {
+
+  class DxvkDevice;
+  struct DxvkDeviceQueue;
+
+  /**
+   * \brief Checkpoint for hang debugging
+   */
+  struct DxvkCheckpoint {
+    int32_t prev = -1;
+    int32_t next = -1;
+
+    std::array<char, 120> info = {};
+  };
+
+
+  /**
+   * \brief Checkpoint buffer for
+   */
+  class DxvkCheckpointBuffer {
+    // Allocate ring buffer of 256k entries, should suffice
+    static constexpr size_t NumCheckpoints = 1u << 18u;
+  public:
+
+    DxvkCheckpointBuffer(DxvkDevice* device);
+    ~DxvkCheckpointBuffer();
+
+    /**
+     * \brief Adds checkpoint
+     *
+     * \param [in] queue Target queue for command buffer
+     * \param [in] cmd Command buffer
+     * \param [in] prev Last checkpoint on the same
+     *    command buffer, or -1 if this is the frist.
+     * \param [in] text String representation of checkpoint data
+     * \returns Checkpoint ID
+     */
+    int32_t addCheckpoint(
+      const DxvkDeviceQueue&      queue,
+            VkCommandBuffer       cmd,
+            int32_t               prev,
+      const char*                 text);
+
+    /**
+     * \brief Ends command list
+     *
+     * If necessary, records the last checkpoint
+     * associated with the command buffer.
+     * \param [in] queue Target queue for command buffer
+     * \param [in] cmd Command buffer
+     * \param [in] prev Last checkpoint
+     */
+    void endCommandBuffer(
+      const DxvkDeviceQueue&      queue,
+            VkCommandBuffer       cmd,
+            int32_t               prev);
+
+    /**
+     * \brief Prints commands associated with a hang
+     *
+     * Must only be called when DEVICE_LOST was detected.
+     */
+    void printHangInfo();
+
+  private:
+
+    struct Marker {
+      int32_t top;
+      int32_t bottom;
+    };
+
+    DxvkDevice* m_device = nullptr;
+
+    bool        m_hung = false;
+
+    dxvk::mutex m_mutex;
+    int32_t     m_next = 0;
+
+    Rc<DxvkBuffer> m_markerBuffer;
+
+    std::vector<DxvkDeviceQueue> m_markerQueues;
+    std::vector<DxvkCheckpoint> m_checkpoints;
+
+    int32_t getNextCheckpoint();
+
+    size_t getQueueIndex(
+      const DxvkDeviceQueue&        queue);
+
+    DxvkResourceBufferInfo getMarkerBuffer(
+      const DxvkDeviceQueue&        queue,
+            VkPipelineStageFlagBits stage);
+
+    Rc<DxvkBuffer> createMarkerBuffer();
+
+    void logHangCommands(
+      const DxvkDeviceQueue&        queue,
+            int32_t                 lastBegun,
+            int32_t                 lastComplete);
+
+    void logHangCommandSequence(
+      const std::pair<int32_t, int32_t>& list,
+            int32_t                 lastBegun,
+            int32_t                 lastComplete);
+
+    std::pair<int32_t, int32_t> getCommandList(int32_t command) const;
+
+  };
+
+}

--- a/src/dxvk/dxvk_hang.h
+++ b/src/dxvk/dxvk_hang.h
@@ -112,7 +112,13 @@ namespace dxvk {
             int32_t                 lastBegun,
             int32_t                 lastComplete);
 
+    void logDeviceFaults();
+
+    void dumpDeviceFaultInfo();
+
     std::pair<int32_t, int32_t> getCommandList(int32_t command) const;
+
+    static std::string faultAddressToString(const VkDeviceFaultAddressInfoKHR& address);
 
   };
 

--- a/src/dxvk/dxvk_instance.cpp
+++ b/src/dxvk/dxvk_instance.cpp
@@ -177,6 +177,8 @@ namespace dxvk {
       m_debugFlags.set(DxvkDebugFlag::Capture, DxvkDebugFlag::Markers);
     else if (debugEnv == "capture" || m_options.enableDebugUtils || capture)
       m_debugFlags.set(DxvkDebugFlag::Capture);
+    else if (debugEnv == "hang")
+      m_debugFlags.set(DxvkDebugFlag::Capture, DxvkDebugFlag::Hang);
 
     if (m_debugFlags.isClear()) {
       // Disable any usage of the extension altogether

--- a/src/dxvk/dxvk_instance.h
+++ b/src/dxvk/dxvk_instance.h
@@ -41,6 +41,7 @@ namespace dxvk {
     Validation        = 0,
     Capture           = 1,
     Markers           = 2,
+    Hang              = 3,
   };
 
   using DxvkDebugFlags = Flags<DxvkDebugFlag>;

--- a/src/dxvk/dxvk_memory.cpp
+++ b/src/dxvk/dxvk_memory.cpp
@@ -2388,7 +2388,25 @@ namespace dxvk {
 
   uint32_t DxvkMemoryAllocator::getMemoryTypeMask(
           VkMemoryPropertyFlags properties) const {
-    return m_memTypesByPropertyFlags[uint32_t(properties) % uint32_t(m_memTypesByPropertyFlags.size())];
+    uint32_t index = uint32_t(properties);
+    uint32_t count = uint32_t(m_memTypesByPropertyFlags.size());
+
+    if (likely(index < count))
+      return m_memTypesByPropertyFlags[index];
+
+    // If we get asked for uncommon memory properties, scan
+    // memory types for the requested flags
+    uint32_t mask = 0u;
+
+    for (uint32_t i = 0u; i < m_memTypes.size(); i++) {
+      if ((m_memTypes[i].properties.propertyFlags & properties) == properties)
+        mask |= 1u << i;
+    }
+
+    if (!mask)
+      mask = m_memTypesByPropertyFlags[index % count];
+
+    return mask;
   }
 
 

--- a/src/dxvk/dxvk_queue.cpp
+++ b/src/dxvk/dxvk_queue.cpp
@@ -4,9 +4,11 @@
 namespace dxvk {
   
   DxvkSubmissionQueue::DxvkSubmissionQueue(DxvkDevice* device, const DxvkQueueCallback& callback)
-  : m_device(device), m_callback(callback),
-    m_submitThread([this] () { submitCmdLists(); }),
-    m_finishThread([this] () { finishCmdLists(); }) {
+  : m_device        (device),
+    m_checkpoints   (device->getCheckpointBuffer()),
+    m_callback      (callback),
+    m_submitThread  ([this] () { submitCmdLists(); }),
+    m_finishThread  ([this] () { finishCmdLists(); }) {
     auto vk = m_device->vkd();
 
     VkSemaphoreTypeCreateInfo semaphoreType = { VK_STRUCTURE_TYPE_SEMAPHORE_TYPE_CREATE_INFO };
@@ -191,7 +193,10 @@ namespace dxvk {
 
       if (entry.status)
         entry.status->result = entry.result;
-      
+
+      if (entry.result == VK_ERROR_DEVICE_LOST && m_checkpoints)
+        m_checkpoints->printHangInfo();
+
       // On success, pass it on to the queue thread
       { std::unique_lock<dxvk::mutex> lock(m_mutex);
 
@@ -264,6 +269,9 @@ namespace dxvk {
           if (entry.latency.tracker && status == VK_SUCCESS)
             entry.latency.tracker->notifyGpuExecutionEnd(entry.latency.frameId);
         }
+
+        if (status == VK_ERROR_DEVICE_LOST && m_checkpoints)
+          m_checkpoints->printHangInfo();
 
         if (status != VK_SUCCESS) {
           m_lastError = status;

--- a/src/dxvk/dxvk_queue.h
+++ b/src/dxvk/dxvk_queue.h
@@ -13,6 +13,7 @@
 namespace dxvk {
   
   class DxvkDevice;
+  class DxvkCheckpointBuffer;
 
   /**
    * \brief Submission status
@@ -195,6 +196,7 @@ namespace dxvk {
   private:
 
     DxvkDevice*                 m_device;
+    DxvkCheckpointBuffer*       m_checkpoints = nullptr;
     DxvkQueueCallback           m_callback;
 
     DxvkTimelineSemaphores      m_semaphores;

--- a/src/dxvk/meson.build
+++ b/src/dxvk/meson.build
@@ -50,6 +50,7 @@ dxvk_src = [
   'dxvk_gpu_event.cpp',
   'dxvk_gpu_query.cpp',
   'dxvk_graphics.cpp',
+  'dxvk_hang.cpp',
   'dxvk_image.cpp',
   'dxvk_implicit_resolve.cpp',
   'dxvk_instance.cpp',

--- a/src/vulkan/vulkan_loader.h
+++ b/src/vulkan/vulkan_loader.h
@@ -514,6 +514,11 @@ namespace dxvk::vk {
     VULKAN_FN(wine_vkReleaseKeyedMutex);
     #endif
 
+    #ifdef VK_AMD_buffer_marker
+    VULKAN_FN(vkCmdWriteBufferMarkerAMD);
+    VULKAN_FN(vkCmdWriteBufferMarker2AMD);
+    #endif
+
     #ifdef VK_NV_device_diagnostic_checkpoints
     VULKAN_FN(vkCmdSetCheckpointNV);
     VULKAN_FN(vkGetQueueCheckpointDataNV);

--- a/src/vulkan/vulkan_loader.h
+++ b/src/vulkan/vulkan_loader.h
@@ -514,6 +514,12 @@ namespace dxvk::vk {
     VULKAN_FN(wine_vkReleaseKeyedMutex);
     #endif
 
+    #ifdef VK_NV_device_diagnostic_checkpoints
+    VULKAN_FN(vkCmdSetCheckpointNV);
+    VULKAN_FN(vkGetQueueCheckpointDataNV);
+    VULKAN_FN(vkGetQueueCheckpointData2NV);
+    #endif
+
     #ifdef VK_NV_low_latency2
     VULKAN_FN(vkSetLatencySleepModeNV);
     VULKAN_FN(vkLatencySleepNV);

--- a/src/vulkan/vulkan_loader.h
+++ b/src/vulkan/vulkan_loader.h
@@ -514,6 +514,11 @@ namespace dxvk::vk {
     VULKAN_FN(wine_vkReleaseKeyedMutex);
     #endif
 
+    #ifdef VK_KHR_device_fault
+    VULKAN_FN(vkGetDeviceFaultReportsKHR);
+    VULKAN_FN(vkGetDeviceFaultDebugInfoKHR);
+    #endif
+
     #ifdef VK_AMD_buffer_marker
     VULKAN_FN(vkCmdWriteBufferMarkerAMD);
     VULKAN_FN(vkCmdWriteBufferMarker2AMD);


### PR DESCRIPTION
Fallout from #5785.

TL;DR setting `DXVK_DEBUG=hang` will enable `VK_NV_device_diagnostic_checkpoints` or `VK_AMD_buffer_marker` to track which commands are executed on the GPU, and once a `DEVICE_LOST` error is detected, print stuff to the log:

```
err:   DXVK: Hang detected:
err:   Queue family 0, index 0
err:   Last command completed: 66145
err:   Last command started:   66146
[...]
err:    66144: Barrier (1, 0): 0x800:0x40 -> 0x18fa:0x1869
err:    66145: [cs.6bf5a8a]
err:   !!! Potential hang region BEGIN !!!
err:    66146: Dispatch (80, 48, 1)
err:   !!! Potential hang region END !!!
err:    66147: [cs.059fd34]
err:    66148: Dispatch (80, 49, 1)
```

Not nearly as sophisticated as the vkd3d-proton equivalent, but this can at least give us an idea *which command* and *which shader* might be hanging, without adding much overhead when it's not needed. Also uses `KHR_device_fault` if supported, but Nvidia (on Linux) currently doesn't.