### PR TITLE
[dxvk] Add a hack to support equal-value fence signals

### DIFF
--- a/src/dxvk/dxvk_cmdlist.cpp
+++ b/src/dxvk/dxvk_cmdlist.cpp
@@ -343,9 +343,15 @@ namespace dxvk {
 
       if (isLast) {
         // Signal per-command list semaphores on the final submission
-        for (size_t i = 0; i < m_signalSemaphores.size(); i++) {
-          m_commandSubmission.signalSemaphore(m_signalSemaphores[i].fence->handle(),
-            m_signalSemaphores[i].value, VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT);
+        for (const auto& semaphore : m_signalSemaphores) {
+          // HACK: Support equal-value signals, including shared fences,
+          // by skipping the redundant Vulkan timeline signal.
+          if (semaphore.fence->getValue() == semaphore.value) {
+            continue;
+          }
+
+          m_commandSubmission.signalSemaphore(semaphore.fence->handle(),
+            semaphore.value, VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT);
         }
 
         // Signal WSI semaphore on the final submission


### PR DESCRIPTION
D3D permits signaling a fence to its current value, including for shared fences, while Vulkan timeline semaphore signals must strictly increase. The Skyrim Upscaling Community Shaders mod, with FSR frame generation enabled, signals a shared fence with equal value from both D3D11 and D3D12, resulting in invalid Vulkan usage and device loss, hence causing the game to hang and crash.

This hack skips the redundant Vulkan signal when the fence has already reached the requested value.