### PR TITLE
[d3d11] Implement NVAPI multiview rendering

### DIFF
--- a/src/d3d11/d3d11_context.cpp
+++ b/src/d3d11/d3d11_context.cpp
@@ -94,7 +94,8 @@ namespace dxvk {
     }
 
     if (riid == __uuidof(ID3D11VkExtContext)
-     || riid == __uuidof(ID3D11VkExtContext1)) {
+     || riid == __uuidof(ID3D11VkExtContext1)
+     || riid == __uuidof(ID3D11VkExtContext2)) {
       *ppvObject = ref(&m_contextExt);
       return S_OK;
     }
@@ -1386,6 +1387,87 @@ namespace dxvk {
 
       BindShader<D3D11ShaderType::eVertex>(GetCommonShader(shader));
     }
+
+    // If this VS carries NV multi-view metadata, the live toggle says
+    // multi-view is on right now, and the application has not bound its
+    // own geometry shader, attach the synthesised broadcast GS.
+    //
+    // The live toggle matters: applications may tag shaders with this
+    // metadata regardless of the toggle state, so checking the metadata
+    // alone would fire the broadcast during ordinary single-screen play.
+    // Where the application has bound its own GS, that shader carries its
+    // own multiview metadata and is left alone here.
+    //
+    // Every call resolves the full intended state and emits whatever that
+    // decision requires, including clearing an earlier injection. An
+    // earlier version only acted when the multiview condition was true,
+    // which left the companion GS bound across unrelated draws for the
+    // rest of the frame. GSSetShader has the same property: it always
+    // decides the whole state rather than leaving it as it was.
+    if (shader) {
+      auto* commonShader = GetCommonShader(shader);
+      bool hasNvMultiview = false;
+      Rc<DxvkShader> dxvkShader;
+      DxvkIrShader* irShader = nullptr;
+
+      if (commonShader != nullptr) {
+        dxvkShader = commonShader->GetShader();
+        irShader = dxvkShader != nullptr
+          ? static_cast<DxvkIrShader*>(dxvkShader.ptr())
+          : nullptr;
+        hasNvMultiview = irShader != nullptr
+          && irShader->getShaderCreateInfo().nvMultiview.enabled();
+      }
+
+      uint32_t liveNumViews = GetNvMultiviewNumViews();
+      bool wantAmpGs = !m_state.gs && commonShader != nullptr
+        && hasNvMultiview && liveNumViews > 1u;
+
+      if (wantAmpGs) {
+        static std::atomic<int32_t> s_attachLogBudget = { 8 };
+
+        if (s_attachLogBudget.fetch_sub(1, std::memory_order_relaxed) > 0) {
+          Logger::info(str::format("NvAmplificationGs: auto-attach for VS ",
+            dxvkShader->debugName(), " (", commonShader->GetNvPassthroughIo().size(),
+            " passthrough entries, ", liveNumViews, " live views)"));
+        }
+
+        auto ampGs = commonShader->GetOrCreateNvAmplificationGs(
+          m_parent, commonShader->GetShaderKey(), liveNumViews,
+          irShader->getShaderCreateInfo().nvMultiview);
+
+        // Skip the bind if this exact shader is already the one we
+        // injected. Without this, every VSSetShader re-binds the same
+        // geometry shader and invalidates pipeline state, thousands of
+        // times per frame.
+        if (!m_nvAmpGsAutoAttached || m_nvAmpGsBound != ampGs.ptr()) {
+          EmitCs([cShader = ampGs](DxvkContext* ctx) {
+            ctx->bindShader<VK_SHADER_STAGE_GEOMETRY_BIT>(
+                Rc<DxvkShader>(cShader));
+          });
+          m_nvAmpGsBound = ampGs.ptr();
+        }
+
+        m_nvAmpGsAutoAttached = true;
+      } else if (m_nvAmpGsAutoAttached && !m_state.gs) {
+        // We previously injected a companion GS and this draw's own
+        // VS doesn't need one - clear it explicitly rather than
+        // letting it silently ride onto a draw it has nothing to do
+        // with. (!m_state.gs here confirms the app hasn't bound its
+        // own real GS in the meantime; if it had, GSSetShader's own
+        // normal bind already replaced whatever we injected, correctly,
+        // through the ordinary pathway.)
+        EmitCs([](DxvkContext* ctx) {
+          ctx->bindShader<VK_SHADER_STAGE_GEOMETRY_BIT>(Rc<DxvkShader>());
+        });
+        m_nvAmpGsAutoAttached = false;
+      } else if (m_state.gs) {
+        // App has a real GS of its own bound - not ours to touch.
+        // Keep our own bookkeeping honest: we are not the one
+        // controlling the geometry shader stage right now.
+        m_nvAmpGsAutoAttached = false;
+      }
+    }
   }
 
 
@@ -1791,6 +1873,7 @@ namespace dxvk {
 
     if (m_state.gs != shader) {
       m_state.gs = shader;
+      m_nvAmpGsAutoAttached = false;
 
       BindShader<D3D11ShaderType::eGeometry>(GetCommonShader(shader));
     }
@@ -4927,6 +5010,7 @@ namespace dxvk {
     m_state.hs = nullptr;
     m_state.ds = nullptr;
     m_state.gs = nullptr;
+    m_nvAmpGsAutoAttached = false;
     m_state.ps = nullptr;
     m_state.cs = nullptr;
 

--- a/src/d3d11/d3d11_context.h
+++ b/src/d3d11/d3d11_context.h
@@ -89,6 +89,27 @@ namespace dxvk {
 
     ~D3D11CommonContext();
 
+    /**
+     * \brief Sets NVAPI multi-view toggle state
+     *
+     * Written by D3D11DeviceContextExt::SetMultiviewModeNV, under the
+     * same D3D10DeviceLock every other piece of state on this class
+     * already uses. Read back by Milestone 4.C's auto-attach check -
+     * this is the one true copy; nothing else keeps its own.
+     */
+    void SetNvMultiviewToggleState(uint32_t NumViews, bool IndependentMask) {
+      m_nvMultiviewNumViews = NumViews;
+      m_nvMultiviewIndependentMask = IndependentMask;
+    }
+
+    uint32_t GetNvMultiviewNumViews() const {
+      return m_nvMultiviewNumViews;
+    }
+
+    bool GetNvMultiviewIndependentMask() const {
+      return m_nvMultiviewIndependentMask;
+    }
+
     HRESULT STDMETHODCALLTYPE QueryInterface(
             REFIID  riid,
             void**  ppvObject);
@@ -1259,6 +1280,15 @@ namespace dxvk {
     }
 
   private:
+    uint32_t m_nvMultiviewNumViews = 1u;
+    bool m_nvMultiviewIndependentMask = false;
+
+    // True if the currently-bound geometry shader is one WE injected via
+    // the NV multiview auto-attach path, rather than something the app
+    // itself bound through GSSetShader. Lets VSSetShader tell "nothing to
+    // do" apart from "we need to clear our own leftover injection."
+    bool m_nvAmpGsAutoAttached = false;
+    const DxvkShader* m_nvAmpGsBound = nullptr;
 
     ContextType* GetTypedContext() {
       return static_cast<ContextType*>(this);

--- a/src/d3d11/d3d11_context_ext.cpp
+++ b/src/d3d11/d3d11_context_ext.cpp
@@ -17,8 +17,31 @@ namespace dxvk {
   : m_ctx(pContext) {
     
   }
-  
-  
+
+  template <typename ContextType>
+  void STDMETHODCALLTYPE D3D11DeviceContextExt<ContextType>::SetMultiviewModeNV(
+      uint32_t NumViews, BOOL IndependentViewportMask) {
+    D3D10DeviceLock lock = m_ctx->LockContext();
+
+    // A large share of the application's calls are redundant re-sets of
+    // the same values. Dedupe under the context lock, before the CS
+    // stream. Reads the authoritative copy on D3D11CommonContext rather
+    // than keeping a second copy here that could drift out of step.
+    if (NumViews == m_ctx->GetNvMultiviewNumViews() &&
+        bool(IndependentViewportMask) ==
+            m_ctx->GetNvMultiviewIndependentMask()) {
+      return;
+    }
+
+    m_ctx->SetNvMultiviewToggleState(NumViews, bool(IndependentViewportMask));
+
+    m_ctx->EmitCs(
+        [cNumViews = NumViews,
+         cIndependentMask = bool(IndependentViewportMask)](DxvkContext* ctx) {
+          ctx->setNvMultiviewState(cNumViews, cIndependentMask);
+        });
+  }
+
   template<typename ContextType>
   ULONG STDMETHODCALLTYPE D3D11DeviceContextExt<ContextType>::AddRef() {
     return m_ctx->AddRef();

--- a/src/d3d11/d3d11_context_ext.h
+++ b/src/d3d11/d3d11_context_ext.h
@@ -8,7 +8,7 @@ namespace dxvk {
   class D3D11ImmediateContext;
 
   template<typename ContextType>
-  class D3D11DeviceContextExt : public ID3D11VkExtContext1 {
+  class D3D11DeviceContextExt : public ID3D11VkExtContext2 {
     
   public:
     
@@ -70,6 +70,10 @@ namespace dxvk {
             uint32_t                NumReadResources,
             void* const*            pWriteResources,
             uint32_t                NumWriteResources);
+
+    void STDMETHODCALLTYPE SetMultiviewModeNV(
+            uint32_t                NumViews,
+            BOOL                    IndependentViewportMask);
 
   private:
     

--- a/src/d3d11/d3d11_device.cpp
+++ b/src/d3d11/d3d11_device.cpp
@@ -810,6 +810,40 @@ namespace dxvk {
   }
   
   
+  HRESULT D3D11Device::CreateVertexShaderNvMultiview(
+    const void*                   pShaderBytecode,
+          SIZE_T                  BytecodeLength,
+          ID3D11ClassLinkage*     pClassLinkage,
+    const DxvkNvMultiviewInfo&    NvMultiview,
+          std::vector<DxvkNvPassthroughIoEntry> PassthroughIo,
+          ID3D11VertexShader**    ppVertexShader) {
+
+    InitReturnPtr(ppVertexShader);
+    D3D11CommonShader module;
+
+    DxvkIrShaderCreateInfo moduleInfo = { };
+    moduleInfo.options = m_shaderOptions;
+    moduleInfo.nvMultiview = NvMultiview;
+
+    HRESULT hr = CreateShaderModule(&module, pClassLinkage,
+      ComputeShaderKey(VK_SHADER_STAGE_VERTEX_BIT, pShaderBytecode, BytecodeLength, NvMultiview),
+      pShaderBytecode, BytecodeLength, moduleInfo);
+
+    if (FAILED(hr)) {
+      return hr;
+    }
+
+    module.SetNvPassthroughIo(std::move(PassthroughIo));
+
+    if (!ppVertexShader) {
+      return S_FALSE;
+    }
+
+    *ppVertexShader = ref(new D3D11VertexShader(this, module));
+
+    return S_OK;
+  }
+
   HRESULT STDMETHODCALLTYPE D3D11Device::CreateGeometryShader(
     const void*                       pShaderBytecode,
           SIZE_T                      BytecodeLength,
@@ -836,6 +870,40 @@ namespace dxvk {
   }
   
   
+  HRESULT D3D11Device::CreateGeometryShaderNvMultiview(
+    const void*                   pShaderBytecode,
+          SIZE_T                  BytecodeLength,
+          ID3D11ClassLinkage*     pClassLinkage,
+    const DxvkNvMultiviewInfo&    NvMultiview,
+          std::vector<DxvkNvPassthroughIoEntry> PassthroughIo,
+          ID3D11GeometryShader**  ppGeometryShader) {
+    InitReturnPtr(ppGeometryShader);
+    D3D11CommonShader module;
+
+    DxvkIrShaderCreateInfo moduleInfo = { };
+    moduleInfo.options = m_shaderOptions;
+    moduleInfo.nvMultiview = NvMultiview;
+
+    HRESULT hr = CreateShaderModule(&module, pClassLinkage,
+      ComputeShaderKey(VK_SHADER_STAGE_GEOMETRY_BIT, pShaderBytecode, BytecodeLength, NvMultiview),
+      pShaderBytecode, BytecodeLength, moduleInfo);
+
+    if (FAILED(hr)) {
+      return hr;
+    }
+
+    module.SetNvPassthroughIo(std::move(PassthroughIo));
+
+    if (!ppGeometryShader) {
+    return S_FALSE;
+    }
+
+    *ppGeometryShader = ref(new D3D11GeometryShader(this, module));
+
+    return S_OK;
+  }
+
+
   HRESULT STDMETHODCALLTYPE D3D11Device::CreateGeometryShaderWithStreamOutput(
     const void*                       pShaderBytecode,
           SIZE_T                      BytecodeLength,
@@ -2304,6 +2372,29 @@ namespace dxvk {
   }
 
 
+  DxvkShaderHash D3D11Device::ComputeShaderKey(
+          VkShaderStageFlagBits   Stage,
+    const void*                   pShaderBytecode,
+          size_t                  BytecodeLength,
+    const DxvkNvMultiviewInfo&    NvMultiview) {
+    // Same bytecode with and without NV multi-view metadata must not
+    // collide in the module set, the debug name, or the on-disk cache.
+    // Mirrors the stream-output overload above: bytecode hash + salt.
+    dxbc_spv::dxbc::Container container(pShaderBytecode, BytecodeLength);
+    auto binHash = container.getHash();
+
+    dxbc_spv::util::md5::Hasher nvHasher;
+    nvHasher.update(&NvMultiview, sizeof(NvMultiview));
+    nvHasher.finalize();
+
+    auto nvHash = nvHasher.getDigest();
+
+    return DxvkShaderHash(Stage, BytecodeLength,
+      binHash.data.data(), binHash.data.size(),
+      nvHash.data.data(), nvHash.data.size());
+  }
+
+
   HRESULT D3D11Device::GetFormatSupportFlags(DXGI_FORMAT Format, UINT* pFlags1, UINT* pFlags2) const {
     const DXGI_VK_FORMAT_INFO fmtMapping = LookupFormat(Format, DXGI_VK_FORMAT_MODE_ANY);
 
@@ -2932,6 +3023,9 @@ namespace dxvk {
       case D3D11_VK_NVX_BINARY_IMPORT:
         return deviceFeatures.nvxBinaryImport;
 
+      case D3D11_VK_NV_MULTIVIEW:
+        return deviceFeatures.nvViewportArray2;
+
       default:
         return false;
     }
@@ -3185,6 +3279,180 @@ namespace dxvk {
     // will need to look-up sampler from uint32 handle later
     AddSamplerAndHandleNVX(*ppSamplerState, *pDriverHandle);
     return true;
+  }
+
+
+  // Resolve an NVAPI custom-semantic array against the DXBC output
+  // signature:
+  //  - type 5 (NV_POSITION): the signature carries the per-view family
+  //    NV_POSITION_VIEW_{1,2,3}_SEMANTIC; view 0's position is SV_POSITION
+  //  - types 2 and 4 (viewport masks): request strings match exactly, u32x4
+  //  - types 1 and 3 (NV_X_RIGHT and NV_XYZW_RIGHT, single-pass stereo):
+  //    absent from every signature observed; recorded as ignored
+  static DxvkNvMultiviewInfo ResolveNvCustomSemantics(
+    const char*                         ShaderType,
+    const void*                         pShaderBytecode,
+          SIZE_T                        BytecodeLength,
+    const D3D11_VK_NV_CUSTOM_SEMANTIC*  pSemantics,
+          uint32_t                      NumSemantics,
+          std::vector<DxvkNvPassthroughIoEntry>* pPassthroughIo = nullptr) {
+    DxvkNvMultiviewInfo result = { };
+
+    dxbc_spv::dxbc::Container container(pShaderBytecode, BytecodeLength);
+
+    if (!container) {
+      Logger::warn(str::format("NvSemantics(", ShaderType, "): invalid DXBC container"));
+      return result;
+    }
+
+    auto osgnChunk = container.getOutputSignatureChunk();
+
+    if (!osgnChunk) {
+      Logger::warn(str::format("NvSemantics(", ShaderType, "): no output signature chunk"));
+      return result;
+    }
+
+    dxbc_spv::dxbc::Signature outputSignature(std::move(osgnChunk));
+
+    static const std::array<const char*, 3> s_positionViewNames = {{
+      "NV_POSITION_VIEW_1_SEMANTIC",
+      "NV_POSITION_VIEW_2_SEMANTIC",
+      "NV_POSITION_VIEW_3_SEMANTIC",
+    }};
+
+    if (pPassthroughIo) {
+      static const std::array<const char*, 5> s_nvInteropNamesForFilter = {{
+        "NV_POSITION_VIEW_1_SEMANTIC", "NV_POSITION_VIEW_2_SEMANTIC",
+        "NV_POSITION_VIEW_3_SEMANTIC", "NV_VIEWPORT_MASK",
+        "NV_VIEWPORT_MASK_2_SEMANTIC",
+      }};
+
+      for (auto e = outputSignature.begin(); e != outputSignature.end(); e++) {
+        bool isNvInterop = false;
+
+        for (auto name : s_nvInteropNamesForFilter) {
+          if (e->matches(name))
+            isNvInterop = true;
+        }
+
+        if (isNvInterop)
+          continue;
+
+        // SV_POSITION rides the Position built-in on the vertex shader,
+        // not a generic location. The amplification GS declares it as a
+        // built-in input separately.
+        if (e->matches("SV_POSITION"))
+          continue;
+
+        pPassthroughIo->push_back({
+          uint32_t(e->getRegisterIndex()), e->getVectorType(),
+          std::string(e->getSemanticName()), e->getSemanticIndex(),
+          e->computeComponentIndex()
+        });
+      }
+
+      Logger::info(str::format("NvSemantics(", ShaderType, ", ",
+        container.getHash(), "): captured ", pPassthroughIo->size(),
+        " passthrough IO entries for amplification"));
+    }
+
+    std::stringstream msg;
+    msg << "NvSemantics(" << ShaderType << ", " << container.getHash() << "):";
+
+    for (uint32_t i = 0; i < NumSemantics; i++) {
+      const auto& sem = pSemantics[i];
+
+      switch (sem.Type) {
+        case 2u: { // NV_VIEWPORT_MASK_SEMANTIC
+          for (auto e = outputSignature.begin(); e != outputSignature.end(); e++) {
+            if (e->matches(sem.Name)) {
+              result.viewportMaskReg = e->getRegisterIndex();
+              result.viewportMaskType[0] = e->getVectorType();
+            }
+          }
+          msg << " mask->o" << result.viewportMaskReg;
+        } break;
+
+        case 4u: { // NV_VIEWPORT_MASK_2_SEMANTIC
+          for (auto e = outputSignature.begin(); e != outputSignature.end(); e++) {
+            if (e->matches(sem.Name)) {
+              result.viewportMask2Reg = e->getRegisterIndex();
+              result.viewportMaskType[1] = e->getVectorType();
+            }
+          }
+          msg << " mask2->o" << result.viewportMask2Reg;
+        } break;
+
+        case 5u: { // NV_POSITION_SEMANTIC: per-view family, view 0 = SV_POSITION
+          for (size_t v = 0; v < s_positionViewNames.size(); v++) {
+            for (auto e = outputSignature.begin(); e != outputSignature.end(); e++) {
+              if (e->matches(s_positionViewNames[v])) {
+                result.positionViewReg[v] = e->getRegisterIndex();
+                result.positionViewType[v] = e->getVectorType();
+              }
+            }
+          }
+          msg << " posViews->o" << result.positionViewReg[0]
+              << "/o" << result.positionViewReg[1]
+              << "/o" << result.positionViewReg[2];
+        } break;
+
+        default: // type 3 = NV_XYZW_RIGHT_SEMANTIC and anything else unexpected
+          msg << " " << sem.Name << "(type=" << sem.Type << ") ignored";
+      }
+    }
+
+    Logger::info(msg.str());
+    return result;
+  }
+
+
+  HRESULT STDMETHODCALLTYPE D3D11DeviceExt::CreateVertexShaderNvSemantics(
+    const void*                     pShaderBytecode,
+          SIZE_T                    BytecodeLength,
+          ID3D11ClassLinkage*       pClassLinkage,
+    const D3D11_VK_NV_CUSTOM_SEMANTIC* pSemantics,
+          uint32_t                  NumSemantics,
+          ID3D11VertexShader**      ppVertexShader) {
+    std::vector<DxvkNvPassthroughIoEntry> passthroughIo;
+    DxvkNvMultiviewInfo nv = ResolveNvCustomSemantics("VS",
+      pShaderBytecode, BytecodeLength, pSemantics, NumSemantics, &passthroughIo);
+
+    if (!nv.enabled()) {
+      return m_device->CreateVertexShader(pShaderBytecode, BytecodeLength,
+                                          pClassLinkage, ppVertexShader);
+    }
+
+    return m_device->CreateVertexShaderNvMultiview(
+        pShaderBytecode, BytecodeLength, pClassLinkage, nv,
+        std::move(passthroughIo), ppVertexShader);
+  }
+
+
+  HRESULT STDMETHODCALLTYPE D3D11DeviceExt::CreateGeometryShaderNvSemantics(
+    const void*                     pShaderBytecode,
+          SIZE_T                    BytecodeLength,
+          ID3D11ClassLinkage*       pClassLinkage,
+    const D3D11_VK_NV_CUSTOM_SEMANTIC* pSemantics,
+          uint32_t                  NumSemantics,
+          BOOL                      UseViewportMask,
+          ID3D11GeometryShader**    ppGeometryShader) {
+    std::vector<DxvkNvPassthroughIoEntry> passthroughIo;
+    DxvkNvMultiviewInfo nv = ResolveNvCustomSemantics(
+      UseViewportMask ? "GS vpMask=1" : "GS vpMask=0",
+      pShaderBytecode, BytecodeLength, pSemantics, NumSemantics, &passthroughIo);
+    nv.useViewportMask = UseViewportMask ? 1u : 0u;
+
+    if (!nv.enabled()) {
+      // Single-pass-stereo geometry shaders land here, with no mask
+      // output: plain compile.
+      return m_device->CreateGeometryShader(
+        pShaderBytecode, BytecodeLength, pClassLinkage, ppGeometryShader);
+    }
+
+    return m_device->CreateGeometryShaderNvMultiview(
+      pShaderBytecode, BytecodeLength, pClassLinkage, nv,
+      std::move(passthroughIo), ppGeometryShader);
   }
 
 
@@ -3859,7 +4127,8 @@ namespace dxvk {
     }
     
     if (riid == __uuidof(ID3D11VkExtDevice)
-     || riid == __uuidof(ID3D11VkExtDevice1)) {
+     || riid == __uuidof(ID3D11VkExtDevice1)
+     || riid == __uuidof(ID3D11VkExtDevice2)) {
       *ppvObject = ref(&m_d3d11DeviceExt);
       return S_OK;
     }

--- a/src/d3d11/d3d11_device.h
+++ b/src/d3d11/d3d11_device.h
@@ -486,6 +486,22 @@ namespace dxvk {
 
       return barrierControl;
     }
+
+    HRESULT CreateVertexShaderNvMultiview(
+      const void*                   pShaderBytecode,
+            SIZE_T                  BytecodeLength,
+            ID3D11ClassLinkage*     pClassLinkage,
+      const DxvkNvMultiviewInfo&    NvMultiview,
+            std::vector<DxvkNvPassthroughIoEntry> PassthroughIo,
+            ID3D11VertexShader**    ppVertexShader);
+
+    HRESULT CreateGeometryShaderNvMultiview(
+      const void*                   pShaderBytecode,
+            SIZE_T                  BytecodeLength,
+            ID3D11ClassLinkage*     pClassLinkage,
+      const DxvkNvMultiviewInfo&    NvMultiview,
+            std::vector<DxvkNvPassthroughIoEntry> PassthroughIo,
+            ID3D11GeometryShader**  ppGeometryShader);
     
   private:
     
@@ -541,6 +557,12 @@ namespace dxvk {
             UINT                    NumStrides,
             UINT                    RasterizedStream);
 
+    DxvkShaderHash ComputeShaderKey(
+            VkShaderStageFlagBits   Stage,
+      const void*                   pShaderBytecode,
+            size_t                  BytecodeLength,
+      const DxvkNvMultiviewInfo&    NvMultiview);
+
     HRESULT GetFormatSupportFlags(
             DXGI_FORMAT             Format,
             UINT*                   pFlags1,
@@ -585,7 +607,7 @@ namespace dxvk {
   /**
    * \brief Extended D3D11 device
    */
-  class D3D11DeviceExt : public ID3D11VkExtDevice1 {
+  class D3D11DeviceExt : public ID3D11VkExtDevice2 {
     
   public:
     
@@ -639,6 +661,23 @@ namespace dxvk {
             const D3D11_SAMPLER_DESC* pSamplerDesc,
             ID3D11SamplerState**      ppSamplerState,
             uint32_t*                 pDriverHandle);
+
+HRESULT STDMETHODCALLTYPE CreateVertexShaderNvSemantics(
+      const void*                     pShaderBytecode,
+            SIZE_T                    BytecodeLength,
+            ID3D11ClassLinkage*       pClassLinkage,
+      const D3D11_VK_NV_CUSTOM_SEMANTIC* pSemantics,
+            uint32_t                  NumSemantics,
+            ID3D11VertexShader**      ppVertexShader) override;
+
+    HRESULT STDMETHODCALLTYPE CreateGeometryShaderNvSemantics(
+      const void*                     pShaderBytecode,
+            SIZE_T                    BytecodeLength,
+            ID3D11ClassLinkage*       pClassLinkage,
+      const D3D11_VK_NV_CUSTOM_SEMANTIC* pSemantics,
+            uint32_t                  NumSemantics,
+            BOOL                      UseViewportMask,
+            ID3D11GeometryShader**    ppGeometryShader) override;
     
   private:
     

--- a/src/d3d11/d3d11_interfaces.h
+++ b/src/d3d11/d3d11_interfaces.h
@@ -16,6 +16,7 @@ enum D3D11_VK_EXTENSION : uint32_t {
   D3D11_VK_EXT_BARRIER_CONTROL            = 3,
   D3D11_VK_NVX_BINARY_IMPORT              = 4,
   D3D11_VK_NVX_IMAGE_VIEW_HANDLE          = 5,
+  D3D11_VK_NV_MULTIVIEW                   = 6,
 };
 
 
@@ -166,6 +167,68 @@ ID3D11VkExtContext1 : public ID3D11VkExtContext {
 
 
 /**
+ * \brief NVAPI custom shader semantic (SMP / multi-view)
+ *
+ * Mirrors the information from NVAPI's NV_CUSTOM_SEMANTIC without
+ * depending on NVIDIA headers. Type values match NV_CUSTOM_SEMANTIC_TYPE
+ * (2 = viewport mask, 4 = viewport mask 2, 5 = per-view position).
+ *
+ * Name[256] matches NVIDIA's own NVCustomSemanticNameString buffer size
+ * exactly. Every semantic name observed fits comfortably in far less,
+ * but matching NVIDIA's maximum removes any truncation risk and lets the
+ * compiler prove the strncpy calls below cannot truncate, which silences
+ * -Wstringop-truncation properly rather than suppressing it.
+ */
+struct D3D11_VK_NV_CUSTOM_SEMANTIC {
+  uint32_t Type;
+  char     Name[256];
+  BOOL     RegisterSpecified;
+  uint32_t RegisterNum;
+  uint32_t RegisterMask;
+};
+
+/**
+ * \brief Extended D3D11 device, revision 2
+ *
+ * Adds NVAPI-style extended shader creation for
+ * SMP / multi-view rendering (dxvk-nvapi interop).
+ */
+MIDL_INTERFACE("1d5c6a10-9f4b-4e0a-b6a4-2c8e13d70f51")
+ID3D11VkExtDevice2 : public ID3D11VkExtDevice1 {
+
+  virtual HRESULT STDMETHODCALLTYPE CreateVertexShaderNvSemantics(
+    const void*                     pShaderBytecode,
+          SIZE_T                    BytecodeLength,
+          ID3D11ClassLinkage*       pClassLinkage,
+    const D3D11_VK_NV_CUSTOM_SEMANTIC* pSemantics,
+          uint32_t                  NumSemantics,
+          ID3D11VertexShader**      ppVertexShader) = 0;
+
+  virtual HRESULT STDMETHODCALLTYPE CreateGeometryShaderNvSemantics(
+    const void*                     pShaderBytecode,
+          SIZE_T                    BytecodeLength,
+          ID3D11ClassLinkage*       pClassLinkage,
+    const D3D11_VK_NV_CUSTOM_SEMANTIC* pSemantics,
+          uint32_t                  NumSemantics,
+          BOOL                      UseViewportMask,
+          ID3D11GeometryShader**    ppGeometryShader) = 0;
+};
+
+/**
+ * \brief Extended D3D11 context, revision 2
+ *
+ * Adds the SMP multi-view mode toggle (dxvk-nvapi interop).
+ */
+MIDL_INTERFACE("7e2c1b9f-4d38-4a11-9b6e-0f5a8c42d3e7")
+ID3D11VkExtContext2 : public ID3D11VkExtContext1 {
+
+  virtual void STDMETHODCALLTYPE SetMultiviewModeNV(
+          uint32_t                  NumViews,
+          BOOL                      IndependentViewportMask) = 0;
+};
+
+
+/**
  * \brief Frame reports used for Reflex interop
  */
 struct D3D_LOW_LATENCY_FRAME_REPORT
@@ -227,7 +290,9 @@ ID3DLowLatencyDevice : public IUnknown {
 #ifndef _MSC_VER
 __CRT_UUID_DECL(ID3D11VkExtDevice,         0x8a6e3c42,0xf74c,0x45b7,0x82,0x65,0xa2,0x31,0xb6,0x77,0xca,0x17);
 __CRT_UUID_DECL(ID3D11VkExtDevice1,        0xcfcf64ef,0x9586,0x46d0,0xbc,0xa4,0x97,0xcf,0x2c,0xa6,0x1b,0x06);
+__CRT_UUID_DECL(ID3D11VkExtDevice2,        0x1d5c6a10,0x9f4b,0x4e0a,0xb6,0xa4,0x2c,0x8e,0x13,0xd7,0x0f,0x51);
 __CRT_UUID_DECL(ID3D11VkExtContext,        0xfd0bca13,0x5cb6,0x4c3a,0x98,0x7e,0x47,0x50,0xde,0x2c,0xa7,0x91);
 __CRT_UUID_DECL(ID3D11VkExtContext1,       0x874b09b2,0xae0b,0x41d8,0x84,0x76,0x5f,0x3b,0x7a,0x0e,0x87,0x9d);
+__CRT_UUID_DECL(ID3D11VkExtContext2,       0x7e2c1b9f,0x4d38,0x4a11,0x9b,0x6e,0x0f,0x5a,0x8c,0x42,0xd3,0xe7);
 __CRT_UUID_DECL(ID3DLowLatencyDevice,      0xf3112584,0x41f9,0x348d,0xa5,0x9b,0x00,0xb7,0xe1,0xd2,0x85,0xd6);
 #endif

--- a/src/d3d11/d3d11_shader.cpp
+++ b/src/d3d11/d3d11_shader.cpp
@@ -8,7 +8,303 @@
 #include "d3d11_device.h"
 #include "d3d11_shader.h"
 
+#include <cstring>
+
 namespace dxvk {
+
+  // Builds a geometry shader that does not exist in the application's
+  // bytecode. It broadcasts one input primitive to NumViews viewports
+  // using GS instancing (SetGsInstances plus gl_InvocationID), selects
+  // the matching per-view position for each invocation, and routes the
+  // primitive using the viewport mask the vertex shader supplies.
+  // Triangle input only, which covers every NV multi-view vertex shader
+  // observed so far; no point or line multi-view shaders have been seen.
+  //
+  // Deliberately does not touch dxbc-spirv. DxvkIrShaderConverter is
+  // DXVK's own interface, so anything that fills in an ir::Builder is
+  // acceptable, whether hand-built or converted from DXBC.
+  class D3D11NvAmplificationGsConverter : public DxvkIrShaderConverter {
+
+  public:
+
+    D3D11NvAmplificationGsConverter(
+      const DxvkShaderHash&                        VsKey,
+      std::vector<DxvkNvPassthroughIoEntry>        PassthroughIo,
+            uint32_t                                NumViews,
+      const DxvkNvMultiviewInfo&                    NvMultiview)
+    : m_key(VsKey), m_passthroughIo(std::move(PassthroughIo)),
+      m_numViews(NumViews), m_nvMultiview(NvMultiview) { }
+
+void convertShader(dxbc_spv::ir::Builder& builder) override {
+      using namespace dxbc_spv;
+
+      auto mainFunc = builder.add(ir::Op::Function(ir::ScalarType::eVoid));
+      builder.add(ir::Op::FunctionEnd());
+      builder.add(ir::Op::DebugName(mainFunc, "main"));
+
+      auto entryPoint = builder.addAfter(ir::SsaDef(),
+        ir::Op::EntryPoint(mainFunc, ir::ShaderStage::eGeometry));
+
+      auto debugName = m_key.toString() + "_nvAmpGs";
+      builder.add(ir::Op::DebugName(entryPoint, debugName.c_str()));
+      builder.setCursor(mainFunc);
+
+      builder.add(ir::Op::SetGsInstances(entryPoint, m_numViews));
+      builder.add(ir::Op::SetGsInputPrimitive(entryPoint, ir::PrimitiveType::eTriangles));
+      builder.add(ir::Op::SetGsOutputPrimitive(entryPoint, ir::PrimitiveType::eTriangles, 0x1u));
+      builder.add(ir::Op::SetGsOutputVertices(entryPoint, 3u));
+
+      auto instanceIdDecl = builder.add(ir::Op::DclInputBuiltIn(
+        ir::ScalarType::eU32, entryPoint, ir::BuiltIn::eGsInstanceId, ir::InterpolationModes()));
+      auto viewportDecl = builder.add(ir::Op::DclOutputBuiltIn(
+        ir::Type(ir::ScalarType::eU32), entryPoint, ir::BuiltIn::eViewportIndex));
+
+      auto instanceId = builder.add(ir::Op::InputLoad(
+        ir::ScalarType::eU32, instanceIdDecl, ir::SsaDef()));
+
+      // The position output, declared once, up front.
+      auto positionOutDecl = builder.add(ir::Op::DclOutputBuiltIn(
+        ir::Type(ir::BasicType(ir::ScalarType::eF32, 4u)), entryPoint, ir::BuiltIn::ePosition));
+
+      // [view][vertex] -> that view's position for that vertex. Index 0
+      // is view 0, which uses the ordinary SV_POSITION built-in; indices
+      // 1 to 3 come from the NV_POSITION_VIEW_* registers below.
+      std::array<std::array<ir::SsaDef, 3u>, 4u> positionPerViewPerVertex = { };
+
+      // Per-vertex pass-through: 3 input vertices (triangle), every
+      // captured entry carried through unchanged, at its own component
+      // count (the resolver's getVectorType() - never a fixed float4).
+      //
+      // Location assignment: use the source register index and component
+      // offset directly. A geometry shader's input interface has to match
+      // the vertex shader output interface it consumes, and DXVK numbers
+      // vertex shader outputs by register index. Two signature entries can
+      // share a register with different write masks, in which case they
+      // share a location and differ by component; renumbering sequentially
+      // loses that pairing and slides every later location.
+
+      // Collect every passthrough attribute's per-corner value AND its
+      // output declaration here, instead of writing to the output the
+      // moment it's loaded. We need all 3 corners' values in hand before
+      // we can safely write+emit corner-by-corner further down.
+      std::vector<ir::SsaDef> passthroughOutDecls;
+      std::vector<std::array<ir::SsaDef, 3u>> passthroughValuesPerVertex;
+
+      // View 0's position is SV_POSITION, which the vertex shader emits as
+      // the Position built-in rather than at a generic location. It is
+      // excluded from m_passthroughIo for that reason and read here.
+      auto positionInDecl = builder.add(ir::Op::DclInputBuiltIn(
+        ir::Type(ir::BasicType(ir::ScalarType::eF32, 4u)).addArrayDimension(3u),
+        entryPoint, ir::BuiltIn::ePosition, ir::InterpolationModes()));
+
+      for (uint32_t v = 0u; v < 3u; v++) {
+        positionPerViewPerVertex[0][v] = builder.add(ir::Op::InputLoad(
+          ir::Type(ir::BasicType(ir::ScalarType::eF32, 4u)),
+          positionInDecl, builder.makeConstant(v)));
+      }
+
+      for (const auto& io : m_passthroughIo) {
+        auto inputType = ir::Type(io.type).addArrayDimension(3u);
+
+        auto inDecl = builder.add(ir::Op::DclInput(
+          inputType, entryPoint, io.regIndex, io.component));
+        auto outDecl = builder.add(ir::Op::DclOutput(
+          ir::Type(io.type), entryPoint, io.regIndex, io.component));
+
+        builder.add(ir::Op::Semantic(inDecl, io.semanticIndex, io.semanticName.c_str()));
+        builder.add(ir::Op::Semantic(outDecl, io.semanticIndex, io.semanticName.c_str()));
+
+        std::array<ir::SsaDef, 3u> values = { };
+        for (uint32_t v = 0u; v < 3u; v++) {
+          values[v] = builder.add(ir::Op::InputLoad(
+            ir::Type(io.type), inDecl, builder.makeConstant(v)));
+        }
+
+        passthroughOutDecls.push_back(outDecl);
+        passthroughValuesPerVertex.push_back(values);
+      }
+
+      // Per-view position registers. This only loads values into
+      // positionPerViewPerVertex; it never writes to an output.
+      static const std::array<const char*, 3> s_positionViewSemanticNames = {{
+        "NV_POSITION_VIEW_1_SEMANTIC", "NV_POSITION_VIEW_2_SEMANTIC", "NV_POSITION_VIEW_3_SEMANTIC" }};
+
+      for (uint32_t view = 0u; view < 3u; view++) {
+        if (m_nvMultiview.positionViewReg[view] < 0)
+          continue;
+
+        auto viewPosType = m_nvMultiview.positionViewType[view];
+        auto viewPosDecl = builder.add(ir::Op::DclInput(
+          ir::Type(viewPosType).addArrayDimension(3u), entryPoint,
+          uint32_t(m_nvMultiview.positionViewReg[view]), 0u));
+        builder.add(ir::Op::Semantic(viewPosDecl, 0u, s_positionViewSemanticNames[view]));
+
+        for (uint32_t v = 0u; v < 3u; v++) {
+          positionPerViewPerVertex[view + 1][v] = builder.add(ir::Op::InputLoad(
+            ir::Type(viewPosType), viewPosDecl, builder.makeConstant(v)));
+        }
+      }
+
+      // Viewport routing. iRacing packs two 16-bit viewport bitmasks
+      // per register - NV_VIEWPORT_MASK holds views 0 and 1, and
+      // NV_VIEWPORT_MASK_2 holds views 2 and 3, low half first. Only the
+      // .x component carries routing; .yzw are written with the same value
+      // and their purpose is unknown, so they are ignored.
+      static const std::array<const char*, 2> s_viewportMaskSemanticNames = {{
+        "NV_VIEWPORT_MASK", "NV_VIEWPORT_MASK_2_SEMANTIC" }};
+
+      std::array<ir::SsaDef, 2u> maskRegValues = { };
+
+      for (uint32_t m = 0u; m < 2u; m++) {
+        int32_t reg = m ? m_nvMultiview.viewportMask2Reg
+                        : m_nvMultiview.viewportMaskReg;
+
+        if (reg < 0)
+          continue;
+
+        auto maskType = m_nvMultiview.viewportMaskType[m];
+
+        // A register with no recorded type would build an array-of-void
+        // declaration. Skip rather than emit something malformed.
+        if (maskType.isVoidType())
+          continue;
+
+        auto maskDecl = builder.add(ir::Op::DclInput(
+          ir::Type(maskType).addArrayDimension(3u),
+          entryPoint, uint32_t(reg), 0u));
+        builder.add(ir::Op::Semantic(maskDecl, 0u, s_viewportMaskSemanticNames[m]));
+
+        // Viewport routing is per-primitive, so the provoking vertex's
+        // copy decides for the whole triangle.
+        auto maskVector = builder.add(ir::Op::InputLoad(
+          ir::Type(maskType), maskDecl, builder.makeConstant(0u)));
+
+        maskRegValues[m] = builder.add(ir::Op::CompositeExtract(
+          ir::ScalarType::eU32, maskVector, builder.makeConstant(0u)));
+      }
+
+      // This invocation's 16-bit half, chosen with the same IEq/Select
+      // chain shape the positions use. Register = view >> 1, half = view & 1.
+      ir::SsaDef viewportMaskHalf = { };
+
+      for (uint32_t view = 0u; view < 4u; view++) {
+        if (!maskRegValues[view >> 1])
+          continue;
+
+        auto half = builder.add(ir::Op::UBitExtract(
+          ir::ScalarType::eU32, maskRegValues[view >> 1],
+          builder.makeConstant((view & 1u) * 16u),
+          builder.makeConstant(16u)));
+
+        if (!viewportMaskHalf) {
+          viewportMaskHalf = half;
+          continue;
+        }
+
+        auto isThisView = builder.add(ir::Op::IEq(
+          ir::ScalarType::eBool, instanceId, builder.makeConstant(view)));
+        viewportMaskHalf = builder.add(ir::Op::Select(
+          ir::Type(ir::ScalarType::eU32), isThisView, half, viewportMaskHalf));
+      }
+
+      // Cold path, once per synthesised shader. Records whether the
+      // mask read was wired up for this shader; the mask values are
+      // draw-time data and cannot be known here.
+      Logger::info(str::format("NvMultiview: ", debugName,
+        ": maskReg=o", m_nvMultiview.viewportMaskReg,
+        " mask2Reg=o", m_nvMultiview.viewportMask2Reg,
+        " routing=", viewportMaskHalf ? "mask" : "instanceId"));
+
+      // Compute each corner's chosen position and stash it per-corner,
+      // rather than writing to the output immediately. Same reasoning as
+      // the passthrough loop above.
+      std::array<ir::SsaDef, 3u> chosenPositionPerVertex = { };
+
+      for (uint32_t v = 0u; v < 3u; v++) {
+        ir::SsaDef chosen = positionPerViewPerVertex[0][v];
+
+        for (uint32_t view = 1u; view < 4u; view++) {
+          if (!positionPerViewPerVertex[view][v])
+            continue;
+          auto isThisView = builder.add(ir::Op::IEq(
+            ir::ScalarType::eBool, instanceId, builder.makeConstant(view)));
+          chosen = builder.add(ir::Op::Select(
+            ir::Type(ir::BasicType(ir::ScalarType::eF32, 4u)),
+            isThisView, positionPerViewPerVertex[view][v], chosen));
+        }
+
+        chosenPositionPerVertex[v] = chosen;
+      }
+
+      // Only the lowest set bit of the mask is honoured, because
+      // ViewportIndex takes a single index. iRacing names exactly one
+      // viewport per view, so nothing is lost here; landing one primitive
+      // on several viewports at once needs ViewportMaskNV, which is M5.
+      ir::SsaDef viewportIndex = instanceId;
+      ir::SsaDef shouldEmit = builder.makeConstant(true);
+
+      if (viewportMaskHalf) {
+        viewportIndex = builder.add(ir::Op::IFindLsb(
+          ir::Type(ir::ScalarType::eU32), viewportMaskHalf));
+        shouldEmit = builder.add(ir::Op::INe(
+          ir::Type(ir::ScalarType::eBool), viewportMaskHalf, builder.makeConstant(0u)));
+      }
+
+      // iRacing masks a view off entirely when the configuration doesn't
+      // use it - view 3 at three screens. Skip it rather than emitting the
+      // degenerate geometry its -1,-1,-1,-1 position sentinel would give.
+      // The ViewportIndex store lives inside the guard because IFindLsb(0)
+      // is -1, which is out of range for a viewport index.
+      auto emitGuard = builder.add(ir::Op::ScopedIf(ir::SsaDef(), shouldEmit));
+
+      builder.add(ir::Op::OutputStore(viewportDecl, ir::SsaDef(), viewportIndex));
+
+      // One corner at a time - write every output for this corner, THEN
+      // emit, THEN move to the next corner. This is the store -> emit
+      // pattern a geometry shader requires.
+      for (uint32_t v = 0u; v < 3u; v++) {
+        for (size_t i = 0u; i < passthroughOutDecls.size(); i++) {
+          builder.add(ir::Op::OutputStore(
+            passthroughOutDecls[i], ir::SsaDef(), passthroughValuesPerVertex[i][v]));
+        }
+
+        builder.add(ir::Op::OutputStore(positionOutDecl, ir::SsaDef(), chosenPositionPerVertex[v]));
+        builder.add(ir::Op::EmitVertex(0u));
+      }
+
+      auto emitGuardEnd = builder.add(ir::Op::ScopedEndIf(emitGuard));
+      builder.rewriteOp(emitGuard,
+        ir::Op(builder.getOp(emitGuard)).setOperand(0u, emitGuardEnd));
+    }
+
+    uint32_t determineResourceIndex(
+            dxbc_spv::ir::ShaderStage stage,
+            dxbc_spv::ir::ScalarType  type,
+            uint32_t                  regSpace,
+            uint32_t                  regIndex) const override {
+      // This converter states no resource bindings at all (no CBV/
+      // SRV/UAV/sampler - only IO pass-through and one builtin write),
+      // so this should never actually be called. A harmless answer if
+      // it ever is.
+      return regIndex;
+    }
+
+    void dumpSource(const std::string& path) const override {
+      // No DXBC source behind a hand-built converter - nothing to dump.
+    }
+
+    std::string getDebugName() const override {
+      return m_key.toString() + "_nvAmpGs";
+    }
+
+  private:
+
+    DxvkShaderHash                          m_key;
+    std::vector<DxvkNvPassthroughIoEntry>   m_passthroughIo;
+    uint32_t                                m_numViews;
+    DxvkNvMultiviewInfo                     m_nvMultiview;
+
+  };
 
   class D3D11ShaderConverter : public DxvkIrShaderConverter {
 
@@ -41,6 +337,15 @@ namespace dxvk {
       options.classInstanceRegisterSpace = 0u;
       options.classInstanceRegisterIndex = D3D11_COMMONSHADER_CONSTANT_BUFFER_API_SLOT_COUNT + 1u;
       options.limitTessFactor = true;
+
+      if (m_info.nvMultiview.enabled()) {
+        Logger::info(str::format("NvMultiview: compiling ", debugName,
+          " (posViews o", m_info.nvMultiview.positionViewReg[0],
+          "/o", m_info.nvMultiview.positionViewReg[1],
+          "/o", m_info.nvMultiview.positionViewReg[2],
+          ", mask o", m_info.nvMultiview.viewportMaskReg,
+          ", vpMask=", m_info.nvMultiview.useViewportMask, ")"));
+      }
 
       dxbc_spv::dxbc::Container container(m_dxbc.data(), m_dxbc.size());
 
@@ -221,6 +526,7 @@ namespace dxvk {
     const D3D11ShaderIcbInfo&     Icb,
     const D3D11BindingMask&       BindingMask)
   : m_bindings(BindingMask) {
+    m_shaderKey = ShaderKey;
     if (Logger::logLevel() <= LogLevel::Debug)
       Logger::debug(str::format("Compiling shader ", ShaderKey.toString()));
 
@@ -229,6 +535,62 @@ namespace dxvk {
 
     CreateIrShader(pDevice, ShaderKey, ModuleInfo, pShaderBytecode, BytecodeLength, Icb);
     pDevice->GetDXVKDevice()->registerShader(m_shader);
+  }
+
+
+  Rc<DxvkShader> D3D11CommonShader::GetOrCreateNvAmplificationGs(
+          D3D11Device*            pDevice,
+    const DxvkShaderHash&         VsKey,
+          uint32_t                NumViews,
+    const DxvkNvMultiviewInfo&    NvMultiview) const {
+    std::lock_guard lock(*m_nvAmplificationMutex);
+
+    // A cache entry is only trustworthy if it was actually built for
+    // THIS NumViews/NvMultiview. Trusting "non-null" alone let a VS
+    // that was first amplified under one live config silently keep
+    // serving that config forever, even to later draws that need a
+    // genuinely different one.
+    bool cacheMatches = *m_nvAmplificationGs != nullptr
+      && *m_nvAmplificationNumViews == NumViews
+      && std::memcmp(m_nvAmplificationInfo.get(), &NvMultiview, sizeof(DxvkNvMultiviewInfo)) == 0;
+
+    if (cacheMatches) {
+      static std::atomic<int32_t> s_reuseLogBudget = { 8 };
+
+      if (s_reuseLogBudget.fetch_sub(1, std::memory_order_relaxed) > 0) {
+        Logger::info(str::format("NvAmplificationGs: reusing cached companion for ",
+          VsKey.toString(), " (", m_nvPassthroughIo.size(), " passthrough entries)"));
+      }
+      return *m_nvAmplificationGs;
+    }
+
+    if (*m_nvAmplificationGs != nullptr) {
+      static std::atomic<int32_t> s_staleLogBudget = { 8 };
+
+      if (s_staleLogBudget.fetch_sub(1, std::memory_order_relaxed) > 0) {
+        Logger::info(str::format("NvAmplificationGs: cached companion for ",
+          VsKey.toString(), " no longer matches (was ", *m_nvAmplificationNumViews,
+          " views, now ", NumViews, " views) - rebuilding"));
+      }
+    }
+
+    Logger::info(str::format("NvAmplificationGs: building companion for ",
+      VsKey.toString(), " (", m_nvPassthroughIo.size(), " passthrough entries, ",
+      NumViews, " views)"));
+
+    Rc<D3D11NvAmplificationGsConverter> converter =
+      new D3D11NvAmplificationGsConverter(VsKey, m_nvPassthroughIo, NumViews, NvMultiview);
+
+    DxvkIrShaderCreateInfo nvAmpGsInfo = { };
+    nvAmpGsInfo.options.flags.set(DxvkShaderCompileFlag::SemanticIo);
+
+    *m_nvAmplificationGs = pDevice->GetDXVKDevice()->createCachedShader(
+      VsKey.toString() + "_nvAmpGs", nvAmpGsInfo, std::move(converter));
+
+    *m_nvAmplificationNumViews = NumViews;
+    *m_nvAmplificationInfo = NvMultiview;
+
+    return *m_nvAmplificationGs;
   }
 
 

--- a/src/d3d11/d3d11_shader.h
+++ b/src/d3d11/d3d11_shader.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 #include <mutex>
 #include <unordered_map>
 
@@ -156,6 +157,48 @@ namespace dxvk {
       return m_shader;
     }
 
+    /**
+     * \brief NV multi-view pass-through IO list
+     *
+     * Empty for shaders with no NV multi-view metadata. Filled once,
+     * at creation time, from the same signature walk that resolves NV
+     * custom semantics - never re-read from bytecode.
+     */
+    const std::vector<DxvkNvPassthroughIoEntry>& GetNvPassthroughIo() const {
+      return m_nvPassthroughIo;
+    }
+
+    void SetNvPassthroughIo(std::vector<DxvkNvPassthroughIoEntry>&& io) {
+      m_nvPassthroughIo = std::move(io);
+    }
+
+    /**
+     * \brief Shader key this object was created with
+     *
+     * Nothing on DxvkShader/DxvkIrShader hands this back once creation
+     * is done - kept here since GetOrCreateNvAmplificationGs needs it.
+     */
+    DxvkShaderHash GetShaderKey() const {
+      return m_shaderKey;
+    }
+
+    /**
+     * \brief Gets or builds (only when needed) this VS's NV multi-view broadcast GS
+     *
+     * Only meaningful when this shader is a vertex shader with
+     * nvMultiview metadata and no application-bound geometry shader.
+     * Built once and shared by every copy of this object. The cache slot
+     * below is a shared_ptr because D3D11ShaderModuleSet::GetShaderModule
+     * returns this object by copy on both a hit and a miss, so the slot
+     * has to be something a copy can still share; same reasoning as the
+     * mutex beside it.
+     */
+    Rc<DxvkShader> GetOrCreateNvAmplificationGs(
+          D3D11Device*            pDevice,
+    const DxvkShaderHash&         VsKey,
+          uint32_t                NumViews,
+    const DxvkNvMultiviewInfo&    NvMultiview) const;
+
     DxvkBufferSlice GetIcb() const {
       return m_buffer != nullptr
         ? DxvkBufferSlice(m_buffer)
@@ -180,6 +223,17 @@ namespace dxvk {
 
     Rc<DxvkShader> m_shader;
     Rc<DxvkBuffer> m_buffer;
+
+    std::vector<DxvkNvPassthroughIoEntry> m_nvPassthroughIo;
+    DxvkShaderHash                        m_shaderKey;
+    std::shared_ptr<Rc<DxvkShader>>       m_nvAmplificationGs    = std::make_shared<Rc<DxvkShader>>();
+    std::shared_ptr<dxvk::mutex>          m_nvAmplificationMutex = std::make_shared<dxvk::mutex>();
+    // What NumViews/NvMultiview the cached GS above was actually built
+    // with. Needed so GetOrCreateNvAmplificationGs can tell a genuinely
+    // stale cache entry apart from a valid one, instead of trusting
+    // "non-null" as the only signal that the cache is still correct.
+    std::shared_ptr<uint32_t>             m_nvAmplificationNumViews = std::make_shared<uint32_t>(0u);
+    std::shared_ptr<DxvkNvMultiviewInfo>  m_nvAmplificationInfo     = std::make_shared<DxvkNvMultiviewInfo>();
 
     D3D11BindingMask    m_bindings = { };
     D3D11InterfaceInfo  m_interfaces = { };

--- a/src/dxvk/dxvk_context.h
+++ b/src/dxvk/dxvk_context.h
@@ -1103,9 +1103,22 @@ namespace dxvk {
      * and updates the values if necessary.
      * \param [in] depthBounds Depth bounds
      */
-    void setDepthBounds(
-            DxvkDepthBounds     depthBounds);
-    
+    void setDepthBounds(DxvkDepthBounds depthBounds);
+
+    /**
+     * \brief Sets NVAPI multi-view state
+     *
+     * Per-draw toggle forwarded from the D3D11 interop layer
+     * (dxvk-nvapi SetMultiViewMode). Stored only in this milestone;
+     * consumed from Milestone 4.C.
+     * \param [in] numViews Number of views (1 = multi-view off)
+     * \param [in] independentViewportMask Per-view viewport masks in use
+     */
+    void setNvMultiviewState(uint32_t numViews, bool independentViewportMask) {
+      m_nvMultiviewNumViews = numViews;
+      m_nvMultiviewIndependentMask = independentViewportMask;
+    }
+
     /**
      * \brief Sets stencil reference
      * 
@@ -1355,6 +1368,9 @@ namespace dxvk {
     DxvkContextState        m_state;
     DxvkContextFeatures     m_features;
     DxvkDescriptorState     m_descriptorState;
+
+    uint32_t                m_nvMultiviewNumViews = 1u;
+    bool                    m_nvMultiviewIndependentMask = false;
 
     Rc<DxvkDescriptorPool>  m_descriptorPool;
 

--- a/src/dxvk/dxvk_device_info.cpp
+++ b/src/dxvk/dxvk_device_info.cpp
@@ -71,8 +71,10 @@ namespace dxvk {
     HANDLE_EXT(khrWin32KeyedMutex);                \
     HANDLE_EXT(amdBufferMarker);                   \
     HANDLE_EXT(nvDeviceDiagnosticCheckpoints);     \
+    HANDLE_EXT(nvGeometryShaderPassthrough);       \
     HANDLE_EXT(nvLowLatency2);                     \
     HANDLE_EXT(nvRawAccessChains);                 \
+    HANDLE_EXT(nvViewportArray2);                  \
     HANDLE_EXT(nvxBinaryImport);                   \
     HANDLE_EXT(nvxImageViewHandle);
 
@@ -1081,6 +1083,10 @@ namespace dxvk {
 
       /* Raw access chains, improves performance on NV */
       ENABLE_EXT_FEATURE(nvRawAccessChains, shaderRawAccessChains, false),
+
+      /* SMP multi-view rendering (dxvk-nvapi interop) */
+      ENABLE_EXT(nvGeometryShaderPassthrough, false),
+      ENABLE_EXT(nvViewportArray2, false),
 
       /* CUDA interop extensions */
       ENABLE_EXT(nvxBinaryImport, false),

--- a/src/dxvk/dxvk_device_info.h
+++ b/src/dxvk/dxvk_device_info.h
@@ -114,8 +114,10 @@ namespace dxvk {
     VkBool32                                                  khrWin32KeyedMutex              = VK_FALSE;
     VkBool32                                                  amdBufferMarker                 = VK_FALSE;
     VkBool32                                                  nvDeviceDiagnosticCheckpoints   = VK_FALSE;
+    VkBool32                                                  nvGeometryShaderPassthrough     = VK_FALSE;
     VkBool32                                                  nvLowLatency2                   = VK_FALSE;
     VkPhysicalDeviceRawAccessChainsFeaturesNV                 nvRawAccessChains               = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAW_ACCESS_CHAINS_FEATURES_NV };
+    VkBool32                                                  nvViewportArray2                = VK_FALSE;
     VkBool32                                                  nvxBinaryImport                 = VK_FALSE;
     VkBool32                                                  nvxImageViewHandle              = VK_FALSE;
   };
@@ -189,8 +191,10 @@ namespace dxvk {
     VkExtensionProperties khrWin32KeyedMutex                = vk::makeExtension(VK_KHR_WIN32_KEYED_MUTEX_EXTENSION_NAME);
     VkExtensionProperties amdBufferMarker                   = vk::makeExtension(VK_AMD_BUFFER_MARKER_EXTENSION_NAME);
     VkExtensionProperties nvDeviceDiagnosticCheckpoints     = vk::makeExtension(VK_NV_DEVICE_DIAGNOSTIC_CHECKPOINTS_EXTENSION_NAME);
+    VkExtensionProperties nvGeometryShaderPassthrough       = vk::makeExtension(VK_NV_GEOMETRY_SHADER_PASSTHROUGH_EXTENSION_NAME);
     VkExtensionProperties nvLowLatency2                     = vk::makeExtension(VK_NV_LOW_LATENCY_2_EXTENSION_NAME);
     VkExtensionProperties nvRawAccessChains                 = vk::makeExtension(VK_NV_RAW_ACCESS_CHAINS_EXTENSION_NAME);
+    VkExtensionProperties nvViewportArray2                  = vk::makeExtension(VK_NV_VIEWPORT_ARRAY_2_EXTENSION_NAME);
     VkExtensionProperties nvxBinaryImport                   = vk::makeExtension(VK_NVX_BINARY_IMPORT_EXTENSION_NAME);
     VkExtensionProperties nvxImageViewHandle                = vk::makeExtension(VK_NVX_IMAGE_VIEW_HANDLE_EXTENSION_NAME);
   };

--- a/src/dxvk/dxvk_shader_cache.cpp
+++ b/src/dxvk/dxvk_shader_cache.cpp
@@ -260,7 +260,8 @@ namespace dxvk {
   bool DxvkShaderCache::writeShaderCreateInfo(util::File& stream, const DxvkIrShaderCreateInfo& createInfo) {
     bool status = write(stream, createInfo.options)
                && write(stream, createInfo.flatShadingInputs)
-               && write(stream, createInfo.rasterizedStream);
+               && write(stream, createInfo.rasterizedStream)
+               && write(stream, createInfo.nvMultiview);
 
     status = status && write(stream, uint32_t(createInfo.xfbEntries.size()));
 
@@ -452,7 +453,8 @@ namespace dxvk {
     bool status = readString(stream, offset, key.name)
                && read(stream, offset, key.createInfo.options)
                && read(stream, offset, key.createInfo.flatShadingInputs)
-               && read(stream, offset, key.createInfo.rasterizedStream);
+               && read(stream, offset, key.createInfo.rasterizedStream)
+               && read(stream, offset, key.createInfo.nvMultiview);
 
     uint32_t xfbCount = 0u;
     status = status && read(stream, offset, xfbCount);

--- a/src/dxvk/dxvk_shader_ir.cpp
+++ b/src/dxvk/dxvk_shader_ir.cpp
@@ -15,6 +15,8 @@ namespace dxvk {
     hash.add(bit::fnv1a_hash(reinterpret_cast<const char*>(&options), sizeof(options)));
     hash.add(flatShadingInputs);
     hash.add(rasterizedStream);
+    static_assert(std::is_trivially_copyable_v<DxvkNvMultiviewInfo>);
+    hash.add(bit::fnv1a_hash(reinterpret_cast<const char*>(&nvMultiview), sizeof(nvMultiview)));
 
     for (const auto& xfb : xfbEntries)
       hash.add(std::hash<dxbc_spv::ir::IoXfbInfo>()(xfb));
@@ -33,7 +35,10 @@ namespace dxvk {
      || rasterizedStream != other.rasterizedStream)
       return false;
 
-    if (xfbEntries.size() != other.xfbEntries.size())
+    if (std::memcmp(&nvMultiview, &other.nvMultiview, sizeof(nvMultiview)))
+      return false;
+
+      if (xfbEntries.size() != other.xfbEntries.size())
       return false;
 
     for (size_t i = 0u; i != xfbEntries.size(); i++) {

--- a/src/dxvk/dxvk_shader_ir.h
+++ b/src/dxvk/dxvk_shader_ir.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <array>
 #include <atomic>
 #include <string>
 #include <vector>
@@ -17,6 +18,56 @@
 namespace dxvk {
 
   /**
+   * \brief One pass-through IO register for the amplification GS
+   *
+   * Caught once, at VS creation time, from the same output-signature
+   * walk that resolves NV custom semantics - never the NV interop
+   * registers themselves (position-view family, viewport masks), only
+   * the plain registers a rasterizer/PS reads.
+   */
+  struct DxvkNvPassthroughIoEntry {
+    uint32_t                 regIndex      = 0u;
+    dxbc_spv::ir::BasicType  type          = dxbc_spv::ir::BasicType();
+    std::string              semanticName  = { };
+    uint32_t                 semanticIndex = 0u;
+    /// First written component. Two signature entries can share a register
+    /// with different write masks; both need this to be declared correctly.
+    uint32_t                 component     = 0u;
+  };
+
+
+  /**
+   * \brief NVAPI multi-view semantic mapping
+   *
+   * Output registers resolved from the DXBC output signature of a shader
+   * created through the NVAPI extended entry points (dxvk-nvapi interop).
+   * View 0's position is SV_POSITION; views 1-3 ride the
+   * NV_POSITION_VIEW_{1,2,3}_SEMANTIC outputs. Register indices are -1
+   * when the corresponding output is not present. Trivially copyable, and
+   * hashed by raw bytes: hash() and eq() operate on the whole struct, so
+   * the static_assert below pins the layout.
+   */
+  struct DxvkNvMultiviewInfo {
+    std::array<int32_t, 3> positionViewReg = { -1, -1, -1 };
+    /// Data type of each register above, the index alone isn't enough
+    /// to declare a matching GS input for it.
+    std::array<dxbc_spv::ir::BasicType, 3> positionViewType = { };
+    int32_t viewportMaskReg = -1;
+    int32_t viewportMask2Reg = -1;
+    /// Data type of the two registers above, same reasoning as
+    /// positionViewType.
+    std::array<dxbc_spv::ir::BasicType, 2> viewportMaskType = { };
+    uint32_t useViewportMask = 0u;
+
+    bool enabled() const {
+      return positionViewReg[0] >= 0 || viewportMaskReg >= 0;
+    }
+  };
+
+  static_assert(sizeof(DxvkNvMultiviewInfo) == 32u);
+
+
+  /**
    * \brief IR shader properties
    *
    * Stores some metadata that cannot be inferred from
@@ -29,6 +80,8 @@ namespace dxvk {
     uint32_t flatShadingInputs = 0u;
     /// Rasterized geometry stream
     int32_t rasterizedStream = 0;
+    /// NVAPI multi-view semantic mapping (dxvk-nvapi interop)
+    DxvkNvMultiviewInfo nvMultiview = { };
     /// Streamout parameters
     small_vector<dxbc_spv::ir::IoXfbInfo, 8u> xfbEntries = { };
 
@@ -36,7 +89,6 @@ namespace dxvk {
 
     bool eq(const DxvkIrShaderCreateInfo& other) const;
   };
-
 
   /**
    * \brief Raw shader binary for dxbc-spirv


### PR DESCRIPTION
These changes receive information from dxvk-nvapi to generate and position geometry correctly and quickly for Simultaneous Multi-Projection implementation.

iRacing is the main program using this SMP/MVP technology, and as far as I can tell the only game to actually do so.  These changes only affect users with an NVIDIA card of the Turing generation or newer and nothing changes for any users not using this feature either with an incompatible graphics card or SMP simply being disabled in game.

Multiple test runs and the DXVK_HUD and Mangohud data collected from them are in this graphic:

![smp-triple-screen](https://github.com/user-attachments/assets/22953390-d6db-4381-a7ec-5e38d536976c)

The paired dxvk-nvapi PR that this PR needs to work correctly is
https://github.com/jp7677/dxvk-nvapi/pull/388 and both need to be
merged for either to do anything.

I'm happy to do further testing that may be needed.