### PR TITLE
[util] Only spoof vendor id in New Vegas

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -951,7 +951,7 @@ namespace dxvk {
      * depth buffer resolves                      */
     { R"(\\Fallout( -)? New Vegas.*\\(FalloutNV)?(Launcher)?\.exe$)", {{
       { "d3d9.floatEmulation",            "Strict" },
-      { "d3d9.hideNvidiaGpu",               "True" },
+      { "d3d9.customVendorId",              "1002" },
     }} },
     /* Dungeons and Dragons: Dragonshard          *
      * Massive FPS decreases in some scenes       */


### PR DESCRIPTION
Prevents the confusion from listing every GPU as a 6700 XT in the launchers Graphics Adapter list. As seen multiple times by now.

As far as i can recall neither New Vegas itself or the Reloaded mod bases any ingame decisions on the GPU description, but rather vendor id or detected feature support. I've drafted this to begin with anyway until that has been confirmed in practice.