### PR TITLE
[FFXI] d3d8: state blocks use-after-free on Apply

### DIFF
--- a/src/d3d8/d3d8_state_block.cpp
+++ b/src/d3d8/d3d8_state_block.cpp
@@ -100,7 +100,7 @@ namespace dxvk {
     HRESULT res = m_stateBlock->Apply();
 
     if (m_captures.flags.test(D3D8CapturedStateFlag::Indices))
-      m_device->SetIndices(m_state.indices, m_state.baseVertexIndex);
+      m_device->SetIndices(m_state.indices.ptr(), m_state.baseVertexIndex);
 
     // This was a very easy footgun for D3D8 applications.
     if (m_captures.flags.test(D3D8CapturedStateFlag::SWVP))
@@ -109,14 +109,14 @@ namespace dxvk {
     if (m_captures.flags.test(D3D8CapturedStateFlag::VertexBuffers)) {
       for (DWORD stream = 0; stream < m_state.streams.size(); stream++) {
         if (m_captures.streams.get(stream))
-          m_device->SetStreamSource(stream, m_state.streams[stream].buffer, m_state.streams[stream].stride);
+          m_device->SetStreamSource(stream, m_state.streams[stream].buffer.ptr(), m_state.streams[stream].stride);
       }
     }
 
     if (m_captures.flags.test(D3D8CapturedStateFlag::Textures)) {
       for (DWORD stage = 0; stage < m_state.textures.size(); stage++) {
         if (m_captures.textures.get(stage))
-          m_device->SetTexture(stage, m_state.textures[stage]);
+          m_device->SetTexture(stage, m_state.textures[stage].ptr());
       }
     }
 

--- a/src/d3d8/d3d8_state_block.h
+++ b/src/d3d8/d3d8_state_block.h
@@ -37,15 +37,19 @@ namespace dxvk {
   };
 
   struct D3D8VBOP {
-    IDirect3DVertexBuffer8* buffer = nullptr;
-    UINT                    stride = 0;
+    Com<D3D8VertexBuffer, false> buffer = nullptr;
+    UINT                         stride = 0;
   };
 
+  // Captured bindings hold private references, mirroring the device's own
+  // m_textures/m_streams/m_indices: a state block may outlive the application's
+  // last public reference to a captured resource, and Apply() would otherwise
+  // rebind a dangling pointer.
   struct D3D8CapturableState {
-    std::array<D3D8VBOP, d8caps::MAX_STREAMS>                      streams;
-    std::array<IDirect3DBaseTexture8*, d8caps::MAX_TEXTURE_STAGES> textures;
+    std::array<D3D8VBOP, d8caps::MAX_STREAMS>                         streams;
+    std::array<Com<D3D8Texture2D, false>, d8caps::MAX_TEXTURE_STAGES> textures;
 
-    IDirect3DIndexBuffer8* indices = nullptr;
+    Com<D3D8IndexBuffer, false> indices = nullptr;
     UINT  baseVertexIndex    = 0;
     DWORD vertexShaderHandle = 0;
     DWORD pixelShaderHandle  = 0;
@@ -89,7 +93,7 @@ namespace dxvk {
     HRESULT Apply();
 
     inline HRESULT SetIndices(IDirect3DIndexBuffer8* pIndexData, UINT BaseVertexIndex) {
-      m_state.indices = pIndexData;
+      m_state.indices = static_cast<D3D8IndexBuffer*>(pIndexData);
       m_state.baseVertexIndex = BaseVertexIndex;
       m_captures.flags.set(D3D8CapturedStateFlag::Indices);
       return D3D_OK;
@@ -102,7 +106,7 @@ namespace dxvk {
     }
 
     inline HRESULT SetStreamSource(UINT StreamNumber, IDirect3DVertexBuffer8* pStreamData, UINT Stride) {
-      m_state.streams[StreamNumber].buffer = pStreamData;
+      m_state.streams[StreamNumber].buffer = static_cast<D3D8VertexBuffer*>(pStreamData);
       // The previous stride is preserved if pStreamData is NULL
       if (likely(pStreamData != nullptr))
         m_state.streams[StreamNumber].stride = Stride;
@@ -112,7 +116,7 @@ namespace dxvk {
     }
 
     inline HRESULT SetTexture(DWORD Stage, IDirect3DBaseTexture8* pTexture) {
-      m_state.textures[Stage] = pTexture;
+      m_state.textures[Stage] = static_cast<D3D8Texture2D*>(pTexture);
       m_captures.flags.set(D3D8CapturedStateFlag::Textures);
       m_captures.textures.set(Stage, true);
       return D3D_OK;


### PR DESCRIPTION
I'd been hitting a pretty obscure use-after-free in FFXI. I had Claude take a stab at fixing it, and it figured out that it seems to have been a reuse in ApplyStateBlock. I added the most relevant summary lines below. It's entirely possible this behavior is specific to FFXI though.

`Capture()` stores `m_device->m_indices.ptr()` (and the analogous stream/texture pointers), and `Apply()` re-binds them via `SetIndices`/`SetStreamSource`/ `SetTexture`. If the application releases a captured resource to refcount zero after the capture, the D3D8 wrapper is destroyed while the state block still holds its pointer; the next `ApplyStateBlock` re-binds freed memory. Native D3D8 state blocks hold references on recorded state objects, so applications are entitled to this pattern.

Fix:

Hold private references in the captured state, exactly like the device's own `m_indices`/`m_streams`/`m_textures` bindings (`Com<T, false>`).