### PR TITLE
[util] Use hybrid_patchable attribute for DXVK_HOTPATCHABLE on ARM64EC

### DIFF
--- a/src/dxvk/dxvk_graphics_state.h
+++ b/src/dxvk/dxvk_graphics_state.h
@@ -630,15 +630,15 @@ namespace dxvk {
    */
   struct alignas(32) DxvkGraphicsPipelineStateInfo {
     DxvkGraphicsPipelineStateInfo() {
-      std::memset(this, 0, sizeof(*this));
+      std::memset((void *)this, 0, sizeof(*this));
     }
 
     DxvkGraphicsPipelineStateInfo(const DxvkGraphicsPipelineStateInfo& other) {
-      std::memcpy(this, &other, sizeof(*this));
+      std::memcpy((void *)this, &other, sizeof(*this));
     }
     
     DxvkGraphicsPipelineStateInfo& operator = (const DxvkGraphicsPipelineStateInfo& other) {
-      std::memcpy(this, &other, sizeof(*this));
+      std::memcpy((void *)this, &other, sizeof(*this));
       return *this;
     }
     
@@ -732,15 +732,15 @@ namespace dxvk {
    */
   struct alignas(32) DxvkComputePipelineStateInfo {
     DxvkComputePipelineStateInfo() {
-      std::memset(this, 0, sizeof(*this));
+      std::memset((void *)this, 0, sizeof(*this));
     }
 
     DxvkComputePipelineStateInfo(const DxvkComputePipelineStateInfo& other) {
-      std::memcpy(this, &other, sizeof(*this));
+      std::memcpy((void *)this, &other, sizeof(*this));
     }
     
     DxvkComputePipelineStateInfo& operator = (const DxvkComputePipelineStateInfo& other) {
-      std::memcpy(this, &other, sizeof(*this));
+      std::memcpy((void *)this, &other, sizeof(*this));
       return *this;
     }
     

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <array>
 #include <fstream>
 #include <sstream>

--- a/src/util/util_hotpatch.h
+++ b/src/util/util_hotpatch.h
@@ -6,6 +6,10 @@
 
 #if __has_attribute(ms_hook_prologue) && (defined(__i386__) || defined(__x86_64__))
 #define DXVK_HOTPATCHABLE __attribute__((__ms_hook_prologue__))
+#elif defined(DECLSPEC_CHPE_PATCHABLE)
+#define DXVK_HOTPATCHABLE DECLSPEC_CHPE_PATCHABLE
+#elif defined(__arm64ec__)
+#define DXVK_HOTPATCHABLE __attribute__((hybrid_patchable))
 #else
 #define DXVK_HOTPATCHABLE
 #endif

--- a/src/util/util_small_vector.h
+++ b/src/util/util_small_vector.h
@@ -4,6 +4,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <new>
 #include <initializer_list>
 #include <type_traits>
 #include <utility>


### PR DESCRIPTION
Followup from #5846 for ARM64EC.

The linker generates x86 thunks (needed to make a function patchable) only for exports, COM functions need an explicit attribute.

I also added a fix for building with LLVM 23 and for noisy warnings.