### PR TITLE
[d3d8] Rework legacy D3D compatibility mode handling

### DIFF
--- a/src/d3d8/d3d8_device.cpp
+++ b/src/d3d8/d3d8_device.cpp
@@ -24,7 +24,7 @@ namespace dxvk {
     , m_behaviorFlags(BehaviorFlags)
     , m_multithread(BehaviorFlags & D3DCREATE_MULTITHREADED) {
     // Get the bridge interface to D3D9.
-    if (unlikely(FAILED(GetD3D9()->QueryInterface(__uuidof(IDxvkD3D8Bridge), reinterpret_cast<void**>(&m_bridge))))) {
+    if (unlikely(FAILED(GetD3D9()->QueryInterface(__uuidof(IDxvkLegacyD3DDeviceBridge), reinterpret_cast<void**>(&m_bridge))))) {
       throw DxvkError("D3D8Device: ERROR! Failed to get D3D9 Bridge. d3d9.dll might not be DXVK!");
     }
 

--- a/src/d3d8/d3d8_device.h
+++ b/src/d3d8/d3d8_device.h
@@ -432,19 +432,19 @@ namespace dxvk {
 
   private:
 
-    Com<IDxvkD3D8Bridge>  m_bridge;
-    const D3D8Options&    m_d3d8Options;
+    Com<IDxvkLegacyD3DDeviceBridge> m_bridge;
+    const D3D8Options&              m_d3d8Options;
 
-    Com<D3D8Interface>    m_parent;
+    Com<D3D8Interface>              m_parent;
 
-    D3DPRESENT_PARAMETERS m_presentParams;
+    D3DPRESENT_PARAMETERS           m_presentParams;
     
     // Value of D3DRS_LINEPATTERN
-    D3DLINEPATTERN        m_linePattern = { };
+    D3DLINEPATTERN                  m_linePattern = { };
     // Value of D3DRS_ZVISIBLE (although the RS is not supported, its value is stored)
-    DWORD                 m_zVisible    = 0;
+    DWORD                           m_zVisible    = 0;
 
-    bool                  m_shadowPerspectiveDivide = false;
+    bool                            m_shadowPerspectiveDivide = false;
 
     D3D8StateBlock*                           m_recorder = nullptr;
     DWORD                                     m_recorderToken = 0;
@@ -453,8 +453,8 @@ namespace dxvk {
     D3D8Batcher*                              m_batcher  = nullptr;
 
     struct D3D8VBO {
-      Com<D3D8VertexBuffer, false>   buffer = nullptr;
-      UINT                           stride = 0;
+      Com<D3D8VertexBuffer, false>  buffer = nullptr;
+      UINT                          stride = 0;
     };
 
     std::array<Com<D3D8Texture2D, false>, d8caps::MAX_TEXTURE_STAGES> m_textures;

--- a/src/d3d8/d3d8_interface.cpp
+++ b/src/d3d8/d3d8_interface.cpp
@@ -10,11 +10,11 @@ namespace dxvk {
   D3D8Interface::D3D8Interface()
     : m_d3d9(d3d9::Direct3DCreate9(D3D_SDK_VERSION)) {
     // Get the bridge interface to D3D9.
-    if (unlikely(FAILED(m_d3d9->QueryInterface(__uuidof(IDxvkD3D8InterfaceBridge), reinterpret_cast<void**>(&m_bridge))))) {
+    if (unlikely(FAILED(m_d3d9->QueryInterface(__uuidof(IDxvkLegacyD3DInterfaceBridge), reinterpret_cast<void**>(&m_bridge))))) {
       throw DxvkError("D3D8Interface: ERROR! Failed to get D3D9 Bridge. d3d9.dll might not be DXVK!");
     }
 
-    m_bridge->EnableD3D8CompatibilityMode();
+    m_bridge->SetD3DCompatibility(D3DCompatibility::D3D8);
 
     m_d3d8Options = D3D8Options(*m_bridge->GetConfig());
 

--- a/src/d3d8/d3d8_interface.h
+++ b/src/d3d8/d3d8_interface.h
@@ -183,7 +183,7 @@ namespace dxvk {
     std::vector<std::vector<d3d9::D3DDISPLAYMODE>>  m_adapterModes;
 
     Com<d3d9::IDirect3D9>                           m_d3d9;
-    Com<IDxvkD3D8InterfaceBridge>                   m_bridge;
+    Com<IDxvkLegacyD3DInterfaceBridge>              m_bridge;
     D3D8Options                                     m_d3d8Options;
   };
 

--- a/src/d3d9/d3d9_adapter.cpp
+++ b/src/d3d9/d3d9_adapter.cpp
@@ -122,7 +122,7 @@ namespace dxvk {
     if (!IsSupportedAdapterFormat(AdapterFormat))
       return D3DERR_NOTAVAILABLE;
 
-    const bool isD3D8Compatible = m_parent->IsD3D8Compatible();
+    const bool isD3D8Compatible = m_parent->IsD3DCompatibile(D3DCompatibility::D3D8);
     const bool isNvidia         = m_vendorId == uint32_t(DxvkGpuVendor::Nvidia);
     const bool isAmd            = m_vendorId == uint32_t(DxvkGpuVendor::Amd);
 
@@ -396,7 +396,7 @@ namespace dxvk {
       return D3DERR_INVALIDCALL;
 
     if (unlikely(DeviceType == D3DDEVTYPE_SW)) {
-      if (m_parent->IsD3D8Compatible())
+      if (m_parent->IsD3DCompatibile(D3DCompatibility::D3D8))
         return D3DERR_INVALIDCALL;
       else
         return D3DERR_NOTAVAILABLE;
@@ -404,7 +404,8 @@ namespace dxvk {
 
     auto& options = m_parent->GetOptions();
 
-    const uint32_t maxShaderModel = m_parent->IsD3D8Compatible() ? std::min(1u, options.shaderModel) : options.shaderModel;
+    const uint32_t maxShaderModel = m_parent->IsD3DCompatibile(D3DCompatibility::D3D8) ? std::min(1u, options.shaderModel)
+                                                                                       : options.shaderModel;
     const auto& limits = m_caps.getProperties().core.properties.limits;
 
     // TODO: Actually care about what the adapter supports here.
@@ -883,8 +884,8 @@ namespace dxvk {
   }
 
 
-  bool D3D9Adapter::IsD3D8Compatible() const {
-    return m_parent->IsD3D8Compatible();
+  bool D3D9Adapter::IsD3DCompatibile(D3DCompatibility d3dCompatibility) const {
+    return m_parent->IsD3DCompatibile(d3dCompatibility);
   }
 
 

--- a/src/d3d9/d3d9_adapter.h
+++ b/src/d3d9/d3d9_adapter.h
@@ -4,6 +4,7 @@
 
 #include "d3d9_options.h"
 #include "d3d9_format.h"
+#include "d3d9_bridge.h"
 
 #include "../dxvk/dxvk_adapter.h"
 
@@ -103,7 +104,7 @@ namespace dxvk {
 
     bool IsExtended() const;
 
-    bool IsD3D8Compatible() const;
+    bool IsD3DCompatibile(D3DCompatibility d3dCompatibility) const;
 
     force_inline void incRef() {
       m_refCount.fetch_add(1u);

--- a/src/d3d9/d3d9_bridge.cpp
+++ b/src/d3d9/d3d9_bridge.cpp
@@ -8,28 +8,28 @@
 
 namespace dxvk {
 
-  DxvkD3D8Bridge::DxvkD3D8Bridge(D3D9DeviceEx* pDevice)
+  DxvkLegacyD3DDeviceBridge::DxvkLegacyD3DDeviceBridge(D3D9DeviceEx* pDevice)
     : m_device(pDevice) {
   }
 
-  DxvkD3D8Bridge::~DxvkD3D8Bridge() {
+  DxvkLegacyD3DDeviceBridge::~DxvkLegacyD3DDeviceBridge() {
   }
 
-  ULONG STDMETHODCALLTYPE DxvkD3D8Bridge::AddRef() {
+  ULONG STDMETHODCALLTYPE DxvkLegacyD3DDeviceBridge::AddRef() {
     return m_device->AddRef();
   }
 
-  ULONG STDMETHODCALLTYPE DxvkD3D8Bridge::Release() {
+  ULONG STDMETHODCALLTYPE DxvkLegacyD3DDeviceBridge::Release() {
     return m_device->Release();
   }
 
-  HRESULT STDMETHODCALLTYPE DxvkD3D8Bridge::QueryInterface(
+  HRESULT STDMETHODCALLTYPE DxvkLegacyD3DDeviceBridge::QueryInterface(
           REFIID  riid,
           void** ppvObject) {
     return m_device->QueryInterface(riid, ppvObject);
   }
 
-  HRESULT DxvkD3D8Bridge::UpdateTextureFromBuffer(
+  HRESULT DxvkLegacyD3DDeviceBridge::UpdateTextureFromBuffer(
         IDirect3DSurface9*  pDestSurface,
         IDirect3DSurface9*  pSrcSurface,
         const RECT*         pSrcRect,
@@ -89,37 +89,37 @@ namespace dxvk {
     return D3D_OK;
   }
 
-  bool DxvkD3D8Bridge::IsSupportedSurfaceFormat(D3DFORMAT Format) {
+  bool DxvkLegacyD3DDeviceBridge::IsSupportedSurfaceFormat(D3DFORMAT Format) {
     auto mapping = m_device->LookupFormat(EnumerateFormat(Format));
     return mapping.IsValid();
   }
 
-  DxvkD3D8InterfaceBridge::DxvkD3D8InterfaceBridge(D3D9InterfaceEx* pObject)
+  DxvkLegacyD3DInterfaceBridge::DxvkLegacyD3DInterfaceBridge(D3D9InterfaceEx* pObject)
     : m_interface(pObject) {
   }
 
-  DxvkD3D8InterfaceBridge::~DxvkD3D8InterfaceBridge() {
+  DxvkLegacyD3DInterfaceBridge::~DxvkLegacyD3DInterfaceBridge() {
   }
 
-  ULONG STDMETHODCALLTYPE DxvkD3D8InterfaceBridge::AddRef() {
+  ULONG STDMETHODCALLTYPE DxvkLegacyD3DInterfaceBridge::AddRef() {
     return m_interface->AddRef();
   }
 
-  ULONG STDMETHODCALLTYPE DxvkD3D8InterfaceBridge::Release() {
+  ULONG STDMETHODCALLTYPE DxvkLegacyD3DInterfaceBridge::Release() {
     return m_interface->Release();
   }
 
-  HRESULT STDMETHODCALLTYPE DxvkD3D8InterfaceBridge::QueryInterface(
+  HRESULT STDMETHODCALLTYPE DxvkLegacyD3DInterfaceBridge::QueryInterface(
           REFIID  riid,
           void** ppvObject) {
     return m_interface->QueryInterface(riid, ppvObject);
   }
 
-  void DxvkD3D8InterfaceBridge::EnableD3D8CompatibilityMode() {
-    m_interface->EnableD3D8CompatibilityMode();
+  void DxvkLegacyD3DInterfaceBridge::SetD3DCompatibility(D3DCompatibility d3dCompatibility) const {
+    m_interface->SetD3DCompatibility(d3dCompatibility);
   }
 
-  const Config* DxvkD3D8InterfaceBridge::GetConfig() const {
+  const Config* DxvkLegacyD3DInterfaceBridge::GetConfig() const {
     return &m_interface->GetInstance()->config();
   }
 

--- a/src/d3d9/d3d9_bridge.h
+++ b/src/d3d9/d3d9_bridge.h
@@ -2,6 +2,11 @@
 
 #include <windows.h>
 #include "../util/config/config.h"
+#include "../util/util_flags.h"
+
+enum class DxvkD3DCompatibility : uint8_t {
+  D3D8,
+};
 
 /**
  * The D3D9 bridge allows D3D8 to access DXVK internals.
@@ -13,8 +18,8 @@
 /**
  * \brief D3D9 device interface for D3D8 interop
  */
-MIDL_INTERFACE("D3D9D3D8-42A9-4C1E-AA97-BEEFCAFE2000")
-IDxvkD3D8Bridge : public IUnknown {
+MIDL_INTERFACE("D3D0D3D9-42A9-4C1E-AA97-BEEFCAFE2000")
+IDxvkLegacyD3DDeviceBridge : public IUnknown {
 
   // D3D8 keeps D3D9 objects contained in a namespace.
   #ifdef DXVK_D3D9_NAMESPACE
@@ -47,12 +52,14 @@ IDxvkD3D8Bridge : public IUnknown {
 /**
  * \brief D3D9 instance interface for D3D8 interop
  */
-MIDL_INTERFACE("D3D9D3D8-A407-773E-18E9-CAFEBEEF3000")
-IDxvkD3D8InterfaceBridge : public IUnknown {
+MIDL_INTERFACE("D3D0D3D9-A407-773E-18E9-CAFEBEEF3000")
+IDxvkLegacyD3DInterfaceBridge : public IUnknown {
   /**
-   * \brief Enforces D3D8-specific features and validations
+   * \brief Enforces legacy D3D features and validations
+   *
+   * \param [in] d3dCompatibility D3D compatibility level to be set
    */
-  virtual void EnableD3D8CompatibilityMode() = 0;
+  virtual void SetD3DCompatibility(DxvkD3DCompatibility d3dCompatibility) const = 0;
 
   /**
    * \brief Retrieves the DXVK configuration
@@ -63,22 +70,25 @@ IDxvkD3D8InterfaceBridge : public IUnknown {
 };
 
 #ifndef _MSC_VER
-__CRT_UUID_DECL(IDxvkD3D8Bridge, 0xD3D9D3D8, 0x42A9, 0x4C1E, 0xAA, 0x97, 0xBE, 0xEF, 0xCA, 0xFE, 0x20, 0x00);
-__CRT_UUID_DECL(IDxvkD3D8InterfaceBridge, 0xD3D9D3D8, 0xA407, 0x773E, 0x18, 0xE9, 0xCA, 0xFE, 0xBE, 0xEF, 0x30, 0x00);
+__CRT_UUID_DECL(IDxvkLegacyD3DDeviceBridge,    0xD3D0D3D9, 0x42A9, 0x4C1E, 0xAA, 0x97, 0xBE, 0xEF, 0xCA, 0xFE, 0x20, 0x00);
+__CRT_UUID_DECL(IDxvkLegacyD3DInterfaceBridge, 0xD3D0D3D9, 0xA407, 0x773E, 0x18, 0xE9, 0xCA, 0xFE, 0xBE, 0xEF, 0x30, 0x00);
 #endif
 
 namespace dxvk {
 
+  using D3DCompatibility = DxvkD3DCompatibility;
+  using D3DCompatibilityFlags = Flags<D3DCompatibility>;
+
   class D3D9DeviceEx;
   class D3D9InterfaceEx;
 
-  class DxvkD3D8Bridge : public IDxvkD3D8Bridge {
+  class DxvkLegacyD3DDeviceBridge : public IDxvkLegacyD3DDeviceBridge {
 
   public:
 
-    DxvkD3D8Bridge(D3D9DeviceEx* pDevice);
+    DxvkLegacyD3DDeviceBridge(D3D9DeviceEx* pDevice);
 
-    ~DxvkD3D8Bridge();
+    ~DxvkLegacyD3DDeviceBridge();
 
     ULONG STDMETHODCALLTYPE AddRef();
     ULONG STDMETHODCALLTYPE Release();
@@ -100,13 +110,13 @@ namespace dxvk {
 
   };
 
-  class DxvkD3D8InterfaceBridge : public IDxvkD3D8InterfaceBridge {
+  class DxvkLegacyD3DInterfaceBridge : public IDxvkLegacyD3DInterfaceBridge {
 
   public:
 
-    DxvkD3D8InterfaceBridge(D3D9InterfaceEx* pObject);
+    DxvkLegacyD3DInterfaceBridge(D3D9InterfaceEx* pObject);
 
-    ~DxvkD3D8InterfaceBridge();
+    ~DxvkLegacyD3DInterfaceBridge();
 
     ULONG STDMETHODCALLTYPE AddRef();
     ULONG STDMETHODCALLTYPE Release();
@@ -114,7 +124,7 @@ namespace dxvk {
             REFIID  riid,
             void** ppvObject);
 
-    void EnableD3D8CompatibilityMode();
+    void SetD3DCompatibility(D3DCompatibility d3dCompatibility) const;
 
     const Config* GetConfig() const;
 

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -54,7 +54,6 @@ namespace dxvk {
     , m_stagingBufferFence ( new sync::Fence() )
     , m_multithread        ( BehaviorFlags & D3DCREATE_MULTITHREADED )
     , m_isSWVP             ( (BehaviorFlags & D3DCREATE_SOFTWARE_VERTEXPROCESSING) != 0 )
-    , m_isD3D8Compatible   ( pParent->IsD3D8Compatible() )
     , m_csThread           ( dxvkDevice, dxvkDevice->createContext() )
     , m_csChunk            ( AllocCsChunk() )
     , m_submissionFence    ( new sync::Fence() )
@@ -62,7 +61,8 @@ namespace dxvk {
     , m_d3d9Interop        ( this )
     , m_d3d9On12Args       ( pAdapter->Get9On12Args() )
     , m_d3d9On12           ( this )
-    , m_d3d8Bridge         ( this ) {
+    , m_legacyD3DBridge    ( this )
+    , m_d3dCompatibility   ( pParent->GetD3DCompatibilityFlags() ) {
 
     InitShaderOptions();
 
@@ -189,8 +189,8 @@ namespace dxvk {
       return S_OK;
     }
 
-    if (riid == __uuidof(IDxvkD3D8Bridge)) {
-      *ppvObject = ref(&m_d3d8Bridge);
+    if (riid == __uuidof(IDxvkLegacyD3DDeviceBridge)) {
+      *ppvObject = ref(&m_legacyD3DBridge);
       return S_OK;
     }
 
@@ -514,7 +514,7 @@ namespace dxvk {
       Logger::warn(str::format("Device reset failed because device still has alive losable resources: Device not reset. Remaining resources: ", m_losableResourceCounter.load()));
       m_deviceLostState = D3D9DeviceLostState::NotReset;
       // D3D8 returns D3DERR_DEVICELOST here, whereas D3D9 returns D3DERR_INVALIDCALL.
-      return m_isD3D8Compatible ? D3DERR_DEVICELOST : D3DERR_INVALIDCALL;
+      return m_d3dCompatibility.test(D3DCompatibility::D3D8) ? D3DERR_DEVICELOST : D3DERR_INVALIDCALL;
     }
 
     hr = ResetSwapChain(pPresentationParameters, nullptr);
@@ -1374,7 +1374,8 @@ namespace dxvk {
       // - both destination and source are depth stencil surfaces
       // - both destination and source are offscreen plain surfaces.
       // The only way to get a surface with resource type D3DRTYPE_SURFACE without USAGE_RT or USAGE_DS is CreateOffscreenPlainSurface.
-      if (unlikely((!dstHasAttachmentUsage && (!dstIsSurface || !srcIsSurface || srcHasAttachmentUsage)) && !m_isD3D8Compatible && !isCopy))
+      if (unlikely((!dstHasAttachmentUsage && (!dstIsSurface || !srcIsSurface || srcHasAttachmentUsage)) &&
+                                               !m_d3dCompatibility.test(D3DCompatibility::D3D8) && !isCopy))
         return D3DERR_INVALIDCALL;
     }
 
@@ -2495,7 +2496,7 @@ namespace dxvk {
             if ((Value == AlphaToCoverageEnable
               || Value == AlphaToCoverageDisable) &&
                  vendorId == amdVendorId &&
-                 !m_isD3D8Compatible) {
+                 !m_d3dCompatibility.test(D3DCompatibility::D3D8)) {
               UpdateAlphaToCoverangeAndAlphaTest();
               break;
             }
@@ -2512,7 +2513,7 @@ namespace dxvk {
             // INST (AMD specific)
             if (unlikely(Value == uint32_t(D3D9Format::INST) &&
                          vendorId == amdVendorId &&
-                         !m_isD3D8Compatible)) {
+                         !m_d3dCompatibility.test(D3DCompatibility::D3D8))) {
               // Geometry instancing is supported by SM3, but ATI/AMD
               // exposed this hack to retroactively enable it on their
               // SM2-capable hardware. It's esentially a no-op.
@@ -2521,7 +2522,7 @@ namespace dxvk {
 
             // CENT (AMD & Nvidia)
             if (unlikely(Value == uint32_t(D3D9Format::CENT) &&
-                         !m_isD3D8Compatible)) {
+                         !m_d3dCompatibility.test(D3DCompatibility::D3D8))) {
               // Centroid (alternate pixel center) hack.
               // Taken into account anyway, so yet another no-op.
               break;
@@ -2578,7 +2579,7 @@ namespace dxvk {
           const uint32_t vendorId = m_adapter->GetVendorId();
 
           // Nvidia's driver hack for ATOC (also supported on Intel), COPM and SSAA
-          if (likely(vendorId != amdVendorId && !m_isD3D8Compatible)) {
+          if (likely(vendorId != amdVendorId && !m_d3dCompatibility.test(D3DCompatibility::D3D8))) {
             // ATOC (Nvidia & Intel)
             constexpr uint32_t AlphaToCoverageEnable  = uint32_t(D3D9Format::ATOC);
             // Disabling both ATOC and SSAA is done using D3DFMT_UNKNOWN (0)
@@ -2695,7 +2696,7 @@ namespace dxvk {
     try {
       const Com<D3D9StateBlock> sb = new D3D9StateBlock(this, stateBlockType);
       *ppSB = sb.ref();
-      if (!m_isD3D8Compatible)
+      if (!m_d3dCompatibility.test(D3DCompatibility::D3D8))
         m_losableResourceCounter++;
 
       return D3D_OK;
@@ -2730,7 +2731,7 @@ namespace dxvk {
     InitReturnPtr(ppSB);
 
     *ppSB = m_recorder.ref();
-    if (!m_isD3D8Compatible)
+    if (!m_d3dCompatibility.test(D3DCompatibility::D3D8))
       m_losableResourceCounter++;
     m_recorder = nullptr;
 
@@ -6887,7 +6888,7 @@ namespace dxvk {
 
 
   void D3D9DeviceEx::UpdateAlphaToCoverangeAndAlphaTest() {
-    if (likely(!m_isD3D8Compatible)) {
+    if (likely(!m_d3dCompatibility.test(D3DCompatibility::D3D8))) {
       // ATOC is not supported by D3D8
       bool alphaToCoverageEnabled = true;
 
@@ -7907,8 +7908,8 @@ namespace dxvk {
     // Vertex shader version checks
     if (ShaderType == D3D9ShaderType::VertexShader) {
       // Late fixed-function capable hardware exposed support for VS 1.1
-      const uint32_t shaderModelVS = IsD3D8Compatible() ? 1u : std::max(1u, m_d3d9Options.shaderModel);
-
+      const uint32_t shaderModelVS = m_d3dCompatibility.test(D3DCompatibility::D3D8) ? 1u
+                                                                                     : std::max(1u, m_d3d9Options.shaderModel);
       if (unlikely(info.getVersion().first > shaderModelVS
                || (info.getVersion().first == 1 && info.getVersion().second > 1)
                // Skip checking the SM2 minor version, as it has a 2_x mode apparently
@@ -7918,8 +7919,8 @@ namespace dxvk {
       }
     // Pixel shader version checks
     } else if (ShaderType == D3D9ShaderType::PixelShader) {
-      const uint32_t shaderModelPS = IsD3D8Compatible() ? std::min(1u, m_d3d9Options.shaderModel) : m_d3d9Options.shaderModel;
-
+      const uint32_t shaderModelPS = m_d3dCompatibility.test(D3DCompatibility::D3D8) ? std::min(1u, m_d3d9Options.shaderModel)
+                                                                                     : m_d3d9Options.shaderModel;
       if (unlikely(info.getVersion().first > shaderModelPS
                || (info.getVersion().first == 1 && info.getVersion().second > 4)
                // Skip checking the SM2 minor version, as it has a 2_x mode apparently
@@ -8721,7 +8722,8 @@ namespace dxvk {
     rs[D3DRS_POINTSCALE_B]               = bit::cast<DWORD>(0.0f);
     rs[D3DRS_POINTSCALE_C]               = bit::cast<DWORD>(0.0f);
     rs[D3DRS_POINTSIZE]                  = bit::cast<DWORD>(1.0f);
-    rs[D3DRS_POINTSIZE_MIN]              = m_isD3D8Compatible ? bit::cast<DWORD>(0.0f) : bit::cast<DWORD>(1.0f);
+    rs[D3DRS_POINTSIZE_MIN]              = m_d3dCompatibility.test(D3DCompatibility::D3D8) ? bit::cast<DWORD>(0.0f)
+                                                                                           : bit::cast<DWORD>(1.0f);
     rs[D3DRS_POINTSIZE_MAX]              = bit::cast<DWORD>(limits.pointSizeRange[1]);
     m_pushData.vs.pointSize = EncodePointSize(rs[D3DRS_POINTSIZE]);
     m_pushData.vs.pointSizeMin = EncodePointSize(rs[D3DRS_POINTSIZE_MIN]);
@@ -8863,7 +8865,7 @@ namespace dxvk {
 
     // In D3D8, this represents the value of D3DRS_PATCHSEGMENTS.
     // It defaults to 1.0f and is reset as any other render state.
-    if (m_isD3D8Compatible)
+    if (m_d3dCompatibility.test(D3DCompatibility::D3D8))
       m_state.nPatchSegments = 1.0f;
 
     m_alphaTestEnabled = false;

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -226,7 +226,7 @@ namespace dxvk {
     friend struct D3D9WindowContext;
     friend class D3D9ConstantBuffer;
     friend class D3D9UserDefinedAnnotation;
-    friend class DxvkD3D8Bridge;
+    friend class DxvkLegacyD3DDeviceBridge;
     friend D3D9VkInteropDevice;
 
     using CbvIndex = D3D9ShaderResourceMapping::CbvIndex;
@@ -969,7 +969,7 @@ namespace dxvk {
 
     inline bool IsNVDepthBoundsTestEnabled () {
       // NVDB is not supported by D3D8
-      if (unlikely(m_isD3D8Compatible))
+      if (unlikely(m_d3dCompatibility.test(D3DCompatibility::D3D8)))
         return false;
 
       return m_state.renderStates[D3DRS_ADAPTIVETESS_X] == uint32_t(D3D9Format::NVDB);
@@ -1134,8 +1134,8 @@ namespace dxvk {
       return m_recorder != nullptr;
     }
 
-    bool IsD3D8Compatible() const {
-      return m_isD3D8Compatible;
+    bool IsD3DCompatibile(D3DCompatibility d3dCompatibility) const {
+      return m_d3dCompatibility.test(d3dCompatibility);
     }
 
     // Device Lost
@@ -1627,7 +1627,6 @@ namespace dxvk {
     D3D9VBSlotTracking              m_vbSlotTracking;
 
     bool                            m_isSWVP;
-    bool                            m_isD3D8Compatible;
     bool                            m_ffZTest          = false;
 
     // the enablement of below features is tracked independently
@@ -1697,7 +1696,9 @@ namespace dxvk {
     D3D9VkInteropDevice             m_d3d9Interop;
     D3D9ON12_ARGS                   m_d3d9On12Args = { };
     D3D9On12                        m_d3d9On12;
-    DxvkD3D8Bridge                  m_d3d8Bridge;
+
+    DxvkLegacyD3DDeviceBridge       m_legacyD3DBridge;
+    D3DCompatibilityFlags           m_d3dCompatibility;
 
     // Sampler statistics
     constexpr static uint32_t       SamplerCountBits = 12u;

--- a/src/d3d9/d3d9_format.cpp
+++ b/src/d3d9/d3d9_format.cpp
@@ -650,7 +650,7 @@ namespace dxvk {
   void D3D9VkFormatTable::RefreshFormatSupport(
     const D3D9Adapter*          pParent) {
     // W11V11U10 is only supported by D3D8
-    m_w11v11u10Support = pParent->IsD3D8Compatible();
+    m_w11v11u10Support = pParent->IsD3DCompatibile(D3DCompatibility::D3D8);
   }
 
 }

--- a/src/d3d9/d3d9_interface.cpp
+++ b/src/d3d9/d3d9_interface.cpp
@@ -15,12 +15,12 @@ namespace dxvk {
   Singleton<DxvkInstance> g_dxvkInstance;
 
   D3D9InterfaceEx::D3D9InterfaceEx(bool bExtended, const D3D9ON12_ARGS* pOverrideList, uint32_t OverrideCount)
-    : m_instance    ( g_dxvkInstance.acquire(DxvkInstanceFlag::ClientApiIsD3D9) )
-    , m_d3d8Bridge  ( this )
-    , m_extended    ( bExtended ) 
-    , m_d3d9Options ( nullptr, m_instance->config() )
-    , m_d3d9Interop ( this )
-    , m_d3d9ExtInterface( this ) {
+    : m_instance         ( g_dxvkInstance.acquire(DxvkInstanceFlag::ClientApiIsD3D9) )
+    , m_legacyD3DBridge  ( this )
+    , m_extended         ( bExtended )
+    , m_d3d9Options      ( nullptr, m_instance->config() )
+    , m_d3d9Interop      ( this )
+    , m_d3d9ExtInterface ( this ) {
     // D3D9 doesn't enumerate adapters like physical adapters...
     // only as connected displays.
 
@@ -97,8 +97,8 @@ namespace dxvk {
       return S_OK;
     }
 
-    if (riid == __uuidof(IDxvkD3D8InterfaceBridge)) {
-      *ppvObject = ref(&m_d3d8Bridge);
+    if (riid == __uuidof(IDxvkLegacyD3DInterfaceBridge)) {
+      *ppvObject = ref(&m_legacyD3DBridge);
       return S_OK;
     }
 
@@ -149,7 +149,7 @@ namespace dxvk {
     filter.Size             = sizeof(D3DDISPLAYMODEFILTER);
     filter.Format           = Format;
     filter.ScanLineOrdering = D3DSCANLINEORDERING_PROGRESSIVE;
-    
+
     return this->GetAdapterModeCountEx(Adapter, &filter);
   }
 
@@ -213,7 +213,7 @@ namespace dxvk {
           D3DFORMAT           SurfaceFormat,
           BOOL                Windowed,
           D3DMULTISAMPLE_TYPE MultiSampleType,
-          DWORD*              pQualityLevels) { 
+          DWORD*              pQualityLevels) {
     if (auto* adapter = GetAdapter(Adapter))
       return adapter->CheckDeviceMultiSampleType(
         DeviceType, EnumerateFormat(SurfaceFormat),
@@ -500,7 +500,7 @@ namespace dxvk {
     // Allow D3DSWAPEFFECT_COPY to bypass this restriction in D3D8 compatibility
     // mode, since it may be a remapping of D3DSWAPEFFECT_COPY_VSYNC and RC Cars
     // depends on it not being validated.
-    if (unlikely(!IsD3D8Compatible()
+    if (unlikely(!m_d3dCompatibility.test(D3DCompatibility::D3D8)
               && pPresentationParameters->SwapEffect == D3DSWAPEFFECT_COPY
               && pPresentationParameters->BackBufferCount > 1))
       return D3DERR_INVALIDCALL;

--- a/src/d3d9/d3d9_interface.h
+++ b/src/d3d9/d3d9_interface.h
@@ -131,7 +131,7 @@ namespace dxvk {
     HRESULT ValidatePresentationParameters(
         const D3DPRESENT_PARAMETERS* pPresentationParameters);
 
-    const D3D9Options& GetOptions() { return m_d3d9Options; }
+    const D3D9Options& GetOptions() const { return m_d3d9Options; }
 
     D3D9Adapter* GetAdapter(UINT Ordinal) {
       return Ordinal < m_adapters.size()
@@ -141,14 +141,20 @@ namespace dxvk {
 
     bool IsExtended() { return m_extended; }
 
-    bool IsD3D8Compatible() const {
-      return m_isD3D8Compatible;
+    D3DCompatibilityFlags GetD3DCompatibilityFlags() const {
+      return m_d3dCompatibility;
     }
 
-    void EnableD3D8CompatibilityMode() {
-      m_isD3D8Compatible = true;
+    bool IsD3DCompatibile(D3DCompatibility d3dCompatibility) const {
+      return m_d3dCompatibility.test(d3dCompatibility);
+    }
+
+    void SetD3DCompatibility(D3DCompatibility d3dCompatibility) {
+      m_d3dCompatibility.set(d3dCompatibility);
       RefreshAdapterFormatTables();
-      Logger::info("The D3D9 interface is now operating in D3D8 compatibility mode.");
+
+      if (d3dCompatibility == D3DCompatibility::D3D8)
+        Logger::info("The D3D9 interface is now operating in D3D8 compatibility mode.");
     }
 
     Rc<DxvkInstance> GetInstance() { return m_instance; }
@@ -168,11 +174,10 @@ namespace dxvk {
 
     Rc<DxvkInstance>              m_instance;
 
-    DxvkD3D8InterfaceBridge       m_d3d8Bridge;
+    DxvkLegacyD3DInterfaceBridge  m_legacyD3DBridge;
+    D3DCompatibilityFlags         m_d3dCompatibility;
 
     bool                          m_extended;
-
-    bool                          m_isD3D8Compatible = false;
 
     D3D9Options                   m_d3d9Options;
 

--- a/src/d3d9/d3d9_stateblock.cpp
+++ b/src/d3d9/d3d9_stateblock.cpp
@@ -18,7 +18,7 @@ namespace dxvk {
   }
 
   D3D9StateBlock::~D3D9StateBlock() {
-    if (!m_parent->IsD3D8Compatible())
+    if (!m_parent->IsD3DCompatibile(D3DCompatibility::D3D8))
       m_parent->DecrementLosableCounter();
   }
 

--- a/src/d3d9/d3d9_surface.cpp
+++ b/src/d3d9/d3d9_surface.cpp
@@ -137,7 +137,8 @@ namespace dxvk {
     // for surfaces in D3DPOOL_DEFAULT. D3D8 additionally clears the content
     // for non-D3DPOOL_DEFAULT surfaces if their type is not D3DRTYPE_TEXTURE.
     if (desc.Pool == D3DPOOL_DEFAULT
-     || (m_texture->Device()->IsD3D8Compatible() && type != D3DRTYPE_TEXTURE)) {
+     || (m_texture->Device()->IsD3DCompatibile(D3DCompatibility::D3D8) &&
+         type != D3DRTYPE_TEXTURE)) {
       pLockedRect->pBits = nullptr;
       pLockedRect->Pitch = 0;
     }
@@ -152,7 +153,7 @@ namespace dxvk {
       // with formats which need to be block aligned, surfaces created via
       // CreateImageSurface and D3D8 cube textures outside of D3DPOOL_DEFAULT
       if ((isBlockAlignedFormat && desc.Pool == D3DPOOL_DEFAULT) || isSystemMemSurface
-       || (m_texture->Device()->IsD3D8Compatible() &&
+       || (m_texture->Device()->IsD3DCompatibile(D3DCompatibility::D3D8) &&
            desc.Pool != D3DPOOL_DEFAULT && type == D3DRTYPE_CUBETEXTURE)) {
         const LONG width  = pRect->right  - pRect->left;
         const LONG height = pRect->bottom - pRect->top;

--- a/src/d3d9/d3d9_swapchain.cpp
+++ b/src/d3d9/d3d9_swapchain.cpp
@@ -1377,7 +1377,7 @@ namespace dxvk {
     if (this->GetParent()->Is9On12Device())
       return this->GetParent()->IsExtended() ? "D3D9On12Ex" : "D3D9On12";
 
-    return this->GetParent()->IsD3D8Compatible() ? "D3D8" :
+    return this->GetParent()->IsD3DCompatibile(D3DCompatibility::D3D8) ? "D3D8" :
            this->GetParent()->IsExtended() ? "D3D9Ex" : "D3D9";
   }
 


### PR DESCRIPTION
Refactors the D3D9 bridge with regards to naming and generalizes both the interfaces as well as the setting/storing/checking of D3D compatibility modes, using a `util_flags` bitmap. Very meh when considering D3D8 by itself, however.... you can imagine how "nice" it is to have 5 bools and 5 separate compatibility calls in D7VK. This PR provides a framework on which that entire mess can be simplified.