### PR TITLE
[dxgi] Reserve a hot-patchable entry on the DXGI entry points overlays hook

### DIFF
--- a/src/dxgi/dxgi_factory.h
+++ b/src/dxgi/dxgi_factory.h
@@ -8,6 +8,7 @@
 #include "dxgi_options.h"
 
 #include "../dxvk/dxvk_instance.h"
+#include "../util/util_hotpatch.h"
 
 namespace dxvk {
 
@@ -73,11 +74,13 @@ namespace dxvk {
             HMODULE               Module,
             IDXGIAdapter**        ppAdapter) final;
     
+    DXVK_HOTPATCHABLE
     HRESULT STDMETHODCALLTYPE CreateSwapChain(
             IUnknown*             pDevice,
             DXGI_SWAP_CHAIN_DESC* pDesc,
             IDXGISwapChain**      ppSwapChain) final;
     
+    DXVK_HOTPATCHABLE
     HRESULT STDMETHODCALLTYPE CreateSwapChainForHwnd(
             IUnknown*             pDevice,
             HWND                  hWnd,
@@ -86,6 +89,7 @@ namespace dxvk {
             IDXGIOutput*          pRestrictToOutput,
             IDXGISwapChain1**     ppSwapChain) final;
 
+    DXVK_HOTPATCHABLE
     HRESULT STDMETHODCALLTYPE CreateSwapChainForCoreWindow(
             IUnknown*             pDevice,
             IUnknown*             pWindow,
@@ -93,6 +97,7 @@ namespace dxvk {
             IDXGIOutput*          pRestrictToOutput,
             IDXGISwapChain1**     ppSwapChain) final;
     
+    DXVK_HOTPATCHABLE
     HRESULT STDMETHODCALLTYPE CreateSwapChainForComposition(
             IUnknown*             pDevice,
       const DXGI_SWAP_CHAIN_DESC1* pDesc,

--- a/src/dxgi/dxgi_swapchain.h
+++ b/src/dxgi/dxgi_swapchain.h
@@ -13,6 +13,7 @@
 
 #include "../wsi/wsi_window.h"
 #include "../wsi/wsi_monitor.h"
+#include "../util/util_hotpatch.h"
 
 namespace dxvk {
   
@@ -93,15 +94,18 @@ namespace dxvk {
     
     BOOL STDMETHODCALLTYPE IsTemporaryMonoSupported() final;
 
+    DXVK_HOTPATCHABLE
     HRESULT STDMETHODCALLTYPE Present(
             UINT                      SyncInterval,
             UINT                      Flags) final;
     
+    DXVK_HOTPATCHABLE
     HRESULT STDMETHODCALLTYPE Present1(
             UINT                      SyncInterval,
             UINT                      PresentFlags,
       const DXGI_PRESENT_PARAMETERS*  pPresentParameters) final;
 
+    DXVK_HOTPATCHABLE
     HRESULT STDMETHODCALLTYPE ResizeBuffers(
             UINT                      BufferCount,
             UINT                      Width,
@@ -121,6 +125,7 @@ namespace dxvk {
     HRESULT STDMETHODCALLTYPE ResizeTarget(
       const DXGI_MODE_DESC*           pNewTargetParameters) final;
     
+    DXVK_HOTPATCHABLE
     HRESULT STDMETHODCALLTYPE SetFullscreenState(
             BOOL                      Fullscreen,
             IDXGIOutput*              pTarget) final;

--- a/src/util/util_hotpatch.h
+++ b/src/util/util_hotpatch.h
@@ -1,0 +1,29 @@
+#pragma once
+
+/**
+ * \brief Reserves a hot-patchable function entry
+ *
+ * Emits padding at the start of a function so that an inline-hook engine can
+ * overwrite the first five bytes with a `jmp rel32` and relocate what it
+ * displaced. This is the GCC/clang equivalent of MSVC's /hotpatch.
+ *
+ * Third-party overlays hook the DXGI entry points this way. Without the
+ * padding they must length-decode whatever the compiler happened to emit, and
+ * their decoders generally only cover the instruction forms MSVC produces --
+ * a frame-pointer build of DXVK starts CreateSwapChainForHwnd with
+ * `mov rax,[rbp+disp8]`, which such a decoder does not recognise, leaving it
+ * one byte short of a patchable prologue and silently unhooked.
+ *
+ * Five bytes is the minimum a `jmp rel32` needs. GCC emits five one-byte NOPs,
+ * clang a single five-byte NOP; both are ordinary padding that costs nothing at
+ * run time and is trivially relocatable.
+ */
+#if defined(__i386__) || defined(__x86_64__)
+  #if defined(__GNUC__) || defined(__clang__)
+    #define DXVK_HOTPATCHABLE __attribute__((patchable_function_entry(5)))
+  #endif
+#endif
+
+#ifndef DXVK_HOTPATCHABLE
+  #define DXVK_HOTPATCHABLE
+#endif


### PR DESCRIPTION
### Problem

Inline-hook engines (the Steam overlay, RTSS, Discord, ReShade's loader) install hooks by copying a function's first bytes into a trampoline and writing a 5-byte `jmp rel32` over them. To do that they must length-decode the prologue, and in practice their decoders only cover the instruction forms MSVC emits — on Windows that has always been sufficient.

Built with frame pointers, clang gives `DxgiFactory::CreateSwapChainForHwnd`:

```
55              push rbp
48 89 e5        mov  rbp, rsp
48 8b 45 40     mov  rax, [rbp+0x40]     <- ModRM mod=01, rm=101
```

`mov r64,[rbp+disp8]` is effectively absent from MSVC x86-64 output, which omits frame pointers and reaches stack arguments through `rsp`+SIB. Steam's decoder stops there holding 4 decoded bytes, one short of the 5 it needs, and skips the hook:

```
Unknown opcodes for AMD64 at 4 bytes: 55 48 89 E5 48 8B 45 40 ...,
    module=dxgi.dll,IDXGIFactory2_CreateSwapChainForHWND
```

`CreateSwapChainForHwnd` is the entry point every modern D3D11/D3D12 title uses, so nothing downstream is wrapped: no `Present` hook, no renderer, and the overlay silently never draws. D3D9 titles are unaffected because they never touch DXGI. This is the same user-visible symptom as #1241.

It is exactly **one function out of 7542** in `dxgi.dll` — and it happens to be the one that matters.

### Why not just change build flags

Frame pointers are what trigger it here, and several downstream distributions build DXVK that way. But turning the flag off is a fix that depends on the compiler continuing to make a favourable choice for this particular function; at `-O2` without frame pointers clang emits `48 8b 44 24 38` and it happens to work. Nothing guarantees that stays true across compilers, versions or optimisation levels — and DXVK currently offers no guarantee that its COM entry points are hot-patchable at all, while inline-hook engines have been hooking DXGI on Windows for a decade.

### Fix

Do what MSVC's `/hotpatch` does — guarantee decodable, relocatable bytes at the function entry — using the GCC/clang `patchable_function_entry` attribute, applied only to the virtual entry points overlays actually hook. This is codegen-independent: it holds under any flags, compiler or optimisation level. The cost is a few NOP bytes per function, on swapchain-creation and present paths that already do far more work.

### Verification

Emitted padding, checked with clang 22 and gcc 16 targeting `x86_64-windows`:

| compiler | bytes |
|---|---|
| clang | `0f 1f 44 00 08` (one 5-byte NOP) |
| gcc | `90 90 90 90 90` (five 1-byte NOPs) |

Both were confirmed to be **accepted by Steam's decoder**, not assumed:

* gcc's form — the overlay's hook installer contains an explicit `cmp al, 0x90`.
* clang's form — tested end to end by placing `0f 1f 44 00 08` at the real `CreateSwapChainForHwnd` entry in a shipped `dxgi.dll` and running a D3D12 title. The overlay then logs `IWrapDXGIFactory2::IDXGIFactory2_CreateSwapChainForHWND called` and goes on to hook the swapchain vtable and create its renderer, where the unmodified build stops at the `Unknown opcodes` line.

Built with `meson --cross-file build-win64.txt -Dcpp_args=-fno-omit-frame-pointer` (i.e. the configuration that reproduces the bug) and confirmed in the resulting binary — `CreateSwapChainForHwnd` now begins with the padding, and the previously-undecodable instruction sits harmlessly at offset 5:

```
0x7e90  90 90 90 90 90
0x7e95  55              push rbp
0x7e96  48 89 e5        mov  rbp, rsp
0x7e99  48 8b 45 40     mov  rax, [rbp+0x40]
```

I'm happy to trim this to just the four factory methods if the swapchain ones (`Present`, `Present1`, `ResizeBuffers`, `SetFullscreenState`) are more surface than you want — the factory entry points alone fix the reported failure.

### Benefit
This one fix allows Steam Overlay to work within Wayland sessions in DXVK/VKD3D games (with the caveat that the steam.exe stub from within Proton must be an *actual* Wine-ran Steam.exe; this is possible in [modern Proton builds](https://github.com/nanomatters/proton-cachyos)).

### Implementation
Via [dxvk-hotpatchable-entry.patch](https://github.com/user-attachments/files/30862954/dxvk-hotpatchable-entry.patch)
