### PR TITLE
[d3d11] Guard against binding an already-destroyed resource view

### DIFF
--- a/src/d3d11/d3d11_context.cpp
+++ b/src/d3d11/d3d11_context.cpp
@@ -191,6 +191,9 @@ namespace dxvk {
     if (!pResourceView || (NumRects && pRects))
       return;
 
+    if (unlikely(m_parent->GetOptions()->viewUAFGuard) && !D3D11ViewUAFGuard::isViewLive(pResourceView))
+      return;
+
     // ID3D11View has no methods to query the exact type of
     // the view, so we'll have to check each possible class
     auto dsv = dynamic_cast<D3D11DepthStencilView*>(pResourceView);
@@ -414,6 +417,9 @@ namespace dxvk {
     if (!buf || !uav)
       return;
 
+    if (unlikely(m_parent->GetOptions()->viewUAFGuard) && !D3D11ViewUAFGuard::isViewLive(uav))
+      return;
+
     auto counterView = uav->GetCounterView();
 
     if (counterView == nullptr)
@@ -449,6 +455,9 @@ namespace dxvk {
     if (!rtv)
       return;
 
+    if (unlikely(m_parent->GetOptions()->viewUAFGuard) && !D3D11ViewUAFGuard::isViewLive(rtv))
+      return;
+
     AddCost(GpuCostEstimate::Transfer);
 
     DxvkAttachment attachment = {};
@@ -472,6 +481,9 @@ namespace dxvk {
     D3D10DeviceLock lock = LockContext();
 
     if (!pUnorderedAccessView)
+      return;
+
+    if (unlikely(m_parent->GetOptions()->viewUAFGuard) && !D3D11ViewUAFGuard::isViewLive(pUnorderedAccessView))
       return;
 
     Com<ID3D11UnorderedAccessView> qiUav;
@@ -621,6 +633,9 @@ namespace dxvk {
     if (!uav)
       return;
 
+    if (unlikely(m_parent->GetOptions()->viewUAFGuard) && !D3D11ViewUAFGuard::isViewLive(uav))
+      return;
+
     auto imgView = uav->GetImageView();
     auto bufView = uav->GetBufferView();
 
@@ -677,6 +692,9 @@ namespace dxvk {
     if (!dsv)
       return;
 
+    if (unlikely(m_parent->GetOptions()->viewUAFGuard) && !D3D11ViewUAFGuard::isViewLive(dsv))
+      return;
+
     // Figure out which aspects to clear based on
     // the image view properties and clear flags.
     VkImageAspectFlags aspectMask = 0;
@@ -721,6 +739,9 @@ namespace dxvk {
     D3D10DeviceLock lock = LockContext();
 
     if (NumRects && !pRect)
+      return;
+
+    if (unlikely(m_parent->GetOptions()->viewUAFGuard) && pView && !D3D11ViewUAFGuard::isViewLive(pView))
       return;
 
     AddCost(GpuCostEstimate::Transfer);
@@ -808,7 +829,13 @@ namespace dxvk {
 
     auto view = static_cast<D3D11ShaderResourceView*>(pShaderResourceView);
 
-    if (!view || view->GetResourceType() == D3D11_RESOURCE_DIMENSION_BUFFER)
+    if (!view)
+      return;
+
+    if (unlikely(m_parent->GetOptions()->viewUAFGuard) && !D3D11ViewUAFGuard::isViewLive(view))
+      return;
+
+    if (view->GetResourceType() == D3D11_RESOURCE_DIMENSION_BUFFER)
       return;
 
     D3D11_COMMON_RESOURCE_DESC resourceDesc = view->GetResourceDesc();
@@ -2145,6 +2172,22 @@ namespace dxvk {
           ID3D11UnorderedAccessView* const* ppUnorderedAccessViews,
     const UINT*                             pUAVInitialCounts) {
     D3D10DeviceLock lock = LockContext();
+
+    // See SetRenderTargetsAndUnorderedAccessViews for why this rewrites
+    // the local pointer instead of touching the app's own array.
+    std::array<ID3D11UnorderedAccessView*, D3D11_1_UAV_SLOT_COUNT> sanitizedUavs;
+
+    if (unlikely(m_parent->GetOptions()->viewUAFGuard)
+     && ppUnorderedAccessViews && NumUAVs <= sanitizedUavs.size()) {
+      for (uint32_t i = 0; i < NumUAVs; i++) {
+        sanitizedUavs[i] = ppUnorderedAccessViews[i];
+
+        if (sanitizedUavs[i] && !D3D11ViewUAFGuard::isViewLive(sanitizedUavs[i]))
+          sanitizedUavs[i] = nullptr;
+      }
+
+      ppUnorderedAccessViews = sanitizedUavs.data();
+    }
 
     if (TestRtvUavHazards(0, nullptr, NumUAVs, ppUnorderedAccessViews))
       return;
@@ -5288,6 +5331,9 @@ namespace dxvk {
     for (uint32_t i = 0; i < NumResources; i++) {
       auto resView = static_cast<D3D11ShaderResourceView*>(ppResources[i]);
 
+      if (unlikely(m_parent->GetOptions()->viewUAFGuard) && resView && !D3D11ViewUAFGuard::isViewLive(resView))
+        resView = nullptr;
+
       if (bindings.views[StartSlot + i] != resView) {
         if (likely(resView != nullptr)) {
           if (unlikely(resView->TestHazards())) {
@@ -5346,6 +5392,45 @@ namespace dxvk {
           UINT                              NumUAVs,
           ID3D11UnorderedAccessView* const* ppUnorderedAccessViews,
     const UINT*                             pUAVInitialCounts) {
+    // Guard against apps binding a view they have already destroyed. Only
+    // touched when d3d11.viewUAFGuard is enabled, and only rewrites the
+    // local (pass-by-value) pointer parameters, never the app's own arrays.
+    std::array<ID3D11RenderTargetView*, D3D11_SIMULTANEOUS_RENDER_TARGET_COUNT> sanitizedRtvs;
+    std::array<ID3D11UnorderedAccessView*, D3D11_1_UAV_SLOT_COUNT> sanitizedUavs;
+
+    if (unlikely(m_parent->GetOptions()->viewUAFGuard)) {
+      // Only take over the array if NumRTVs/NumUAVs is within the bounds the
+      // D3D11 API allows (and that our fixed-size local buffers are sized
+      // for). An out-of-spec call falls through unguarded rather than risk
+      // reading past the end of the local array.
+      if (ppRenderTargetViews && NumRTVs != D3D11_KEEP_RENDER_TARGETS_AND_DEPTH_STENCIL
+       && NumRTVs <= sanitizedRtvs.size()) {
+        for (uint32_t i = 0; i < NumRTVs; i++) {
+          sanitizedRtvs[i] = ppRenderTargetViews[i];
+
+          if (sanitizedRtvs[i] && !D3D11ViewUAFGuard::isViewLive(sanitizedRtvs[i]))
+            sanitizedRtvs[i] = nullptr;
+        }
+
+        ppRenderTargetViews = sanitizedRtvs.data();
+      }
+
+      if (pDepthStencilView && !D3D11ViewUAFGuard::isViewLive(pDepthStencilView))
+        pDepthStencilView = nullptr;
+
+      if (ppUnorderedAccessViews && NumUAVs != D3D11_KEEP_UNORDERED_ACCESS_VIEWS
+       && NumUAVs <= sanitizedUavs.size()) {
+        for (uint32_t i = 0; i < NumUAVs; i++) {
+          sanitizedUavs[i] = ppUnorderedAccessViews[i];
+
+          if (sanitizedUavs[i] && !D3D11ViewUAFGuard::isViewLive(sanitizedUavs[i]))
+            sanitizedUavs[i] = nullptr;
+        }
+
+        ppUnorderedAccessViews = sanitizedUavs.data();
+      }
+    }
+
     if (TestRtvUavHazards(NumRTVs, ppRenderTargetViews, NumUAVs, ppUnorderedAccessViews))
       return;
 

--- a/src/d3d11/d3d11_options.cpp
+++ b/src/d3d11/d3d11_options.cpp
@@ -29,6 +29,7 @@ namespace dxvk {
     this->exposeDriverCommandLists = config.getOption<bool>("d3d11.exposeDriverCommandLists", true);
     this->reproducibleCommandStream = config.getOption<bool>("d3d11.reproducibleCommandStream", false);
     this->disableDirectImageMapping = config.getOption<bool>("d3d11.disableDirectImageMapping", false);
+    this->viewUAFGuard          = config.getOption<bool>("d3d11.viewUAFGuard", false);
 
     // Clamp LOD bias so that people don't abuse this in unintended ways
     this->samplerLodBias = dxvk::fclamp(this->samplerLodBias, -2.0f, 1.0f);

--- a/src/d3d11/d3d11_options.h
+++ b/src/d3d11/d3d11_options.h
@@ -102,6 +102,18 @@ namespace dxvk {
     /// Some games are broken and ignore row pitch.
     bool disableDirectImageMapping = false;
 
+    /// Validate shader resource, render target, unordered access and
+    /// depth-stencil views against a liveness registry before binding
+    /// them to the pipeline.
+    ///
+    /// Workaround for games that bind a view after already having
+    /// released their last reference to it (an application-side
+    /// use-after-free that would otherwise crash DXVK when it
+    /// dereferences the dangling view object). Adds bookkeeping
+    /// overhead to every view's construction, destruction and bind
+    /// call, so this is disabled by default.
+    bool viewUAFGuard = false;
+
     /// Shader dump path
     std::string shaderDumpPath;
   };

--- a/src/d3d11/d3d11_video.cpp
+++ b/src/d3d11/d3d11_video.cpp
@@ -368,12 +368,14 @@ namespace dxvk {
   : D3D11DeviceChild<ID3D11VideoProcessorOutputView>(pDevice),
     m_common(pDevice, pResource, CreateViewInfo(Desc)),
     m_desc(Desc), m_destructionNotifier(this) {
-
+    if (m_parent->GetOptions()->viewUAFGuard)
+      D3D11ViewUAFGuard::registerView(this);
   }
 
 
   D3D11VideoProcessorOutputView::~D3D11VideoProcessorOutputView() {
-
+    if (m_parent->GetOptions()->viewUAFGuard)
+      D3D11ViewUAFGuard::unregisterView(this);
   }
 
 

--- a/src/d3d11/d3d11_view.h
+++ b/src/d3d11/d3d11_view.h
@@ -1,6 +1,11 @@
 #pragma once
 
+#include <mutex>
+#include <unordered_set>
+
 #include "d3d11_include.h"
+
+#include "../util/thread.h"
 
 namespace dxvk {
 
@@ -77,5 +82,58 @@ namespace dxvk {
   bool CheckViewOverlap(const T1* a, const T2* b) {
     return a && b && CheckViewOverlap(a->GetViewInfo(), b->GetViewInfo());
   }
+
+  /**
+   * \brief Resource view liveness guard
+   *
+   * Some applications are known to bind a shader resource, render
+   * target, unordered access or depth-stencil view to the pipeline
+   * after having already released their last reference to it, which
+   * is a use-after-free bug in the application (see DCS World,
+   * https://github.com/doitsujin/dxvk/issues/5856). Since these view
+   * objects are plain C++ objects that get \c delete'd as soon as
+   * their reference count hits zero, binding a stale pointer causes
+   * DXVK to dereference freed memory and crash.
+   *
+   * This tracks the set of currently live view object addresses so
+   * that bind entry points can reject a pointer that no longer refers
+   * to a live object instead of dereferencing it. It is only ever
+   * consulted when \c D3D11Options::viewUAFGuard is enabled, since
+   * both the registration on every view's construction/destruction
+   * and the lookup on every bind call add measurable overhead; the
+   * option defaults to off and is only enabled for known-broken apps.
+   *
+   * Note that this only guards against the "release, then later bind
+   * the same stale pointer" pattern, not against a concurrent Release()
+   * racing a bind on another thread targeting the same object - doing
+   * so would require holding the registry lock across the bind itself,
+   * which isn't worth the extra contention for the guard's one actual
+   * use case.
+   */
+  class D3D11ViewUAFGuard {
+
+  public:
+
+    static void registerView(const void* view) {
+      std::lock_guard<dxvk::mutex> lock(s_mutex);
+      s_liveViews.insert(view);
+    }
+
+    static void unregisterView(const void* view) {
+      std::lock_guard<dxvk::mutex> lock(s_mutex);
+      s_liveViews.erase(view);
+    }
+
+    static bool isViewLive(const void* view) {
+      std::lock_guard<dxvk::mutex> lock(s_mutex);
+      return s_liveViews.find(view) != s_liveViews.end();
+    }
+
+  private:
+
+    static inline dxvk::mutex                     s_mutex;
+    static inline std::unordered_set<const void*> s_liveViews;
+
+  };
 
 }

--- a/src/d3d11/d3d11_view_dsv.cpp
+++ b/src/d3d11/d3d11_view_dsv.cpp
@@ -13,6 +13,9 @@ namespace dxvk {
   : D3D11DeviceChild<ID3D11DepthStencilView>(pDevice),
     m_resource(pResource), m_desc(*pDesc), m_d3d10(this),
     m_destructionNotifier(this) {
+    if (m_parent->GetOptions()->viewUAFGuard)
+      D3D11ViewUAFGuard::registerView(this);
+
     ResourceAddRefPrivate(m_resource);
 
     D3D11_COMMON_RESOURCE_DESC resourceDesc;
@@ -108,6 +111,9 @@ namespace dxvk {
   
   
   D3D11DepthStencilView::~D3D11DepthStencilView() {
+    if (m_parent->GetOptions()->viewUAFGuard)
+      D3D11ViewUAFGuard::unregisterView(this);
+
     m_destructionNotifier.Notify();
 
     ResourceReleasePrivate(m_resource);

--- a/src/d3d11/d3d11_view_rtv.cpp
+++ b/src/d3d11/d3d11_view_rtv.cpp
@@ -13,6 +13,9 @@ namespace dxvk {
   : D3D11DeviceChild<ID3D11RenderTargetView1>(pDevice),
     m_resource(pResource), m_desc(*pDesc), m_d3d10(this),
     m_destructionNotifier(this) {
+    if (m_parent->GetOptions()->viewUAFGuard)
+      D3D11ViewUAFGuard::registerView(this);
+
     ResourceAddRefPrivate(m_resource);
 
     auto texture = GetCommonTexture(pResource);
@@ -172,6 +175,9 @@ namespace dxvk {
   
   
   D3D11RenderTargetView::~D3D11RenderTargetView() {
+    if (m_parent->GetOptions()->viewUAFGuard)
+      D3D11ViewUAFGuard::unregisterView(this);
+
     m_destructionNotifier.Notify();
 
     ResourceReleasePrivate(m_resource);

--- a/src/d3d11/d3d11_view_srv.cpp
+++ b/src/d3d11/d3d11_view_srv.cpp
@@ -13,6 +13,9 @@ namespace dxvk {
   : D3D11DeviceChild<ID3D11ShaderResourceView1>(pDevice),
     m_resource(pResource), m_desc(*pDesc), m_d3d10(this),
     m_destructionNotifier(this) {
+    if (m_parent->GetOptions()->viewUAFGuard)
+      D3D11ViewUAFGuard::registerView(this);
+
     ResourceAddRefPrivate(m_resource);
 
     D3D11_COMMON_RESOURCE_DESC resourceDesc;
@@ -183,6 +186,9 @@ namespace dxvk {
   
   
   D3D11ShaderResourceView::~D3D11ShaderResourceView() {
+    if (m_parent->GetOptions()->viewUAFGuard)
+      D3D11ViewUAFGuard::unregisterView(this);
+
     m_destructionNotifier.Notify();
 
     ResourceReleasePrivate(m_resource);

--- a/src/d3d11/d3d11_view_uav.cpp
+++ b/src/d3d11/d3d11_view_uav.cpp
@@ -13,6 +13,9 @@ namespace dxvk {
   : D3D11DeviceChild<ID3D11UnorderedAccessView1>(pDevice),
     m_resource(pResource), m_desc(*pDesc),
     m_destructionNotifier(this) {
+    if (m_parent->GetOptions()->viewUAFGuard)
+      D3D11ViewUAFGuard::registerView(this);
+
     ResourceAddRefPrivate(m_resource);
 
     D3D11_COMMON_RESOURCE_DESC resourceDesc;
@@ -129,6 +132,9 @@ namespace dxvk {
   
   
   D3D11UnorderedAccessView::~D3D11UnorderedAccessView() {
+    if (m_parent->GetOptions()->viewUAFGuard)
+      D3D11ViewUAFGuard::unregisterView(this);
+
     m_destructionNotifier.Notify();
 
     ResourceReleasePrivate(m_resource);

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -1389,6 +1389,14 @@ namespace dxvk {
     { R"(\\Smash up Derby\\cars\.exe$)", {{
       { "d3d9.allowDirectBufferMapping",   "False" },
     }} },
+    /* DCS World - the game sometimes binds a resource view *
+     * after it has already released its last reference to  *
+     * it, crashing the game when we dereference the freed   *
+     * view object (application-side use-after-free, see     *
+     * https://github.com/doitsujin/dxvk/issues/5856)         */
+    { R"(\\DCS\.exe$)", {{
+      { "d3d11.viewUAFGuard",               "True" },
+    }} },
     /* Age of Pirates: Caribbean Tales            *
      * Crashes due to a texture UAF otherwise     */
     { R"(\\(Age of Pirates|Sea Dogs).*Caribbean Tales\\ENGINE\.exe$)", {{


### PR DESCRIPTION
DCS World sometimes binds a shader resource, render target, unordered access or depth-stencil view after it has already released its last reference to it, which is a use-after-free bug in the game itself. Since these view objects are deleted as soon as their reference count hits zero, binding the stale pointer makes DXVK dereference freed memory and crash (see #5856).

Add an opt-in liveness registry for these view objects and check it at every bind/clear/discard entry point that takes a raw view pointer from the application, treating a pointer that no longer refers to a live object like a null bind instead of dereferencing it. This is gated behind a new d3d11.viewUAFGuard option that defaults to off, since both the registration on every view's construction/destruction and the lookup on every bind call add measurable overhead, and is only enabled by default for DCS.exe via the app profile table.