### PR TITLE
[d3d9] Update window handle during swapchain reset

### DIFF
--- a/src/d3d9/d3d9_swapchain.cpp
+++ b/src/d3d9/d3d9_swapchain.cpp
@@ -628,6 +628,11 @@ namespace dxvk {
 
     bool changeFullscreen = m_presentParams.Windowed != pPresentParams->Windowed;
 
+    if (m_window != pPresentParams->hDeviceWindow) {
+      m_window = pPresentParams->hDeviceWindow;
+      m_displayRefreshRateDirty = true;
+    }
+
     if (pPresentParams->Windowed) {
       if (changeFullscreen)
         this->LeaveFullscreenMode();


### PR DESCRIPTION
The minimally invasive change from a patch set suggested by @GloriousEggroll . It appears to fix the Painkiller WSI jank, by making sure the *actual* window is being used to enter fullscreen mode during a swapchain reset.

It makes sense to me, since we have the same logic applied on Present, however with the current code we end up with a stale window used during Reset, so fullscreen mode isn't signaled properly. As with any WSI change, this has the potential to explode in other places, so I'll leave it as draft until it gets tested thoroughly.

Fixes #3762 at least, could potentially help in other cases.