### PR TITLE
Hide Intel vendor ID for XeSS < 2.0.2.68

### DIFF
--- a/src/dxgi/dxgi_options.cpp
+++ b/src/dxgi/dxgi_options.cpp
@@ -4,10 +4,28 @@
 
 namespace dxvk {
 
+  static bool isVersionAtLeast(
+    uint32_t major,
+    uint32_t minor,
+    uint32_t patch,
+    uint32_t build,
+    uint32_t reqMajor,
+    uint32_t reqMinor,
+    uint32_t reqPatch,
+    uint32_t reqBuild) {
+    if (major != reqMajor)
+      return major > reqMajor;
+    if (minor != reqMinor)
+      return minor > reqMinor;
+    if (patch != reqPatch)
+      return patch > reqPatch;
+    return build >= reqBuild;
+  }
+
   static int32_t parsePciId(const std::string& str) {
     if (str.size() != 4)
       return -1;
-    
+
     int32_t id = 0;
 
     for (size_t i = 0; i < str.size(); i++) {
@@ -26,10 +44,10 @@ namespace dxvk {
     return id;
   }
 
-  /* First generation XeSS causes crash on proton for Intel due to missing
-   * Intel interface. Avoid crash by pretending to be non-Intel if the
-   * libxess.dll module is loaded by an application. */
-  static bool isXess1xUsed() {
+  /* Some XeSS versions crash on Proton for Intel due to missing Intel
+   * interfaces. Avoid crash by pretending to be non-Intel if the libxess.dll
+   * module is loaded by an application. */
+  static bool isXessVendorWaNeeded() {
     #ifdef _WIN32
     HMODULE libxess = nullptr;
 
@@ -86,8 +104,18 @@ namespace dxvk {
       return true;
     }
 
-    // XeSS 2.0 onwards should be fine
-    return fiBlockTyped->dwProductVersionMS < 0x20000u;
+    const uint32_t major = fiBlockTyped->dwProductVersionMS >> 16;
+    const uint32_t minor = fiBlockTyped->dwProductVersionMS & 0xffffu;
+    const uint32_t patch = fiBlockTyped->dwProductVersionLS >> 16;
+    const uint32_t build = fiBlockTyped->dwProductVersionLS & 0xffffu;
+
+    // Some early 2.0 builds are still affected, keep the workaround enabled
+    // until at least 2.0.2.68.
+    const bool isKnownGood = isVersionAtLeast(
+      major, minor, patch, build,
+      2u, 0u, 2u, 68u);
+
+    return !isKnownGood;
     #else
     return false;
     #endif
@@ -130,13 +158,13 @@ namespace dxvk {
     return false;
   }
 
-  
+
   DxgiOptions::DxgiOptions(const Config& config) {
     // Fetch these as a string representing a hexadecimal number and parse it.
     this->customVendorId = parsePciId(config.getOption<std::string>("dxgi.customVendorId"));
     this->customDeviceId = parsePciId(config.getOption<std::string>("dxgi.customDeviceId"));
     this->customDeviceDesc = config.getOption<std::string>("dxgi.customDeviceDesc", "");
-    
+
     // Interpret the memory limits as Megabytes
     this->maxDeviceMemory = VkDeviceSize(config.getOption<int32_t>("dxgi.maxDeviceMemory", 0)) << 20;
     this->maxSharedMemory = VkDeviceSize(config.getOption<int32_t>("dxgi.maxSharedMemory", 0)) << 20;
@@ -164,9 +192,8 @@ namespace dxvk {
     this->hideAmdGpu = config.getOption<Tristate>("dxgi.hideAmdGpu", Tristate::Auto) == Tristate::True;
     this->hideIntelGpu = config.getOption<Tristate>("dxgi.hideIntelGpu", Tristate::Auto) == Tristate::True;
 
-    // Old XeSS libraries will crash if an Intel GPU is detected
-    if (isXess1xUsed()) {
-      Logger::info(str::format("Detected XeSS 1.x usage, hiding Intel GPU Vendor"));
+    if (isXessVendorWaNeeded()) {
+      Logger::info(str::format("XeSS: hiding Intel GPU Vendor ID"));
       this->hideIntelGpu = true;
     }
 
@@ -179,5 +206,5 @@ namespace dxvk {
       this->enableHDR = false;
     }
   }
-  
+
 }


### PR DESCRIPTION
XeSS devs tell me early 2.0 releases can't create contexts properly in Proton with the Intel vendor ID shown. No crashes as seen in XeSS 1.2, but games that don't check for this failure mode will misrender. Misrendering due to XeSS context create failure is observed on Cyberpunk; see https://gitlab.freedesktop.org/mesa/mesa/-/work_items/15739

Merging this change will re-introduce the Pragmata regression logged in https://gitlab.freedesktop.org/mesa/mesa/-/work_items/15450 but that regression is expected to be fixed by https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/42265

IMO the planned Proton shim to intercept + redirect XeSS calls is the proper fix long-term, so I'm also working to clean up that code and make it upstreamable.

