### PR TITLE
Present timing

### DIFF
--- a/VP_DXVK_requirements.json
+++ b/VP_DXVK_requirements.json
@@ -125,6 +125,7 @@
         },
         "dxvk_common_optional": {
             "extensions": {
+                "VK_KHR_calibrated_timestamps": 1,
                 "VK_KHR_incremental_present": 1,
                 "VK_KHR_maintenance7": 1,
                 "VK_KHR_maintenance8": 1,

--- a/dxvk.conf
+++ b/dxvk.conf
@@ -533,6 +533,15 @@
 # dxvk.enableNvCudaInterop = True
 
 
+# Whether to enable present timing features
+#
+# Present timing is used to improve frame time consistency when emulating
+# non-native display modes (e.g. 60 Hz on a high-refresh rate display), and
+# for the frame rate limiter. Can be disabled for debugging purposes.
+
+# dxvk.enablePresentTiming = True
+
+
 # Controls pipeline lifetime tracking
 #
 # If enabled, pipeline libraries will be freed aggressively in order

--- a/src/d3d11/d3d11_swapchain.cpp
+++ b/src/d3d11/d3d11_swapchain.cpp
@@ -348,8 +348,13 @@ namespace dxvk {
 
   void STDMETHODCALLTYPE D3D11SwapChain::GetFrameStatistics(
           DXGI_VK_FRAME_STATISTICS* pFrameStatistics) {
-    std::lock_guard<dxvk::mutex> lock(m_frameStatisticsLock);
-    *pFrameStatistics = m_frameStatistics;
+    PresenterTimingFeedback feedback = {};
+
+    if (m_presenter)
+      feedback = m_presenter->queryPresentTiming();
+
+    pFrameStatistics->PresentCount = std::max<uint64_t>(feedback.frameId, DXGI_MAX_SWAP_CHAIN_BUFFERS) - DXGI_MAX_SWAP_CHAIN_BUFFERS;
+    pFrameStatistics->PresentQPCTime = feedback.presentTime;
   }
 
 
@@ -708,16 +713,11 @@ namespace dxvk {
     // Wait for the sync event so that we respect the maximum frame latency
     m_frameLatencySignal->wait(m_frameId - GetActualFrameLatency());
 
-    m_frameLatencySignal->setCallback(m_frameId, [this,
-      cFrameId           = m_frameId,
+    m_frameLatencySignal->setCallback(m_frameId, [
       cFrameLatencyEvent = m_frameLatencyEvent
     ] () {
       if (cFrameLatencyEvent)
         ReleaseSemaphore(cFrameLatencyEvent, 1, nullptr);
-
-      std::lock_guard<dxvk::mutex> lock(m_frameStatisticsLock);
-      m_frameStatistics.PresentCount = cFrameId - DXGI_MAX_SWAP_CHAIN_BUFFERS;
-      m_frameStatistics.PresentQPCTime = dxvk::high_resolution_clock::get_counter();
     });
   }
 

--- a/src/d3d11/d3d11_swapchain.h
+++ b/src/d3d11/d3d11_swapchain.h
@@ -144,9 +144,6 @@ namespace dxvk {
 
     double                    m_targetFrameRate = 0.0;
 
-    dxvk::mutex               m_frameStatisticsLock;
-    DXGI_VK_FRAME_STATISTICS  m_frameStatistics = { };
-
     bool                      m_hasHud = false;
     Rc<hud::HudLatencyItem>   m_latencyHud;
 

--- a/src/dxvk/dxvk_device_info.cpp
+++ b/src/dxvk/dxvk_device_info.cpp
@@ -44,6 +44,7 @@ namespace dxvk {
     HANDLE_EXT(extSwapchainMaintenance1);          \
     HANDLE_EXT(extTransformFeedback);              \
     HANDLE_EXT(extVertexAttributeDivisor);         \
+    HANDLE_EXT(khrCalibratedTimestamps);           \
     HANDLE_EXT(khrDeviceFault);                    \
     HANDLE_EXT(khrDynamicRenderingLocalRead);      \
     HANDLE_EXT(khrExternalMemoryWin32);            \
@@ -1012,6 +1013,9 @@ namespace dxvk {
       /* Vertex attribute divisor, used by client APIs */
       ENABLE_EXT_FEATURE(extVertexAttributeDivisor, vertexAttributeInstanceRateDivisor, false),
       ENABLE_EXT_FEATURE(extVertexAttributeDivisor, vertexAttributeInstanceRateZeroDivisor, false),
+
+      /* Required for present_timing */
+      ENABLE_EXT(khrCalibratedTimestamps, false),
 
       /* Hang debugging */
       ENABLE_EXT_FEATURE(khrDeviceFault, deviceFault, false),

--- a/src/dxvk/dxvk_device_info.cpp
+++ b/src/dxvk/dxvk_device_info.cpp
@@ -608,6 +608,10 @@ namespace dxvk {
      && m_properties.driverVersion < Version(595u, 0u, 0u))
       m_featuresSupported.khrPresentId2.presentId2 = VK_FALSE;
 
+    // Disable present timing if the corresponding option is turned off.
+    if (!instance.options().enablePresentTiming)
+      m_featuresSupported.extPresentTiming.presentTiming = VK_FALSE;
+
     // Ensure we only enable one of present_id or present_id_2. Prefer the
     // older versions of these extensions if we don't have present timing
     // support since the newer ones are causing issues in some environments.

--- a/src/dxvk/dxvk_device_info.cpp
+++ b/src/dxvk/dxvk_device_info.cpp
@@ -36,6 +36,7 @@ namespace dxvk {
     HANDLE_EXT(extMultiDraw);                      \
     HANDLE_EXT(extNonSeamlessCubeMap);             \
     HANDLE_EXT(extPageableDeviceLocalMemory);      \
+    HANDLE_EXT(extPresentTiming);                  \
     HANDLE_EXT(extRobustness2);                    \
     HANDLE_EXT(extSampleLocations);                \
     HANDLE_EXT(extShaderModuleIdentifier);         \
@@ -602,14 +603,30 @@ namespace dxvk {
     if (!instance.options().enableNvRawAccessChains)
       m_featuresSupported.nvRawAccessChains.shaderRawAccessChains = VK_FALSE;
 
+    // Disable somewhat broken present_id2 on older Nvidia drivers.
+    if (m_properties.vk12.driverID == VK_DRIVER_ID_NVIDIA_PROPRIETARY
+     && m_properties.driverVersion < Version(595u, 0u, 0u))
+      m_featuresSupported.khrPresentId2.presentId2 = VK_FALSE;
+
     // Ensure we only enable one of present_id or present_id_2. Prefer the
-    // older versions of the present_id/wait extensions since the newer ones
-    // cause issues with external layers and apparently some Wayland setups
-    // on Mesa for unknown reasons.
-    if (m_featuresSupported.khrPresentId.presentId)
+    // older versions of these extensions if we don't have present timing
+    // support since the newer ones are causing issues in some environments.
+    if (m_featuresSupported.khrPresentId2.presentId2
+     && m_featuresSupported.extPresentTiming.presentTiming)
+      m_featuresSupported.khrPresentId.presentId = VK_FALSE;
+    else if (m_featuresSupported.khrPresentId.presentId)
       m_featuresSupported.khrPresentId2.presentId2 = VK_FALSE;
 
     // Sanitize features with other feature dependencies
+    if (!m_featuresSupported.khrCalibratedTimestamps
+     || !m_featuresSupported.khrPresentId2.presentId2)
+      m_featuresSupported.extPresentTiming.presentTiming = VK_FALSE;
+
+    if (!m_featuresSupported.extPresentTiming.presentTiming) {
+      m_featuresSupported.extPresentTiming.presentAtAbsoluteTime = VK_FALSE;
+      m_featuresSupported.extPresentTiming.presentAtRelativeTime = VK_FALSE;
+    }
+
     if (!m_featuresSupported.khrPresentId2.presentId2)
       m_featuresSupported.khrPresentWait2.presentWait2 = VK_FALSE;
 
@@ -984,6 +1001,11 @@ namespace dxvk {
 
       /* Enables more dynamic driver-side memory management */
       ENABLE_EXT_FEATURE(extPageableDeviceLocalMemory, pageableDeviceLocalMemory, false),
+
+      /* Present timing features, try to enable everything */
+      ENABLE_EXT_FEATURE(extPresentTiming, presentTiming, false),
+      ENABLE_EXT_FEATURE(extPresentTiming, presentAtAbsoluteTime, false),
+      ENABLE_EXT_FEATURE(extPresentTiming, presentAtRelativeTime, false),
 
       /* Robustness, all features effectively required for correctness */
       ENABLE_EXT_FEATURE(extRobustness2, robustBufferAccess2, true),

--- a/src/dxvk/dxvk_device_info.h
+++ b/src/dxvk/dxvk_device_info.h
@@ -79,6 +79,7 @@ namespace dxvk {
     VkPhysicalDeviceMultiDrawFeaturesEXT                      extMultiDraw                    = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTI_DRAW_FEATURES_EXT };
     VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT             extNonSeamlessCubeMap           = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_NON_SEAMLESS_CUBE_MAP_FEATURES_EXT };
     VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT      extPageableDeviceLocalMemory    = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PAGEABLE_DEVICE_LOCAL_MEMORY_FEATURES_EXT };
+    VkPhysicalDevicePresentTimingFeaturesEXT                  extPresentTiming                = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRESENT_TIMING_FEATURES_EXT };
     VkPhysicalDeviceRobustness2FeaturesEXT                    extRobustness2                  = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ROBUSTNESS_2_FEATURES_EXT };
     VkBool32                                                  extSampleLocations              = VK_FALSE;
     VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT         extShaderModuleIdentifier       = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_MODULE_IDENTIFIER_FEATURES_EXT };
@@ -156,6 +157,7 @@ namespace dxvk {
     VkExtensionProperties extMultiDraw                      = vk::makeExtension(VK_EXT_MULTI_DRAW_EXTENSION_NAME);
     VkExtensionProperties extNonSeamlessCubeMap             = vk::makeExtension(VK_EXT_NON_SEAMLESS_CUBE_MAP_EXTENSION_NAME);
     VkExtensionProperties extPageableDeviceLocalMemory      = vk::makeExtension(VK_EXT_PAGEABLE_DEVICE_LOCAL_MEMORY_EXTENSION_NAME);
+    VkExtensionProperties extPresentTiming                  = vk::makeExtension(VK_EXT_PRESENT_TIMING_EXTENSION_NAME);
     VkExtensionProperties extRobustness2                    = vk::makeExtension(VK_EXT_ROBUSTNESS_2_EXTENSION_NAME);
     VkExtensionProperties extSampleLocations                = vk::makeExtension(VK_EXT_SAMPLE_LOCATIONS_EXTENSION_NAME);
     VkExtensionProperties extShaderModuleIdentifier         = vk::makeExtension(VK_EXT_SHADER_MODULE_IDENTIFIER_EXTENSION_NAME);

--- a/src/dxvk/dxvk_device_info.h
+++ b/src/dxvk/dxvk_device_info.h
@@ -87,6 +87,7 @@ namespace dxvk {
     VkPhysicalDeviceSwapchainMaintenance1FeaturesEXT          extSwapchainMaintenance1        = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SWAPCHAIN_MAINTENANCE_1_FEATURES_EXT };
     VkPhysicalDeviceTransformFeedbackFeaturesEXT              extTransformFeedback            = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TRANSFORM_FEEDBACK_FEATURES_EXT };
     VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT         extVertexAttributeDivisor       = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_ATTRIBUTE_DIVISOR_FEATURES };
+    VkBool32                                                  khrCalibratedTimestamps         = VK_FALSE;
     VkPhysicalDeviceFaultFeaturesKHR                          khrDeviceFault                  = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FAULT_FEATURES_KHR };
     VkPhysicalDeviceDynamicRenderingLocalReadFeatures         khrDynamicRenderingLocalRead    = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DYNAMIC_RENDERING_LOCAL_READ_FEATURES_KHR };
     VkBool32                                                  khrExternalMemoryWin32          = VK_FALSE;
@@ -163,6 +164,7 @@ namespace dxvk {
     VkExtensionProperties extSwapchainMaintenance1          = vk::makeExtension(VK_EXT_SWAPCHAIN_MAINTENANCE_1_EXTENSION_NAME);
     VkExtensionProperties extTransformFeedback              = vk::makeExtension(VK_EXT_TRANSFORM_FEEDBACK_EXTENSION_NAME);
     VkExtensionProperties extVertexAttributeDivisor         = vk::makeExtension(VK_EXT_VERTEX_ATTRIBUTE_DIVISOR_EXTENSION_NAME);
+    VkExtensionProperties khrCalibratedTimestamps           = vk::makeExtension(VK_KHR_CALIBRATED_TIMESTAMPS_EXTENSION_NAME);
     VkExtensionProperties khrDeviceFault                    = vk::makeExtension(VK_KHR_DEVICE_FAULT_EXTENSION_NAME);
     VkExtensionProperties khrDynamicRenderingLocalRead      = vk::makeExtension(VK_KHR_DYNAMIC_RENDERING_LOCAL_READ_EXTENSION_NAME);
     VkExtensionProperties khrExternalMemoryWin32            = vk::makeExtension(VK_KHR_EXTERNAL_MEMORY_WIN32_EXTENSION_NAME);

--- a/src/dxvk/dxvk_options.cpp
+++ b/src/dxvk/dxvk_options.cpp
@@ -14,6 +14,7 @@ namespace dxvk {
     enableImplicitResolves = config.getOption<bool>   ("dxvk.enableImplicitResolves", true);
     enableNvRawAccessChains = config.getOption<bool>  ("dxvk.enableNvRawAccessChains", true);
     enableNvCudaInterop   = config.getOption<bool>    ("dxvk.enableNvCudaInterop",    true);
+    enablePresentTiming   = config.getOption<bool>    ("dxvk.enablePresentTiming",    true);
     trackPipelineLifetime = config.getOption<Tristate>("dxvk.trackPipelineLifetime",  Tristate::Auto);
     useRawSsbo            = config.getOption<Tristate>("dxvk.useRawSsbo",             Tristate::Auto);
     hud                   = config.getOption<std::string>("dxvk.hud", "");

--- a/src/dxvk/dxvk_options.h
+++ b/src/dxvk/dxvk_options.h
@@ -86,6 +86,9 @@ namespace dxvk {
     /// Enables CUDA interop extensions if available
     bool enableNvCudaInterop = true;
 
+    /// Enable present timing features
+    bool enablePresentTiming = true;
+
     /// Enable descriptor update templates
     bool enableDescriptorUpdateTemplates = env::is32BitHostPlatform();
 

--- a/src/dxvk/dxvk_presenter.cpp
+++ b/src/dxvk/dxvk_presenter.cpp
@@ -628,7 +628,7 @@ namespace dxvk {
     surfaceInfo.surface = m_surface;
 
     if (m_device->features().extFullScreenExclusive)
-      surfaceInfo.pNext = &fullScreenExclusiveInfo;
+      fullScreenExclusiveInfo.pNext = const_cast<void*>(std::exchange(surfaceInfo.pNext, &fullScreenExclusiveInfo));
 
     // Query surface capabilities. Some properties might have changed,
     // including the size limits and supported present modes, so we'll
@@ -996,17 +996,19 @@ namespace dxvk {
     VkSurfaceFullScreenExclusiveInfoEXT fullScreenInfo = { VK_STRUCTURE_TYPE_SURFACE_FULL_SCREEN_EXCLUSIVE_INFO_EXT };
     fullScreenInfo.fullScreenExclusive = m_fullscreenMode;
 
-    VkPhysicalDeviceSurfaceInfo2KHR surfaceInfo = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SURFACE_INFO_2_KHR, &fullScreenInfo };
+    VkPhysicalDeviceSurfaceInfo2KHR surfaceInfo = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SURFACE_INFO_2_KHR };
     surfaceInfo.surface = m_surface;
 
+    if (m_device->features().extFullScreenExclusive)
+      fullScreenInfo.pNext = const_cast<void*>(std::exchange(surfaceInfo.pNext, &fullScreenInfo));
+
     VkResult status;
-    
-    if (m_device->features().extFullScreenExclusive) {
+    if (m_device->instance()->extensions().khrGetSurfaceCapabilities2.specVersion) {
       status = m_vki->vkGetPhysicalDeviceSurfaceFormats2KHR(
         m_device->adapter()->handle(), &surfaceInfo, &numFormats, nullptr);
     } else {
       status = m_vki->vkGetPhysicalDeviceSurfaceFormatsKHR(
-        m_device->adapter()->handle(), m_surface, &numFormats, nullptr);
+        m_device->adapter()->handle(), surfaceInfo.surface, &numFormats, nullptr);
     }
 
     if (status != VK_SUCCESS) {
@@ -1016,8 +1018,8 @@ namespace dxvk {
     
     formats.resize(numFormats);
 
-    if (m_device->features().extFullScreenExclusive) {
-      std::vector<VkSurfaceFormat2KHR> tmpFormats(numFormats, 
+    if (m_device->instance()->extensions().khrGetSurfaceCapabilities2.specVersion) {
+      std::vector<VkSurfaceFormat2KHR> tmpFormats(numFormats,
         { VK_STRUCTURE_TYPE_SURFACE_FORMAT_2_KHR, nullptr, VkSurfaceFormatKHR() });
 
       status = m_vki->vkGetPhysicalDeviceSurfaceFormats2KHR(
@@ -1027,7 +1029,7 @@ namespace dxvk {
         formats[i] = tmpFormats[i].surfaceFormat;
     } else {
       status = m_vki->vkGetPhysicalDeviceSurfaceFormatsKHR(
-        m_device->adapter()->handle(), m_surface, &numFormats, formats.data());
+        m_device->adapter()->handle(), surfaceInfo.surface, &numFormats, formats.data());
     }
 
     if (status != VK_SUCCESS)
@@ -1043,8 +1045,11 @@ namespace dxvk {
     VkSurfaceFullScreenExclusiveInfoEXT fullScreenInfo = { VK_STRUCTURE_TYPE_SURFACE_FULL_SCREEN_EXCLUSIVE_INFO_EXT };
     fullScreenInfo.fullScreenExclusive = m_fullscreenMode;
 
-    VkPhysicalDeviceSurfaceInfo2KHR surfaceInfo = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SURFACE_INFO_2_KHR, &fullScreenInfo };
+    VkPhysicalDeviceSurfaceInfo2KHR surfaceInfo = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SURFACE_INFO_2_KHR };
     surfaceInfo.surface = m_surface;
+
+    if (m_device->features().extFullScreenExclusive)
+      fullScreenInfo.pNext = const_cast<void*>(std::exchange(surfaceInfo.pNext, &fullScreenInfo));
 
     VkResult status;
 
@@ -1053,7 +1058,7 @@ namespace dxvk {
         m_device->adapter()->handle(), &surfaceInfo, &numModes, nullptr);
     } else {
       status = m_vki->vkGetPhysicalDeviceSurfacePresentModesKHR(
-        m_device->adapter()->handle(), m_surface, &numModes, nullptr);
+        m_device->adapter()->handle(), surfaceInfo.surface, &numModes, nullptr);
     }
 
     if (status != VK_SUCCESS) {
@@ -1068,7 +1073,7 @@ namespace dxvk {
         m_device->adapter()->handle(), &surfaceInfo, &numModes, modes.data());
     } else {
       status = m_vki->vkGetPhysicalDeviceSurfacePresentModesKHR(
-        m_device->adapter()->handle(), m_surface, &numModes, modes.data());
+        m_device->adapter()->handle(), surfaceInfo.surface, &numModes, modes.data());
     }
 
     if (status != VK_SUCCESS)

--- a/src/dxvk/dxvk_presenter.cpp
+++ b/src/dxvk/dxvk_presenter.cpp
@@ -1441,7 +1441,15 @@ namespace dxvk {
       ? uint64_t(1000000000.0 / std::abs(m_frameRateLimit))
       : uint64_t(0u);
 
-    if (!m_timingMode.presentStage || m_timingMode.frameIntervalNs <= m_timingDisplayInfo->refreshIntervalNs) {
+    // Don't enable timing if we are trying to limit to less than half a
+    // frame per second below maximum refresh. This catches small deltas
+    // between the refresh rates reported by win32 and the Vulkan driver
+    // while running at native refresh.
+    uint64_t thresholdIntervalNs = m_frameRateLimit != 0.0
+      ? uint64_t(1000000000.0 / (std::abs(m_frameRateLimit) + 0.5))
+      : uint64_t(0u);
+
+    if (!m_timingMode.presentStage || thresholdIntervalNs <= m_timingDisplayInfo->refreshIntervalNs) {
       Logger::info("Presenter: Present timing disabled");
       return;
     }

--- a/src/dxvk/dxvk_presenter.cpp
+++ b/src/dxvk/dxvk_presenter.cpp
@@ -292,6 +292,7 @@ namespace dxvk {
       frame.mode = m_presentMode;
       frame.result = status;
       frame.deadline = frameDeadline;
+      frame.isTimed = bool(timingInfo.targetTime);
 
       pushFrame(frame);
     }
@@ -1561,6 +1562,7 @@ namespace dxvk {
 
     // Update display timing and time domains as necessary
     bool updateMode = false;
+
     if (!m_timingDisplayInfo || m_timingDisplayInfo->updateCounter != timingProperties.timingPropertiesCounter) {
       updateMode = true;
       updateDisplayTiming();
@@ -1606,6 +1608,8 @@ namespace dxvk {
         m_timingMode.lastFrameTimeLocal = reportTimeLocal;
         m_timingMode.lastFrameTimeQpc = reportTimeQpc;
 
+        // Implicitly handles the case where deadline is 0, i.e. no
+        // absolute timing was used to control the actual presentation.
         for (const auto& frame : m_frameQueue) {
           if (frame.frameId == report.presentId)
             hasMissedDeadline = reportTimeLocal > frame.deadline;
@@ -1934,8 +1938,6 @@ namespace dxvk {
           Logger::err(str::format("Presenter: vkWaitForPresentKHR failed: ", vr));
       }
 
-      updatePresentTiming();
-
       // Signal latency tracker right away to get more accurate
       // measurements if the frame rate limiter is enabled.
       if (frame.tracker) {
@@ -1946,7 +1948,8 @@ namespace dxvk {
       // Apply FPS limiter here to align it as closely with scanout as we can,
       // and delay signaling the frame latency event to emulate behaviour of a
       // low refresh rate display as closely as we can.
-      m_fpsLimiter.delay();
+      if (!updatePresentTiming() || !frame.isTimed)
+        m_fpsLimiter.delay();
 
       // Wake up any thread that may be waiting for the queue to become empty
       bool canSignal = false;

--- a/src/dxvk/dxvk_presenter.cpp
+++ b/src/dxvk/dxvk_presenter.cpp
@@ -199,11 +199,15 @@ namespace dxvk {
     regionInfo.swapchainCount = 1;
     regionInfo.pRegions = &region;
 
+    // Present timing isn't useful with Immediate or Mailbox
+    bool isFifoMode = m_presentMode == VK_PRESENT_MODE_FIFO_KHR
+                   || m_presentMode == VK_PRESENT_MODE_FIFO_RELAXED_KHR;
+
     VkPresentTimingInfoEXT timingInfo = { VK_STRUCTURE_TYPE_PRESENT_TIMING_INFO_EXT };
     timingInfo.presentStageQueries = m_timingMode.presentStage;
     timingInfo.timeDomainId = m_timingMode.timeDomainId;
 
-    if (m_timingMode.presentStage) {
+    if (m_timingMode.presentStage && isFifoMode) {
       std::lock_guard lock(m_timingMutex);
 
       if (m_timingMode.relativeTiming) {
@@ -527,6 +531,13 @@ namespace dxvk {
 
   void Presenter::setFrameRateLimit(double frameRate, uint32_t maxLatency) {
     m_fpsLimiter.setTargetFrameRate(frameRate, maxLatency);
+
+    std::lock_guard lock(m_timingMutex);
+
+    if (m_frameRateLimit != frameRate) {
+      m_frameRateLimit = frameRate;
+      updateTimingMode();
+    }
   }
 
 
@@ -968,7 +979,7 @@ namespace dxvk {
       updateTimingDomains();
       recalibrateTimeDomains();
 
-      updateTimingMode(m_presentMode);
+      updateTimingMode();
     }
 
     return VK_SUCCESS;
@@ -1402,7 +1413,7 @@ namespace dxvk {
   }
 
 
-  void Presenter::updateTimingMode(VkPresentModeKHR presentMode) {
+  void Presenter::updateTimingMode() {
     m_timingMode.relativeTiming = false;
     m_timingMode.absoluteTiming = false;
 
@@ -1410,15 +1421,12 @@ namespace dxvk {
     if (!m_timingDomains || !m_timingDisplayInfo)
       return;
 
-    uint64_t frameIntervalNs = m_timingMode.frameIntervalNs;
-    uint64_t displayRefreshNs = m_timingDisplayInfo->refreshIntervalNs;
+    // Compute target frame interval from frame rate limit
+    m_timingMode.frameIntervalNs = m_frameRateLimit != 0.0
+      ? uint64_t(1000000000.0 / std::abs(m_frameRateLimit))
+      : uint64_t(0u);
 
-    // Timing isn't useful on IMMEDIATE / MAILBOX, or if there's no frame
-    // rate limit, of if the limit is higher than display refresh.
-    bool isFifoMode = presentMode == VK_PRESENT_MODE_FIFO_KHR
-                   || presentMode == VK_PRESENT_MODE_FIFO_RELAXED_KHR;
-
-    if (!m_timingMode.presentStage || frameIntervalNs <= displayRefreshNs || !isFifoMode) {
+    if (!m_timingMode.presentStage || m_timingMode.frameIntervalNs <= m_timingDisplayInfo->refreshIntervalNs) {
       Logger::info("Presenter: Present timing disabled");
       return;
     }
@@ -1429,16 +1437,16 @@ namespace dxvk {
       if (m_timingDisplayInfo->isVariableRefresh) {
         // Always enable relative timing for VRR
         m_timingMode.relativeTiming = true;
-      } else if (displayRefreshNs) {
+      } else if (m_timingDisplayInfo->refreshIntervalNs) {
         // Otherwise, check if the frame duration is reasonably close
         // to a multiple of the display refresh rate.
-        uint64_t maxDeltaNs = frameIntervalNs / 100u;
-        uint64_t realDeltaNs = (frameIntervalNs + maxDeltaNs) % displayRefreshNs;
+        uint64_t maxDeltaNs = m_timingMode.frameIntervalNs / 100u;
+        uint64_t realDeltaNs = (m_timingMode.frameIntervalNs + maxDeltaNs) % m_timingDisplayInfo->refreshIntervalNs;
 
         m_timingMode.relativeTiming = realDeltaNs <= 2u * maxDeltaNs;
 
         if (m_timingMode.relativeTiming)
-          m_timingMode.frameIntervalNs = (frameIntervalNs + maxDeltaNs) - realDeltaNs;
+          m_timingMode.frameIntervalNs = (m_timingMode.frameIntervalNs + maxDeltaNs) - realDeltaNs;
       }
     }
 
@@ -1452,9 +1460,9 @@ namespace dxvk {
     m_timingMode.referenceFrameId = 0u;
 
     if (m_timingMode.relativeTiming)
-      Logger::info("Presenter: Present timing enabled (relative)");
+      Logger::info("Presenter: Present timing enabled for FIFO modes (relative)");
     else if (m_timingMode.absoluteTiming)
-      Logger::info("Presenter: Present timing enabled (absolute)");
+      Logger::info("Presenter: Present timing enabled for FIFO modes (absolute)");
     else
       Logger::info("Presenter: Present timing disabled (absolute timing unsupported)");
   }
@@ -1516,7 +1524,7 @@ namespace dxvk {
   }
 
 
-  bool Presenter::updatePresentTiming(VkPresentModeKHR presentMode) {
+  bool Presenter::updatePresentTiming() {
     if (!m_timingMode.presentStage)
       return false;
 
@@ -1566,7 +1574,7 @@ namespace dxvk {
     }
 
     if (updateMode)
-      updateTimingMode(presentMode);
+      updateTimingMode();
 
     // Find latest available report and update present statistics. If we run
     // absolute timing and any given frame missed its deadline, restart the
@@ -1926,7 +1934,7 @@ namespace dxvk {
           Logger::err(str::format("Presenter: vkWaitForPresentKHR failed: ", vr));
       }
 
-      updatePresentTiming(frame.mode);
+      updatePresentTiming();
 
       // Signal latency tracker right away to get more accurate
       // measurements if the frame rate limiter is enabled.

--- a/src/dxvk/dxvk_presenter.cpp
+++ b/src/dxvk/dxvk_presenter.cpp
@@ -1416,6 +1416,15 @@ namespace dxvk {
 
     if (!info.refreshIntervalNs && !info.isVariableRefresh)
       info.refreshIntervalNs = swapchainTiming.refreshInterval;
+
+    if (info.isVariableRefresh) {
+      // Note that VRR isn't reported correctly in some environments.
+      Logger::info("Presenter: Reported refresh rate: Variable");
+    } else {
+      auto refreshRateToLog = 10000000000ull / info.refreshIntervalNs;
+      Logger::info(str::format("Presenter: Reported refresh rate: ",
+        (refreshRateToLog / 10u), ".", (refreshRateToLog % 10u), " Hz "));
+    }
   }
 
 

--- a/src/dxvk/dxvk_presenter.cpp
+++ b/src/dxvk/dxvk_presenter.cpp
@@ -173,6 +173,8 @@ namespace dxvk {
     const VkRectLayerKHR*         rects) {
     PresenterSync& currSync = m_semaphores.at(m_frameIndex);
 
+    uint64_t frameDeadline = 0u;
+
     VkPresentIdKHR presentId = { VK_STRUCTURE_TYPE_PRESENT_ID_KHR };
     presentId.swapchainCount = 1;
     presentId.pPresentIds   = &frameId;
@@ -197,6 +199,32 @@ namespace dxvk {
     regionInfo.swapchainCount = 1;
     regionInfo.pRegions = &region;
 
+    VkPresentTimingInfoEXT timingInfo = { VK_STRUCTURE_TYPE_PRESENT_TIMING_INFO_EXT };
+    timingInfo.presentStageQueries = m_timingMode.presentStage;
+    timingInfo.timeDomainId = m_timingMode.timeDomainId;
+
+    if (m_timingMode.presentStage) {
+      std::lock_guard lock(m_timingMutex);
+
+      if (m_timingMode.relativeTiming) {
+        timingInfo.flags |= VK_PRESENT_TIMING_INFO_PRESENT_AT_RELATIVE_TIME_BIT_EXT;
+        timingInfo.targetTime = m_timingMode.frameIntervalNs;
+        timingInfo.targetTimeDomainPresentStage = m_timingMode.presentStage;
+      } else if (m_timingMode.absoluteTiming && m_timingMode.referenceFrameId) {
+        timingInfo.targetTime = m_timingMode.referenceTime + (frameId - m_timingMode.referenceFrameId) * m_timingMode.frameIntervalNs;
+        timingInfo.targetTimeDomainPresentStage = m_timingMode.presentStage;
+
+        if (m_timingDisplayInfo && !m_timingDisplayInfo->isVariableRefresh)
+          timingInfo.flags |= VK_PRESENT_TIMING_INFO_PRESENT_AT_NEAREST_REFRESH_CYCLE_BIT_EXT;
+
+        frameDeadline = timingInfo.targetTime + m_timingMode.frameIntervalNs;
+      }
+    }
+
+    VkPresentTimingsInfoEXT timingsInfo = { VK_STRUCTURE_TYPE_PRESENT_TIMINGS_INFO_EXT };
+    timingsInfo.swapchainCount = 1u;
+    timingsInfo.pTimingInfos = &timingInfo;
+
     VkPresentInfoKHR info = { VK_STRUCTURE_TYPE_PRESENT_INFO_KHR };
     info.waitSemaphoreCount = 1;
     info.pWaitSemaphores    = &currSync.present;
@@ -209,6 +237,9 @@ namespace dxvk {
         presentId2.pNext = const_cast<void*>(std::exchange(info.pNext, &presentId2));
       else
         presentId.pNext = const_cast<void*>(std::exchange(info.pNext, &presentId));
+
+      if (timingInfo.presentStageQueries)
+        timingsInfo.pNext = std::exchange(info.pNext, &timingsInfo);
     }
 
     if (m_hasSwapchainMaintenance1) {
@@ -256,6 +287,7 @@ namespace dxvk {
       frame.tracker = tracker;
       frame.mode = m_presentMode;
       frame.result = status;
+      frame.deadline = frameDeadline;
 
       pushFrame(frame);
     }
@@ -1488,6 +1520,7 @@ namespace dxvk {
     if (!m_timingMode.presentStage)
       return false;
 
+    // Need to access both timing stuff and the frame queue here
     std::lock_guard lock(m_timingMutex);
 
     // Still need to drain the queue even if everything is messed up
@@ -1535,8 +1568,11 @@ namespace dxvk {
     if (updateMode)
       updateTimingMode(presentMode);
 
-    // Find latest available report and update present statistics
-    bool hasValidReport = false;
+    // Find latest available report and update present statistics. If we run
+    // absolute timing and any given frame missed its deadline, restart the
+    // sequence.
+    std::lock_guard frameLock(m_frameMutex);
+    bool hasMissedDeadline = false;
 
     for (size_t i = 0u; i < timingProperties.presentationTimingCount; i++) {
       const auto& time = stageTimes[i];
@@ -1562,11 +1598,14 @@ namespace dxvk {
         m_timingMode.lastFrameTimeLocal = reportTimeLocal;
         m_timingMode.lastFrameTimeQpc = reportTimeQpc;
 
-        hasValidReport = true;
+        for (const auto& frame : m_frameQueue) {
+          if (frame.frameId == report.presentId)
+            hasMissedDeadline = reportTimeLocal > frame.deadline;
+        }
       }
     }
 
-    if (!m_timingMode.referenceFrameId && hasValidReport) {
+    if (!m_timingMode.referenceFrameId || hasMissedDeadline) {
       m_timingMode.referenceFrameId = m_timingMode.lastFrameId;
       m_timingMode.referenceTime = m_timingMode.lastFrameTimeLocal;
     }

--- a/src/dxvk/dxvk_presenter.cpp
+++ b/src/dxvk/dxvk_presenter.cpp
@@ -57,12 +57,7 @@ namespace dxvk {
     destroyLatencySemaphore();
 
     if (m_frameThread.joinable()) {
-      { std::lock_guard lock(m_frameMutex);
-
-        m_frameQueue.push(PresenterFrame());
-        m_frameCond.notify_one();
-      }
-
+      pushFrame(PresenterFrame());
       m_frameThread.join();
     }
   }
@@ -249,15 +244,13 @@ namespace dxvk {
 
     // Add frame to waiter queue with current properties
     if (m_hasPresentWait) {
-      std::lock_guard lock(m_frameMutex);
-
-      auto& frame = m_frameQueue.emplace();
+      PresenterFrame frame;
       frame.frameId = frameId;
       frame.tracker = tracker;
       frame.mode = m_presentMode;
       frame.result = status;
 
-      m_frameCond.notify_one();
+      pushFrame(frame);
     }
 
     // On a successful present, try to acquire next image already, in
@@ -1231,7 +1224,7 @@ namespace dxvk {
     std::unique_lock lock(m_frameMutex);
 
     m_frameDrain.wait(lock, [this] {
-      return m_frameQueue.empty();
+      return m_frameQueuePopId == m_frameQueuePushId;
     });
 
     for (auto& sem : m_semaphores)
@@ -1300,6 +1293,22 @@ namespace dxvk {
   }
 
 
+  void Presenter::pushFrame(const PresenterFrame& frame) {
+    std::unique_lock lock(m_frameMutex);
+
+    // This should realistically never stall; this acts more as a safeguard
+    // in case the frame worker is being starved by the system.
+    m_frameDrain.wait(lock, [this] {
+      return m_frameQueuePushId - m_frameQueuePopId < m_frameQueue.size();
+    });
+
+    m_frameQueue[m_frameQueuePushId % m_frameQueue.size()] = frame;
+    m_frameQueuePushId += 1u;
+
+    m_frameCond.notify_one();
+  }
+
+
   void Presenter::runFrameThread() {
     env::setThreadName("dxvk-frame");
 
@@ -1311,14 +1320,14 @@ namespace dxvk {
       { std::unique_lock lock(m_frameMutex);
 
         m_frameCond.wait(lock, [this] {
-          return !m_frameQueue.empty();
+          return m_frameQueuePushId > m_frameQueuePopId;
         });
 
         // Use a frame ID of 0 as an exit condition
-        frame = m_frameQueue.front();
+        frame = m_frameQueue[m_frameQueuePopId % m_frameQueue.size()];
 
         if (!frame.frameId) {
-          m_frameQueue.pop();
+          m_frameQueuePopId += 1u;
           return;
         }
       }
@@ -1360,8 +1369,7 @@ namespace dxvk {
       bool canSignal = false;
 
       { std::unique_lock lock(m_frameMutex);
-
-        m_frameQueue.pop();
+        m_frameQueuePopId += 1u;
         m_frameDrain.notify_one();
 
         m_lastCompleted = frame.frameId;

--- a/src/dxvk/dxvk_presenter.cpp
+++ b/src/dxvk/dxvk_presenter.cpp
@@ -1482,6 +1482,136 @@ namespace dxvk {
   }
 
 
+  uint64_t Presenter::translateTimestamp(
+          VkTimeDomainKHR           srcTimeDomain,
+          uint64_t                  srcTimeDomainId,
+          uint64_t                  srcTimestamp,
+          VkTimeDomainKHR           dstTimeDomain,
+          uint64_t                  dstTimeDomainId) {
+    // Don't need to do anything if the time domains already match anyway
+    if (srcTimeDomain == dstTimeDomain && srcTimeDomainId == dstTimeDomainId)
+      return srcTimestamp;
+
+    // Can't do anything if we can't calibrate time stamps
+    if (!m_timingDomains)
+      return 0u;
+
+    // Determine tick frequency for QPC timestamps. Our internal high resolution
+    // clock is QPC on Windows, so this should work whenever the time domain is
+    // actually present.
+    static std::atomic<int64_t> s_qpcFreq = { 0 };
+    int64_t qpcFreq = s_qpcFreq.load(std::memory_order_relaxed);
+
+    if (unlikely(!qpcFreq)) {
+      qpcFreq = dxvk::high_resolution_clock::get_frequency();
+      s_qpcFreq.store(qpcFreq, std::memory_order_relaxed);
+    }
+
+    // If the last calibration is older than a second, recalibrate.
+    uint64_t calibrationAgeNs = std::chrono::duration_cast<std::chrono::nanoseconds>(
+      dxvk::high_resolution_clock::now() - m_timingDomains->lastCalibration).count();
+
+    if (calibrationAgeNs > 1000000000ull)
+      recalibrateTimeDomains();
+
+    // Check whether the source and destination time domains are known
+    // and compute the delta in terms of nanoseconds or QPC ticks.
+    uint64_t refTimeSrcDomain = 0u;
+    uint64_t refTimeDstDomain = 0u;
+
+    for (size_t i = 0u; i < m_timingDomains->domains.size(); i++) {
+      if (m_timingDomains->domains[i].timeDomain == srcTimeDomain
+       && m_timingDomains->domains[i].timeDomainId == srcTimeDomainId)
+        refTimeSrcDomain = m_timingDomains->domains[i].referenceTime;
+
+      if (m_timingDomains->domains[i].timeDomain == dstTimeDomain
+       && m_timingDomains->domains[i].timeDomainId == dstTimeDomainId)
+        refTimeDstDomain = m_timingDomains->domains[i].referenceTime;
+    }
+
+    // If we couldn't find one of the time domains, try to calibrate
+    if (!refTimeSrcDomain || !refTimeDstDomain) {
+      std::array<VkSwapchainCalibratedTimestampInfoEXT, 2u> swapchainInfo = {{
+        VkSwapchainCalibratedTimestampInfoEXT { VK_STRUCTURE_TYPE_SWAPCHAIN_CALIBRATED_TIMESTAMP_INFO_EXT },
+        VkSwapchainCalibratedTimestampInfoEXT { VK_STRUCTURE_TYPE_SWAPCHAIN_CALIBRATED_TIMESTAMP_INFO_EXT },
+      }};
+
+      std::array<VkCalibratedTimestampInfoKHR, 2u> calibrationInfo = {{
+        VkCalibratedTimestampInfoKHR { VK_STRUCTURE_TYPE_CALIBRATED_TIMESTAMP_INFO_KHR },
+        VkCalibratedTimestampInfoKHR { VK_STRUCTURE_TYPE_CALIBRATED_TIMESTAMP_INFO_KHR },
+      }};
+
+      calibrationInfo[0].timeDomain = srcTimeDomain;
+      calibrationInfo[1].timeDomain = dstTimeDomain;
+
+      if (srcTimeDomain == VK_TIME_DOMAIN_PRESENT_STAGE_LOCAL_EXT || srcTimeDomain == VK_TIME_DOMAIN_SWAPCHAIN_LOCAL_EXT) {
+        calibrationInfo[0].pNext = &swapchainInfo[0];
+
+        swapchainInfo[0].swapchain = m_swapchain;
+        swapchainInfo[0].presentStage = m_timingMode.presentStage;
+        swapchainInfo[0].timeDomainId = srcTimeDomainId;
+      }
+
+      if (dstTimeDomain == VK_TIME_DOMAIN_PRESENT_STAGE_LOCAL_EXT || dstTimeDomain == VK_TIME_DOMAIN_SWAPCHAIN_LOCAL_EXT) {
+        calibrationInfo[1].pNext = &swapchainInfo[1];
+
+        swapchainInfo[1].swapchain = m_swapchain;
+        swapchainInfo[1].presentStage = m_timingMode.presentStage;
+        swapchainInfo[1].timeDomainId = dstTimeDomainId;
+      }
+
+      // Try to get reference timestamps for the two domains
+      std::array<uint64_t, 2u> timestamps = { };
+
+      uint64_t maxDeviation = 0u;
+
+      VkResult status = m_vkd->vkGetCalibratedTimestampsKHR(m_vkd->device(),
+        calibrationInfo.size(), calibrationInfo.data(), timestamps.data(), &maxDeviation);
+
+      if (status) {
+        Logger::err(str::format("Presenter: Failed to map timestamp from ",
+          srcTimeDomain, "@", srcTimeDomainId," to domain ",
+          dstTimeDomain, "@", dstTimeDomainId, ": ", status));
+        return 0u;
+      }
+
+      // On success, add the domains to the domain list as necessary
+      // and recalibrate all known domains for subsequent steps
+      if (!refTimeSrcDomain) {
+        auto& domain = m_timingDomains->domains.emplace_back();
+        domain.timeDomain = srcTimeDomain;
+        domain.timeDomainId = srcTimeDomainId;
+      }
+
+      if (!refTimeDstDomain) {
+        auto& domain = m_timingDomains->domains.emplace_back();
+        domain.timeDomain = dstTimeDomain;
+        domain.timeDomainId = dstTimeDomainId;
+      }
+
+      refTimeSrcDomain = timestamps[0];
+      refTimeDstDomain = timestamps[1];
+
+      recalibrateTimeDomains();
+    }
+
+    // Compute time delta in terms of the destination time domain
+    int64_t timeDelta = int64_t(srcTimestamp - refTimeSrcDomain);
+
+    if (srcTimeDomain == VK_TIME_DOMAIN_QUERY_PERFORMANCE_COUNTER_KHR) {
+      timeDelta *= 1000000000;
+      timeDelta /= qpcFreq;
+    }
+
+    if (dstTimeDomain == VK_TIME_DOMAIN_QUERY_PERFORMANCE_COUNTER_KHR) {
+      timeDelta *= qpcFreq;
+      timeDelta /= 1000000000;
+    }
+
+    return uint64_t(refTimeDstDomain + timeDelta);
+  }
+
+
   VkResult Presenter::createSurface() {
     VkResult vr = m_surfaceProc(&m_surface);
 

--- a/src/dxvk/dxvk_presenter.cpp
+++ b/src/dxvk/dxvk_presenter.cpp
@@ -1303,6 +1303,8 @@ namespace dxvk {
         auto& domain = info.domains.emplace_back();
         domain.timeDomain = domains[i];
         domain.timeDomainId = domainIds[i];
+
+        m_timingMode.timeDomainId = domainIds[i];
       }
     }
 
@@ -1479,6 +1481,110 @@ namespace dxvk {
     // Remember when we last calibrated everything so that we can periodically
     // re-query. Clock drift is a real issue on certain hardware configurations.
     m_timingDomains->lastCalibration = dxvk::high_resolution_clock::now();
+  }
+
+
+  bool Presenter::updatePresentTiming(VkPresentModeKHR presentMode) {
+    if (!m_timingMode.presentStage)
+      return false;
+
+    std::lock_guard lock(m_timingMutex);
+
+    // Still need to drain the queue even if everything is messed up
+    small_vector<VkPresentStageTimeEXT, FrameQueueSize> stageTimes;
+    small_vector<VkPastPresentationTimingEXT, FrameQueueSize> reports;
+
+    stageTimes.resize(m_timingQueueSize);
+    reports.resize(m_timingQueueSize);
+
+    for (size_t i = 0u; i < m_timingQueueSize; i++) {
+      reports[i].sType = VK_STRUCTURE_TYPE_PAST_PRESENTATION_TIMING_EXT;
+      reports[i].presentStageCount = 1u;
+      reports[i].pPresentStages = &stageTimes[i];
+    }
+
+    VkPastPresentationTimingInfoEXT timingInfo = { VK_STRUCTURE_TYPE_PAST_PRESENTATION_TIMING_INFO_EXT };
+    timingInfo.swapchain = m_swapchain;
+
+    VkPastPresentationTimingPropertiesEXT timingProperties = { VK_STRUCTURE_TYPE_PAST_PRESENTATION_TIMING_PROPERTIES_EXT };
+    timingProperties.presentationTimingCount = reports.size();
+    timingProperties.pPresentationTimings = reports.data();
+
+    VkResult status = m_vkd->vkGetPastPresentationTimingEXT(m_vkd->device(),
+      &timingInfo, &timingProperties);
+
+    if (status) {
+      Logger::warn(str::format("Presenter: Failed to query past present timings: ", status));
+      return false;
+    }
+
+    // Update display timing and time domains as necessary
+    bool updateMode = false;
+    if (!m_timingDisplayInfo || m_timingDisplayInfo->updateCounter != timingProperties.timingPropertiesCounter) {
+      updateMode = true;
+      updateDisplayTiming();
+    }
+
+    if (!m_timingDomains || m_timingDomains->updateCounter != timingProperties.timeDomainsCounter) {
+      updateMode = true;
+      updateTimingDomains();
+
+      recalibrateTimeDomains();
+    }
+
+    if (updateMode)
+      updateTimingMode(presentMode);
+
+    // Find latest available report and update present statistics
+    bool hasValidReport = false;
+
+    for (size_t i = 0u; i < timingProperties.presentationTimingCount; i++) {
+      const auto& time = stageTimes[i];
+      const auto& report = reports[i];
+
+      if (!report.reportComplete || !time.time || time.stage != m_timingMode.presentStage)
+        continue;
+
+      uint64_t reportTimeLocal = translateTimestamp(
+        report.timeDomain, report.timeDomainId, time.time,
+        VK_TIME_DOMAIN_PRESENT_STAGE_LOCAL_EXT, m_timingMode.timeDomainId);
+
+      uint64_t reportTimeQpc = 0u;
+
+      if (hasQpcDomain()) {
+        reportTimeQpc = translateTimestamp(
+          report.timeDomain, report.timeDomainId, time.time,
+          VK_TIME_DOMAIN_QUERY_PERFORMANCE_COUNTER_KHR, 0u);
+      }
+
+      if (reportTimeLocal) {
+        m_timingMode.lastFrameId = report.presentId;
+        m_timingMode.lastFrameTimeLocal = reportTimeLocal;
+        m_timingMode.lastFrameTimeQpc = reportTimeQpc;
+
+        hasValidReport = true;
+      }
+    }
+
+    if (!m_timingMode.referenceFrameId && hasValidReport) {
+      m_timingMode.referenceFrameId = m_timingMode.lastFrameId;
+      m_timingMode.referenceTime = m_timingMode.lastFrameTimeLocal;
+    }
+
+    return true;
+  }
+
+
+  bool Presenter::hasQpcDomain() {
+    if (!m_timingDomains)
+      return false;
+
+    for (const auto& domain : m_timingDomains->domains) {
+      if (domain.timeDomain == VK_TIME_DOMAIN_QUERY_PERFORMANCE_COUNTER_KHR)
+        return true;
+    }
+
+    return false;
   }
 
 
@@ -1780,6 +1886,8 @@ namespace dxvk {
         if (vr < 0 && vr != VK_ERROR_OUT_OF_DATE_KHR && vr != VK_ERROR_SURFACE_LOST_KHR)
           Logger::err(str::format("Presenter: vkWaitForPresentKHR failed: ", vr));
       }
+
+      updatePresentTiming(frame.mode);
 
       // Signal latency tracker right away to get more accurate
       // measurements if the frame rate limiter is enabled.

--- a/src/dxvk/dxvk_presenter.cpp
+++ b/src/dxvk/dxvk_presenter.cpp
@@ -1188,6 +1188,238 @@ namespace dxvk {
   }
 
 
+  void Presenter::updateTimingDomains() {
+    // Reset domain info in case there's an error
+    m_timingDomains = std::nullopt;
+
+    uint64_t updateCounter = 0u;
+
+    small_vector<VkTimeDomainKHR, 16u> domains;
+    small_vector<uint64_t, 16u> domainIds;
+
+    VkResult status = VK_INCOMPLETE;
+
+    while (status == VK_INCOMPLETE) {
+      VkSwapchainTimeDomainPropertiesEXT domainInfo = { VK_STRUCTURE_TYPE_SWAPCHAIN_TIME_DOMAIN_PROPERTIES_EXT };
+
+      status = m_vkd->vkGetSwapchainTimeDomainPropertiesEXT(
+        m_vkd->device(), m_swapchain, &domainInfo, nullptr);
+
+      if (status != VK_SUCCESS)
+        break;
+
+      domains.resize(domainInfo.timeDomainCount);
+      domainIds.resize(domainInfo.timeDomainCount);
+
+      // Fetch update counter now. If the internal counter increases between
+      // the first and the second call, we may end up with a different number
+      // of available domains, so handle VK_INCOMPLETE returns here and resize
+      // the arrays appropriately.
+      domainInfo.pTimeDomains = domains.data();
+      domainInfo.pTimeDomainIds = domainIds.data();
+
+      status = m_vkd->vkGetSwapchainTimeDomainPropertiesEXT(
+        m_vkd->device(), m_swapchain, &domainInfo, &updateCounter);
+
+      domains.resize(domainInfo.timeDomainCount);
+      domainIds.resize(domainInfo.timeDomainCount);
+    }
+
+    if (status != VK_SUCCESS) {
+      Logger::warn(str::format("Presenter: Failed to query swapchain time domains: ", status));
+      return;
+    }
+
+    // We're guaranteed at least one PRESENT_STAGE_LOCAL domain. Just
+    // use that for actual timing purposes and ignore everything else.
+    // We will add report time domains on demand.
+    auto& info = m_timingDomains.emplace();
+    info.updateCounter = updateCounter;
+
+    for (size_t i = 0u; i < domains.size(); i++) {
+      if (domains[i] == VK_TIME_DOMAIN_PRESENT_STAGE_LOCAL_EXT) {
+        auto& domain = info.domains.emplace_back();
+        domain.timeDomain = domains[i];
+        domain.timeDomainId = domainIds[i];
+      }
+    }
+
+    // Check if there is a QPC domain and add it as necessary.
+    uint32_t timeDomainCount = 0u;
+
+    status = m_vki->vkGetPhysicalDeviceCalibrateableTimeDomainsKHR(
+      m_device->adapter()->handle(), &timeDomainCount, nullptr);
+
+    if (status == VK_SUCCESS) {
+      domains.resize(timeDomainCount);
+
+      status = m_vki->vkGetPhysicalDeviceCalibrateableTimeDomainsKHR(
+        m_device->adapter()->handle(), &timeDomainCount, domains.data());
+    }
+
+    if (status) {
+      Logger::warn(str::format("Presenter: Failed to query time domains: ", status));
+      return;
+    }
+
+    for (size_t i = 0u; i < domains.size(); i++) {
+      if (domains[i] == VK_TIME_DOMAIN_QUERY_PERFORMANCE_COUNTER_KHR) {
+        auto& domain = info.domains.emplace_back();
+        domain.timeDomain = domains[i];
+      }
+    }
+  }
+
+
+  void Presenter::updateDisplayTiming() {
+    // Reset state in case of an error
+    m_timingDisplayInfo = std::nullopt;
+
+    uint64_t updateCounter = 0u;
+
+    VkSwapchainTimingPropertiesEXT swapchainTiming = { VK_STRUCTURE_TYPE_SWAPCHAIN_TIMING_PROPERTIES_EXT };
+    VkResult status = m_vkd->vkGetSwapchainTimingPropertiesEXT(
+      m_vkd->device(), m_swapchain, &swapchainTiming, &updateCounter);
+
+    if (status) {
+      Logger::warn(str::format("Presenter: Failed to query display timing: ", status));
+      return;
+    }
+
+    auto& info = m_timingDisplayInfo.emplace();
+    info.updateCounter = updateCounter;
+
+    // This can happen on some platforms. We can't meaningfully enable timing.
+    if (!swapchainTiming.refreshDuration && !swapchainTiming.refreshInterval) {
+      Logger::warn(str::format("Presenter: Unable to determine display refresh rate"));
+      return;
+    }
+
+    // Swapchain timing is all sorts of weird, values of 0 generally indicate that
+    // the corresponding property is unknown, and UINT64_MAX for refreshInterval
+    // implies variable refresh rate.
+    info.isVariableRefresh = swapchainTiming.refreshInterval == uint64_t(-1);
+    info.refreshIntervalNs = swapchainTiming.refreshDuration;
+
+    if (!info.refreshIntervalNs && !info.isVariableRefresh)
+      info.refreshIntervalNs = swapchainTiming.refreshInterval;
+  }
+
+
+  void Presenter::updateTimingMode(VkPresentModeKHR presentMode) {
+    m_timingMode.relativeTiming = false;
+    m_timingMode.absoluteTiming = false;
+
+    // Can't meaningfully do timing if we don't know about display timing
+    if (!m_timingDomains || !m_timingDisplayInfo)
+      return;
+
+    uint64_t frameIntervalNs = m_timingMode.frameIntervalNs;
+    uint64_t displayRefreshNs = m_timingDisplayInfo->refreshIntervalNs;
+
+    // Timing isn't useful on IMMEDIATE / MAILBOX, or if there's no frame
+    // rate limit, of if the limit is higher than display refresh.
+    bool isFifoMode = presentMode == VK_PRESENT_MODE_FIFO_KHR
+                   || presentMode == VK_PRESENT_MODE_FIFO_RELAXED_KHR;
+
+    if (!m_timingMode.presentStage || frameIntervalNs <= displayRefreshNs || !isFifoMode) {
+      Logger::info("Presenter: Present timing disabled");
+      return;
+    }
+
+    // Probe relative timing first since that is most likely to give us
+    // consistent pacing, without any setup work required from our side.
+    if (m_timingMode.supportsRelative) {
+      if (m_timingDisplayInfo->isVariableRefresh) {
+        // Always enable relative timing for VRR
+        m_timingMode.relativeTiming = true;
+      } else if (displayRefreshNs) {
+        // Otherwise, check if the frame duration is reasonably close
+        // to a multiple of the display refresh rate.
+        uint64_t maxDeltaNs = frameIntervalNs / 100u;
+        uint64_t realDeltaNs = (frameIntervalNs + maxDeltaNs) % displayRefreshNs;
+
+        m_timingMode.relativeTiming = realDeltaNs <= 2u * maxDeltaNs;
+
+        if (m_timingMode.relativeTiming)
+          m_timingMode.frameIntervalNs = (frameIntervalNs + maxDeltaNs) - realDeltaNs;
+      }
+    }
+
+    // Fall back to absolute timing if we cannot use relative timimg.
+    if (m_timingMode.supportsAbsolute)
+      m_timingMode.absoluteTiming = !m_timingMode.relativeTiming;
+
+    // Reset reference time and frame ID for absolute timing
+    // so that we don't end up submitting bogus timestamps.
+    m_timingMode.referenceTime = 0u;
+    m_timingMode.referenceFrameId = 0u;
+
+    if (m_timingMode.relativeTiming)
+      Logger::info("Presenter: Present timing enabled (relative)");
+    else if (m_timingMode.absoluteTiming)
+      Logger::info("Presenter: Present timing enabled (absolute)");
+    else
+      Logger::info("Presenter: Present timing disabled (absolute timing unsupported)");
+  }
+
+
+  void Presenter::recalibrateTimeDomains() {
+    if (!m_timingDomains)
+      return;
+
+    // Calibrate all known time domains at once
+    auto& domains = m_timingDomains->domains;
+
+    small_vector<VkSwapchainCalibratedTimestampInfoEXT, 16u> swapchainInfo(domains.size(),
+      VkSwapchainCalibratedTimestampInfoEXT { VK_STRUCTURE_TYPE_SWAPCHAIN_CALIBRATED_TIMESTAMP_INFO_EXT });
+    small_vector<VkCalibratedTimestampInfoKHR, 16u> calibrationInfo(domains.size(),
+      VkCalibratedTimestampInfoKHR { VK_STRUCTURE_TYPE_CALIBRATED_TIMESTAMP_INFO_KHR });
+    small_vector<uint64_t, 16u> timestamps(domains.size());
+
+    for (size_t i = 0u; i < domains.size(); i++) {
+      calibrationInfo[i].timeDomain = domains[i].timeDomain;
+
+      if (domains[i].timeDomain == VK_TIME_DOMAIN_PRESENT_STAGE_LOCAL_EXT
+       || domains[i].timeDomain == VK_TIME_DOMAIN_SWAPCHAIN_LOCAL_EXT) {
+        swapchainInfo[i].swapchain = m_swapchain;
+        swapchainInfo[i].timeDomainId = domains[i].timeDomainId;
+
+        if (domains[i].timeDomain == VK_TIME_DOMAIN_PRESENT_STAGE_LOCAL_EXT)
+          swapchainInfo[i].presentStage = m_timingMode.presentStage;
+
+        calibrationInfo[i].pNext = &swapchainInfo[i];
+      }
+    }
+
+    // Retry calibration until we get reasonable precision (150us)
+    constexpr uint32_t MaxAttempts = 5u;
+    constexpr uint64_t MaxDeviation = 1500000u;
+
+    uint64_t maxDeviation = 0u;
+
+    for (uint32_t i = 0u; i < MaxAttempts; i++) {
+      VkResult status = m_vkd->vkGetCalibratedTimestampsKHR(m_vkd->device(),
+        domains.size(), calibrationInfo.data(), timestamps.data(), &maxDeviation);
+
+      if (status && !i) {
+        Logger::warn(str::format("Presenter: Failed to calibrate timestamps: ", status));
+        return;
+      }
+
+      if (status || maxDeviation <= MaxDeviation)
+        break;
+    }
+
+    for (size_t i = 0u; i < domains.size(); i++)
+      domains[i].referenceTime = timestamps[i];
+
+    // Remember when we last calibrated everything so that we can periodically
+    // re-query. Clock drift is a real issue on certain hardware configurations.
+    m_timingDomains->lastCalibration = dxvk::high_resolution_clock::now();
+  }
+
+
   VkResult Presenter::createSurface() {
     VkResult vr = m_surfaceProc(&m_surface);
 

--- a/src/dxvk/dxvk_presenter.cpp
+++ b/src/dxvk/dxvk_presenter.cpp
@@ -222,6 +222,13 @@ namespace dxvk {
     VkResult status = m_vkd->vkQueuePresentKHR(
       m_device->queues().graphics.queueHandle, &info);
 
+    // Treat a QUEUE_FULL error as a hint to recreate the swapchain with
+    // a larger queue size. This could probably be done more robustly,
+    // but since we have latency constraints in the frontend APIs, we
+    // should never run into this scenario in practice anyway.
+    if (status == VK_ERROR_PRESENT_TIMING_QUEUE_FULL_EXT)
+      m_timingQueueSize *= 2u;
+
     // Maintain valid state if presentation succeeded, even if we want to
     // recreate the swapchain. Spec says that 'queue' operations, i.e. the
     // semaphore and fence signals, still happen if present fails with
@@ -579,6 +586,7 @@ namespace dxvk {
     // Query surface capabilities. Some properties might have changed,
     // including the size limits and supported present modes, so we'll
     // just query everything again.
+    VkPresentTimingSurfaceCapabilitiesEXT presentTimingCaps = { VK_STRUCTURE_TYPE_PRESENT_TIMING_SURFACE_CAPABILITIES_EXT };
     VkSurfaceCapabilitiesPresentWait2KHR presentWait2Caps = { VK_STRUCTURE_TYPE_SURFACE_CAPABILITIES_PRESENT_WAIT_2_KHR };
     VkSurfaceCapabilitiesPresentId2KHR presentId2Caps = { VK_STRUCTURE_TYPE_SURFACE_CAPABILITIES_PRESENT_ID_2_KHR };
 
@@ -589,6 +597,9 @@ namespace dxvk {
 
       if (m_device->features().khrPresentWait2.presentWait2)
         presentWait2Caps.pNext = std::exchange(caps.pNext, &presentWait2Caps);
+
+      if (m_device->features().extPresentTiming.presentTiming)
+        presentTimingCaps.pNext = std::exchange(caps.pNext, &presentTimingCaps);
     }
 
     std::vector<VkSurfaceFormatKHR> formats;
@@ -718,6 +729,38 @@ namespace dxvk {
       dynamicModes.clear();
     }
 
+    // If present timing is supported, also check if there is a useful present
+    // stage we can use. Prioritize the latest available stage for absolute
+    // timing since we need to correlate with timing reports.
+    // Also, opt out of timing if we have issues keeping the report queue to
+    // a reasonable size.
+    if (presentTimingCaps.presentTimingSupported && presentId2Caps.presentId2Supported
+     && presentWait2Caps.presentWait2Supported && m_timingQueueSize <= MaxFrameQueueSize) {
+      small_vector<VkPresentStageFlagBitsEXT, 3> stages;
+
+      if (presentTimingCaps.presentAtAbsoluteTimeSupported) {
+        stages.push_back(VK_PRESENT_STAGE_IMAGE_FIRST_PIXEL_VISIBLE_BIT_EXT);
+        stages.push_back(VK_PRESENT_STAGE_IMAGE_FIRST_PIXEL_OUT_BIT_EXT);
+      } else {
+        stages.push_back(VK_PRESENT_STAGE_IMAGE_FIRST_PIXEL_OUT_BIT_EXT);
+        stages.push_back(VK_PRESENT_STAGE_IMAGE_FIRST_PIXEL_VISIBLE_BIT_EXT);
+      }
+
+      stages.push_back(VK_PRESENT_STAGE_REQUEST_DEQUEUED_BIT_EXT);
+
+      for (auto stage : stages) {
+        if (presentTimingCaps.presentStageQueries & stage) {
+          m_timingMode.presentStage = stage;
+          break;
+        }
+      }
+
+      if (m_timingMode.presentStage) {
+        m_timingMode.supportsRelative = presentTimingCaps.presentAtRelativeTimeSupported;
+        m_timingMode.supportsAbsolute = presentTimingCaps.presentAtAbsoluteTimeSupported;
+      }
+    }
+
     // Compute swap chain image count based on available info
     VkSurfaceFullScreenExclusiveInfoEXT fullScreenInfo = { VK_STRUCTURE_TYPE_SURFACE_FULL_SCREEN_EXCLUSIVE_INFO_EXT };
     fullScreenInfo.fullScreenExclusive = m_fullscreenMode;
@@ -759,6 +802,9 @@ namespace dxvk {
     if (presentWait2Caps.presentWait2Supported)
       swapInfo.flags |= VK_SWAPCHAIN_CREATE_PRESENT_WAIT_2_BIT_KHR;
 
+    if (m_timingMode.presentStage)
+      swapInfo.flags |= VK_SWAPCHAIN_CREATE_PRESENT_TIMING_BIT_EXT;
+
     if (m_device->features().extFullScreenExclusive)
       fullScreenInfo.pNext = const_cast<void*>(std::exchange(swapInfo.pNext, &fullScreenInfo));
 
@@ -770,12 +816,15 @@ namespace dxvk {
 
     Logger::info(str::format(
       "Presenter: Actual swapchain properties:"
-      "\n  Format:       ", swapInfo.imageFormat,
-      "\n  Color space:  ", swapInfo.imageColorSpace,
-      "\n  Present mode: ", swapInfo.presentMode, " (dynamic: ", (dynamicModes.empty() ? "no)" : "yes)"),
-      "\n  Buffer size:  ", swapInfo.imageExtent.width, "x", swapInfo.imageExtent.height,
-      "\n  Image count:  ", swapInfo.minImageCount));
-    
+      "\n  Format:          ", swapInfo.imageFormat,
+      "\n  Color space:     ", swapInfo.imageColorSpace,
+      "\n  Present mode:    ", swapInfo.presentMode, " (dynamic: ", (dynamicModes.empty() ? "no)" : "yes)"),
+      "\n  Buffer size:     ", swapInfo.imageExtent.width, "x", swapInfo.imageExtent.height,
+      "\n  Image count:     ", swapInfo.minImageCount,
+      "\n  Timing:          ", (m_timingMode.supportsAbsolute
+        ? (m_timingMode.supportsRelative ? "yes (absolute, relative)" : "yes (absolute)")
+        : (m_timingMode.supportsRelative ? "yes (relative)" : "no"))));
+
     if ((status = m_vkd->vkCreateSwapchainKHR(m_vkd->device(), &swapInfo, nullptr, &m_swapchain))) {
       Logger::err(str::format("Presenter: Failed to create Vulkan swapchain: ", status));
       return status;
@@ -877,6 +926,19 @@ namespace dxvk {
       m_frameThread = dxvk::thread([this] { runFrameThread(); });
 
     m_presentRepaint = true;
+
+    // Set up initial present timing state
+    if (m_timingMode.presentStage) {
+      m_vkd->vkSetSwapchainPresentTimingQueueSizeEXT(m_vkd->device(), m_swapchain, m_timingQueueSize);
+
+      updateDisplayTiming();
+
+      updateTimingDomains();
+      recalibrateTimeDomains();
+
+      updateTimingMode(m_presentMode);
+    }
+
     return VK_SUCCESS;
   }
 
@@ -1490,6 +1552,10 @@ namespace dxvk {
     m_hasPresentId = false;
     m_hasPresentWait = false;
     m_hasIncrementalPresent = false;
+
+    m_timingDomains = std::nullopt;
+    m_timingDisplayInfo = std::nullopt;
+    m_timingMode = PresenterTimingInfo();
   }
 
 

--- a/src/dxvk/dxvk_presenter.cpp
+++ b/src/dxvk/dxvk_presenter.cpp
@@ -3,6 +3,8 @@
 #include "dxvk_device.h"
 #include "dxvk_presenter.h"
 
+#include "../util/util_sleep.h"
+
 #include "../wsi/wsi_window.h"
 
 namespace dxvk {
@@ -291,6 +293,7 @@ namespace dxvk {
       frame.tracker = tracker;
       frame.mode = m_presentMode;
       frame.result = status;
+      frame.targetTime = frameDeadline ? timingInfo.targetTime : 0u;
       frame.deadline = frameDeadline;
       frame.isTimed = bool(timingInfo.targetTime);
 
@@ -1626,6 +1629,28 @@ namespace dxvk {
   }
 
 
+  void Presenter::waitUntilFrameTargetTime(
+    const PresenterFrame&           frame) {
+    if (!frame.targetTime)
+      return;
+
+    uint64_t qpcTargetTime = 0u;
+
+    { std::lock_guard lock(m_timingMutex);
+      if (hasQpcDomain()) {
+        qpcTargetTime = translateTimestamp(
+          VK_TIME_DOMAIN_PRESENT_STAGE_LOCAL_EXT, m_timingMode.timeDomainId, frame.targetTime,
+          VK_TIME_DOMAIN_QUERY_PERFORMANCE_COUNTER_KHR, 0u);
+      }
+    }
+
+    if (qpcTargetTime) {
+      auto dxvkTargetTime = dxvk::high_resolution_clock::get_time_from_counter(qpcTargetTime);
+      Sleep::sleepUntil(dxvk::high_resolution_clock::now(), dxvkTargetTime);
+    }
+  }
+
+
   bool Presenter::hasQpcDomain() {
     if (!m_timingDomains)
       return false;
@@ -1948,7 +1973,9 @@ namespace dxvk {
       // Apply FPS limiter here to align it as closely with scanout as we can,
       // and delay signaling the frame latency event to emulate behaviour of a
       // low refresh rate display as closely as we can.
-      if (!updatePresentTiming() || !frame.isTimed)
+      if (updatePresentTiming() && frame.isTimed)
+        waitUntilFrameTargetTime(frame);
+      else
         m_fpsLimiter.delay();
 
       // Wake up any thread that may be waiting for the queue to become empty

--- a/src/dxvk/dxvk_presenter.cpp
+++ b/src/dxvk/dxvk_presenter.cpp
@@ -1465,12 +1465,14 @@ namespace dxvk {
     m_timingMode.referenceTime = 0u;
     m_timingMode.referenceFrameId = 0u;
 
-    if (m_timingMode.relativeTiming)
-      Logger::info("Presenter: Present timing enabled for FIFO modes (relative)");
-    else if (m_timingMode.absoluteTiming)
-      Logger::info("Presenter: Present timing enabled for FIFO modes (absolute)");
-    else
-      Logger::info("Presenter: Present timing disabled (absolute timing unsupported)");
+    // Log frame rate target like we would for the built-in limiter
+    if (m_timingMode.relativeTiming || m_timingMode.absoluteTiming) {
+      auto frameRateToLog = uint32_t(10000000000.0 / double(m_timingMode.frameIntervalNs));
+      Logger::info(str::format("Presenter: ", m_timingMode.relativeTiming ? "Relative" : "Absolute",
+        " timing enabled (", (frameRateToLog / 10u), ".", (frameRateToLog % 10u), " FPS)"));
+    } else {
+      Logger::info("Presenter: Absolute timing not supported, disabling timing.");
+    }
   }
 
 

--- a/src/dxvk/dxvk_presenter.cpp
+++ b/src/dxvk/dxvk_presenter.cpp
@@ -205,6 +205,8 @@ namespace dxvk {
     bool isFifoMode = m_presentMode == VK_PRESENT_MODE_FIFO_KHR
                    || m_presentMode == VK_PRESENT_MODE_FIFO_RELAXED_KHR;
 
+    bool waitForPresent = m_hasPresentWait && isFifoMode;
+
     VkPresentTimingInfoEXT timingInfo = { VK_STRUCTURE_TYPE_PRESENT_TIMING_INFO_EXT };
     timingInfo.presentStageQueries = m_timingMode.presentStage;
     timingInfo.timeDomainId = m_timingMode.timeDomainId;
@@ -224,6 +226,10 @@ namespace dxvk {
           timingInfo.flags |= VK_PRESENT_TIMING_INFO_PRESENT_AT_NEAREST_REFRESH_CYCLE_BIT_EXT;
 
         frameDeadline = timingInfo.targetTime + m_timingMode.frameIntervalNs;
+
+        // Skip present_wait in fixed refresh mode if the frame is timed
+        if (!m_timingDisplayInfo || !m_timingDisplayInfo->isVariableRefresh)
+          waitForPresent = waitForPresent && !timingInfo.targetTime;
       }
     }
 
@@ -287,18 +293,17 @@ namespace dxvk {
     }
 
     // Add frame to waiter queue with current properties
-    if (m_hasPresentWait) {
-      PresenterFrame frame;
-      frame.frameId = frameId;
-      frame.tracker = tracker;
-      frame.mode = m_presentMode;
-      frame.result = status;
-      frame.targetTime = frameDeadline ? timingInfo.targetTime : 0u;
-      frame.deadline = frameDeadline;
-      frame.isTimed = bool(timingInfo.targetTime);
+    PresenterFrame frame;
+    frame.frameId = frameId;
+    frame.tracker = tracker;
+    frame.mode = m_presentMode;
+    frame.result = status;
+    frame.targetTime = frameDeadline ? timingInfo.targetTime : 0u;
+    frame.deadline = frameDeadline;
+    frame.isTimed = bool(timingInfo.targetTime);
+    frame.doWait = waitForPresent;
 
-      pushFrame(frame);
-    }
+    pushFrame(frame);
 
     // On a successful present, try to acquire next image already, in
     // order to hide potential delays from the application thread.
@@ -335,24 +340,16 @@ namespace dxvk {
     if (m_signal == nullptr || !frameId)
       return;
 
-    if (m_hasPresentWait) {
-      bool canSignal = false;
+    bool canSignal = false;
 
-      { std::unique_lock lock(m_frameMutex);
+    { std::unique_lock lock(m_frameMutex);
 
-        m_lastSignaled = frameId;
-        canSignal = m_lastCompleted >= frameId;
-      }
-
-      if (canSignal)
-        m_signal->signal(frameId);
-    } else {
-      m_fpsLimiter.delay();
-      m_signal->signal(frameId);
-
-      if (tracker)
-        tracker->notifyGpuPresentEnd(frameId);
+      m_lastSignaled = frameId;
+      canSignal = m_lastCompleted >= frameId;
     }
+
+    if (canSignal)
+      m_signal->signal(frameId);
   }
 
 
@@ -969,7 +966,7 @@ namespace dxvk {
     if (m_device->features().khrIncrementalPresent)
       m_hasIncrementalPresent = caps.surfaceCapabilities.currentTransform == VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR;
 
-    if (m_signal && m_hasPresentWait && !m_frameThread.joinable())
+    if (m_signal && !m_frameThread.joinable())
       m_frameThread = dxvk::thread([this] { runFrameThread(); });
 
     m_presentRepaint = true;
@@ -1950,7 +1947,7 @@ namespace dxvk {
       // If the present operation has succeeded, actually wait for it to complete.
       // Don't bother with it on MAILBOX / IMMEDIATE modes since doing so would
       // restrict us to the display refresh rate on some platforms (XWayland).
-      if (frame.result >= 0 && (frame.mode == VK_PRESENT_MODE_FIFO_KHR || frame.mode == VK_PRESENT_MODE_FIFO_RELAXED_KHR)) {
+      if (frame.result >= 0 && frame.doWait) {
         VkResult vr;
 
         if (m_device->features().khrPresentWait2.presentWait2) {

--- a/src/dxvk/dxvk_presenter.cpp
+++ b/src/dxvk/dxvk_presenter.cpp
@@ -580,6 +580,12 @@ namespace dxvk {
   }
 
 
+  PresenterTimingFeedback Presenter::queryPresentTiming() {
+    std::lock_guard lock(m_timingMutex);
+    return m_timingFeedback;
+  }
+
+
   VkResult Presenter::recreateSwapChain() {
     VkResult vr;
 
@@ -1549,12 +1555,18 @@ namespace dxvk {
   }
 
 
-  bool Presenter::updatePresentTiming() {
-    if (!m_timingMode.presentStage)
-      return false;
-
+  bool Presenter::updatePresentTiming(uint64_t frameId) {
     // Need to access both timing stuff and the frame queue here
     std::lock_guard lock(m_timingMutex);
+
+    PresenterTimingFeedback feedback = {};
+    feedback.frameId = frameId;
+    feedback.presentTime = dxvk::high_resolution_clock::get_counter();
+
+    if (!m_timingMode.presentStage) {
+      commitTimingFeedback(feedback);
+      return false;
+    }
 
     // Still need to drain the queue even if everything is messed up
     small_vector<VkPresentStageTimeEXT, FrameQueueSize> stageTimes;
@@ -1581,6 +1593,7 @@ namespace dxvk {
 
     if (status) {
       Logger::warn(str::format("Presenter: Failed to query past present timings: ", status));
+      commitTimingFeedback(feedback);
       return false;
     }
 
@@ -1646,7 +1659,26 @@ namespace dxvk {
       m_timingMode.referenceTime = m_timingMode.lastFrameTimeLocal;
     }
 
+    // We can't give meaningful feedback w/o QPC timing currently.
+    // TODO figure out correct time domain for dxvk-native if we're
+    // reslly interested, otherwise just ignore the problem.
+    if (hasQpcDomain()) {
+      feedback.frameId = m_timingMode.lastFrameId;
+      feedback.presentTime = m_timingMode.lastFrameTimeQpc;
+    }
+
+    commitTimingFeedback(feedback);
     return true;
+  }
+
+
+  void Presenter::commitTimingFeedback(
+    const PresenterTimingFeedback&  feedback) {
+    // Only commit present timing if the new frame ID is larger than the
+    // previous frame ID, in order to avoid reverting the counter in case
+    // the application spins on present statistics.
+    if (feedback.frameId > m_timingFeedback.frameId)
+      m_timingFeedback = feedback;
   }
 
 
@@ -1994,7 +2026,7 @@ namespace dxvk {
       // Apply FPS limiter here to align it as closely with scanout as we can,
       // and delay signaling the frame latency event to emulate behaviour of a
       // low refresh rate display as closely as we can.
-      if (updatePresentTiming() && frame.isTimed)
+      if (updatePresentTiming(frame.frameId) && frame.isTimed)
         waitUntilFrameTargetTime(frame);
       else
         m_fpsLimiter.delay();

--- a/src/dxvk/dxvk_presenter.h
+++ b/src/dxvk/dxvk_presenter.h
@@ -60,6 +60,7 @@ namespace dxvk {
     Rc<DxvkLatencyTracker>  tracker       = nullptr;
     VkPresentModeKHR        mode          = VK_PRESENT_MODE_FIFO_KHR;
     VkResult                result        = VK_NOT_READY;
+    uint64_t                deadline      = 0u;
   };
 
   /**

--- a/src/dxvk/dxvk_presenter.h
+++ b/src/dxvk/dxvk_presenter.h
@@ -61,6 +61,7 @@ namespace dxvk {
     VkPresentModeKHR        mode          = VK_PRESENT_MODE_FIFO_KHR;
     VkResult                result        = VK_NOT_READY;
     uint64_t                deadline      = 0u;
+    bool                    isTimed       = false;
   };
 
   /**

--- a/src/dxvk/dxvk_presenter.h
+++ b/src/dxvk/dxvk_presenter.h
@@ -122,6 +122,9 @@ namespace dxvk {
     uint64_t frameIntervalNs = 0u;
     uint64_t referenceTime = 0u;
     uint64_t referenceFrameId = 0u;
+    uint64_t lastFrameTimeLocal = 0u;
+    uint64_t lastFrameTimeQpc = 0u;
+    uint64_t lastFrameId = 0u;
   };
 
   /**
@@ -451,6 +454,10 @@ namespace dxvk {
     void updateTimingMode(VkPresentModeKHR presentMode);
 
     void recalibrateTimeDomains();
+
+    bool updatePresentTiming(VkPresentModeKHR presentMode);
+
+    bool hasQpcDomain();
 
     uint64_t translateTimestamp(
             VkTimeDomainKHR           srcTimeDomain,

--- a/src/dxvk/dxvk_presenter.h
+++ b/src/dxvk/dxvk_presenter.h
@@ -132,7 +132,8 @@ namespace dxvk {
    * window system integration.
    */
   class Presenter : public RcObject {
-    static constexpr size_t FrameQueueSize = 16u;
+    static constexpr size_t FrameQueueSize = 32u;
+    static constexpr size_t MaxFrameQueueSize = 256u;
   public:
 
     Presenter(
@@ -390,6 +391,7 @@ namespace dxvk {
     std::optional<PresenterTimeDomainInfo>  m_timingDomains;
     std::optional<PresenterDisplayInfo>     m_timingDisplayInfo;
     PresenterTimingInfo                     m_timingMode = { };
+    uint32_t                                m_timingQueueSize = FrameQueueSize;
 
     alignas(CACHE_LINE_SIZE)
     FpsLimiter                  m_fpsLimiter;

--- a/src/dxvk/dxvk_presenter.h
+++ b/src/dxvk/dxvk_presenter.h
@@ -63,6 +63,7 @@ namespace dxvk {
     uint64_t                targetTime    = 0u;
     uint64_t                deadline      = 0u;
     bool                    isTimed       = false;
+    bool                    doWait        = false;
   };
 
   /**

--- a/src/dxvk/dxvk_presenter.h
+++ b/src/dxvk/dxvk_presenter.h
@@ -56,10 +56,10 @@ namespace dxvk {
    * \brief Queued frame
    */
   struct PresenterFrame {
-    uint64_t                frameId   = 0u;
-    Rc<DxvkLatencyTracker>  tracker   = nullptr;
-    VkPresentModeKHR        mode      = VK_PRESENT_MODE_FIFO_KHR;
-    VkResult                result    = VK_NOT_READY;
+    uint64_t                frameId       = 0u;
+    Rc<DxvkLatencyTracker>  tracker       = nullptr;
+    VkPresentModeKHR        mode          = VK_PRESENT_MODE_FIFO_KHR;
+    VkResult                result        = VK_NOT_READY;
   };
 
   /**
@@ -69,6 +69,59 @@ namespace dxvk {
     VkColorSpaceKHR colorSpace;
     size_t formatCount;
     const VkFormat* formats;
+  };
+
+  /**
+   * \brief Presenter time domain entry
+   *
+   * Used for timestamp calibration. Reference times are given in units
+   * of nanoseconds, except for QPC which is given in raw QPC ticks.
+   * QPC will be unavailable in dxvk-native environments.
+   */
+  struct PresenterTimeDomain {
+    VkTimeDomainKHR timeDomain = VK_TIME_DOMAIN_MAX_ENUM_KHR;
+    uint64_t timeDomainId = 0u;
+    uint64_t referenceTime = 0u;
+  };
+
+  /**
+   * \brief Presenter time domain info
+   *
+   * Stores info and calibration for all time domains that we need to
+   * keep track of. This will generally include a QPC entry on Windows
+   * so that we can accurately return frame statistics.
+   */
+  struct PresenterTimeDomainInfo {
+    dxvk::high_resolution_clock::time_point lastCalibration = { };
+    uint64_t updateCounter = 0u;
+    small_vector<PresenterTimeDomain, 16u> domains;
+  };
+
+  /**
+   * \brief Display timing properties
+   */
+  struct PresenterDisplayInfo {
+    uint64_t updateCounter = 0u;
+    uint64_t refreshIntervalNs = 0u;
+    bool isVariableRefresh = false;
+  };
+
+  /**
+   * \brief Present timing mode for the swapchain
+   *
+   * Stores reference time point for absolute present timing, and
+   * whether or not to use relative timing for frame pacing purposes.
+   */
+  struct PresenterTimingInfo {
+    VkPresentStageFlagsEXT presentStage = 0u;
+    bool supportsRelative = false;
+    bool supportsAbsolute = false;
+    bool relativeTiming = false;
+    bool absoluteTiming = false;
+    uint64_t timeDomainId = 0u;
+    uint64_t frameIntervalNs = 0u;
+    uint64_t referenceTime = 0u;
+    uint64_t referenceFrameId = 0u;
   };
 
   /**
@@ -332,6 +385,13 @@ namespace dxvk {
     uint64_t                    m_lastCompleted = 0u;
 
     alignas(CACHE_LINE_SIZE)
+    dxvk::mutex                             m_timingMutex;
+
+    std::optional<PresenterTimeDomainInfo>  m_timingDomains;
+    std::optional<PresenterDisplayInfo>     m_timingDisplayInfo;
+    PresenterTimingInfo                     m_timingMode = { };
+
+    alignas(CACHE_LINE_SIZE)
     FpsLimiter                  m_fpsLimiter;
 
     bool                        m_hasGamescopeFenceSignalBug = false;
@@ -381,6 +441,14 @@ namespace dxvk {
     uint32_t pickImageCount(
             uint32_t                  minImageCount,
             uint32_t                  maxImageCount);
+
+    void updateTimingDomains();
+
+    void updateDisplayTiming();
+
+    void updateTimingMode(VkPresentModeKHR presentMode);
+
+    void recalibrateTimeDomains();
 
     VkResult createSurface();
 

--- a/src/dxvk/dxvk_presenter.h
+++ b/src/dxvk/dxvk_presenter.h
@@ -60,6 +60,7 @@ namespace dxvk {
     Rc<DxvkLatencyTracker>  tracker       = nullptr;
     VkPresentModeKHR        mode          = VK_PRESENT_MODE_FIFO_KHR;
     VkResult                result        = VK_NOT_READY;
+    uint64_t                targetTime    = 0u;
     uint64_t                deadline      = 0u;
     bool                    isTimed       = false;
   };
@@ -460,6 +461,9 @@ namespace dxvk {
     void recalibrateTimeDomains();
 
     bool updatePresentTiming();
+
+    void waitUntilFrameTargetTime(
+      const PresenterFrame&           frame);
 
     bool hasQpcDomain();
 

--- a/src/dxvk/dxvk_presenter.h
+++ b/src/dxvk/dxvk_presenter.h
@@ -397,6 +397,8 @@ namespace dxvk {
     PresenterTimingInfo                     m_timingMode = { };
     uint32_t                                m_timingQueueSize = FrameQueueSize;
 
+    double                      m_frameRateLimit = 0.0;
+
     alignas(CACHE_LINE_SIZE)
     FpsLimiter                  m_fpsLimiter;
 
@@ -452,11 +454,11 @@ namespace dxvk {
 
     void updateDisplayTiming();
 
-    void updateTimingMode(VkPresentModeKHR presentMode);
+    void updateTimingMode();
 
     void recalibrateTimeDomains();
 
-    bool updatePresentTiming(VkPresentModeKHR presentMode);
+    bool updatePresentTiming();
 
     bool hasQpcDomain();
 

--- a/src/dxvk/dxvk_presenter.h
+++ b/src/dxvk/dxvk_presenter.h
@@ -79,7 +79,7 @@ namespace dxvk {
    * window system integration.
    */
   class Presenter : public RcObject {
-
+    static constexpr size_t FrameQueueSize = 16u;
   public:
 
     Presenter(
@@ -322,7 +322,11 @@ namespace dxvk {
     dxvk::condition_variable    m_frameCond;
     dxvk::condition_variable    m_frameDrain;
     dxvk::thread                m_frameThread;
-    std::queue<PresenterFrame>  m_frameQueue;
+
+    size_t                      m_frameQueuePushId = 0u;
+    size_t                      m_frameQueuePopId = 0u;
+
+    std::array<PresenterFrame, FrameQueueSize> m_frameQueue;
 
     uint64_t                    m_lastSignaled = 0u;
     uint64_t                    m_lastCompleted = 0u;
@@ -390,6 +394,8 @@ namespace dxvk {
 
     void waitForSwapchainFence(
             PresenterSync&            sync);
+
+    void pushFrame(const PresenterFrame& frame);
 
     void runFrameThread();
 

--- a/src/dxvk/dxvk_presenter.h
+++ b/src/dxvk/dxvk_presenter.h
@@ -452,6 +452,13 @@ namespace dxvk {
 
     void recalibrateTimeDomains();
 
+    uint64_t translateTimestamp(
+            VkTimeDomainKHR           srcTimeDomain,
+            uint64_t                  srcTimeDomainId,
+            uint64_t                  srcTimestamp,
+            VkTimeDomainKHR           dstTimeDomain,
+            uint64_t                  dstTimeDomainId);
+
     VkResult createSurface();
 
     VkResult createLatencySemaphore();

--- a/src/dxvk/dxvk_presenter.h
+++ b/src/dxvk/dxvk_presenter.h
@@ -132,6 +132,14 @@ namespace dxvk {
   };
 
   /**
+   * \brief Timing info for the last presented frame
+   */
+  struct PresenterTimingFeedback {
+    uint64_t frameId = 0u;
+    uint64_t presentTime = 0u;
+  };
+
+  /**
    * \brief Vulkan presenter
    * 
    * Provides abstractions for some of the
@@ -324,6 +332,16 @@ namespace dxvk {
             uint32_t                timingCount,
             VkLatencyTimingsFrameReportNV* timings);
 
+    /**
+     * \brief Queries timing info of last frame
+     *
+     * Returns the ID of the last presented frame and the current timestamp
+     * of when presentation completed, if that information is available. If
+     * no timing info is available, the returned frame ID will be 0.
+     * \returns Timing info for the last presented frame
+     */
+    PresenterTimingFeedback queryPresentTiming();
+
   private:
 
     Rc<DxvkDevice>              m_device;
@@ -398,6 +416,7 @@ namespace dxvk {
     std::optional<PresenterTimeDomainInfo>  m_timingDomains;
     std::optional<PresenterDisplayInfo>     m_timingDisplayInfo;
     PresenterTimingInfo                     m_timingMode = { };
+    PresenterTimingFeedback                 m_timingFeedback = {};
     uint32_t                                m_timingQueueSize = FrameQueueSize;
 
     double                      m_frameRateLimit = 0.0;
@@ -461,7 +480,10 @@ namespace dxvk {
 
     void recalibrateTimeDomains();
 
-    bool updatePresentTiming();
+    bool updatePresentTiming(uint64_t frameId);
+
+    void commitTimingFeedback(
+      const PresenterTimingFeedback&  feedback);
 
     void waitUntilFrameTargetTime(
       const PresenterFrame&           frame);

--- a/src/util/util_fps_limiter.cpp
+++ b/src/util/util_fps_limiter.cpp
@@ -37,10 +37,6 @@ namespace dxvk {
       m_heuristicEnable = false;
 
       m_maxLatency = maxLatency;
-
-      if (!std::exchange(m_warningShown, false))
-        Logger::warn("Built-in frame rate limiter enabled. Please enable an external"
-                     " limiter instead in order to avoid poor frame pacing.");
     }
   }
 

--- a/src/util/util_fps_limiter.h
+++ b/src/util/util_fps_limiter.h
@@ -55,8 +55,6 @@ namespace dxvk {
     TimePoint       m_heuristicFrameTime  = TimePoint();
     bool            m_heuristicEnable     = false;
 
-    bool            m_warningShown    = false;
-
     bool testRefreshHeuristic(TimerDuration interval, TimePoint now, uint32_t maxLatency);
 
   };

--- a/src/vulkan/vulkan_loader.h
+++ b/src/vulkan/vulkan_loader.h
@@ -117,6 +117,10 @@ namespace dxvk::vk {
     VULKAN_FN(vkGetPhysicalDeviceSparseImageFormatProperties);
     VULKAN_FN(vkGetPhysicalDeviceSparseImageFormatProperties2);
 
+    #ifdef VK_KHR_calibrated_timestamps
+    VULKAN_FN(vkGetPhysicalDeviceCalibrateableTimeDomainsKHR);
+    #endif
+
     #ifdef VK_KHR_get_surface_capabilities2
     VULKAN_FN(vkGetPhysicalDeviceSurfaceCapabilities2KHR);
     VULKAN_FN(vkGetPhysicalDeviceSurfaceFormats2KHR);
@@ -472,6 +476,10 @@ namespace dxvk::vk {
     VULKAN_FN(vkDestroyCuModuleNVX);
     VULKAN_FN(vkDestroyCuFunctionNVX);
     VULKAN_FN(vkCmdCuLaunchKernelNVX);
+    #endif
+
+    #ifdef VK_KHR_calibrated_timestamps
+    VULKAN_FN(vkGetCalibratedTimestampsKHR);
     #endif
 
     #ifdef VK_KHR_external_memory_win32

--- a/src/vulkan/vulkan_loader.h
+++ b/src/vulkan/vulkan_loader.h
@@ -447,6 +447,13 @@ namespace dxvk::vk {
     VULKAN_FN(vkCmdDrawMultiIndexedEXT);
     #endif
 
+    #ifdef VK_EXT_present_timing
+    VULKAN_FN(vkSetSwapchainPresentTimingQueueSizeEXT);
+    VULKAN_FN(vkGetSwapchainTimingPropertiesEXT);
+    VULKAN_FN(vkGetSwapchainTimeDomainPropertiesEXT);
+    VULKAN_FN(vkGetPastPresentationTimingEXT);
+    #endif
+
     #ifdef VK_EXT_sample_locations
     VULKAN_FN(vkCmdSetSampleLocationsEXT);
     #endif


### PR DESCRIPTION
Rebased the work that I already did quite a while ago and (somewhat reluctantly) installed Gnome for testing. Turns out it basically works fine there, both with and without VRR.

TL;DR is that this kicks in if
- VSync is enabled with a sync interval > 1 or with a "fake" display mode (e.g. 60 Hz on 144 Hz display), or
- VSync is enabled and the built-in frame rate limiter is used.

Not gonna land this any time soon, this needs a *lot* more testing on a large number of environments, and I'd definitely want to wait until KWin has some sort of usable commit-timing support upstream. Also currently only works with something like proton-ge + `PROTON_ENABLE_WAYLAND=1` for now. X11 is completely untested and XWayland doesn't support this.

| Compositor | Mesa | Mesa VRR | XWayland | Nvidia | Nvidia VRR | Nvidia + PRIME | Nvidia + PRIME VRR |
|---|---|---|---|---|---|---|---|
| Mutter (Gnome 50) | &check; | &check; | &cross;<sup>1, 4</sup> | &check; | &check;<sup>2</sup> | &check;<sup>2</sup> | &check; |
| Kwin (Plasma 6.8)    | TBD | TBD | &cross;<sup>1, 4</sup> | TBD | TBD | TBD | TBD |
| Gamescope             | &cross; | &cross; | &cross;<sup>1, 4</sup> | &cross; | &cross; | &cross; | &cross; |
| DWM (Windows)    | N/A | N/A | N/A | &cross;<sup>1</sup> | &check;<sup>3</sup> | N/A | N/A |

<ul>
<li><sup>1</sup> Only supports relative timing and not with VRR. Can handle SyncInterval > 1 at native refresh, but not much else.</li>
<li><sup>2</sup> Slightly inconsistent perf</li>
<li><sup>3</sup> Requires enabling FSE</li>
<li><sup>4</sup> Not supported on Nvidia</li>
</ul>

XWayland only supports relative mode on Mesa and doesn't report VRR, so we'd only use it for the SyncInterval > 1 case there, but hey, it works.

Definitely gonna have to add a config for this as well so peolpe can at least disable it in case of issues.