### PR TITLE
[d3d9] Ignore zero extent stretch rect

### DIFF
--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -1332,6 +1332,10 @@ namespace dxvk {
       uint32_t(blitInfo.dstOffsets[1].y - blitInfo.dstOffsets[0].y),
       uint32_t(blitInfo.dstOffsets[1].z - blitInfo.dstOffsets[0].z) };
 
+    if (unlikely(srcCopyExtent.width == 0 || srcCopyExtent.height == 0
+      || dstCopyExtent.width == 0 || dstCopyExtent.height == 0))
+      return D3D_OK;
+
     bool srcIsDS = IsDepthStencilFormat(srcFormat);
     bool dstIsDS = IsDepthStencilFormat(dstFormat);
     if (unlikely(srcIsDS || dstIsDS)) {


### PR DESCRIPTION
Fixes a Vulkan validation error with Mirrors Edge.