### PR TITLE
[dxvk] Load Intel vendor hack DLL

### DIFF
--- a/src/d3d11/d3d11_device.cpp
+++ b/src/d3d11/d3d11_device.cpp
@@ -3764,6 +3764,27 @@ namespace dxvk {
   
 
 
+  static HMODULE d3d11_device_init_vendor_hacks(
+      const Rc<DxvkAdapter>& Adapter) {
+    if (Adapter->deviceProperties().core.properties.vendorID == uint32_t(DxvkGpuVendor::Intel)) {
+      char sysdir[MAX_PATH], path[MAX_PATH];
+      GetSystemDirectoryA(sysdir, sizeof(sysdir));
+      snprintf(path, sizeof(path),
+               "%s\\DriverStore\\FileRepository\\igd_faux.inf_1\\igd10iumd64.dll", sysdir);
+      HMODULE igd10iumd = ::LoadLibraryA(path);
+      if (igd10iumd)
+        Logger::info("Loaded igd10iumd64.dll for Intel driver workarounds");
+      return igd10iumd;
+    }
+    return nullptr;
+  }
+
+  static void d3d11_device_cleanup_vendor_hacks(HMODULE igd10iumd64) {
+    if (igd10iumd64)
+      ::FreeLibrary(igd10iumd64);
+  }
+
+
   D3D11DXGIDevice::D3D11DXGIDevice(
           IDXGIAdapter*       pAdapter,
           ID3D12Device*       pD3D12Device,
@@ -3786,12 +3807,12 @@ namespace dxvk {
     m_metaDevice    (this),
     m_dxvkFactory   (this, &m_d3d11Device),
     m_destructionNotifier(this) {
-
+    m_vendorHacks.igd10iumd64 = d3d11_device_init_vendor_hacks(m_dxvkAdapter);
   }
-  
-  
-  D3D11DXGIDevice::~D3D11DXGIDevice() {
 
+
+  D3D11DXGIDevice::~D3D11DXGIDevice() {
+    d3d11_device_cleanup_vendor_hacks(m_vendorHacks.igd10iumd64);
   }
   
   

--- a/src/d3d11/d3d11_device.cpp
+++ b/src/d3d11/d3d11_device.cpp
@@ -3766,7 +3766,7 @@ namespace dxvk {
 
   static HMODULE d3d11_device_init_vendor_hacks(
       const Rc<DxvkAdapter>& Adapter) {
-    if (Adapter->deviceProperties().core.properties.vendorID == uint32_t(DxvkGpuVendor::Intel)) {
+    if (Adapter->info().vendorId == uint32_t(DxvkGpuVendor::Intel)) {
       char sysdir[MAX_PATH], path[MAX_PATH];
       GetSystemDirectoryA(sysdir, sizeof(sysdir));
       snprintf(path, sizeof(path),

--- a/src/d3d11/d3d11_device.cpp
+++ b/src/d3d11/d3d11_device.cpp
@@ -3764,9 +3764,9 @@ namespace dxvk {
   
 
 
-  static HMODULE d3d11_device_init_vendor_hacks(
-      const Rc<DxvkAdapter>& Adapter) {
-    if (Adapter->info().vendorId == uint32_t(DxvkGpuVendor::Intel)) {
+  HMODULE D3D11DXGIDevice::initVendorHacks() {
+#ifdef _WIN32
+    if (m_dxvkAdapter->info().vendorId == uint32_t(DxvkGpuVendor::Intel)) {
       char sysdir[MAX_PATH], path[MAX_PATH];
       GetSystemDirectoryA(sysdir, sizeof(sysdir));
       snprintf(path, sizeof(path),
@@ -3776,12 +3776,15 @@ namespace dxvk {
         Logger::info("Loaded igd10iumd64.dll for Intel driver workarounds");
       return igd10iumd;
     }
+#endif
     return nullptr;
   }
 
-  static void d3d11_device_cleanup_vendor_hacks(HMODULE igd10iumd64) {
-    if (igd10iumd64)
-      ::FreeLibrary(igd10iumd64);
+  void D3D11DXGIDevice::cleanupVendorHacks() {
+#ifdef _WIN32
+    if (m_vendorHacks.igd10iumd64)
+      ::FreeLibrary(m_vendorHacks.igd10iumd64);
+#endif
   }
 
 
@@ -3807,12 +3810,12 @@ namespace dxvk {
     m_metaDevice    (this),
     m_dxvkFactory   (this, &m_d3d11Device),
     m_destructionNotifier(this) {
-    m_vendorHacks.igd10iumd64 = d3d11_device_init_vendor_hacks(m_dxvkAdapter);
+    m_vendorHacks.igd10iumd64 = initVendorHacks();
   }
 
 
   D3D11DXGIDevice::~D3D11DXGIDevice() {
-    d3d11_device_cleanup_vendor_hacks(m_vendorHacks.igd10iumd64);
+    cleanupVendorHacks();
   }
   
   

--- a/src/d3d11/d3d11_device.h
+++ b/src/d3d11/d3d11_device.h
@@ -1019,6 +1019,10 @@ namespace dxvk {
 
     uint32_t m_frameLatency = DefaultFrameLatency;
 
+    HMODULE initVendorHacks();
+
+    void cleanupVendorHacks();
+
   };
   
 }

--- a/src/d3d11/d3d11_device.h
+++ b/src/d3d11/d3d11_device.h
@@ -1012,7 +1012,11 @@ namespace dxvk {
     DXGIVkSwapChainFactory   m_dxvkFactory;
 
     D3DDestructionNotifier   m_destructionNotifier;
-    
+
+    struct {
+      HMODULE igd10iumd64 = nullptr;
+    } m_vendorHacks;
+
     uint32_t m_frameLatency = DefaultFrameLatency;
 
   };


### PR DESCRIPTION
This vendor hack allows the Intel Extensions Loader to locate and load the igdext.dll library. This is because the loader searches for the library based partly on the location of the loaded fake DirectX 11 Intel UMD.