### PR TITLE
[d3d8] Assorted debug loggers cleanup

### DIFF
--- a/src/d3d8/d3d8_device.cpp
+++ b/src/d3d8/d3d8_device.cpp
@@ -41,8 +41,6 @@ namespace dxvk {
   }
 
   HRESULT STDMETHODCALLTYPE D3D8Device::GetInfo(DWORD DevInfoID, void* pDevInfoStruct, DWORD DevInfoStructSize) {
-    Logger::debug(str::format("D3D8Device::GetInfo: ", DevInfoID));
-
     if (unlikely(pDevInfoStruct == nullptr || DevInfoStructSize == 0))
       return D3DERR_INVALIDCALL;
 
@@ -727,7 +725,6 @@ namespace dxvk {
     }
 
     for (uint32_t i = 0; i < cRects; i++) {
-
       RECT srcRect, dstRect;
       srcRect = pSourceRectsArray[i];
 
@@ -752,20 +749,6 @@ namespace dxvk {
 
       POINT dstPt = { dstRect.left, dstRect.top };
 
-      auto unsupported = [&] {
-        Logger::err(str::format("D3D8Device::CopyRects: Unsupported case from src pool ", srcDesc.Pool, " to dst pool ", dstDesc.Pool));
-        return D3DERR_INVALIDCALL;
-      };
-
-      auto logError = [&] (HRESULT res) {
-        if (FAILED(res)) {
-          // Only a debug message because some games mess up CopyRects every frame in a way
-          // that fails on native too but are perfectly fine with it.
-          Logger::debug(str::format("D3D8Device::CopyRects: Failed to copy from src pool ", srcDesc.Pool, " to dst pool ", dstDesc.Pool));
-        }
-        return res;
-      };
-
       switch (dstDesc.Pool) {
 
         // Dest: DEFAULT
@@ -773,31 +756,31 @@ namespace dxvk {
           switch (srcDesc.Pool) {
             case d3d9::D3DPOOL_DEFAULT: {
               // DEFAULT -> DEFAULT: use StretchRect
-              return logError(GetD3D9()->StretchRect(
+              return GetD3D9()->StretchRect(
                 src->GetD3D9(),
                 &srcRect,
                 dst->GetD3D9(),
                 &dstRect,
                 d3d9::D3DTEXF_NONE
-              ));
+              );
             }
             case d3d9::D3DPOOL_MANAGED: {
               // MANAGED -> DEFAULT: UpdateTextureFromBuffer
-              return logError(m_bridge->UpdateTextureFromBuffer(
+              return m_bridge->UpdateTextureFromBuffer(
                 src->GetD3D9(),
                 dst->GetD3D9(),
                 &srcRect,
                 &dstPt
-              ));
+              );
             }
             case d3d9::D3DPOOL_SYSTEMMEM: {
               // SYSTEMMEM -> DEFAULT: use UpdateSurface
-              return logError(GetD3D9()->UpdateSurface(
+              return GetD3D9()->UpdateSurface(
                 src->GetD3D9(),
                 &srcRect,
                 dst->GetD3D9(),
                 &dstPt
-              ));
+              );
             }
             case d3d9::D3DPOOL_SCRATCH: {
               // SCRATCH -> DEFAULT: memcpy to a SYSTEMMEM temporary buffer and use UpdateSurface
@@ -805,7 +788,7 @@ namespace dxvk {
               const bool isSupportedSurfaceFormat = m_bridge->IsSupportedSurfaceFormat(srcDesc.Format);
               // UpdateSurface will not work on surface formats unsupported by D3DPOOL_DEFAULT
               if (unlikely(!isSupportedSurfaceFormat))
-                return logError(D3DERR_INVALIDCALL);
+                return D3DERR_INVALIDCALL;
 
               Com<IDirect3DSurface8> pTempImageSurface;
               // The temporary image surface is guaranteed to end up in SYSTEMMEM for supported formats
@@ -815,28 +798,24 @@ namespace dxvk {
                 D3DFORMAT(srcDesc.Format),
                 &pTempImageSurface
               );
-
-              if (FAILED(res)) {
-                return logError(res);
-              }
+              if (unlikely(FAILED(res)))
+                return res;
 
               Com<D3D8Surface> pBlitImage = static_cast<D3D8Surface*>(pTempImageSurface.ptr());
               // Temporary image surface dimensions are identical, so we can reuse srcDesc/Rect
               res = copyTextureBuffers(src.ptr(), pBlitImage.ptr(), srcDesc, srcDesc, srcRect, srcRect);
+              if (unlikely(FAILED(res)))
+                return res;
 
-              if (FAILED(res)) {
-                return logError(res);
-              }
-
-              return logError(GetD3D9()->UpdateSurface(
+              return GetD3D9()->UpdateSurface(
                 pBlitImage->GetD3D9(),
                 &srcRect,
                 dst->GetD3D9(),
                 &dstPt
-              ));
+              );
             }
             default: {
-              return unsupported();
+              return D3DERR_INVALIDCALL;
             }
           } break;
 
@@ -855,27 +834,24 @@ namespace dxvk {
                 pBlitImage.ptr(),
                 &dstRect,
                 d3d9::D3DTEXF_NONE);
-
-              if (FAILED(res)) {
-                return logError(res);
-              }
+              if (unlikely(FAILED(res)))
+                return res;
 
               // Now sync the rendertarget data into main memory.
-              return logError(GetD3D9()->GetRenderTargetData(pBlitImage.ptr(), dst->GetD3D9()));
+              return GetD3D9()->GetRenderTargetData(pBlitImage.ptr(), dst->GetD3D9());
             }
             case d3d9::D3DPOOL_MANAGED:
             case d3d9::D3DPOOL_SYSTEMMEM:
             case d3d9::D3DPOOL_SCRATCH: {
               // MANAGED/SYSMEM/SCRATCH -> MANAGED: LockRect / memcpy
 
-              if (stretch) {
-                return logError(D3DERR_INVALIDCALL);
-              }
+              if (unlikely(stretch))
+                return D3DERR_INVALIDCALL;
 
-              return logError(copyTextureBuffers(src.ptr(), dst.ptr(), srcDesc, dstDesc, srcRect, dstRect));
+              return copyTextureBuffers(src.ptr(), dst.ptr(), srcDesc, dstDesc, srcRect, dstRect);
             }
             default: {
-              return unsupported();
+              return D3DERR_INVALIDCALL;
             }
           } break;
 
@@ -891,7 +867,7 @@ namespace dxvk {
                 && srcDesc.Height == dstDesc.Height
                 && srcDesc.Format == dstDesc.Format
                 && !asymmetric) {
-              return logError(GetD3D9()->GetRenderTargetData(src->GetD3D9(), dst->GetD3D9()));
+              return GetD3D9()->GetRenderTargetData(src->GetD3D9(), dst->GetD3D9());
             }
           }
 
@@ -907,26 +883,23 @@ namespace dxvk {
                 pBlitImage.ptr(),
                 &dstRect,
                 d3d9::D3DTEXF_NONE);
-
-              if (FAILED(res)) {
-                return logError(res);
-              }
+              if (unlikely(FAILED(res)))
+                return res;
 
               // Now sync the rendertarget data into main memory.
-              return logError(GetD3D9()->GetRenderTargetData(pBlitImage.ptr(), dst->GetD3D9()));
+              return GetD3D9()->GetRenderTargetData(pBlitImage.ptr(), dst->GetD3D9());
             }
             // MANAGED/SYSMEM/SCRATCH -> SYSMEM: LockRect / memcpy
             case d3d9::D3DPOOL_MANAGED:
             case d3d9::D3DPOOL_SYSTEMMEM:
             case d3d9::D3DPOOL_SCRATCH: {
-              if (stretch) {
-                return logError(D3DERR_INVALIDCALL);
-              }
+              if (unlikely(stretch))
+                return D3DERR_INVALIDCALL;
 
-              return logError(copyTextureBuffers(src.ptr(), dst.ptr(), srcDesc, dstDesc, srcRect, dstRect));
+              return copyTextureBuffers(src.ptr(), dst.ptr(), srcDesc, dstDesc, srcRect, dstRect);
             }
             default: {
-              return unsupported();
+              return D3DERR_INVALIDCALL;
             }
           } break;
         }
@@ -943,7 +916,7 @@ namespace dxvk {
                 && srcDesc.Height == dstDesc.Height
                 && srcDesc.Format == dstDesc.Format
                 && !asymmetric) {
-              return logError(GetD3D9()->GetRenderTargetData(src->GetD3D9(), dst->GetD3D9()));
+              return GetD3D9()->GetRenderTargetData(src->GetD3D9(), dst->GetD3D9());
             }
           }
 
@@ -959,31 +932,28 @@ namespace dxvk {
                 pBlitImage.ptr(),
                 &dstRect,
                 d3d9::D3DTEXF_NONE);
-
-              if (FAILED(res)) {
-                return logError(res);
-              }
+              if (unlikely(FAILED(res)))
+                return res;
 
               // Now sync the rendertarget data into main memory.
-              return logError(GetD3D9()->GetRenderTargetData(pBlitImage.ptr(), dst->GetD3D9()));
+              return GetD3D9()->GetRenderTargetData(pBlitImage.ptr(), dst->GetD3D9());
             }
             // MANAGED/SYSMEM/SCRATCH -> SCRATCH: LockRect / memcpy
             case d3d9::D3DPOOL_MANAGED:
             case d3d9::D3DPOOL_SYSTEMMEM:
             case d3d9::D3DPOOL_SCRATCH: {
-              if (stretch) {
-                return logError(D3DERR_INVALIDCALL);
-              }
+              if (unlikely(stretch))
+                return D3DERR_INVALIDCALL;
 
-              return logError(copyTextureBuffers(src.ptr(), dst.ptr(), srcDesc, dstDesc, srcRect, dstRect));
+              return copyTextureBuffers(src.ptr(), dst.ptr(), srcDesc, dstDesc, srcRect, dstRect);
             }
             default: {
-              return unsupported();
+              return D3DERR_INVALIDCALL;
             }
           } break;
         }
         default: {
-          return unsupported();
+          return D3DERR_INVALIDCALL;
         }
       }
     }
@@ -1888,13 +1858,13 @@ namespace dxvk {
   inline D3D8VertexShaderInfo* getVertexShaderInfo(D3D8Device* device, DWORD Handle) {
     Handle = getShaderIndex(Handle);
     if (unlikely(Handle >= device->m_vertexShaders.size())) {
-      Logger::debug(str::format("D3D8: Invalid vertex shader index ", std::hex, Handle));
+      Logger::warn(str::format("D3D8Device: Invalid vertex shader handle ", std::hex, Handle));
       return nullptr;
     }
 
     D3D8VertexShaderInfo& info = device->m_vertexShaders[Handle];
     if (unlikely(info.pVertexDecl == nullptr && info.pVertexShader == nullptr)) {
-      Logger::debug(str::format("D3D8: Application provided deleted vertex shader ", std::hex, Handle));
+      Logger::warn(str::format("D3D8Device: Application provided deleted vertex shader ", std::hex, Handle));
       return nullptr;
     }
 
@@ -1914,7 +1884,7 @@ namespace dxvk {
     if (!isFVF(Handle)) {
       D3D8VertexShaderInfo* info = getVertexShaderInfo(this, Handle);
 
-      if (!info)
+      if (unlikely(!info))
         return D3DERR_INVALIDCALL;
 
       StateChange();
@@ -1980,7 +1950,7 @@ namespace dxvk {
     if (!isFVF(Handle)) {
       D3D8VertexShaderInfo* info = getVertexShaderInfo(this, Handle);
 
-      if (!info)
+      if (unlikely(!info))
         return D3DERR_INVALIDCALL;
 
       info->pVertexDecl = nullptr;
@@ -2082,14 +2052,14 @@ namespace dxvk {
     Handle = getShaderIndex(Handle);
 
     if (unlikely(Handle >= device->m_pixelShaders.size())) {
-      Logger::debug(str::format("D3D8: Invalid pixel shader index ", std::hex, Handle));
+      Logger::warn(str::format("D3D8Device: Invalid pixel shader handle ", std::hex, Handle));
       return nullptr;
     }
 
     d3d9::IDirect3DPixelShader9* pPixelShader = device->m_pixelShaders[Handle].ptr();
 
     if (unlikely(pPixelShader == nullptr)) {
-      Logger::debug(str::format("D3D8: Application provided deleted pixel shader ", std::hex, Handle));
+      Logger::warn(str::format("D3D8Device: Application provided deleted pixel shader ", std::hex, Handle));
       return nullptr;
     }
 
@@ -2103,17 +2073,16 @@ namespace dxvk {
       return m_recorder->SetPixelShader(Handle);
     }
 
-    if (Handle == DWORD(NULL)) {
+    if (!Handle) {
       StateChange();
-      m_currentPixelShader = DWORD(NULL);
+      m_currentPixelShader = 0;
       return GetD3D9()->SetPixelShader(nullptr);
     }
 
     d3d9::IDirect3DPixelShader9* pPixelShader = getPixelShaderPtr(this, Handle);
 
-    if (unlikely(!pPixelShader)) {
+    if (unlikely(!pPixelShader))
       return D3DERR_INVALIDCALL;
-    }
 
     StateChange();
     HRESULT res = GetD3D9()->SetPixelShader(pPixelShader);
@@ -2143,9 +2112,8 @@ namespace dxvk {
 
     d3d9::IDirect3DPixelShader9* pPixelShader = getPixelShaderPtr(this, Handle);
 
-    if (unlikely(!pPixelShader)) {
+    if (unlikely(!pPixelShader))
       return D3DERR_INVALIDCALL;
-    }
 
     m_pixelShaders[getShaderIndex(Handle)] = nullptr;
 

--- a/src/d3d8/d3d8_shader.cpp
+++ b/src/d3d8/d3d8_shader.cpp
@@ -136,8 +136,8 @@ namespace dxvk {
     uint32_t i = 0;
     DWORD token;
 
-    std::stringstream dbg;
-    dbg << "D3D8: Vertex Declaration Tokens:\n\t";
+    //std::stringstream dbg;
+    //dbg << "D3D8: Vertex Declaration Tokens:\n\t";
 
     WORD currentStream = 0;
     WORD currentOffset = 0;
@@ -165,74 +165,89 @@ namespace dxvk {
     if (options.forceVsDecl.size() == 0) do {
       token = pDeclaration[i++];
 
-      D3DVSD_TOKENTYPE tokenType = D3DVSD_TOKENTYPE(VSD_SHIFT_MASK(token, D3DVSD_TOKENTYPE));
+      const D3DVSD_TOKENTYPE tokenType = D3DVSD_TOKENTYPE(VSD_SHIFT_MASK(token, D3DVSD_TOKENTYPE));
 
       switch (tokenType) {
         case D3DVSD_TOKEN_NOP:
-          dbg << "NOP";
+          //dbg << "NOP";
           break;
         case D3DVSD_TOKEN_STREAM: {
-          dbg << "STREAM ";
+          //dbg << "STREAM ";
 
           // TODO: D3DVSD_STREAM_TESS
-          if (token & D3DVSD_STREAMTESSMASK) {
-            dbg << "TESS";
+          if (unlikely(token & D3DVSD_STREAMTESSMASK)) {
+            //dbg << "TESS";
+
+            static bool s_streamTessErrorShown;
+
+            if (!std::exchange(s_streamTessErrorShown, true))
+              Logger::warn("D3D8Device::CreateVertexShader: Unhandled D3DVSD_STREAMTESSMASK");
           }
 
-          DWORD streamNum = VSD_SHIFT_MASK(token, D3DVSD_STREAMNUMBER);
+          const DWORD streamNum = VSD_SHIFT_MASK(token, D3DVSD_STREAMNUMBER);
+          //dbg << ", num=" << streamNum;
 
           currentStream = WORD(streamNum);
           currentOffset = 0; // reset offset
 
-          dbg << ", num=" << streamNum;
           break;
         }
         case D3DVSD_TOKEN_STREAMDATA: {
-
-          dbg << "STREAMDATA ";
+          //dbg << "STREAMDATA ";
 
           // D3DVSD_SKIP
           if (token & VSD_SKIP_FLAG) {
-            auto skipCount = VSD_SHIFT_MASK(token, D3DVSD_SKIPCOUNT);
-            dbg << "SKIP " << " count=" << skipCount;
+            const DWORD skipCount = VSD_SHIFT_MASK(token, D3DVSD_SKIPCOUNT);
+            //dbg << "SKIP " << " count=" << skipCount;
             currentOffset += WORD(skipCount) * sizeof(DWORD);
             break;
           }
 
           // D3DVSD_REG
-          DWORD dataLoadType = VSD_SHIFT_MASK(token, D3DVSD_DATALOADTYPE);
+          const DWORD dataLoadType = VSD_SHIFT_MASK(token, D3DVSD_DATALOADTYPE);
 
-          if ( dataLoadType == 0 ) { // vertex
+          if (likely(dataLoadType == 0)) { // vertex
             D3DVSDT_TYPE     type = D3DVSDT_TYPE(VSD_SHIFT_MASK(token, D3DVSD_DATATYPE));
             D3DVSDE_REGISTER reg  = D3DVSDE_REGISTER(VSD_SHIFT_MASK(token, D3DVSD_VERTEXREG));
+            //dbg << "type=" << type << ", register=" << reg;
 
             // FVF normals are expected to only have 3 components
             if (unlikely(pFunction == nullptr && reg == D3DVSDE_NORMAL && type != D3DVSDT_FLOAT3)) {
-              Logger::err("D3D8Device::CreateVertexShader: Invalid FVF declaration: D3DVSDE_NORMAL must use D3DVSDT_FLOAT3");
+              Logger::warn("D3D8Device::CreateVertexShader: Invalid FVF declaration: D3DVSDE_NORMAL must use D3DVSDT_FLOAT3");
               return D3DERR_INVALIDCALL;
             }
 
             addVertexElement(reg, type);
-
-            dbg << "type=" << type << ", register=" << reg;
+          // TODO: When would this bit be 1?
           } else {
-            // TODO: When would this bit be 1?
-            dbg << "D3DVSD_DATALOADTYPE " << dataLoadType;
+            //dbg << "D3DVSD_DATALOADTYPE " << dataLoadType;
+
+            static bool s_dataLoadTypeErrorShown;
+
+            if (!std::exchange(s_dataLoadTypeErrorShown, true))
+              Logger::warn("D3D8Device::CreateVertexShader: Unhandled non-zero D3DVSD_DATALOADTYPE");
           }
           break;
         }
-        case D3DVSD_TOKEN_TESSELLATOR:
-          dbg << "TESSELLATOR " << std::hex << token;
-          // TODO: D3DVSD_TOKEN_TESSELLATOR
-          break;
-        case D3DVSD_TOKEN_CONSTMEM: {
-          dbg << "CONSTMEM ";
-          DWORD count     = VSD_SHIFT_MASK(token, D3DVSD_CONSTCOUNT);
-          DWORD regCount  = count * 4;
-          DWORD addr      = VSD_SHIFT_MASK(token, D3DVSD_CONSTADDRESS);
-          DWORD rs        = VSD_SHIFT_MASK(token, D3DVSD_CONSTRS);
+        // TODO: D3DVSD_TOKEN_TESSELLATOR
+        case D3DVSD_TOKEN_TESSELLATOR: {
+          //dbg << "TESSELLATOR " << std::hex << token;
 
-          dbg << "count=" << count << ", addr=" << addr << ", rs=" << rs;
+          static bool s_tesselatorErrorShown;
+
+          if (!std::exchange(s_tesselatorErrorShown, true))
+            Logger::warn("D3D8Device::CreateVertexShader: Unhandled D3DVSD_TOKEN_TESSELLATOR");
+
+          break;
+        }
+        case D3DVSD_TOKEN_CONSTMEM: {
+          //dbg << "CONSTMEM ";
+
+          const DWORD count    = VSD_SHIFT_MASK(token, D3DVSD_CONSTCOUNT);
+          const DWORD regCount = count * 4;
+          //const DWORD rs       = VSD_SHIFT_MASK(token, D3DVSD_CONSTRS);
+          DWORD addr           = VSD_SHIFT_MASK(token, D3DVSD_CONSTADDRESS);
+          //dbg << "count=" << count << ", rs=" << rs << ", addr=" << addr;
 
           // Add a DEF instruction for each constant
           for (uint32_t j = 0; j < regCount; j += 4) {
@@ -248,26 +263,29 @@ namespace dxvk {
           break;
         }
         case D3DVSD_TOKEN_EXT: {
-          dbg << "EXT " << std::hex << token << " ";
-          DWORD extInfo = VSD_SHIFT_MASK(token, D3DVSD_EXTINFO);
-          DWORD extCount = VSD_SHIFT_MASK(token, D3DVSD_EXTCOUNT);
-          dbg << "info=" << extInfo << ", count=" << extCount;
+          //dbg << "EXT " << std::hex << token << " ";
+
+          /*const DWORD extInfo = VSD_SHIFT_MASK(token, D3DVSD_EXTINFO);
+          const DWORD extCount = VSD_SHIFT_MASK(token, D3DVSD_EXTCOUNT);
+          dbg << "info=" << extInfo << ", count=" << extCount;*/
+
           break;
         }
         case D3DVSD_TOKEN_END: {
+          //dbg << "END";
           vertexElements[elementIdx++] = D3DDECL_END();
-          dbg << "END";
           break;
         }
         default:
-          dbg << "UNKNOWN TYPE";
+          //dbg << "UNKNOWN TYPE " << std::hex << token << " ";
+          Logger::warn(str::format("D3D8Device::CreateVertexShader: Unhandled token type ", std::hex, token));
           break;
       }
-      dbg << "\n\t";
-      //dbg << std::hex << token << " ";
+
+      //dbg << "\n\t";
     } while (token != D3DVSD_END());
 
-    Logger::debug(dbg.str());
+    //Logger::debug(dbg.str());
 
     // If forceVsDecl is set, use that decl instead.
     if (options.forceVsDecl.size() > 0) {
@@ -283,20 +301,18 @@ namespace dxvk {
       // Copy first token (version)
       tokens.push_back(pFunction[0]);
 
-      DWORD vsMajor = D3DSHADER_VERSION_MAJOR(pFunction[0]);
-      DWORD vsMinor = D3DSHADER_VERSION_MINOR(pFunction[0]);
-      Logger::debug(str::format("VS version: ", vsMajor, ".", vsMinor));
+      /*const DWORD vsMajor = D3DSHADER_VERSION_MAJOR(pFunction[0]);
+      const DWORD vsMinor = D3DSHADER_VERSION_MINOR(pFunction[0]);
+      Logger::debug(str::format("VS version: ", vsMajor, ".", vsMinor));*/
 
       // Insert dcl instructions
       for (UINT vn = 0; vn < D3D8_NUM_VERTEX_INPUT_REGISTERS; vn++) {
-
         // If bit N is set then we need to dcl register vN
         if ((shaderInputRegisters & (1 << vn)) != 0) {
+          //Logger::debug(str::format("\tShader Input Regsiter: v", vn));
 
-          Logger::debug(str::format("\tShader Input Regsiter: v", vn));
-
-          DWORD usage = D3D8_VERTEX_INPUT_REGISTERS[vn][0];
-          DWORD index = D3D8_VERTEX_INPUT_REGISTERS[vn][1];
+          const DWORD usage = D3D8_VERTEX_INPUT_REGISTERS[vn][0];
+          const DWORD index = D3D8_VERTEX_INPUT_REGISTERS[vn][1];
 
           tokens.push_back(encodeInstruction(d3d9::D3DSIO_DCL));                  // dcl opcode
           tokens.push_back(encodeDeclaration(d3d9::D3DDECLUSAGE(usage), index));  // usage token
@@ -315,18 +331,17 @@ namespace dxvk {
       do {
         token = pFunction[i++];
 
-        DWORD opcode = token & D3DSI_OPCODE_MASK;
+        const DWORD opcode = token & D3DSI_OPCODE_MASK;
 
         // Instructions
         if ((token & VS_BIT_PARAM) == 0) {
-
           // Swizzle fixup for opcodes that require explicit use of a replicate swizzle.
           if (opcode == D3DSIO_RSQ  || opcode == D3DSIO_RCP
            || opcode == D3DSIO_EXP  || opcode == D3DSIO_LOG
            || opcode == D3DSIO_EXPP || opcode == D3DSIO_LOGP) {
-            tokens.push_back(token);                            // instr
-            tokens.push_back(token = pFunction[i++]);           // dest
-            token = pFunction[i++];                             // src0
+            tokens.push_back(token);                   // instr
+            tokens.push_back(token = pFunction[i++]);  // dest
+            token = pFunction[i++];                    // src0
 
             // If no swizzling is done, then use the w-component.
             // See d8vk#43 for more information as this may need to change in some cases.


### PR DESCRIPTION
I've seen these can get spammed quite a bit even during rendering in certain cases, and they're not exactly free real estate even when they don't get printed, as I found out the hard way in D7VK. If they're not generally useful for some odd reason I think it's best to remove them altogether, since they can always be brought back temporarily if any testing/debugging is needed.

Edit: Added 2 more things:
- A cleanup of CopyRects logging, since it is now fully implemented and doesn't have any known edge cases. Moreover, some games expect it to fail at times, and it's a fairly hot path.
- Explicitly log unhandled token types in TranslateVertexShader8 (and comment out the verbose debug loggers by default)