### PR TITLE
D3D9: No clip planes for pre-transformed vertices

### DIFF
--- a/src/d3d9/d3d9_common_texture.cpp
+++ b/src/d3d9/d3d9_common_texture.cpp
@@ -483,6 +483,22 @@ namespace dxvk {
     if (!CheckImageSupport(&imageInfo, imageInfo.tiling))
       return nullptr;
 
+    std::string debugName;
+    if (unlikely(m_device->GetDXVKDevice()->debugFlags().test(DxvkDebugFlag::Markers))) {
+      std::string resourceType;
+      switch (m_type) {
+        case D3DRTYPE_SURFACE: resourceType = "Surface"; break;
+        case D3DRTYPE_VOLUME: resourceType = "Volume"; break;
+        case D3DRTYPE_TEXTURE: resourceType = "Texture"; break;
+        case D3DRTYPE_VOLUMETEXTURE: resourceType = "VolumeTexture"; break;
+        case D3DRTYPE_CUBETEXTURE: resourceType = "CubeTexture"; break;
+        default: resourceType = "Other"; break;
+      }
+      debugName = str::format(resourceType, " ", m_desc.Format, " - ", imageInfo.extent.width, "x",
+        imageInfo.extent.height, "x", imageInfo.extent.depth);
+      imageInfo.debugName = debugName.c_str();
+    }
+
     return m_device->GetDXVKDevice()->createImage(imageInfo, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
   }
 

--- a/src/d3d9/shaders/d3d9_fixed_function_vert.vert
+++ b/src/d3d9/shaders/d3d9_fixed_function_vert.vert
@@ -371,7 +371,8 @@ void emitVsClipping(vec4 vtx) {
     vec4 worldPos = data.InverseView * vtx;
 
     // Always consider clip planes enabled when doing GPL by forcing 6 for the quick value.
-    uint clipPlaneCount = getClipPlaneCount();
+    // Ignore clip planes for pre-transformed vertices.
+    uint clipPlaneCount = !vertexHasPositionT() ? getClipPlaneCount() : 0u;
 
     // Compute clip distances
     for (uint i = 0u; i < MaxClipPlaneCount; i++)


### PR DESCRIPTION
Fixes #5830

I also threw in a little change that helped with debugging.