### PR TITLE
Annotate ResizeTarget() as  __declspec(hybrid_patchable)

### DIFF
--- a/src/dxgi/dxgi_swapchain.h
+++ b/src/dxgi/dxgi_swapchain.h
@@ -112,7 +112,8 @@ namespace dxvk {
             UINT                      Height,
             DXGI_FORMAT               NewFormat,
             UINT                      SwapChainFlags) final;
-    
+
+    DXVK_HOTPATCHABLE
     HRESULT STDMETHODCALLTYPE ResizeBuffers1(
             UINT                      BufferCount,
             UINT                      Width,
@@ -122,6 +123,7 @@ namespace dxvk {
       const UINT*                     pCreationNodeMask,
             IUnknown* const*          ppPresentQueue) final;
 
+    DXVK_HOTPATCHABLE
     HRESULT STDMETHODCALLTYPE ResizeTarget(
       const DXGI_MODE_DESC*           pNewTargetParameters) final;
     

--- a/src/dxgi/dxgi_swapchain.h
+++ b/src/dxgi/dxgi_swapchain.h
@@ -112,7 +112,7 @@ namespace dxvk {
             UINT                      Height,
             DXGI_FORMAT               NewFormat,
             UINT                      SwapChainFlags) final;
-
+    
     DXVK_HOTPATCHABLE
     HRESULT STDMETHODCALLTYPE ResizeBuffers1(
             UINT                      BufferCount,


### PR DESCRIPTION
Related to FEX issue here: https://github.com/FEX-Emu/FEX/issues/5833

The modding tool REFramework detours this function at runtime to hook itself into the target game. This fails under emulation unless this method is annotated with ```__declspec(hybrid_patchable)```.

Relevant REFramework code can be found here, https://github.com/praydog/REFramework/blob/master/src/D3D12Hook.cpp line number 606.