### PR TITLE
[dxgi] Implement IDXGISwapChain1::SetBackgroundColor

### DIFF
--- a/src/d3d11/d3d11_swapchain.cpp
+++ b/src/d3d11/d3d11_swapchain.cpp
@@ -338,6 +338,18 @@ namespace dxvk {
     return S_OK;
   }
 
+  HRESULT STDMETHODCALLTYPE D3D11SwapChain::SetBackgroundColor(
+          const DXGI_RGBA*                pColor) {
+    if (!pColor)
+      return E_INVALIDARG;
+
+    m_backgroundColor.float32[0] = pColor->r;
+    m_backgroundColor.float32[1] = pColor->g;
+    m_backgroundColor.float32[2] = pColor->b;
+    m_backgroundColor.float32[3] = pColor->a;
+    return S_OK;
+  }
+
 
   void STDMETHODCALLTYPE D3D11SwapChain::GetLastPresentCount(
           UINT64*                   pLastPresentCount) {
@@ -466,7 +478,8 @@ namespace dxvk {
       cLatency        = m_latency,
       cColorSpace     = m_colorSpace,
       cFrameId        = m_frameId,
-      cDirtyRects     = std::move(dirtyRects)
+      cDirtyRects     = std::move(dirtyRects),
+      cBgColor        = m_backgroundColor
     ] (DxvkContext* ctx) {
       // Update back buffer color space as necessary
       if (cSwapImage->image()->info().colorSpace != cColorSpace) {
@@ -474,6 +487,17 @@ namespace dxvk {
         usage.colorSpace = cColorSpace;
 
         ctx->ensureImageCompatibility(cSwapImage->image(), usage);
+      }
+
+      // Clear swap chain image with background color before blitting.
+      // This simulates DXGI SetBackgroundColor for DXGI_SCALING_NONE
+      // windowed mode where DWM would fill uncovered areas.
+      {
+        DxvkAttachment attachment = { };
+        attachment.view = cBackBuffer;
+        VkClearValue clearValue = { };
+        clearValue.color = cBgColor;
+        ctx->clearRenderTarget(attachment, 0u, clearValue, VK_IMAGE_ASPECT_COLOR_BIT);
       }
 
       // Blit the D3D back buffer onto the actual Vulkan

--- a/src/d3d11/d3d11_swapchain.h
+++ b/src/d3d11/d3d11_swapchain.h
@@ -81,6 +81,9 @@ namespace dxvk {
     HRESULT STDMETHODCALLTYPE SetHDRMetaData(
       const DXGI_VK_HDR_METADATA*     pMetaData);
 
+    HRESULT STDMETHODCALLTYPE SetBackgroundColor(
+            const DXGI_RGBA*                pColor);
+
     void STDMETHODCALLTYPE GetLastPresentCount(
             UINT64*                   pLastPresentCount);
 
@@ -134,6 +137,7 @@ namespace dxvk {
     Rc<sync::CallbackFence>   m_frameLatencySignal;
 
     VkColorSpaceKHR           m_colorSpace = VK_COLOR_SPACE_SRGB_NONLINEAR_KHR;
+    VkClearColorValue         m_backgroundColor = { { 0.0f, 0.0f, 0.0f, 0.0f } };
 
     double                    m_targetFrameRate = 0.0;
 

--- a/src/dxgi/dxgi_interfaces.h
+++ b/src/dxgi/dxgi_interfaces.h
@@ -124,6 +124,9 @@ IDXGIVkSwapChain : public IUnknown {
 
   virtual HRESULT STDMETHODCALLTYPE SetHDRMetaData(
     const DXGI_VK_HDR_METADATA*     pMetaData) = 0;
+
+  virtual HRESULT STDMETHODCALLTYPE SetBackgroundColor(
+    const DXGI_RGBA*                pColor) = 0;
 };
 
 

--- a/src/dxgi/dxgi_swapchain.cpp
+++ b/src/dxgi/dxgi_swapchain.cpp
@@ -180,8 +180,11 @@ namespace dxvk {
   
   HRESULT STDMETHODCALLTYPE DxgiSwapChain::GetBackgroundColor(
           DXGI_RGBA*                pColor) {
-    Logger::err("DxgiSwapChain::GetBackgroundColor: Not implemented");
-    return E_NOTIMPL;
+    if (!pColor)
+      return E_INVALIDARG;
+
+    *pColor = m_backgroundColor;
+    return S_OK;
   }
   
   
@@ -551,8 +554,17 @@ namespace dxvk {
   
   HRESULT STDMETHODCALLTYPE DxgiSwapChain::SetBackgroundColor(
     const DXGI_RGBA*                pColor) {
-    Logger::err("DxgiSwapChain::SetBackgroundColor: Not implemented");
-    return E_NOTIMPL;
+    if (!pColor)
+      return E_INVALIDARG;
+
+    m_backgroundColor = *pColor;
+
+    // Only applies to DXGI_SCALING_NONE in windowed mode per MSDN,
+    // but we forward it unconditionally so the presenter can decide.
+    if (m_presenter)
+      m_presenter->SetBackgroundColor(pColor);
+
+    return S_OK;
   }
   
   

--- a/src/dxgi/dxgi_swapchain.h
+++ b/src/dxgi/dxgi_swapchain.h
@@ -208,6 +208,7 @@ namespace dxvk {
     bool                            m_is_d3d12;
 
     DXGI_COLOR_SPACE_TYPE           m_colorSpace = DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P709;
+    DXGI_RGBA                       m_backgroundColor = { 0.0f, 0.0f, 0.0f, 0.0f };
 
     uint32_t                        m_globalHDRStateSerial = 0;
     bool                            m_hasLatencyControl = false;


### PR DESCRIPTION
Adobe After Effects 2024 calls `SetBackgroundColor` during viewport initialization. When this returns `E_NOTIMPL`, the viewport renders as a blank window.

~~This only surfaces when vkd3d or vkd3d-proton is installed, which effectively locks Linux users to AE 2024 -- which was the last version of After Effects that didn't mandate DirectX 12.~~

This only surfaces when vkd3d or vkd3d-proton is installed, which effectively locks users out of DirectX12 plugins (AE 2025 and higher still don't work properly on Wine.)

Previously reported in #5069 for Premiere Pro and closed under the assumption it was a missing video decode API. The actual root cause is this unimplemented DXGI method (per my A/B testing, swapping between dxvk-only and dxvk + vkd3d prefixes).

Per [MSDN](https://learn.microsoft.com/en-us/windows/win32/api/dxgi1_2/nf-dxgi1_2-idxgiswapchain1-setbackgroundcolor), this sets the background color DWM uses to fill areas outside presented content. Since DXVK bypasses DWM and presents directly via Vulkan, we simulate this by clearing the swap chain image with the specified color before blitting the back buffer.

The color is threaded through `IDXGIVkSwapChain` to the D3D11 presenter, where it's applied as a `VkClearColorValue` in `PresentImage` before the blit. `GetBackgroundColor` is also implemented to return the stored value.

Notably, this required **zero changes to vkd3d**; the fix lives entirely in DXVK's DXGI and D3D11 swapchain layers, which AE routes through even when DX12 plugins are active.

Tested with Adobe After Effects 2024 on Wine 11.16 + vkd3d-proton (Fedora). Viewport renders correctly; no regressions in other D3D11 apps.

References:
- https://learn.microsoft.com/en-us/windows/win32/api/dxgi1_2/nf-dxgi1_2-idxgiswapchain1-setbackgroundcolor
- https://learn.microsoft.com/en-us/windows/win32/api/dxgi1_2/nf-dxgi1_2-idxgiswapchain1-getbackgroundcolor