### PR TITLE
[util] Enable cached dynamic constant buffers for Skyrim SE

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -503,6 +503,10 @@ namespace dxvk {
       { "d3d11.disableDirectImageMapping",  "True" },
       { "dxvk.enableImplicitResolves",     "False" },
     }} },
+    /* Skyrim Speshul Edition                     */
+    { R"(\\SkyrimSE\.exe$)", {{
+      { "d3d11.cachedDynamicResources",        "a" },
+    }} },
 
     /**********************************************/
     /* D3D9 GAMES                                 */


### PR DESCRIPTION
Should fix CPU perf when FPS is unlocked. Doubt it'll affect the vanilla experience, it's Skyrim after all and even an Intel A380 can probably run that at 60 FPS in one way or another.