### PR TITLE
[d3d9] Handle D3D9Ex checks with the D3D compatibility flags

### DIFF
--- a/src/d3d9/d3d9_adapter.cpp
+++ b/src/d3d9/d3d9_adapter.cpp
@@ -80,12 +80,14 @@ namespace dxvk {
     copyToStringArray(pIdentifier->DeviceName,  displayName.c_str());    // The GDI device name. Not the actual device name.
     copyToStringArray(pIdentifier->Driver,      m_deviceDriver.c_str()); // This is the driver's dll.
 
+    const bool isExtended = m_parent->IsD3DCompatibile(D3DCompatibility::D3D9Ex);
+
     pIdentifier->DeviceIdentifier       = m_deviceGuid;
     pIdentifier->DeviceId               = m_deviceId;
     pIdentifier->VendorId               = m_vendorId;
     pIdentifier->Revision               = 0;
     pIdentifier->SubSysId               = 0;
-    pIdentifier->WHQLLevel              = m_parent->IsExtended() ? 1 : 0; // This doesn't check with the driver on Direct3D9Ex and is always 1.
+    pIdentifier->WHQLLevel              = isExtended ? 1 : 0; // This doesn't check with the driver on Direct3D9Ex and is always 1.
     pIdentifier->DriverVersion.QuadPart = INT64_MAX;
 
     return D3D_OK;
@@ -526,7 +528,7 @@ namespace dxvk {
                                     | D3DPBLENDCAPS_BLENDFACTOR;
 
     // Only 9Ex devices advertise D3DPBLENDCAPS_SRCCOLOR2 and D3DPBLENDCAPS_INVSRCCOLOR2
-    if (m_parent->IsExtended())
+    if (m_parent->IsD3DCompatibile(D3DCompatibility::D3D9Ex))
       pCaps->SrcBlendCaps          |= D3DPBLENDCAPS_SRCCOLOR2
                                     | D3DPBLENDCAPS_INVSRCCOLOR2;
 
@@ -878,11 +880,6 @@ namespace dxvk {
 
   void D3D9Adapter::RefreshFormatsTable() const {
     m_d3d9Formats->RefreshFormatSupport(this);
-  }
-
-
-  bool D3D9Adapter::IsExtended() const {
-    return m_parent->IsExtended();
   }
 
 

--- a/src/d3d9/d3d9_adapter.h
+++ b/src/d3d9/d3d9_adapter.h
@@ -102,8 +102,6 @@ namespace dxvk {
 
     void RefreshFormatsTable() const;
 
-    bool IsExtended() const;
-
     bool IsD3DCompatibile(D3DCompatibility d3dCompatibility) const;
 
     force_inline void incRef() {

--- a/src/d3d9/d3d9_bridge.cpp
+++ b/src/d3d9/d3d9_bridge.cpp
@@ -116,7 +116,12 @@ namespace dxvk {
   }
 
   void DxvkLegacyD3DInterfaceBridge::SetD3DCompatibility(D3DCompatibility d3dCompatibility) const {
-    m_interface->SetD3DCompatibility(d3dCompatibility);
+    // The D3D9Ex compatibility flag is internal only, and can't be set by the bridge
+    if (likely(d3dCompatibility != D3DCompatibility::D3D9Ex)) {
+      m_interface->SetD3DCompatibility(d3dCompatibility);
+    } else {
+      Logger::err("DxvkLegacyD3DInterfaceBridge::SetD3DCompatibility: Invalid compatibility level: D3D9Ex");
+    }
   }
 
   const Config* DxvkLegacyD3DInterfaceBridge::GetConfig() const {

--- a/src/d3d9/d3d9_bridge.h
+++ b/src/d3d9/d3d9_bridge.h
@@ -5,7 +5,8 @@
 #include "../util/util_flags.h"
 
 enum class DxvkD3DCompatibility : uint8_t {
-  D3D8,
+  D3D9Ex,
+  D3D8
 };
 
 /**

--- a/src/d3d9/d3d9_common_texture.cpp
+++ b/src/d3d9/d3d9_common_texture.cpp
@@ -163,10 +163,12 @@ namespace dxvk {
     ///////////////////
     // Desc Validation
 
+    const bool isExtended = pDevice->IsD3DCompatibile(D3DCompatibility::D3D9Ex);
+
     // Resources can't be created in D3DPOOL_MANAGED
     // when using extended devices. Note that the D3DPOOL
     // value of 6 (D3DPOOL_MANAGED_EX) can be used.
-    if (pDevice->IsExtended() && pDesc->Pool == D3DPOOL_MANAGED)
+    if (isExtended && pDesc->Pool == D3DPOOL_MANAGED)
       return D3DERR_INVALIDCALL;
 
     if (pDesc->Width == 0 || pDesc->Height == 0 || pDesc->Depth == 0)
@@ -262,7 +264,7 @@ namespace dxvk {
     // plain surfaces outside of D3DPOOL_SCRATCH in D3D9Ex
     if (pDesc->Format == D3D9Format::ATI2
      && (pDesc->Usage & D3DUSAGE_RENDERTARGET ||
-        (pDevice->IsExtended() && isPlainSurface && pDesc->Pool != D3DPOOL_SCRATCH)))
+        (isExtended && isPlainSurface && pDesc->Pool != D3DPOOL_SCRATCH)))
       return D3DERR_INVALIDCALL;
 
     // Auto-Mipgen is only valid on textures (for obvious reasons)

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -179,12 +179,10 @@ namespace dxvk {
 
     *ppvObject = nullptr;
 
-    bool extended = m_parent->IsExtended()
-                 && riid == __uuidof(IDirect3DDevice9Ex);
-
     if (riid == __uuidof(IUnknown)
      || riid == __uuidof(IDirect3DDevice9)
-     || extended) {
+     || (m_d3dCompatibility.test(D3DCompatibility::D3D9Ex) &&
+         riid == __uuidof(IDirect3DDevice9Ex))) {
       *ppvObject = ref(this);
       return S_OK;
     }
@@ -392,7 +390,7 @@ namespace dxvk {
   }
 
 
-  void    STDMETHODCALLTYPE D3D9DeviceEx::SetCursorPosition(int X, int Y, DWORD Flags) {
+  void STDMETHODCALLTYPE D3D9DeviceEx::SetCursorPosition(int X, int Y, DWORD Flags) {
     D3D9DeviceLock lock = LockDevice();
 
     // I was not able to find an instance
@@ -407,7 +405,7 @@ namespace dxvk {
   }
 
 
-  BOOL    STDMETHODCALLTYPE D3D9DeviceEx::ShowCursor(BOOL bShow) {
+  BOOL STDMETHODCALLTYPE D3D9DeviceEx::ShowCursor(BOOL bShow) {
     D3D9DeviceLock lock = LockDevice();
 
     return m_cursor.ShowCursor(bShow);
@@ -440,7 +438,7 @@ namespace dxvk {
   }
 
 
-  UINT    STDMETHODCALLTYPE D3D9DeviceEx::GetNumberOfSwapChains() {
+  UINT STDMETHODCALLTYPE D3D9DeviceEx::GetNumberOfSwapChains() {
     // This only counts the implicit swapchain...
 
     return 1;
@@ -463,7 +461,7 @@ namespace dxvk {
         return hr;
     }
 
-    if (!IsExtended()) {
+    if (!m_d3dCompatibility.test(D3DCompatibility::D3D9Ex)) {
       // The internal references are always cleared, regardless of whether the Reset call succeeds.
       ResetState(pPresentationParameters);
       m_implicitSwapchain->DestroyBackBuffers();
@@ -501,6 +499,8 @@ namespace dxvk {
 
     m_cursor.ResetCursor();
 
+    const bool isExtended = m_d3dCompatibility.test(D3DCompatibility::D3D9Ex);
+
     /*
       * Before calling the IDirect3DDevice9::Reset method for a device,
       * an application should release any explicit render targets,
@@ -510,7 +510,7 @@ namespace dxvk {
       * We have to check after ResetState clears the references held by SetTexture, etc.
       * This matches what Windows D3D9 does.
     */
-    if (unlikely(m_losableResourceCounter.load() != 0 && !IsExtended() && m_d3d9Options.countLosableResources)) {
+    if (unlikely(m_losableResourceCounter.load() != 0 && !isExtended && m_d3d9Options.countLosableResources)) {
       Logger::warn(str::format("Device reset failed because device still has alive losable resources: Device not reset. Remaining resources: ", m_losableResourceCounter.load()));
       m_deviceLostState = D3D9DeviceLostState::NotReset;
       // D3D8 returns D3DERR_DEVICELOST here, whereas D3D9 returns D3DERR_INVALIDCALL.
@@ -519,7 +519,7 @@ namespace dxvk {
 
     hr = ResetSwapChain(pPresentationParameters, nullptr);
     if (unlikely(FAILED(hr))) {
-      if (!IsExtended()) {
+      if (!isExtended) {
         Logger::warn("Device reset failed: Device not reset");
         m_deviceLostState = D3D9DeviceLostState::NotReset;
       }
@@ -654,7 +654,8 @@ namespace dxvk {
                    !ValidateSharedTexture(*pSharedHandle, D3DRTYPE_TEXTURE, desc)))
         return E_INVALIDARG;
 
-      const Com<D3D9Texture2D> texture = new D3D9Texture2D(this, &desc, IsExtended(), pSharedHandle);
+      const bool isExtended = m_d3dCompatibility.test(D3DCompatibility::D3D9Ex);
+      const Com<D3D9Texture2D> texture = new D3D9Texture2D(this, &desc, isExtended, pSharedHandle);
 
       m_initializer->InitTexture(texture->GetCommonTexture(), initialData);
       *ppTexture = texture.ref();
@@ -722,7 +723,8 @@ namespace dxvk {
       return E_INVALIDARG;
 
     try {
-      const Com<D3D9Texture3D> texture = new D3D9Texture3D(this, &desc, IsExtended());
+      const bool isExtended = m_d3dCompatibility.test(D3DCompatibility::D3D9Ex);
+      const Com<D3D9Texture3D> texture = new D3D9Texture3D(this, &desc, isExtended);
       m_initializer->InitTexture(texture->GetCommonTexture());
       *ppVolumeTexture = texture.ref();
 
@@ -788,7 +790,8 @@ namespace dxvk {
       return E_INVALIDARG;
 
     try {
-      const Com<D3D9TextureCube> texture = new D3D9TextureCube(this, &desc, IsExtended());
+      const bool isExtended = m_d3dCompatibility.test(D3DCompatibility::D3D9Ex);
+      const Com<D3D9TextureCube> texture = new D3D9TextureCube(this, &desc, isExtended);
       m_initializer->InitTexture(texture->GetCommonTexture());
       *ppCubeTexture = texture.ref();
 
@@ -831,7 +834,9 @@ namespace dxvk {
     desc.Type   = D3DRTYPE_VERTEXBUFFER;
     desc.Usage  = Usage;
 
-    if (FAILED(D3D9CommonBuffer::ValidateBufferProperties(&desc, IsExtended())))
+    const bool isExtended = m_d3dCompatibility.test(D3DCompatibility::D3D9Ex);
+
+    if (FAILED(D3D9CommonBuffer::ValidateBufferProperties(&desc, isExtended)))
       return D3DERR_INVALIDCALL;
 
     if (unlikely(pSharedHandle != nullptr && *pSharedHandle != nullptr &&
@@ -839,7 +844,7 @@ namespace dxvk {
       return E_INVALIDARG;
 
     try {
-      const Com<D3D9VertexBuffer> buffer = new D3D9VertexBuffer(this, &desc, IsExtended());
+      const Com<D3D9VertexBuffer> buffer = new D3D9VertexBuffer(this, &desc, isExtended);
       m_initializer->InitBuffer(buffer->GetCommonBuffer());
       *ppVertexBuffer = buffer.ref();
 
@@ -881,7 +886,9 @@ namespace dxvk {
     desc.Type   = D3DRTYPE_INDEXBUFFER;
     desc.Usage  = Usage;
 
-    if (FAILED(D3D9CommonBuffer::ValidateBufferProperties(&desc, IsExtended())))
+    const bool isExtended = m_d3dCompatibility.test(D3DCompatibility::D3D9Ex);
+
+    if (FAILED(D3D9CommonBuffer::ValidateBufferProperties(&desc, isExtended)))
       return D3DERR_INVALIDCALL;
 
     if (unlikely(pSharedHandle != nullptr && *pSharedHandle != nullptr &&
@@ -889,7 +896,7 @@ namespace dxvk {
       return E_INVALIDARG;
 
     try {
-      const Com<D3D9IndexBuffer> buffer = new D3D9IndexBuffer(this, &desc, IsExtended());
+      const Com<D3D9IndexBuffer> buffer = new D3D9IndexBuffer(this, &desc, isExtended);
       m_initializer->InitBuffer(buffer->GetCommonBuffer());
       *ppIndexBuffer = buffer.ref();
 
@@ -1363,7 +1370,7 @@ namespace dxvk {
       bool srcHasAttachmentUsage = (srcTextureInfo->Desc()->Usage & (D3DUSAGE_RENDERTARGET | D3DUSAGE_DEPTHSTENCIL)) != 0;
 
       // D3D9Ex allows StretchRect to regular (non-RT) textures if it is a simple copy.
-      bool isCopy = IsExtended()
+      bool isCopy = m_d3dCompatibility.test(D3DCompatibility::D3D9Ex)
         && pSourceRect == nullptr && pDestRect == nullptr // Yes, the rects have to be null. Even passing a rect that is the same size as the texture is invalid.
         && srcTextureInfo->Desc()->Pool == D3DPOOL_DEFAULT
         && dstTextureInfo->Desc()->Pool == D3DPOOL_DEFAULT
@@ -4304,7 +4311,8 @@ namespace dxvk {
       return E_INVALIDARG;
 
     try {
-      const Com<D3D9Surface> surface = new D3D9Surface(this, &desc, IsExtended(), nullptr, pSharedHandle);
+      const bool isExtended = m_d3dCompatibility.test(D3DCompatibility::D3D9Ex);
+      const Com<D3D9Surface> surface = new D3D9Surface(this, &desc, isExtended, nullptr, pSharedHandle);
       m_initializer->InitTexture(surface->GetCommonTexture());
       *ppSurface = surface.ref();
       m_losableResourceCounter++;
@@ -4383,7 +4391,8 @@ namespace dxvk {
                    !ValidateSharedTexture(*pSharedHandle, D3DRTYPE_SURFACE, desc)))
         return E_INVALIDARG;
 
-      const Com<D3D9Surface> surface = new D3D9Surface(this, &desc, IsExtended(), nullptr, pSharedHandle);
+      const bool isExtended = m_d3dCompatibility.test(D3DCompatibility::D3D9Ex);
+      const Com<D3D9Surface> surface = new D3D9Surface(this, &desc, isExtended, nullptr, pSharedHandle);
       m_initializer->InitTexture(surface->GetCommonTexture(), initialData);
       *ppSurface = surface.ref();
 
@@ -4448,7 +4457,8 @@ namespace dxvk {
       return E_INVALIDARG;
 
     try {
-      const Com<D3D9Surface> surface = new D3D9Surface(this, &desc, IsExtended(), nullptr, pSharedHandle);
+      const bool isExtended = m_d3dCompatibility.test(D3DCompatibility::D3D9Ex);
+      const Com<D3D9Surface> surface = new D3D9Surface(this, &desc, isExtended, nullptr, pSharedHandle);
       m_initializer->InitTexture(surface->GetCommonTexture());
       *ppSurface = surface.ref();
       m_losableResourceCounter++;
@@ -4709,11 +4719,6 @@ namespace dxvk {
     }
 
     return D3D_OK;
-  }
-
-
-  bool D3D9DeviceEx::IsExtended() {
-    return m_parent->IsExtended();
   }
 
 
@@ -8922,6 +8927,8 @@ namespace dxvk {
       m_mostRecentlyUsedSwapchain = m_implicitSwapchain.ptr();
     }
 
+    const bool isExtended = m_d3dCompatibility.test(D3DCompatibility::D3D9Ex);
+
     if (pPresentationParameters->EnableAutoDepthStencil) {
       D3D9_COMMON_TEXTURE_DESC desc;
       desc.Width              = pPresentationParameters->BackBufferWidth;
@@ -8942,13 +8949,13 @@ namespace dxvk {
       if (FAILED(D3D9CommonTexture::NormalizeTextureProperties(this, D3DRTYPE_SURFACE, &desc)))
         return D3DERR_NOTAVAILABLE;
 
-      m_autoDepthStencil = new D3D9Surface(this, &desc, IsExtended(), nullptr, nullptr);
+      m_autoDepthStencil = new D3D9Surface(this, &desc, isExtended, nullptr, nullptr);
       m_initializer->InitTexture(m_autoDepthStencil->GetCommonTexture());
       SetDepthStencilSurface(m_autoDepthStencil.ptr());
       m_losableResourceCounter++;
     }
 
-    if (!IsExtended()) {
+    if (!isExtended) {
       SetRenderTarget(0, m_implicitSwapchain->GetBackBuffer(0));
     } else {
       // Extended devices will not reset the MinZ/MaxZ viewport values
@@ -9091,7 +9098,7 @@ namespace dxvk {
   void D3D9DeviceEx::NotifyWindowActivated(HWND window, bool activated) {
     D3D9DeviceLock lock = LockDevice();
 
-    if (likely(!m_d3d9Options.deviceLossOnFocusLoss || IsExtended()))
+    if (likely(!m_d3d9Options.deviceLossOnFocusLoss || m_d3dCompatibility.test(D3DCompatibility::D3D9Ex)))
       return;
 
     if (activated && m_deviceLostState == D3D9DeviceLostState::Lost) {

--- a/src/d3d9/d3d9_device.h
+++ b/src/d3d9/d3d9_device.h
@@ -807,8 +807,6 @@ namespace dxvk {
 
     bool SupportsVCacheQuery() const;
 
-    bool IsExtended();
-
     HWND GetWindow();
 
     const Rc<DxvkDevice>& GetDXVKDevice() {
@@ -1079,7 +1077,7 @@ namespace dxvk {
     void ConsiderFlush(GpuFlushType FlushType);
 
     bool ChangeReportedMemory(int64_t delta) {
-      if (IsExtended())
+      if (m_d3dCompatibility.test(D3DCompatibility::D3D9Ex))
         return true;
 
       int64_t availableMemory = m_availableMemory.fetch_add(delta);

--- a/src/d3d9/d3d9_format.cpp
+++ b/src/d3d9/d3d9_format.cpp
@@ -478,7 +478,7 @@ namespace dxvk {
             D3D9Adapter*     pParent,
       const Rc<DxvkAdapter>& adapter,
       const D3D9Options&     options)
-    : m_isExtended (pParent->IsExtended()) {
+    : m_isExtended (pParent->IsD3DCompatibile(D3DCompatibility::D3D9Ex)) {
 
     const uint32_t vendorId = pParent->GetVendorId();
     const bool     isNvidia = vendorId == uint32_t(DxvkGpuVendor::Nvidia);
@@ -616,14 +616,14 @@ namespace dxvk {
       case D3D9Format::D32F_LOCKABLE:
         return &d32f_lockable;
 
-      // only considered on d3d9Ex interfaces
+      // only considered on D3D9Ex interfaces
       case D3D9Format::D32_LOCKABLE:
         if (m_isExtended)
           return &d32_lockable;
 
         [[fallthrough]];
 
-      // only considered on d3d9Ex interfaces
+      // only considered on D3D9Ex interfaces
       case D3D9Format::S8_LOCKABLE:
         if (m_isExtended)
           return &s8_lockable;

--- a/src/d3d9/d3d9_interface.cpp
+++ b/src/d3d9/d3d9_interface.cpp
@@ -15,12 +15,11 @@ namespace dxvk {
   Singleton<DxvkInstance> g_dxvkInstance;
 
   D3D9InterfaceEx::D3D9InterfaceEx(bool bExtended, const D3D9ON12_ARGS* pOverrideList, uint32_t OverrideCount)
-    : m_instance         ( g_dxvkInstance.acquire(DxvkInstanceFlag::ClientApiIsD3D9) )
-    , m_legacyD3DBridge  ( this )
-    , m_extended         ( bExtended )
-    , m_d3d9Options      ( nullptr, m_instance->config() )
-    , m_d3d9Interop      ( this )
-    , m_d3d9ExtInterface ( this ) {
+    : m_instance           ( g_dxvkInstance.acquire(DxvkInstanceFlag::ClientApiIsD3D9) )
+    , m_legacyD3DBridge    ( this )
+    , m_d3d9Options        ( nullptr, m_instance->config() )
+    , m_d3d9Interop        ( this )
+    , m_d3d9VkExtInterface ( this ) {
     // D3D9 doesn't enumerate adapters like physical adapters...
     // only as connected displays.
 
@@ -74,8 +73,13 @@ namespace dxvk {
     }
 #endif
 
+    if (bExtended) {
+      m_d3dCompatibility.set(D3DCompatibility::D3D9Ex);
+      Logger::info("The D3D9 interface is operating in D3D9Ex mode.");
+    }
+
     if (unlikely(m_d3d9Options.shaderModel == 0))
-      Logger::warn("D3D9InterfaceEx: WARNING! Fixed-function exclusive mode is enabled.");
+      Logger::warn("WARNING! Fixed-function exclusive mode is enabled.");
   }
 
 
@@ -92,7 +96,8 @@ namespace dxvk {
 
     if (riid == __uuidof(IUnknown)
      || riid == __uuidof(IDirect3D9)
-     || (m_extended && riid == __uuidof(IDirect3D9Ex))) {
+     || (m_d3dCompatibility.test(D3DCompatibility::D3D9Ex) &&
+         riid == __uuidof(IDirect3D9Ex))) {
       *ppvObject = ref(this);
       return S_OK;
     }
@@ -109,7 +114,7 @@ namespace dxvk {
     }
 
     if (riid == __uuidof(ID3D9VkExtInterface)) {
-      *ppvObject = ref(&m_d3d9ExtInterface);
+      *ppvObject = ref(&m_d3d9VkExtInterface);
       return S_OK;
     }
 
@@ -472,7 +477,7 @@ namespace dxvk {
     if (unlikely(pPresentationParameters == nullptr))
       return D3DERR_INVALIDCALL;
 
-    if (m_extended) {
+    if (m_d3dCompatibility.test(D3DCompatibility::D3D9Ex)) {
       // The swap effect value on a D3D9Ex device
       // can not be higher than D3DSWAPEFFECT_FLIPEX.
       if (unlikely(pPresentationParameters->SwapEffect > D3DSWAPEFFECT_FLIPEX))

--- a/src/d3d9/d3d9_interface.h
+++ b/src/d3d9/d3d9_interface.h
@@ -139,8 +139,6 @@ namespace dxvk {
         : nullptr;
     }
 
-    bool IsExtended() { return m_extended; }
-
     D3DCompatibilityFlags GetD3DCompatibilityFlags() const {
       return m_d3dCompatibility;
     }
@@ -151,10 +149,16 @@ namespace dxvk {
 
     void SetD3DCompatibility(D3DCompatibility d3dCompatibility) {
       m_d3dCompatibility.set(d3dCompatibility);
-      RefreshAdapterFormatTables();
 
-      if (d3dCompatibility == D3DCompatibility::D3D8)
-        Logger::info("The D3D9 interface is now operating in D3D8 compatibility mode.");
+      switch (d3dCompatibility) {
+        case D3DCompatibility::D3D8:
+          Logger::info("The D3D9 interface is now operating in D3D8 compatibility mode.");
+          break;
+        default:
+          break;
+      }
+
+      RefreshAdapterFormatTables();
     }
 
     Rc<DxvkInstance> GetInstance() { return m_instance; }
@@ -177,8 +181,6 @@ namespace dxvk {
     DxvkLegacyD3DInterfaceBridge  m_legacyD3DBridge;
     D3DCompatibilityFlags         m_d3dCompatibility;
 
-    bool                          m_extended;
-
     D3D9Options                   m_d3d9Options;
 
     std::vector<Rc<D3D9Adapter>>  m_adapters;
@@ -187,7 +189,7 @@ namespace dxvk {
 
     bool m_unlockAdditionalFormats = false;
 
-    D3D9VkExtInterface            m_d3d9ExtInterface;
+    D3D9VkExtInterface            m_d3d9VkExtInterface;
 
     static const D3D9ON12_ARGS* Find9On12Args(
       const Rc<DxvkAdapter>& Adapter,

--- a/src/d3d9/d3d9_interop.cpp
+++ b/src/d3d9/d3d9_interop.cpp
@@ -358,7 +358,8 @@ namespace dxvk {
           const D3D9_COMMON_TEXTURE_DESC& desc,
           IDirect3DResource9**            ppResult) {
     try {
-      const Com<ResourceType> texture = new ResourceType(m_device, &desc, m_device->IsExtended());
+      const bool isExtended = m_device->IsD3DCompatibile(D3DCompatibility::D3D9Ex);
+      const Com<ResourceType> texture = new ResourceType(m_device, &desc, isExtended);
       m_device->m_initializer->InitTexture(texture->GetCommonTexture());
       *ppResult = texture.ref();
 

--- a/src/d3d9/d3d9_interop.h
+++ b/src/d3d9/d3d9_interop.h
@@ -157,6 +157,7 @@ namespace dxvk {
     void STDMETHODCALLTYPE UnlockAdditionalFormats();
 
   private:
+
     D3D9InterfaceEx *m_interface;
 
   };

--- a/src/d3d9/d3d9_swapchain.cpp
+++ b/src/d3d9/d3d9_swapchain.cpp
@@ -84,7 +84,8 @@ namespace dxvk {
 
     if (riid == __uuidof(IUnknown)
      || riid == __uuidof(IDirect3DSwapChain9)
-     || (GetParent()->IsExtended() && riid == __uuidof(IDirect3DSwapChain9Ex))) {
+     || (m_parent->IsD3DCompatibile(D3DCompatibility::D3D9Ex) &&
+         riid == __uuidof(IDirect3DSwapChain9Ex))) {
       *ppvObject = ref(this);
       return S_OK;
     }
@@ -1042,10 +1043,12 @@ namespace dxvk {
     // we might need to lock for the BlitGDI fallback path
     desc.IsLockable         = true;
 
+    const bool isExtended = m_parent->IsD3DCompatibile(D3DCompatibility::D3D9Ex);
+
     for (uint32_t i = 0; i < bufferCount; i++) {
       D3D9Surface* surface;
       try {
-        surface = new D3D9Surface(m_parent, &desc, m_parent->IsExtended(), this, nullptr);
+        surface = new D3D9Surface(m_parent, &desc, isExtended, this, nullptr);
         m_parent->IncrementLosableCounter();
       } catch (const DxvkError& e) {
         DestroyBackBuffers();
@@ -1331,10 +1334,9 @@ namespace dxvk {
       m_srcRect.left   = 0;
       m_srcRect.right  = m_presentParams.BackBufferWidth;
       m_srcRect.bottom = m_presentParams.BackBufferHeight;
-    }
-    else
+    } else {
       m_srcRect = *pSourceRect;
-
+    }
     
     UINT width, height;
     wsi::getWindowSize(m_window, &width, &height);
@@ -1346,10 +1348,9 @@ namespace dxvk {
       dstRect.left   = 0;
       dstRect.right  = LONG(width);
       dstRect.bottom = LONG(height);
-      
-    }
-    else
+    } else {
       dstRect = *pDestRect;
+    }
 
     m_partialCopy =
        dstRect.left != 0
@@ -1374,11 +1375,11 @@ namespace dxvk {
 
 
   std::string D3D9SwapChainEx::GetApiName() {
-    if (this->GetParent()->Is9On12Device())
-      return this->GetParent()->IsExtended() ? "D3D9On12Ex" : "D3D9On12";
+    if (m_parent->Is9On12Device())
+      return m_parent->IsD3DCompatibile(D3DCompatibility::D3D9Ex) ? "D3D9ExOn12" : "D3D9On12";
 
-    return this->GetParent()->IsD3DCompatibile(D3DCompatibility::D3D8) ? "D3D8" :
-           this->GetParent()->IsExtended() ? "D3D9Ex" : "D3D9";
+    return m_parent->IsD3DCompatibile(D3DCompatibility::D3D8) ? "D3D8" :
+           m_parent->IsD3DCompatibile(D3DCompatibility::D3D9Ex) ? "D3D9Ex" : "D3D9";
   }
 
 


### PR DESCRIPTION
@CkNoSFeRaTU gave me the idea to also merge the D3D9Ex/IsExtended() checks into our recently added D3D compatibility flags logic. I think it cleans up quite a bit of extra handling, and makes more sense this way - I know it's not a "compatibility mode" per se, but it very much behaves like one anyway for the most part.