### PR TITLE
[dxgi] Write back altered swapchain flags

### DIFF
--- a/src/dxgi/dxgi_swapchain.cpp
+++ b/src/dxgi/dxgi_swapchain.cpp
@@ -436,6 +436,7 @@ namespace dxvk {
     std::lock_guard<dxvk::mutex> lock(m_lockBuffer);
     m_desc.Width  = Width;
     m_desc.Height = Height;
+    m_desc.Flags  = SwapChainFlags;
     
     if (m_window) {
       wsi::getWindowSize(m_window,


### PR DESCRIPTION
Should restore the core functionality from #5794.

Maybe we should actually test it this time so that we don't literally break *everything* again.