### PR TITLE
Do not call the Win32 external-handle entry points when they are null

### DIFF
--- a/src/dxvk/dxvk_fence.cpp
+++ b/src/dxvk/dxvk_fence.cpp
@@ -207,6 +207,20 @@ namespace dxvk {
     win32HandleInfo.handleType = m_info.sharedType;
 
     HANDLE sharedHandle = INVALID_HANDLE_VALUE;
+
+    /* Same trap as sharedHandle() above, and this one is the path a
+     * keyed-mutex texture takes first: the constructor warned that this
+     * semaphore type cannot be exported and carried on, so on a device
+     * without VK_KHR_external_semaphore_win32 -- MoltenVK -- this entry
+     * point is null and the call below is a jump to address zero. GOG
+     * Galaxy's Chromium compositor creates exactly such a texture and
+     * died here on the guest side, with nothing in the log but the
+     * canShareImage warning far upstream. */
+    if (!m_vkd->vkGetSemaphoreWin32HandleKHR) {
+      Logger::err("DxvkFence::initKmtHandles: VK_KHR_external_semaphore_win32 not supported");
+      return;
+    }
+
     VkResult vr = m_vkd->vkGetSemaphoreWin32HandleKHR(m_vkd->device(), &win32HandleInfo, &sharedHandle);
     if (vr != VK_SUCCESS) {
       Logger::err(str::format("Failed to get semaphore handle: ", vr));

--- a/src/dxvk/dxvk_fence.cpp
+++ b/src/dxvk/dxvk_fence.cpp
@@ -182,6 +182,15 @@ namespace dxvk {
     win32HandleInfo.handleType = m_info.sharedType;
 
     HANDLE sharedHandle = INVALID_HANDLE_VALUE;
+
+    /* Same reasoning as DxvkResourceAllocation::initKmtHandles. The constructor
+     * already warns that exporting this semaphore type is unsupported and then
+     * carries on, so this is reachable with a null entry point. */
+    if (!m_vkd->vkGetSemaphoreWin32HandleKHR) {
+      Logger::err("DxvkFence::sharedHandle: VK_KHR_external_semaphore_win32 not supported");
+      return INVALID_HANDLE_VALUE;
+    }
+
     VkResult vr = m_vkd->vkGetSemaphoreWin32HandleKHR(m_vkd->device(), &win32HandleInfo, &sharedHandle);
 
     if (vr != VK_SUCCESS)

--- a/src/dxvk/dxvk_image.cpp
+++ b/src/dxvk/dxvk_image.cpp
@@ -211,6 +211,11 @@ namespace dxvk {
     handleInfo.handleType = m_info.sharing.type;
     handleInfo.memory = memoryInfo.memory;
 
+    if (!m_vkd->vkGetMemoryWin32HandleKHR) {
+      Logger::warn("DxvkImage::sharedHandle: VK_KHR_external_memory_win32 not supported");
+      return INVALID_HANDLE_VALUE;
+    }
+
     if (m_vkd->vkGetMemoryWin32HandleKHR(m_vkd->device(), &handleInfo, &handle) != VK_SUCCESS)
       Logger::warn("DxvkImage::DxvkImage: Failed to get shared handle for image");
 #endif

--- a/src/dxvk/dxvk_memory.cpp
+++ b/src/dxvk/dxvk_memory.cpp
@@ -339,6 +339,21 @@ namespace dxvk {
     auto device = m_allocator->device();
     auto vk = device->vkd();
 
+    /* The entry point is null when the device has no VK_KHR_external_memory_win32,
+     * which is every MoltenVK device: Metal has no Win32 handles to give out.
+     * Calling it anyway is a jump to address zero, and the program that asked
+     * for a shared texture dies instead of being told no.
+     *
+     * Measured on macOS with EA's launcher, which composites its browser
+     * subprocess through a shared D3D11 texture: DXVK logged "Failed to create
+     * shared resource: VK_KHR_EXTERNAL_MEMORY_WIN32 not supported" and then
+     * jumped to zero three lines later. Refusing here leaves the caller with a
+     * failed handle, which is a thing it can handle. */
+    if (!vk->vkGetMemoryWin32HandleKHR) {
+      Logger::warn("DxvkResourceAllocation::initKmtHandles: VK_KHR_external_memory_win32 not supported");
+      return;
+    }
+
     VkMemoryGetWin32HandleInfoKHR handleInfo = { VK_STRUCTURE_TYPE_MEMORY_GET_WIN32_HANDLE_INFO_KHR };
     handleInfo.handleType = handleType;
     handleInfo.memory = m_memory;


### PR DESCRIPTION
On a device that has neither `VK_KHR_external_memory_win32` nor
`VK_KHR_external_semaphore_win32`, `vkGetMemoryWin32HandleKHR` and
`vkGetSemaphoreWin32HandleKHR` are null. Four call sites invoke them
unconditionally, so what should be a failed handle export is instead a call
through a null function pointer.

That describes every MoltenVK device — Metal has no Win32 handles to hand out,
so those extensions cannot be present — and the result is a jump to address
zero rather than an error the caller can act on.

### How it shows up

Reproduced with EA's launcher, which composites its browser subprocess into its
Qt shell through a shared D3D11 texture. DXVK diagnoses the situation correctly
and then dies three lines later:

```
err:   Failed to create shared resource: VK_KHR_EXTERNAL_MEMORY_WIN32 not supported
trace:seh:dispatch_exception code=c0000005 addr=0000000000000000
trace:seh:dispatch_exception rip=0000000000000000 rsp=0000000000107a78
stack 0000000000107A78: 00006fffe8826cfa  d3d11.dll+106cfa
```

`rip = 0` with the pushed return address landing in `d3d11.dll` is the
signature. The user sees a launcher that signs in successfully and then
disappears with nothing on screen, and — downstream — a game that crash-loops
in its loading screen because the launcher it was talking to has died.

GOG Galaxy hits the same path through Qt WebEngine.

### The change

Two commits, 43 added lines, no behaviour change on any device where the
extensions exist:

- **`[dxvk] Do not call the Win32 external-handle entry points when null`** —
  guards `DxvkResourceAllocation::initKmtHandles` (which had no guard at all,
  and is reached whenever an allocation carries a handle type),
  `DxvkImage::sharedHandle`, and `DxvkFence::getSemaphoreHandle`.
- **`[dxvk] Guard the KMT semaphore export against a null entry point`** —
  `DxvkFence::initKmtHandles`, the one site the first commit left.

Each guard sits on a path that already logs and returns on its other failure
modes, so the failure stays diagnosable; it just stops being fatal. On a
Windows driver the extensions are always present and the branch never runs.

Nothing here is macOS-specific except the circumstances that surface it — the
same null dereference is reachable on any Vulkan device lacking those
extensions.

### Testing

Built and run on macOS 26.6.2 / Apple M4 Max, DXVK on MoltenVK under Wine
11.9. EA's launcher and GOG Galaxy both go from crashing to rendering their
interfaces. No behaviour change observed on paths where the extensions are
present.

Happy to split, reword, or drop either commit.
