### PR TITLE
[d3d8] Extend legacy discard handling to handle legacy buffer mapping

### DIFF
--- a/dxvk.conf
+++ b/dxvk.conf
@@ -982,16 +982,17 @@
 # d3d8.placeP8InScratch = False
 
 
-# Legacy discard buffer behavior
+# Legacy buffer behavior
 #
 # Older applications may rely on D3DLOCK_DISCARD being ignored for everything
 # except D3DUSAGE_DYNAMIC + D3DUSAGE_WRITEONLY buffers, however this approach
-# incurs a performance penalty.
+# incurs a performance penalty. It was also observed that the mapping of
+# D3DUSAGE_WRITEONLY buffers is expected to be direct in such cases.
 #
 # Supported values:
 # - True/False
 
-# d3d8.forceLegacyDiscard = False
+# d3d8.forceLegacyBuffers = False
 
 
 # Overrides memory budget

--- a/src/d3d8/d3d8_buffer.h
+++ b/src/d3d8/d3d8_buffer.h
@@ -27,11 +27,9 @@ namespace dxvk {
             BYTE** ppbData,
             DWORD  Flags) {
 
-      if (m_options->forceLegacyDiscard &&
-          (Flags & D3DLOCK_DISCARD) &&
-         !((m_usage & D3DUSAGE_DYNAMIC) &&
-           (m_usage & D3DUSAGE_WRITEONLY)))
-          Flags &= ~D3DLOCK_DISCARD;
+      if (unlikely(m_options->forceLegacyBuffers &&
+                !((m_usage & D3DUSAGE_DYNAMIC) && (m_usage & D3DUSAGE_WRITEONLY))))
+        Flags &= ~D3DLOCK_DISCARD;
 
       return this->GetD3D9()->Lock(
         OffsetToLock,

--- a/src/d3d8/d3d8_device.cpp
+++ b/src/d3d8/d3d8_device.cpp
@@ -421,6 +421,13 @@ namespace dxvk {
     if (unlikely(ppVertexBuffer == nullptr))
       return D3DERR_INVALIDCALL;
 
+    // Mark all D3DPOOL_DEFAULT D3DUSAGE_WRITEONLY buffers as
+    // D3DUSAGE_DYNAMIC, to ensure they're directly mapped
+    if (unlikely(m_d3d8Options.forceLegacyBuffers
+              && d3d9::D3DPOOL(Pool) == d3d9::D3DPOOL_DEFAULT
+              && (Usage & D3DUSAGE_WRITEONLY)))
+      Usage |= D3DUSAGE_DYNAMIC;
+
     if (unlikely(ShouldBatch())) {
       *ppVertexBuffer = m_batcher->CreateVertexBuffer(Length, Usage, FVF, Pool);
       return D3D_OK;
@@ -446,6 +453,13 @@ namespace dxvk {
 
     if (unlikely(ppIndexBuffer == nullptr))
       return D3DERR_INVALIDCALL;
+
+    // Mark all D3DPOOL_DEFAULT D3DUSAGE_WRITEONLY buffers as
+    // D3DUSAGE_DYNAMIC, to ensure they're directly mapped
+    if (unlikely(m_d3d8Options.forceLegacyBuffers
+              && d3d9::D3DPOOL(Pool) == d3d9::D3DPOOL_DEFAULT
+              && (Usage & D3DUSAGE_WRITEONLY)))
+      Usage |= D3DUSAGE_DYNAMIC;
 
     Com<d3d9::IDirect3DIndexBuffer9> pIndexBuffer9;
     HRESULT res = GetD3D9()->CreateIndexBuffer(Length, Usage, d3d9::D3DFORMAT(Format), d3d9::D3DPOOL(Pool), &pIndexBuffer9, NULL);

--- a/src/d3d8/d3d8_options.cpp
+++ b/src/d3d8/d3d8_options.cpp
@@ -59,7 +59,7 @@ namespace dxvk {
 
     this->batching                = config.getOption<bool>       ("d3d8.batching",                false);
     this->placeP8InScratch        = config.getOption<bool>       ("d3d8.placeP8InScratch",        false);
-    this->forceLegacyDiscard      = config.getOption<bool>       ("d3d8.forceLegacyDiscard",      false);
+    this->forceLegacyBuffers      = config.getOption<bool>       ("d3d8.forceLegacyBuffers",      false);
     this->shadowPerspectiveDivide = config.getOption<bool>       ("d3d8.shadowPerspectiveDivide", false);
     this->textureUAFGuard         = config.getOption<bool>       ("d3d8.textureUAFGuard",         false);
 

--- a/src/d3d8/d3d8_options.h
+++ b/src/d3d8/d3d8_options.h
@@ -26,8 +26,9 @@ namespace dxvk {
     /// Place all P8 textures in D3DPOOL_SCRATCH.
     bool placeP8InScratch;
 
-    /// Ignore D3DLOCK_DISCARD for everything except D3DUSAGE_DYNAMIC + D3DUSAGE_WRITEONLY buffers.
-    bool forceLegacyDiscard;
+    /// Ignore D3DLOCK_DISCARD on everything except D3DUSAGE_DYNAMIC + D3DUSAGE_WRITEONLY buffers,
+    /// and mark all D3DUSAGE_WRITEONLY buffers in D3DPOOL_DEFAULT as D3DUSAGE_DYNAMIC.
+    bool forceLegacyBuffers;
 
     /// Force D3DTTFF_PROJECTED for the necessary stages when a depth texture is bound to slot 0.
     bool shadowPerspectiveDivide;

--- a/src/d3d9/d3d9_options.cpp
+++ b/src/d3d9/d3d9_options.cpp
@@ -64,7 +64,7 @@ namespace dxvk {
     this->modeCountCompatibility        = config.getOption<bool>        ("d3d9.modeCountCompatibility",        false);
     this->allowDiscard                  = config.getOption<bool>        ("d3d9.allowDiscard",                  true);
     this->enumerateByDisplays           = config.getOption<bool>        ("d3d9.enumerateByDisplays",           true);
-    this->cachedWriteOnlyBuffers        = config.getOption<bool>        ("d3d9.cachedWriteOnlyBuffers",          false);
+    this->cachedWriteOnlyBuffers        = config.getOption<bool>        ("d3d9.cachedWriteOnlyBuffers",        false);
     this->deviceLocalConstantBuffers    = config.getOption<Tristate>    ("d3d9.deviceLocalConstantBuffers",    Tristate::Auto);
     this->allowDirectBufferMapping      = config.getOption<bool>        ("d3d9.allowDirectBufferMapping",      true);
     this->forceDrawTimeBufferUpload     = config.getOption<bool>        ("d3d9.forceDrawTimeBufferUpload",     false);

--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -1320,11 +1320,11 @@ namespace dxvk {
       { "d3d9.maxFrameRate",                 "-60" },
     }} },
     /* Rayman 3: Hoodlum Havoc                    *
-     * Missing geometry and textures without      *
-     * legacy DISCARD behavior                    */
+     * Fixes missing geometry and textures        *
+     * as well as some broken effects             */
     { R"(\\Rayman3\.exe$)", {{
       { "d3d9.maxFrameRate",                 "-60" },
-      { "d3d8.forceLegacyDiscard",          "True" },
+      { "d3d8.forceLegacyBuffers",          "True" },
     }} },
     /* Tom Clancy's Splinter Cell                 *
      * Fixes shadow buffers, broken physics       *
@@ -1374,10 +1374,9 @@ namespace dxvk {
       { "d3d9.modeCountCompatibility",      "True" },
     }} },
     /* Top Spin (2005)                            *
-     * Missing geometry and textures without      *
-     * legacy DISCARD behavior                    */
+     * Fixes missing geometry and textures        */
     { R"(\\TopSpin\.exe$)", {{
-      { "d3d8.forceLegacyDiscard",          "True" },
+      { "d3d8.forceLegacyBuffers",          "True" },
     }} },
     /* Lego Racers 2 - Hits an incredible amount  *
      * of queue syncs with direct buffer mapping  */


### PR DESCRIPTION
Works around the regression identified in #5886. The change that regressed the behavior is correct, in that modern Windows/native does behave this way, however some old games appear to rely on how it was being handled back in the times of Windows 95/98.

Rather than introducing a new config option for it, I've expanded the old `forceLegacyDiscard` logic we had in d3d8, by making the affected WRITEONLY buffers as DYNAMIC, which works well enough for the jank called Rayman 3.

On a side note, buffer mapping is all over the place in early D3D, and in D7VK I'm forced to mark all backing D3D9 buffers as DYNAMIC or otherwise hit very slow upload patterns in general (the APIs don't provide the flag explicitly).