### PR TITLE
[CI] Switch Arch builder image

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -19,7 +19,7 @@ jobs:
 
     - name: Build release
       id: build-release
-      uses: Joshua-Ashton/arch-mingw-github-action@v8
+      uses: WinterSnowfall/arch-mingw-github-action@v2
       with:
         command: |
           export VERSION_NAME="${GITHUB_REF##*/}-${GITHUB_SHA##*/}"


### PR DESCRIPTION
Fixes CI failure since `lib32-xcb-util` got removed from the Arch repos.

Switched Arch image to https://github.com/WinterSnowfall/arch-mingw-github-action which removed the package above from the install list.
It is also a scaled down version of the current master of misyltoad's action without the extra 32bit glfw packages pulled from the aur. Since neither vkd3d-proton or dxvk use them in their CI builds.