### PR TITLE
Use VK_KHR_incremental_present

### DIFF
--- a/VP_DXVK_requirements.json
+++ b/VP_DXVK_requirements.json
@@ -125,6 +125,7 @@
         },
         "dxvk_common_optional": {
             "extensions": {
+                "VK_KHR_incremental_present": 1,
                 "VK_KHR_maintenance7": 1,
                 "VK_KHR_maintenance8": 1,
                 "VK_KHR_maintenance9": 1,

--- a/src/d3d11/d3d11_swapchain.cpp
+++ b/src/d3d11/d3d11_swapchain.cpp
@@ -423,8 +423,18 @@ namespace dxvk {
       return DXGI_ERROR_INVALID_CALL;
     }
 
+    DirtyRectList dirtyRects;
+
     if (incrementalPresent) {
       CompositeIncrementalPresent(immediateContext, pPresentParameters);
+
+      // Redraw everything if the HUD is active since we don't
+      // keep track of the exact screen areas there. Likewise,
+      // nope out if there is any scaling going on.
+      VkExtent3D swapExtent = { m_desc.Width, m_desc.Height, 1u };
+
+      if (!m_hasHud && backBuffer->info().extent == swapExtent )
+        dirtyRects = NormalizeDirtyRects(pPresentParameters);
     } else {
       // Nuke incremental present image out of existence to
       // save memory, also to pick the correct source image
@@ -455,7 +465,8 @@ namespace dxvk {
       cPresenter      = m_presenter,
       cLatency        = m_latency,
       cColorSpace     = m_colorSpace,
-      cFrameId        = m_frameId
+      cFrameId        = m_frameId,
+      cDirtyRects     = std::move(dirtyRects)
     ] (DxvkContext* ctx) {
       // Update back buffer color space as necessary
       if (cSwapImage->image()->info().colorSpace != cColorSpace) {
@@ -477,7 +488,8 @@ namespace dxvk {
       ctx->synchronizeWsi(cSync);
       ctx->flushCommandList(nullptr, nullptr);
 
-      cDevice->presentImage(cPresenter, cLatency, cFrameId, 0, nullptr, nullptr);
+      cDevice->presentImage(cPresenter, cLatency, cFrameId,
+        cDirtyRects.size(), cDirtyRects.data(), nullptr);
     });
 
     if (m_backBuffers.size() > 1u)
@@ -636,6 +648,7 @@ namespace dxvk {
         m_latencyHud = hud->addItem<hud::HudLatencyItem>("latency", 4);
     }
 
+    m_hasHud = hud && !hud->empty();
     m_blitter = new DxvkSwapchainBlitter(m_device, std::move(hud));
   }
 
@@ -1040,6 +1053,65 @@ namespace dxvk {
     fsInfo.bindings = fsBindings.data();
     fsInfo.debugName = "DXGI_FS";
     m_compositionFs = new DxvkSpirvShader(fsInfo, d3d11_composition_frag);
+  }
+
+
+  D3D11SwapChain::DirtyRectList D3D11SwapChain::NormalizeDirtyRects(const DXGI_PRESENT_PARAMETERS* pPresentParameters) const {
+    DirtyRectList result;
+
+    if (pPresentParameters->pScrollRect && pPresentParameters->pScrollOffset
+     && (pPresentParameters->pScrollOffset->x || pPresentParameters->pScrollOffset->y))
+      AddDirtyRect(result, *pPresentParameters->pScrollRect);
+
+    for (uint32_t i = 0u; i < pPresentParameters->DirtyRectsCount; i++)
+      AddDirtyRect(result, pPresentParameters->pDirtyRects[i]);
+
+    return result;
+  }
+
+
+  void D3D11SwapChain::AddDirtyRect(DirtyRectList& List, RECT Rect) const {
+    // Clamp rect to screen area, and ignore if the result is empty
+    Rect.left = std::max<int32_t>(Rect.left, 0);
+    Rect.top = std::max<int32_t>(Rect.top, 0);
+    Rect.right = std::min<int32_t>(Rect.right, m_desc.Width);
+    Rect.bottom = std::min<int32_t>(Rect.bottom, m_desc.Height);
+
+    if (Rect.left >= Rect.right || Rect.top >= Rect.bottom)
+      return;
+
+    // Scan existing list and remove any rects that overlap,
+    // merging the overlapping rectangles into the new rect.
+    auto iter = List.begin();
+
+    while (iter != List.end()) {
+      RECT next = {};
+      next.left = iter->offset.x;
+      next.right = iter->offset.x + iter->extent.width;
+      next.top = iter->offset.y;
+      next.bottom = iter->offset.y + iter->extent.height;
+
+      bool overlap = next.left < Rect.right && Rect.left < next.right
+                  && next.top < Rect.bottom && Rect.top < next.bottom;
+
+      if (overlap) {
+        iter = List.erase(iter);
+
+        Rect.left = std::min(Rect.left, next.left);
+        Rect.top = std::min(Rect.top, next.top);
+        Rect.right = std::max(Rect.right, next.right);
+        Rect.bottom = std::max(Rect.bottom, next.bottom);
+      } else {
+        iter++;
+      }
+    }
+
+    // No more overlapping rectangles in list, add new one.
+    auto& vkRect = List.emplace_back();
+    vkRect.offset.x = Rect.left;
+    vkRect.offset.y = Rect.top;
+    vkRect.extent.width = Rect.right - Rect.left;
+    vkRect.extent.height = Rect.bottom - Rect.top;
   }
 
 

--- a/src/d3d11/d3d11_swapchain.cpp
+++ b/src/d3d11/d3d11_swapchain.cpp
@@ -899,8 +899,6 @@ namespace dxvk {
       ctx->setViewports(1u, &viewport);
     });
 
-    // If we're scrolling, draw the back buffer to the offset
-    // scroll region first, then draw the scrolled image itself
     if (scroll) {
       pContext->EmitCs([
         cScrollView   = m_compositionScroll->createView(shaderViewInfo),
@@ -909,44 +907,36 @@ namespace dxvk {
         cScrollOffset = *pPresentParameters->pScrollOffset,
         cResolution   = resolution
       ] (DxvkContext* ctx) mutable {
-        ctx->bindResourceImageView(VK_SHADER_STAGE_FRAGMENT_BIT, 0, std::move(cBufferView));
+        CompositionArgs args = {};
+        args.srcOffset = { cScrollRect.left - cScrollOffset.x, cScrollRect.top - cScrollOffset.y };
+        args.dstOffset = { cScrollRect.left, cScrollRect.top };
+        args.extent.width = cScrollRect.right - cScrollRect.left;
+        args.extent.height = cScrollRect.bottom - cScrollRect.top;
+        args.resolution = cResolution;
 
         VkDrawIndirectCommand draw = {};
         draw.vertexCount = 4u;
         draw.instanceCount = 1u;
 
-        if (cScrollOffset.x) {
-          CompositionArgs args = {};
-          args.srcOffset.x = cScrollOffset.x > 0 ? cScrollRect.left - cScrollOffset.x : cScrollRect.right;
-          args.srcOffset.y = cScrollRect.top;
-          args.dstOffset = args.srcOffset;
-          args.extent.width = std::abs(cScrollOffset.x);
-          args.extent.height = cScrollRect.bottom - cScrollRect.top;
-          args.resolution = cResolution;
+        ctx->bindResourceImageView(VK_SHADER_STAGE_FRAGMENT_BIT, 0, std::move(cBufferView));
+        ctx->pushData(VK_SHADER_STAGE_VERTEX_BIT, 0, sizeof(args), &args);
+        ctx->draw(1u, &draw);
 
-          ctx->pushData(VK_SHADER_STAGE_VERTEX_BIT, 0, sizeof(args), &args);
-          ctx->draw(1u, &draw);
-        }
-
-        if (cScrollOffset.y) {
-          CompositionArgs args = {};
-          args.srcOffset.x = cScrollOffset.x > 0 ? cScrollRect.left - cScrollOffset.x : cScrollRect.left;
-          args.srcOffset.y = cScrollOffset.y > 0 ? cScrollRect.top - cScrollOffset.y : cScrollRect.bottom;
-          args.dstOffset = args.srcOffset;
-          args.extent.width = std::abs(cScrollOffset.x) + cScrollRect.right - cScrollRect.left;
-          args.extent.height = std::abs(cScrollOffset.y);
-          args.resolution = cResolution;
-
-          ctx->pushData(VK_SHADER_STAGE_VERTEX_BIT, 0, sizeof(args), &args);
-          ctx->draw(1u, &draw);
-        }
-
-        CompositionArgs args = {};
         args.srcOffset = { 0, 0 };
         args.dstOffset = { cScrollRect.left, cScrollRect.top };
-        args.extent.width = cScrollRect.right - cScrollRect.left;
-        args.extent.height = cScrollRect.bottom - cScrollRect.top;
+        args.extent.width = cScrollRect.right - cScrollRect.left - std::abs(cScrollOffset.x);
+        args.extent.height = cScrollRect.bottom - cScrollRect.top - std::abs(cScrollOffset.y);
         args.resolution = cResolution;
+
+        if (cScrollOffset.x > 0) {
+          args.srcOffset.x += cScrollOffset.x;
+          args.dstOffset.x += cScrollOffset.x;
+        }
+
+        if (cScrollOffset.y > 0) {
+          args.srcOffset.y += cScrollOffset.y;
+          args.dstOffset.y += cScrollOffset.y;
+        }
 
         ctx->bindResourceImageView(VK_SHADER_STAGE_FRAGMENT_BIT, 0, std::move(cScrollView));
         ctx->pushData(VK_SHADER_STAGE_VERTEX_BIT, 0, sizeof(args), &args);

--- a/src/d3d11/d3d11_swapchain.cpp
+++ b/src/d3d11/d3d11_swapchain.cpp
@@ -477,7 +477,7 @@ namespace dxvk {
       ctx->synchronizeWsi(cSync);
       ctx->flushCommandList(nullptr, nullptr);
 
-      cDevice->presentImage(cPresenter, cLatency, cFrameId, nullptr);
+      cDevice->presentImage(cPresenter, cLatency, cFrameId, 0, nullptr, nullptr);
     });
 
     if (m_backBuffers.size() > 1u)

--- a/src/d3d11/d3d11_swapchain.h
+++ b/src/d3d11/d3d11_swapchain.h
@@ -92,6 +92,8 @@ namespace dxvk {
 
   private:
 
+    using DirtyRectList = small_vector<VkRectLayerKHR, 4>;
+
     enum BindingIds : uint32_t {
       Image = 0,
       Gamma = 1,
@@ -138,6 +140,7 @@ namespace dxvk {
     dxvk::mutex               m_frameStatisticsLock;
     DXGI_VK_FRAME_STATISTICS  m_frameStatistics = { };
 
+    bool                      m_hasHud = false;
     Rc<hud::HudLatencyItem>   m_latencyHud;
 
     Rc<DxvkImageView> GetBackBufferView();
@@ -176,6 +179,10 @@ namespace dxvk {
       const DXGI_PRESENT_PARAMETERS* pPresentParameters) const;
 
     void CreateCompositionShaders();
+
+    DirtyRectList NormalizeDirtyRects(const DXGI_PRESENT_PARAMETERS* pPresentParameters) const;
+
+    void AddDirtyRect(DirtyRectList& List, RECT Rect) const;
 
     std::string GetApiName() const;
 

--- a/src/d3d9/d3d9_swapchain.cpp
+++ b/src/d3d9/d3d9_swapchain.cpp
@@ -909,7 +909,7 @@ namespace dxvk {
         ctx->synchronizeWsi(cSync);
         ctx->flushCommandList(nullptr, nullptr);
 
-        cDevice->presentImage(cPresenter, cLatency, cFrameId, nullptr);
+        cDevice->presentImage(cPresenter, cLatency, cFrameId, 0, nullptr, nullptr);
       });
 
       m_parent->FlushCsChunk();

--- a/src/dxvk/dxvk_device.cpp
+++ b/src/dxvk/dxvk_device.cpp
@@ -605,10 +605,15 @@ namespace dxvk {
     const Rc<Presenter>&            presenter,
     const Rc<DxvkLatencyTracker>&   tracker,
           uint64_t                  frameId,
+          uint32_t                  rectCount,
+    const VkRectLayerKHR*           rects,
           DxvkSubmitStatus*         status) {
     DxvkPresentInfo presentInfo = { };
     presentInfo.presenter = presenter;
     presentInfo.frameId = frameId;
+
+    for (uint32_t i = 0u; i < rectCount; i++)
+      presentInfo.rects.push_back(rects[i]);
 
     DxvkLatencyInfo latencyInfo;
     latencyInfo.tracker = tracker;

--- a/src/dxvk/dxvk_device.h
+++ b/src/dxvk/dxvk_device.h
@@ -650,12 +650,16 @@ namespace dxvk {
      * \param [in] presenter The presenter
      * \param [in] tracker Latency tracker
      * \param [in] frameId Frame ID
+     * \param [in] rectCount Number of dirty rectangles,
+     * \param [in] rects Dirty rectangles
      * \param [out] status Present status
      */
     void presentImage(
       const Rc<Presenter>&            presenter,
       const Rc<DxvkLatencyTracker>&   tracker,
             uint64_t                  frameId,
+            uint32_t                  rectCount,
+      const VkRectLayerKHR*           rects,
             DxvkSubmitStatus*         status);
     
     /**

--- a/src/dxvk/dxvk_device_info.cpp
+++ b/src/dxvk/dxvk_device_info.cpp
@@ -48,6 +48,7 @@ namespace dxvk {
     HANDLE_EXT(khrDynamicRenderingLocalRead);      \
     HANDLE_EXT(khrExternalMemoryWin32);            \
     HANDLE_EXT(khrExternalSemaphoreWin32);         \
+    HANDLE_EXT(khrIncrementalPresent);             \
     HANDLE_EXT(khrLoadStoreOpNone);                \
     HANDLE_EXT(khrMaintenance5);                   \
     HANDLE_EXT(khrMaintenance6);                   \
@@ -1022,6 +1023,9 @@ namespace dxvk {
       /* External memory features for wine */
       ENABLE_EXT(khrExternalMemoryWin32, false),
       ENABLE_EXT(khrExternalSemaphoreWin32, false),
+
+      /* Dirty rects for presentation */
+      ENABLE_EXT(khrIncrementalPresent, false),
 
       /* LOAD_OP_NONE for certain tiler optimizations. Core feature
        * in Vulkan 1.4, so probably supported by everything we need. */

--- a/src/dxvk/dxvk_device_info.h
+++ b/src/dxvk/dxvk_device_info.h
@@ -91,6 +91,7 @@ namespace dxvk {
     VkPhysicalDeviceDynamicRenderingLocalReadFeatures         khrDynamicRenderingLocalRead    = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DYNAMIC_RENDERING_LOCAL_READ_FEATURES_KHR };
     VkBool32                                                  khrExternalMemoryWin32          = VK_FALSE;
     VkBool32                                                  khrExternalSemaphoreWin32       = VK_FALSE;
+    VkBool32                                                  khrIncrementalPresent           = VK_FALSE;
     VkBool32                                                  khrLoadStoreOpNone              = VK_FALSE;
     VkPhysicalDeviceMaintenance5FeaturesKHR                   khrMaintenance5                 = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_5_FEATURES_KHR };
     VkPhysicalDeviceMaintenance6FeaturesKHR                   khrMaintenance6                 = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_6_FEATURES_KHR };
@@ -166,6 +167,7 @@ namespace dxvk {
     VkExtensionProperties khrDynamicRenderingLocalRead      = vk::makeExtension(VK_KHR_DYNAMIC_RENDERING_LOCAL_READ_EXTENSION_NAME);
     VkExtensionProperties khrExternalMemoryWin32            = vk::makeExtension(VK_KHR_EXTERNAL_MEMORY_WIN32_EXTENSION_NAME);
     VkExtensionProperties khrExternalSemaphoreWin32         = vk::makeExtension(VK_KHR_EXTERNAL_SEMAPHORE_WIN32_EXTENSION_NAME);
+    VkExtensionProperties khrIncrementalPresent             = vk::makeExtension(VK_KHR_INCREMENTAL_PRESENT_EXTENSION_NAME);
     VkExtensionProperties khrLoadStoreOpNone                = vk::makeExtension(VK_KHR_LOAD_STORE_OP_NONE_EXTENSION_NAME);
     VkExtensionProperties khrMaintenance5                   = vk::makeExtension(VK_KHR_MAINTENANCE_5_EXTENSION_NAME);
     VkExtensionProperties khrMaintenance6                   = vk::makeExtension(VK_KHR_MAINTENANCE_6_EXTENSION_NAME);

--- a/src/dxvk/dxvk_presenter.cpp
+++ b/src/dxvk/dxvk_presenter.cpp
@@ -171,7 +171,11 @@ namespace dxvk {
   }
 
 
-  VkResult Presenter::presentImage(uint64_t frameId, const Rc<DxvkLatencyTracker>& tracker) {
+  VkResult Presenter::presentImage(
+          uint64_t                frameId,
+    const Rc<DxvkLatencyTracker>& tracker,
+          uint32_t                rectCount,
+    const VkRectLayerKHR*         rects) {
     PresenterSync& currSync = m_semaphores.at(m_frameIndex);
 
     VkPresentIdKHR presentId = { VK_STRUCTURE_TYPE_PRESENT_ID_KHR };
@@ -189,6 +193,14 @@ namespace dxvk {
     VkSwapchainPresentModeInfoKHR modeInfo = { VK_STRUCTURE_TYPE_SWAPCHAIN_PRESENT_MODE_INFO_KHR };
     modeInfo.swapchainCount = 1;
     modeInfo.pPresentModes  = &m_presentMode;
+
+    VkPresentRegionKHR region = {};
+    region.rectangleCount = rectCount;
+    region.pRectangles = rects;
+
+    VkPresentRegionsKHR regionInfo = { VK_STRUCTURE_TYPE_PRESENT_REGIONS_KHR };
+    regionInfo.swapchainCount = 1;
+    regionInfo.pRegions = &region;
 
     VkPresentInfoKHR info = { VK_STRUCTURE_TYPE_PRESENT_INFO_KHR };
     info.waitSemaphoreCount = 1;
@@ -208,6 +220,9 @@ namespace dxvk {
       modeInfo.pNext = const_cast<void*>(std::exchange(info.pNext, &modeInfo));
       fenceInfo.pNext = const_cast<void*>(std::exchange(info.pNext, &fenceInfo));
     }
+
+    if (m_hasIncrementalPresent && !m_presentRepaint && m_acquireStatus == VK_SUCCESS && rectCount)
+      regionInfo.pNext = const_cast<void*>(std::exchange(info.pNext, &regionInfo));
 
     VkResult status = m_vkd->vkQueuePresentKHR(
       m_device->queues().graphics.queueHandle, &info);
@@ -267,6 +282,8 @@ namespace dxvk {
     }
 
     m_presentPending = false;
+    m_presentRepaint = false;
+
     m_surfaceCond.notify_one();
     return status;
   }
@@ -857,9 +874,16 @@ namespace dxvk {
     m_hasPresentId = presentId2Caps.presentId2Supported || m_device->features().khrPresentId.presentId;
     m_hasPresentWait = presentWait2Caps.presentWait2Supported || m_device->features().khrPresentWait.presentWait;
 
+    // Only support incremental present if the surface isn't transformed. Spec says
+    // that present rects are defined with respect to the current surface transform,
+    // not with the pre-transform set on the swap chain.
+    if (m_device->features().khrIncrementalPresent)
+      m_hasIncrementalPresent = caps.surfaceCapabilities.currentTransform == VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR;
+
     if (m_signal && m_hasPresentWait && !m_frameThread.joinable())
       m_frameThread = dxvk::thread([this] { runFrameThread(); });
 
+    m_presentRepaint = true;
     return VK_SUCCESS;
   }
 
@@ -1231,6 +1255,7 @@ namespace dxvk {
     m_acquireStatus = VK_NOT_READY;
 
     m_presentPending = false;
+    m_presentRepaint = false;
 
     m_hdrMetadataDirty = true;
 
@@ -1239,6 +1264,7 @@ namespace dxvk {
 
     m_hasPresentId = false;
     m_hasPresentWait = false;
+    m_hasIncrementalPresent = false;
   }
 
 

--- a/src/dxvk/dxvk_presenter.h
+++ b/src/dxvk/dxvk_presenter.h
@@ -125,11 +125,15 @@ namespace dxvk {
      * Presents the last successfuly acquired image.
      * \param [in] frameId Frame number.
      * \param [in] tracker Latency tracker
+     * \param [in] rectCount Number of dirty rects
+     * \param [in] rects Dirty rectangles
      * \returns Status of the operation
      */
     VkResult presentImage(
             uint64_t                frameId,
-      const Rc<DxvkLatencyTracker>& tracker);
+      const Rc<DxvkLatencyTracker>& tracker,
+            uint32_t                rectCount,
+      const VkRectLayerKHR*         rects);
 
     /**
      * \brief Signals a given frame
@@ -292,6 +296,7 @@ namespace dxvk {
     bool                        m_hasPresentId = false;
     bool                        m_hasPresentWait = false;
     bool                        m_hasSwapchainMaintenance1 = false;
+    bool                        m_hasIncrementalPresent = false;
 
     VkPresentModeKHR            m_presentMode = VK_PRESENT_MODE_FIFO_KHR;
 
@@ -300,6 +305,7 @@ namespace dxvk {
 
     VkResult                    m_acquireStatus = VK_NOT_READY;
     bool                        m_presentPending = false;
+    bool                        m_presentRepaint = false;
 
     std::optional<VkHdrMetadataEXT> m_hdrMetadata;
     bool                        m_hdrMetadataDirty = false;

--- a/src/dxvk/dxvk_queue.cpp
+++ b/src/dxvk/dxvk_queue.cpp
@@ -172,7 +172,8 @@ namespace dxvk {
             entry.latency.tracker->notifyQueuePresentBegin(entry.latency.frameId);
 
           entry.result = entry.present.presenter->presentImage(
-            entry.present.frameId, entry.latency.tracker);
+            entry.present.frameId, entry.latency.tracker,
+            entry.present.rects.size(), entry.present.rects.data());
 
           if (entry.latency.tracker) {
             entry.latency.tracker->notifyQueuePresentEnd(

--- a/src/dxvk/dxvk_queue.h
+++ b/src/dxvk/dxvk_queue.h
@@ -46,6 +46,7 @@ namespace dxvk {
   struct DxvkPresentInfo {
     Rc<Presenter>       presenter;
     uint64_t            frameId;
+    small_vector<VkRectLayerKHR, 4u> rects;
   };
 
 


### PR DESCRIPTION
Somewhat trivially forwards dirty rectangles to the actual Vulkan swapchain. Verified that Kwin only repaints the actually updated image desktop region when using an app that actually uses DXGI incremental present.

We simply fall back to a full repaint if there's anything weird going on.