### PR TITLE
D3D11: Implement buffer RTV

### DIFF
--- a/src/d3d11/d3d11_context.cpp
+++ b/src/d3d11/d3d11_context.cpp
@@ -226,7 +226,10 @@ namespace dxvk {
 
     if (rtv || dsv) {
       EmitCs([cView = view] (DxvkContext* ctx) {
-        ctx->clearRenderTarget(cView, 0, VkClearValue(), cView->info().aspects);
+        DxvkAttachment attachment = {};
+        attachment.view = cView;
+
+        ctx->clearRenderTarget(attachment, 0, VkClearValue(), cView->info().aspects);
       });
     }
   }
@@ -448,16 +451,16 @@ namespace dxvk {
 
     AddCost(GpuCostEstimate::Transfer);
 
-    auto view  = rtv->GetImageView();
-    auto color = ConvertColorValue(ColorRGBA, view->formatInfo());
+    DxvkAttachment attachment = {};
+    attachment.view = rtv->GetImageView();
+    attachment.shadow = rtv->GetBufferView();
 
     EmitCs([
-      cClearValue = color,
-      cImageView  = std::move(view)
+      cClearValue = ConvertColorValue(ColorRGBA, attachment.view->formatInfo()),
+      cAttachment = std::move(attachment)
     ] (DxvkContext* ctx) {
-      ctx->clearRenderTarget(cImageView,
-        VK_IMAGE_ASPECT_COLOR_BIT,
-        cClearValue, 0u);
+      ctx->clearRenderTarget(cAttachment,
+        VK_IMAGE_ASPECT_COLOR_BIT, cClearValue, 0u);
     });
   }
 
@@ -695,12 +698,15 @@ namespace dxvk {
     clearValue.depthStencil.depth   = Depth;
     clearValue.depthStencil.stencil = Stencil;
 
+    DxvkAttachment attachment = {};
+    attachment.view = dsv->GetImageView();
+
     EmitCs([
       cClearValue = clearValue,
       cAspectMask = aspectMask,
-      cImageView  = dsv->GetImageView()
+      cAttachment = std::move(attachment)
     ] (DxvkContext* ctx) {
-      ctx->clearRenderTarget(cImageView,
+      ctx->clearRenderTarget(cAttachment,
         cAspectMask, cClearValue, 0u);
     });
   }
@@ -4064,21 +4070,14 @@ namespace dxvk {
       cView       = std::move(View),
       cClearValue = clearValue
     ] (DxvkContext* ctx, const VkRect2D* rects, size_t count) {
-      constexpr VkImageUsageFlags rtUsage = VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
       VkImageAspectFlags clearAspect = cView->formatInfo()->aspectMask & (VK_IMAGE_ASPECT_COLOR_BIT | VK_IMAGE_ASPECT_DEPTH_BIT);
 
       for (size_t i = 0; i < count; i++) {
         VkOffset3D offset = { rects[i].offset.x, rects[i].offset.y, 0 };
         VkExtent3D extent = { rects[i].extent.width, rects[i].extent.height, 1u };
 
-        if (extent.width && extent.height) {
-          bool isFullSize = cView->mipLevelExtent(0) == extent;
-
-          if ((cView->info().usage & rtUsage) && isFullSize)
-            ctx->clearRenderTarget(cView, clearAspect, cClearValue, 0u);
-          else
-            ctx->clearImageView(cView, offset, extent, clearAspect, cClearValue);
-        }
+        if (extent.width && extent.height)
+          ctx->clearImageView(cView, offset, extent, clearAspect, cClearValue);
       }
     });
 

--- a/src/d3d11/d3d11_context.cpp
+++ b/src/d3d11/d3d11_context.cpp
@@ -197,6 +197,9 @@ namespace dxvk {
     auto rtv = dynamic_cast<D3D11RenderTargetView*>(pResourceView);
     auto uav = dynamic_cast<D3D11UnorderedAccessView*>(pResourceView);
 
+    if (rtv && rtv->GetBufferView())
+      return;
+
     Rc<DxvkImageView> view;
     if (dsv) view = dsv->GetImageView();
     if (rtv) view = rtv->GetImageView();

--- a/src/d3d11/d3d11_context.cpp
+++ b/src/d3d11/d3d11_context.cpp
@@ -3679,6 +3679,7 @@ namespace dxvk {
     for (UINT i = 0; i < m_state.om.rtvs.size(); i++) {
       if (m_state.om.rtvs[i] != nullptr) {
         attachments.color[i].view = m_state.om.rtvs[i]->GetImageView();
+        attachments.color[i].shadow = m_state.om.rtvs[i]->GetBufferView();
         sampleCount = m_state.om.rtvs[i]->GetSampleCount();
       }
     }

--- a/src/d3d11/d3d11_context.cpp
+++ b/src/d3d11/d3d11_context.cpp
@@ -731,6 +731,12 @@ namespace dxvk {
         ClearImageView(std::move(imgView), Color, pRect, NumRects);
     } else if (rtv) {
       Rc<DxvkImageView> imgView = rtv->GetImageView();
+      Rc<DxvkBufferView> bufView = rtv->GetBufferView();
+
+      if (bufView) {
+        Logger::err("D3D11: ClearView on buffer RTV not supported.");
+        return;
+      }
 
       if (imgView)
         ClearImageView(std::move(imgView), Color, pRect, NumRects);

--- a/src/d3d11/d3d11_device.cpp
+++ b/src/d3d11/d3d11_device.cpp
@@ -567,11 +567,6 @@ namespace dxvk {
     D3D11_COMMON_RESOURCE_DESC resourceDesc;
     GetCommonResourceDesc(pResource, &resourceDesc);
     
-    if (resourceDesc.Dim == D3D11_RESOURCE_DIMENSION_BUFFER) {
-      Logger::warn("D3D11: Cannot create render target view for a buffer");
-      return S_OK; // It is required to run Battlefield 3 and Battlefield 4.
-    }
-    
     // The view description is optional. If not defined, it
     // will use the resource's format and all array layers.
     D3D11_RENDER_TARGET_VIEW_DESC1 desc;
@@ -602,7 +597,12 @@ namespace dxvk {
       return S_FALSE;
     
     try {
-      *ppRTView = ref(new D3D11RenderTargetView(this, pResource, &desc));
+      auto rtv = ref(new D3D11RenderTargetView(this, pResource, &desc));
+
+      if (desc.ViewDimension == D3D11_RTV_DIMENSION_BUFFER)
+        m_initializer->InitRtvImage(rtv);
+
+      *ppRTView = rtv;
       return S_OK;
     } catch (const DxvkError& e) {
       Logger::err(e.message());

--- a/src/d3d11/d3d11_initializer.cpp
+++ b/src/d3d11/d3d11_initializer.cpp
@@ -77,6 +77,24 @@ namespace dxvk {
   }
 
 
+  void D3D11Initializer::InitRtvImage(
+          D3D11RenderTargetView*      pRtv) {
+    // Buffer RTVs own their associated image,
+    // so we need to initialize it properly
+    if (!pRtv->GetBufferView())
+      return;
+
+    std::lock_guard<dxvk::mutex> lock(m_mutex);
+    m_transferCommands += 1;
+
+    EmitCs([
+      cImageView = pRtv->GetImageView()
+    ] (DxvkContext* ctx) {
+      ctx->initImage(cImageView->image(), VK_IMAGE_LAYOUT_UNDEFINED);
+    });
+  }
+
+
   void D3D11Initializer::InitShaderIcb(
           D3D11CommonShader*          pShader,
           size_t                      IcbSize,

--- a/src/d3d11/d3d11_initializer.h
+++ b/src/d3d11/d3d11_initializer.h
@@ -58,7 +58,10 @@ namespace dxvk {
 
     void InitUavCounter(
             D3D11UnorderedAccessView*   pUav);
-    
+
+    void InitRtvImage(
+            D3D11RenderTargetView*      pRtv);
+
     void InitShaderIcb(
             D3D11CommonShader*          pShader,
             size_t                      IcbSize,

--- a/src/d3d11/d3d11_swapchain.cpp
+++ b/src/d3d11/d3d11_swapchain.cpp
@@ -844,7 +844,10 @@ namespace dxvk {
         cScrollRect   = *pPresentParameters->pScrollRect,
         cScrollOffset = *pPresentParameters->pScrollOffset
       ] (DxvkContext* ctx) mutable {
-        ctx->clearRenderTarget(cDstView, 0u, VkClearValue(), VK_IMAGE_ASPECT_COLOR_BIT);
+        DxvkAttachment attachment = {};
+        attachment.view = cDstView;
+
+        ctx->clearRenderTarget(attachment, 0u, VkClearValue(), VK_IMAGE_ASPECT_COLOR_BIT);
 
         DxvkRenderTargets rts = {};
         rts.color[0].view = std::move(cDstView);

--- a/src/d3d11/d3d11_view_rtv.cpp
+++ b/src/d3d11/d3d11_view_rtv.cpp
@@ -86,12 +86,20 @@ namespace dxvk {
         viewInfo.layerIndex = pDesc->Texture3D.FirstWSlice;
         viewInfo.layerCount = pDesc->Texture3D.WSize;
         break;
-      
+
+      case D3D11_RTV_DIMENSION_BUFFER:
+        viewInfo.viewType   = VK_IMAGE_VIEW_TYPE_1D;
+        viewInfo.mipIndex   = 0;
+        viewInfo.mipCount   = 1;
+        viewInfo.layerIndex = 0;
+        viewInfo.layerCount = 1;
+        break;
+
       default:
         throw DxvkError("D3D11: Invalid view dimension for RTV");
     }
     
-    if (texture->GetPlaneCount() > 1)
+    if (texture && texture->GetPlaneCount() > 1)
       viewInfo.aspects = vk::getPlaneAspect(GetPlaneSlice(pDesc));
 
     // Normalize view type so that we won't accidentally
@@ -112,9 +120,54 @@ namespace dxvk {
     m_info.Image.MinLayer  = viewInfo.layerIndex;
     m_info.Image.NumLevels = viewInfo.mipCount;
     m_info.Image.NumLayers = viewInfo.layerCount;
-    
-    // Create the underlying image view object
-    m_view = texture->GetImage()->createView(viewInfo);
+
+    if (texture) {
+      // Simply create view for existing image
+      m_view = texture->GetImage()->createView(viewInfo);
+    } else {
+      // If we're creating a buffer RTV, we need to explicitly
+      // create a 1D image that we can actually render to
+      DxvkImageCreateInfo imageInfo = {};
+      imageInfo.type = VK_IMAGE_TYPE_1D;
+      imageInfo.format = viewInfo.format;
+      imageInfo.sampleCount = VK_SAMPLE_COUNT_1_BIT;
+      imageInfo.extent = VkExtent3D { pDesc->Buffer.NumElements, 1u, 1u };
+      imageInfo.numLayers = 1u;
+      imageInfo.mipLevels = 1u;
+      imageInfo.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT
+                      | VK_IMAGE_USAGE_TRANSFER_SRC_BIT
+                      | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
+      imageInfo.stages = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT
+                       | VK_PIPELINE_STAGE_TRANSFER_BIT;
+      imageInfo.access = VK_ACCESS_COLOR_ATTACHMENT_READ_BIT
+                       | VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT
+                       | VK_ACCESS_TRANSFER_READ_BIT
+                       | VK_ACCESS_TRANSFER_WRITE_BIT;
+      imageInfo.layout = VK_IMAGE_LAYOUT_GENERAL;
+
+      Rc<DxvkImage> image = pDevice->GetDXVKDevice()->createImage(
+        imageInfo, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+
+      m_view = image->createView(viewInfo);
+
+      // Create view for backing buffer storage. If the implementation
+      // supports the format for storage buffers, we can even create a
+      // typed view to simplify clearing the buffer.
+      auto formatSize = image->formatInfo()->elementSize;
+      auto formatFeatures = pDevice->GetDXVKDevice()->adapter()->getFormatFeatures(viewInfo.format);
+
+      DxvkBufferViewKey bufferInfo = {};
+      bufferInfo.usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
+      bufferInfo.offset = pDesc->Buffer.FirstElement * formatSize;
+      bufferInfo.size = pDesc->Buffer.NumElements * formatSize;
+
+      if (formatFeatures.buffer & VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT) {
+        bufferInfo.format = viewInfo.format;
+        bufferInfo.usage = VK_BUFFER_USAGE_STORAGE_TEXEL_BUFFER_BIT;
+      }
+
+      m_buffer = GetCommonBuffer(pResource)->GetBuffer()->createView(bufferInfo);
+    }
   }
   
   
@@ -282,7 +335,11 @@ namespace dxvk {
         pDesc->Texture3D.FirstWSlice = 0;
         pDesc->Texture3D.WSize       = resourceDesc.Depth;
       } return S_OK;
-      
+
+      // Needs explicit format and all that
+      case D3D11_RESOURCE_DIMENSION_BUFFER:
+        return E_INVALIDARG;
+
       default:
         Logger::err(str::format(
           "D3D11: Unsupported dimension for render target view: ",
@@ -357,6 +414,11 @@ namespace dxvk {
       case D3D11_RESOURCE_DIMENSION_BUFFER: {
         if (pDesc->ViewDimension != D3D11_RTV_DIMENSION_BUFFER) {
           Logger::err("D3D11: Incompatible view dimension for Buffer");
+          return E_INVALIDARG;
+        }
+
+        if (!pDesc->Format) {
+          Logger::err("D3D11: Buffer RTV must specify format");
           return E_INVALIDARG;
         }
       } break;

--- a/src/d3d11/d3d11_view_rtv.h
+++ b/src/d3d11/d3d11_view_rtv.h
@@ -47,10 +47,14 @@ namespace dxvk {
       return type;
     }
     
+    Rc<DxvkBufferView> GetBufferView() const {
+      return m_buffer;
+    }
+
     Rc<DxvkImageView> GetImageView() const {
       return m_view;
     }
-    
+
     UINT GetSampleCount() const {
       return UINT(m_view->image()->info().sampleCount);
     }
@@ -80,6 +84,7 @@ namespace dxvk {
     D3D11_RENDER_TARGET_VIEW_DESC1    m_desc;
     D3D11_VK_VIEW_INFO                m_info;
     Rc<DxvkImageView>                 m_view;
+    Rc<DxvkBufferView>                m_buffer;
     D3D10RenderTargetView             m_d3d10;
 
     D3DDestructionNotifier            m_destructionNotifier;

--- a/src/d3d9/d3d9_device.cpp
+++ b/src/d3d9/d3d9_device.cpp
@@ -1600,7 +1600,10 @@ namespace dxvk {
         Rc<DxvkImageView> view = cImage->createView(viewKey);
 
         if (cOffset == VkOffset3D() && cExtent == cImage->mipLevelExtent(viewKey.mipIndex)) {
-          ctx->clearRenderTarget(view, cSubresource.aspectMask, cClearValue, 0u);
+          DxvkAttachment attachment = {};
+          attachment.view = view;
+
+          ctx->clearRenderTarget(attachment, cSubresource.aspectMask, cClearValue, 0u);
         } else {
           ctx->clearImageView(view, cOffset, cExtent,
             cSubresource.aspectMask, cClearValue);
@@ -1980,7 +1983,10 @@ namespace dxvk {
           cAspectMask = aspectMask,
           cImageView  = imageView
         ] (DxvkContext* ctx) {
-          ctx->clearRenderTarget(cImageView,
+          DxvkAttachment attachment = {};
+          attachment.view = cImageView;
+
+          ctx->clearRenderTarget(attachment,
             cAspectMask, cClearValue, 0u);
         });
       }

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -358,14 +358,14 @@ namespace dxvk {
   
   
   void DxvkContext::clearRenderTarget(
-    const Rc<DxvkImageView>&    imageView,
+    const DxvkAttachment&       attachment,
           VkImageAspectFlags    clearAspects,
           VkClearValue          clearValue,
           VkImageAspectFlags    discardAspects) {
     // Make sure the color components are ordered correctly
     if (clearAspects & VK_IMAGE_ASPECT_COLOR_BIT) {
       clearValue.color = util::swizzleClearColor(clearValue.color,
-        util::invertComponentMapping(imageView->info().unpackSwizzle()));
+        util::invertComponentMapping(attachment.view->info().unpackSwizzle()));
     }
 
     // Check whether the render target view is an attachment
@@ -373,8 +373,8 @@ namespace dxvk {
     // If not, we need to create a temporary framebuffer.
     int32_t attachmentIndex = -1;
 
-    if (m_state.om.framebufferInfo.isFullSize(imageView))
-      attachmentIndex = m_state.om.framebufferInfo.findAttachment(imageView);
+    if (m_state.om.framebufferInfo.isFullSize(attachment.view))
+      attachmentIndex = m_state.om.framebufferInfo.findAttachment(attachment.view);
 
     if (attachmentIndex < 0) {
       // Suspend works here because we'll end up with one of these scenarios:
@@ -396,18 +396,23 @@ namespace dxvk {
     // useful to adjust store ops for tilers, and ensures that pending resolves
     // are handled correctly.
     if (discardAspects)
-      this->deferDiscard(imageView, discardAspects);
+      this->deferDiscard(attachment.view, discardAspects);
 
     if (clearAspects)
-      this->deferClear(imageView, clearAspects, clearValue);
+      this->deferClear(attachment.view, clearAspects, clearValue);
 
     // Invalidate implicit resolves
-    if (imageView->isMultisampled()) {
-      auto subresources = imageView->imageSubresources();
+    if (attachment.view->isMultisampled()) {
+      auto subresources = attachment.view->imageSubresources();
       subresources.aspectMask = clearAspects;
 
-      m_implicitResolves.invalidate(*imageView->image(), subresources);
+      m_implicitResolves.invalidate(*attachment.view->image(), subresources);
     }
+
+    // On the off-chance that this is a buffer attachment, update the buffer.
+    // Don't care about optimizing deferred clears, this is extremely rare.
+    if (unlikely(attachment.shadow))
+      releaseShadowAttachment(attachment);
   }
   
   
@@ -4144,7 +4149,10 @@ namespace dxvk {
     // Use regular render target clear path if we're clearing the
     // entire view to hit some additional optimizations.
     if (extent == imageView->mipLevelExtent(0u)) {
-      clearRenderTarget(imageView, aspect, value, 0u);
+      DxvkAttachment attachment = {};
+      attachment.view = imageView;
+
+      clearRenderTarget(attachment, aspect, value, 0u);
       return;
     }
 
@@ -4767,8 +4775,10 @@ namespace dxvk {
     if (dstImage->mipLevelExtent(dstSubresource.mipLevel, dstSubresource.aspectMask) != dstExtent)
       return false;
 
-    clearRenderTarget(dstImage->createView(viewInfo),
-      srcSubresource.aspectMask, clear->clearValue, 0u);
+    DxvkAttachment attachment = {};
+    attachment.view = dstImage->createView(viewInfo);
+
+    clearRenderTarget(attachment, srcSubresource.aspectMask, clear->clearValue, 0u);
     return true;
   }
 

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -1968,6 +1968,28 @@ namespace dxvk {
   }
   
   
+  void DxvkContext::acquireShadowAttachment(const DxvkAttachment& attachment) {
+    copyBufferToImage(attachment.view->image(),
+      vk::pickSubresourceLayers(attachment.view->imageSubresources(), 0u),
+      VkOffset3D(),
+      attachment.view->mipLevelExtent(0u),
+      attachment.shadow->buffer(),
+      attachment.shadow->info().offset, 0u, 0u,
+      attachment.view->info().format);
+  }
+
+
+  void DxvkContext::releaseShadowAttachment(const DxvkAttachment& attachment) {
+    copyImageToBuffer(
+      attachment.shadow->buffer(),
+      attachment.shadow->info().offset, 0u, 0u,
+      attachment.view->info().format,
+      attachment.view->image(),
+      vk::pickSubresourceLayers(attachment.view->imageSubresources(), 0u),
+      VkOffset3D(), attachment.view->mipLevelExtent(0u));
+  }
+
+
   VkAttachmentStoreOp DxvkContext::determineClearStoreOp(
           VkAttachmentLoadOp        loadOp) const {
     if (loadOp == VK_ATTACHMENT_LOAD_OP_NONE)

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -1990,6 +1990,26 @@ namespace dxvk {
   }
 
 
+  void DxvkContext::acquireShadowAttachments() {
+    for (uint32_t i = 0u; i < m_state.om.framebufferInfo.numAttachments(); i++) {
+      const auto& attachment = m_state.om.framebufferInfo.getAttachment(i);
+
+      if (unlikely(attachment.shadow))
+        acquireShadowAttachment(attachment);
+    }
+  }
+
+
+  void DxvkContext::releaseShadowAttachments() {
+    for (uint32_t i = 0u; i < m_state.om.framebufferInfo.numAttachments(); i++) {
+      const auto& attachment = m_state.om.framebufferInfo.getAttachment(i);
+
+      if (unlikely(attachment.shadow))
+        releaseShadowAttachment(attachment);
+    }
+  }
+
+
   VkAttachmentStoreOp DxvkContext::determineClearStoreOp(
           VkAttachmentLoadOp        loadOp) const {
     if (loadOp == VK_ATTACHMENT_LOAD_OP_NONE)
@@ -6111,6 +6131,7 @@ namespace dxvk {
       if (unlikely(m_features.test(DxvkContextFeature::DebugUtils)))
         popDebugRegion(util::DxvkDebugLabelType::InternalBarrierControl);
 
+      acquireShadowAttachments();
       prepareShaderReadableImages(true);
 
       // Make sure all graphics state gets reapplied on the next draw
@@ -6209,6 +6230,8 @@ namespace dxvk {
 
       if (unlikely(m_features.test(DxvkContextFeature::DebugUtils)))
         popDebugRegion(util::DxvkDebugLabelType::InternalRenderPass);
+
+      releaseShadowAttachments();
     } else if (!suspend) {
       // We may be ending a previously suspended render pass
       m_flags.clr(DxvkContextFlag::GpRenderPassSuspended);

--- a/src/dxvk/dxvk_context.cpp
+++ b/src/dxvk/dxvk_context.cpp
@@ -368,6 +368,13 @@ namespace dxvk {
         util::invertComponentMapping(attachment.view->info().unpackSwizzle()));
     }
 
+    // If this is a buffer attachment and we can clear the view
+    // directly, do that instead and ignore the image entirely.
+    if (attachment.shadow && attachment.shadow->info().format) {
+      clearBufferView(attachment.shadow, 0u, attachment.view->mipLevelExtent(0u).width, clearValue.color);
+      return;
+    }
+
     // Check whether the render target view is an attachment
     // of the current framebuffer and is included entirely.
     // If not, we need to create a temporary framebuffer.

--- a/src/dxvk/dxvk_context.h
+++ b/src/dxvk/dxvk_context.h
@@ -1636,6 +1636,9 @@ namespace dxvk {
     void acquireShadowAttachment(const DxvkAttachment& attachment);
     void releaseShadowAttachment(const DxvkAttachment& attachment);
 
+    void acquireShadowAttachments();
+    void releaseShadowAttachments();
+
     VkAttachmentStoreOp determineClearStoreOp(
             VkAttachmentLoadOp        loadOp) const;
 

--- a/src/dxvk/dxvk_context.h
+++ b/src/dxvk/dxvk_context.h
@@ -1633,6 +1633,9 @@ namespace dxvk {
             VkDeviceSize              subresourceAlignment,
             VkDeviceSize              sourceOffset);
 
+    void acquireShadowAttachment(const DxvkAttachment& attachment);
+    void releaseShadowAttachment(const DxvkAttachment& attachment);
+
     VkAttachmentStoreOp determineClearStoreOp(
             VkAttachmentLoadOp        loadOp) const;
 
@@ -1856,7 +1859,6 @@ namespace dxvk {
 
       return DxvkAccessFlags();
     }
-
 
     void emitMemoryBarrier(
             VkPipelineStageFlags      srcStages,

--- a/src/dxvk/dxvk_context.h
+++ b/src/dxvk/dxvk_context.h
@@ -456,13 +456,13 @@ namespace dxvk {
     /**
      * \brief Clears an active render target
      * 
-     * \param [in] imageView Render target view to clear
+     * \param [in] attachment Render target to clear
      * \param [in] clearAspects Image aspects to clear
      * \param [in] clearValue The clear value
      * \param [in] discardAspects Image aspects to discard
      */
     void clearRenderTarget(
-      const Rc<DxvkImageView>&    imageView,
+      const DxvkAttachment&       attachment,
             VkImageAspectFlags    clearAspects,
             VkClearValue          clearValue,
             VkImageAspectFlags    discardAspects);

--- a/src/dxvk/dxvk_framebuffer.h
+++ b/src/dxvk/dxvk_framebuffer.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "dxvk_buffer.h"
 #include "dxvk_image.h"
 #include "dxvk_graphics_state.h"
 #include "dxvk_pipelayout.h"
@@ -26,9 +27,10 @@ namespace dxvk {
    */
   struct DxvkAttachment {
     Rc<DxvkImageView> view = nullptr;
+    Rc<DxvkBufferView> shadow = nullptr;
 
-    bool operator == (const DxvkAttachment& other) const { return view == other.view; }
-    bool operator != (const DxvkAttachment& other) const { return view != other.view; }
+    bool operator == (const DxvkAttachment& other) const { return view == other.view && shadow == other.shadow; }
+    bool operator != (const DxvkAttachment& other) const { return view != other.view || shadow != other.shadow; }
   };
   
   


### PR DESCRIPTION
For the longest time we thought that BF3 and friends don't actually require this to work properly, but that might not be true after all.

Implementation is as basic as it gets, each buffer RTV gets its own private 1D texture that we copy to and from the buffer around render pass boundaries.

See #5857.